### PR TITLE
add explore deck count and draw chance

### DIFF
--- a/src/main/java/ti4/commands/explore/ExpInfo.java
+++ b/src/main/java/ti4/commands/explore/ExpInfo.java
@@ -8,6 +8,7 @@ import ti4.helpers.Helper;
 import ti4.map.Map;
 import ti4.message.MessageHelper;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.StringTokenizer;
@@ -36,10 +37,18 @@ public class ExpInfo extends ExploreSubcommandData {
             StringBuilder info = new StringBuilder();
             ArrayList<String> deck = activeMap.getExploreDeck(currentType);
             Collections.sort(deck);
+            Integer deckCount = deck.size();
+            Double deckDrawChance = 1.0 / deckCount;
+            NumberFormat formatPercent = NumberFormat.getPercentInstance();
+
             ArrayList<String> discard = activeMap.getExploreDiscard(currentType);
             Collections.sort(discard);
-            info.append(Helper.getEmojiFromDiscord(currentType)).append("**").append(currentType.toUpperCase()).append(" EXPLORE DECK**\n").append(listNames(deck)).append("\n");
-            info.append(Helper.getEmojiFromDiscord(currentType)).append("**").append(currentType.toUpperCase()).append(" EXPLORE DISCARD**\n").append(listNames(discard)).append("\n");
+            Integer discardCount = discard.size();
+
+            info.append(Helper.getEmojiFromDiscord(currentType)).append("**").append(currentType.toUpperCase()).append(" EXPLORE DECK** (").append(String.valueOf(deckCount)).append(") _").append(formatPercent.format(deckDrawChance)).append("_\n");
+            info.append(listNames(deck)).append("\n");
+            info.append(Helper.getEmojiFromDiscord(currentType)).append("**").append(currentType.toUpperCase()).append(" EXPLORE DISCARD** (").append(String.valueOf(discardCount)).append(")\n");
+            info.append(listNames(discard)).append("\n\n");
             MessageHelper.replyToMessage(event, info.toString());
         }
     }


### PR DESCRIPTION
Please test this before merging - I don't have a test server/bot setup yet.

added a count of cards remaining in an explore deck, and the percentage chance to draw one card from that deck
also added a newline at the end of a specific trait to divide it up a bit better

orig:
**INDUSTRIAL EXPLORE DECK**

new:
**INDUSTRIAL EXPLORE DECK** (12) _8%_