### PR TITLE
Bringing combat roll fixes into stage II code

### DIFF
--- a/src/main/java/ti4/DataMigrationManager.java
+++ b/src/main/java/ti4/DataMigrationManager.java
@@ -1,0 +1,186 @@
+package ti4;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import ti4.generator.Mapper;
+import ti4.helpers.Constants;
+import ti4.helpers.Helper;
+import ti4.map.Map;
+import ti4.map.MapManager;
+import ti4.map.Player;
+import ti4.map.Tile;
+import ti4.message.BotLogger;
+import ti4.model.FactionModel;
+import ti4.model.TechnologyModel;
+import ti4.model.UnitModel;
+
+public class DataMigrationManager {
+
+    public static void runMigrations() {
+        HashMap<String, List<String>> migrationsAppliedToMaps = new HashMap<>();
+        HashMap<String, Map> loadedMaps = MapManager.getInstance().getMapList();
+
+        migrationsAppliedToMaps.put("migrateFixkeleresUnits_010823", new ArrayList<String>());
+        migrationsAppliedToMaps.put("migrateOwnedUnits_010823", new ArrayList<String>());
+        for (Map map : loadedMaps.values()) {
+            Boolean endVPReachedButNotEnded = map.getPlayers().values().stream()
+                    .anyMatch(player -> player.getTotalVictoryPoints(map) >= map.getVp());
+            if (map.isHasEnded() || endVPReachedButNotEnded) {
+                continue;
+            }
+
+            if (!map.hasRunMigration("migrateFixkeleresUnits_010823")) {
+                migrateFixkeleresUnits_010823(map);
+                map.addMigration("migrateFixkeleresUnits_010823");
+
+                migrationsAppliedToMaps.get("migrateFixkeleresUnits_010823").add(map.getName());
+            }
+
+            if (!map.hasRunMigration("migrateOwnedUnits_010823")) {
+                migrateOwnedUnits_010823(map);
+                map.addMigration("migrateOwnedUnits_010823");
+
+                migrationsAppliedToMaps.get("migrateOwnedUnits_010823").add(map.getName());
+            }
+        }
+
+        if (migrationsAppliedToMaps.size() > 0) {
+
+            for (Entry<String, List<String>> entry : migrationsAppliedToMaps.entrySet()) {
+                String mapNames = String.join(", ", entry.getValue());
+                if (entry.getValue().size() > 0) {
+                    BotLogger.log(
+                            String.format("Migration %s run on following maps successfully: %s", entry.getKey(),
+                                    mapNames));
+                }
+            }
+        }
+    }
+
+    /// MIGRATION: Refresh owned units
+    /// There was a bug recently in Player.doAdditionalThingsWhenAddingTech
+    /// That didnt allow for unit upgrades to be included when there wasnt a pre-req (eg war sun)
+    /// Additionally, there are historical issues of unit upgrades not being included in units_owned
+    /// This migration looks to each players' faction setup for its base units
+    /// Then looks to the player.techs for any upgrades to the base units to get an uptodate list of owned units. 
+    ///
+    public static void migrateOwnedUnits_010823(Map map) {
+        try {
+            for (Player player : map.getRealPlayers()) {
+                FactionModel factionSetupInfo = player.getFactionSetupInfo();
+
+                // Trying to assign an accurate Faction Model for old keleres players.
+                if (factionSetupInfo == null && player.getFaction().equals("keleres")) {
+                    List<FactionModel> keleresSubfactions = Mapper.getFactions().stream()
+                            .filter(factionID -> factionID.startsWith("keleres") && !factionID.equals("keleres"))
+                            .map(factionID -> Mapper.getFactionSetup(factionID))
+                            .collect(Collectors.toList());
+
+                    // guess subfaction based on homeplanet
+                    for (FactionModel factionModel : keleresSubfactions) {
+
+                        // Check if a keleres home system is on the board.
+                        Tile homesystem = map.getTile(factionModel.getHomeSystem());
+                        if (homesystem == null) {
+                            homesystem = map.getTile(factionModel.getHomeSystem().replace("new", ""));
+                        }
+                        if (homesystem != null) {
+                            factionSetupInfo = Mapper.getFactionSetup(factionModel.getAlias());
+                            break;
+                        }
+
+                        // When your kereles your supposed to have a '<planet-alias>k' version of the
+                        // homesystem, but some games do not, so this checks for the normal planet home
+                        // systems
+                        // and checks if the associated faction isnt in the game.
+                        List<String> subfactionHomePlanetsWithoutKeleresSuffix = factionModel.getHomePlanets()
+                                .stream()
+                                .map(alias -> alias.substring(0, alias.length() - 1))
+                                .collect(Collectors.toList());
+
+                        Optional<String> firstHomePlanet = subfactionHomePlanetsWithoutKeleresSuffix.stream()
+                                .findFirst();
+                        if (firstHomePlanet.isPresent()) {
+                            Tile homeSystem = Helper.getTileFromPlanet(firstHomePlanet.get().toLowerCase(), map);
+                            if (homeSystem != null) {
+                                Boolean isHomeSystemUsedBySomeoneElse = false;
+                                for (String factionId : map.getFactions()) {
+                                    FactionModel otherFactionSetup = Mapper.getFactionSetup(factionId);
+                                    if (otherFactionSetup.getHomeSystem().equals(homeSystem.getTileID())) {
+                                        isHomeSystemUsedBySomeoneElse = true;
+                                        break;
+                                    }
+                                }
+                                if (!isHomeSystemUsedBySomeoneElse) {
+                                    factionSetupInfo = factionModel;
+                                }
+                            }
+
+                        }
+                    }
+                }
+
+                if (factionSetupInfo == null) {
+                    throw new Exception(
+                            String.format("Failed to find correct faction to sync units with faction: %s, map: %s",
+                                    player.getFaction(), map.getName()));
+                }
+                List<String> ownedUnitIDs = factionSetupInfo.getUnits();
+
+                List<TechnologyModel> playerTechs = player.getTechs().stream().map(techID -> Mapper.getTech(techID))
+                        .filter(tech -> tech.getType().equals(Constants.UNIT_UPGRADE))
+                        .collect(Collectors.toList());
+
+                for (TechnologyModel technologyModel : playerTechs) {
+                    UnitModel upgradedUnit = Mapper.getUnitModelByTechUpgrade(technologyModel.getAlias());
+                    if (upgradedUnit != null) {
+                        if (StringUtils.isNotBlank(upgradedUnit.getUpgradesFromUnitId())) {
+                            Integer upgradesFromUnitIndex = ownedUnitIDs.indexOf(upgradedUnit.getUpgradesFromUnitId());
+                            if (upgradesFromUnitIndex != null && upgradesFromUnitIndex >= 0) {
+                                ownedUnitIDs.set(upgradesFromUnitIndex, upgradedUnit.getId());
+                            }
+                        } else {
+                            ownedUnitIDs.add(upgradedUnit.getId());
+                        }
+                    }
+                }
+                player.setUnitsOwned(new HashSet<String>(ownedUnitIDs));
+            }
+        } catch (Exception e) {
+            BotLogger.log("Failed to migrate owned units for map" + map.getName(), e);
+        }
+
+    }
+
+    /// MIGRATION: Fix Keleres units 
+    /// We've updated faction_setup.json so that the keleres factions all share the
+    /// same unit type
+    /// and this migration checks for any suffixed keleres units already existing
+    /// incorrectly in games.
+    public static void migrateFixkeleresUnits_010823(Map map) {
+
+        for (Player player : map.getRealPlayers()) {
+
+            List<String> ownedUnitIDs = new ArrayList<>(player.getUnitsOwned());
+            for (String unitID : ownedUnitIDs) {
+                Integer unitIndex = ownedUnitIDs.indexOf(unitID);
+                if (unitID.startsWith("keleres") && unitID.endsWith("_flagship")) {
+                    ownedUnitIDs.set(unitIndex, "keleres_flagship");
+                }
+                if (unitID.startsWith("keleres") && unitID.endsWith("_mech")) {
+                    ownedUnitIDs.set(unitIndex, "keleres_mech");
+                }
+            }
+
+            player.setUnitsOwned(new HashSet<String>(ownedUnitIDs));
+        }
+    }
+}

--- a/src/main/java/ti4/MapGenerator.java
+++ b/src/main/java/ti4/MapGenerator.java
@@ -223,6 +223,8 @@ public class MapGenerator {
         BotLogger.log("BOT STARTED UP: " + guildPrimary.getName());
         MapSaveLoadManager.loadMaps();
 
+        DataMigrationManager.runMigrations(); 
+
         readyToReceiveCommands = true;
         BotLogger.log("BOT HAS FINISHED LOADING MAPS");
 

--- a/src/main/java/ti4/commands/special/CombatRoll.java
+++ b/src/main/java/ti4/commands/special/CombatRoll.java
@@ -41,6 +41,7 @@ public class CombatRoll extends SpecialSubcommandData {
         addOptions(new OptionData(OptionType.STRING, Constants.COMBAT_EXTRA_ROLLS,
                 "comma list of <count> <unit> eg 2 fighter 1 dreadnought for extra roll")
                 .setRequired(false));
+        addOptions(new OptionData(OptionType.USER, Constants.PLAYER, "roll for player (by default your units)").setRequired(false));
     }
 
     @Override
@@ -51,6 +52,7 @@ public class CombatRoll extends SpecialSubcommandData {
         OptionMapping mods = event.getOption(Constants.COMBAT_MODIFIERS);
         OptionMapping planetOption = event.getOption(Constants.PLANET);
         OptionMapping extraRollsOption = event.getOption(Constants.COMBAT_EXTRA_ROLLS);
+        OptionMapping playerOption = event.getOption(Constants.PLAYER);
 
         if (tileOption == null) {
             return;
@@ -75,7 +77,11 @@ public class CombatRoll extends SpecialSubcommandData {
         tileName = " - " + tileName + "[" + tile.getTileID() + "]";
         StringBuilder sb = new StringBuilder();
 
-        Player player = activeMap.getPlayer(getUser().getId());
+        String userID = getUser().getId();
+        if(playerOption != null){
+            userID = playerOption.getAsUser().getId();
+        }
+        Player player = activeMap.getPlayer(userID);
         player = Helper.getGamePlayer(activeMap, player, event, null);
         player = Helper.getPlayer(activeMap, player, event);
         if (player == null) {
@@ -114,9 +120,9 @@ public class CombatRoll extends SpecialSubcommandData {
         String unitHolderFileSuffix = ".png";
         if (unitHolderString.startsWith(colorID)) {
             // format is <color>_<asyncID>.png
-            String modelName = unitHolderString.substring(colorID.length());
-            modelName = modelName.substring(1, modelName.length() - unitHolderFileSuffix.length());
-            result = player.getUnitByAsyncID(modelName.toLowerCase());
+            String unitAsyncID = unitHolderString.substring(colorID.length());
+            unitAsyncID = unitAsyncID.substring(1, unitAsyncID.length() - unitHolderFileSuffix.length());
+            result = player.getUnitByAsyncID(unitAsyncID.toLowerCase());
         }
         return result;
     }

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -816,6 +816,7 @@ public class Constants {
     public static final String FLIP_GRACE = "flip_grace";
     public static final String SIGIL = "token_ds_sigil.png";
     public static final String IMAGE_GEN_COUNT = "image_gen_count";
+    public static final String RUN_DATA_MIGRATIONS = "run_data_migrations";
     public static final String ENDED_DATE = "ended_date";
     public static final String AVERAGE_TURN_TIME = "average_turn_time";
     public static final String TOP_LIMIT = "top_limit";

--- a/src/main/java/ti4/map/Map.java
+++ b/src/main/java/ti4/map/Map.java
@@ -194,6 +194,9 @@ public class Map {
     @JsonIgnore
     List<SimpleEntry<String, String>> planetNameAutocompleteOptionsCache = null;
 
+    @ExportableField
+    private ArrayList<String> runDataMigrations = new ArrayList<>(); 
+
     public Map() {
         creationDate = Helper.getDateRepresentation(new Date().getTime());
         lastModifiedDate = new Date().getTime();
@@ -2439,5 +2442,19 @@ public class Map {
 
     public void incrementMapImageGenerationCount() {
         this.mapImageGenerationCount++;
+    }
+
+    public boolean hasRunMigration(String string) {
+        return this.runDataMigrations.contains(string);
+    }
+
+    public void addMigration(String string) {
+        if(!this.runDataMigrations.contains(string)){
+            this.runDataMigrations.add(string);    
+        }
+    }
+
+    public ArrayList<String> getRunMigrations(){
+        return this.runDataMigrations;
     }
 }

--- a/src/main/java/ti4/map/MapSaveLoadManager.java
+++ b/src/main/java/ti4/map/MapSaveLoadManager.java
@@ -469,6 +469,9 @@ public class MapSaveLoadManager {
         writer.write(Constants.IMAGE_GEN_COUNT + " " + activeMap.getMapImageGenerationCount());
         writer.write(System.lineSeparator());
 
+        writer.write(Constants.RUN_DATA_MIGRATIONS + " " + String.join(",",activeMap.getRunMigrations()));
+        writer.write(System.lineSeparator());
+
         writer.write(ENDGAMEINFO);
         writer.write(System.lineSeparator());
 
@@ -839,7 +842,7 @@ public class MapSaveLoadManager {
                     if (isTxtExtention(file)) {
                         try {
                             Map activeMap = loadMap(file);
-                            if (activeMap != null) {
+                            if (activeMap != null && activeMap.getName() != null) {
                                 mapList.put(activeMap.getName(), activeMap);
                             }
                         } catch (Exception e) {
@@ -1431,6 +1434,13 @@ public class MapSaveLoadManager {
                         activeMap.setMapImageGenerationCount(count);
                     } catch (Exception e) {
                         //Do nothing
+                    }
+                }
+                case Constants.RUN_DATA_MIGRATIONS -> {
+                    StringTokenizer migrationInfo = new StringTokenizer(info, ",");
+    
+                    while (migrationInfo.hasMoreTokens()) {
+                        activeMap.addMigration(migrationInfo.nextToken());
                     }
                 }
             }

--- a/src/main/resources/info/faction_setup.json
+++ b/src/main/resources/info/faction_setup.json
@@ -473,7 +473,7 @@
     "abilities": ["the_tribuni", "council_patronage", "laws_order"],
     "leaders": ["keleresagent", "kelerescommander", "keleresheroharka"],
     "promissoryNotes": ["riderm"],
-    "units": ["fighter", "destroyer", "cruiser", "carrier", "dreadnought", "keleresm_flagship", "infantry", "keleresm_mech", "pds", "spacedock"]
+    "units": ["fighter", "destroyer", "cruiser", "carrier", "dreadnought", "keleres_flagship", "infantry", "keleres_mech", "pds", "spacedock"]
   },
   {
     "alias": "keleresx",
@@ -487,7 +487,7 @@
     "abilities": ["the_tribuni", "council_patronage", "laws_order"],
     "leaders": ["keleresagent", "kelerescommander", "keleresheroodlynn"],
     "promissoryNotes": ["riderx"],
-    "units": ["fighter", "destroyer", "cruiser", "carrier", "dreadnought", "keleresx_flagship", "infantry", "keleresx_mech", "pds", "spacedock"]
+    "units": ["fighter", "destroyer", "cruiser", "carrier", "dreadnought", "keleres_flagship", "infantry", "keleres_mech", "pds", "spacedock"]
   },
   {
     "alias": "keleresa",
@@ -501,7 +501,7 @@
     "abilities": ["the_tribuni", "council_patronage", "laws_order"],
     "leaders": ["keleresagent", "kelerescommander", "keleresherokuuasi"],
     "promissoryNotes": ["ridera"],
-    "units": ["fighter", "destroyer", "cruiser", "carrier", "dreadnought", "keleresa_flagship", "infantry", "keleresa_mech", "pds", "spacedock"]
+    "units": ["fighter", "destroyer", "cruiser", "carrier", "dreadnought", "keleres_flagship", "infantry", "keleres_mech", "pds", "spacedock"]
   },
   {
     "alias": "admins",

--- a/src/main/resources/info/units.json
+++ b/src/main/resources/info/units.json
@@ -770,7 +770,8 @@
         "combatDieCount": 1,
         "afbHitsOn": 9,
         "afbDieCount": 1,
-        "ability": "This unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool."
+        "ability": "This unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool.",
+        "isShip": true
     },
     {
         "id": "florzen_fighter2",
@@ -789,7 +790,8 @@
         "combatDieCount": 1,
         "afbHitsOn": 8,
         "afbDieCount": 1,
-        "ability": "This unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool."
+        "ability": "This unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool.",
+        "isShip": true
     },
     {
         "id": "florzen_flagship",
@@ -1646,7 +1648,8 @@
         "combatHitsOn": 9,
         "combatDieCount": 1,
         "bombardHitsOn": 9,
-        "bombardDieCount": 1
+        "bombardDieCount": 1,
+        "isShip": true
     },
     {
         "id": "lizho_fighter2",
@@ -1665,7 +1668,8 @@
         "combatDieCount": 1,
         "bombardHitsOn": 8,
         "bombardDieCount": 1,
-        "ability": "This unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool."
+        "ability": "This unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool.",
+        "isShip": true
     },
     {
         "id": "lizho_flagship",
@@ -2072,7 +2076,10 @@
         "upgradesToUnitId": "naalu_fighter2",
         "source": "base",
         "faction": "Naalu",
-        "capacityUsed": 1
+        "capacityUsed": 1,
+        "isShip": true,
+        "combatHitsOn": 8,
+        "combatDieCount": 1
     },
     {
         "id": "naalu_fighter2",
@@ -2084,7 +2091,10 @@
         "requiredTechId": "hcf2",
         "source": "base",
         "faction": "Naalu",
-        "capacityUsed": 1
+        "capacityUsed": 1,
+        "isShip": true,
+        "combatHitsOn": 7,
+        "combatDieCount": 1
     },
     {
         "id": "naalu_flagship",


### PR DESCRIPTION
Model tweaks
- faction_setup.json - keleres units should share unit names
- units.json - a couple of the fighters were not set as ships.

Combat roll tweaks
- added an optional player field (mainly to help with debugging but generally helpful too)

Add Data migration manager
- Plan is to use this generally to update the historic map save data when code fixes can only make an effect with new games.

- added migrateFixkeleresUnits_010823 to fix existing games with keleres players with bad owned_units.
- added migrateOwnedUnits_010823 to get owned_units in sync with faction & current unit techs.