### PR TITLE
Update base.json

### DIFF
--- a/src/main/resources/data/factions/base.json
+++ b/src/main/resources/data/factions/base.json
@@ -146,7 +146,7 @@
       "startingFleet": "dn,cv,cr,2 ff,2 inf m,sd m",
       "commodities": 3,
       "factionTech": ["vax", "vay"],
-      "startingTech": ["dxa", "vax", "vay"],
+      "startingTech": ["dxa"],
       "homePlanets": ["mordaiii"],
       "abilities": ["galactic_threat", "technological_singularity", "propagation"],
       "leaders": ["nekroagent", "nekrocommander", "nekrohero"],


### PR DESCRIPTION
Remove Valefar techs from Nekro starting Tech. They are already included in their faction techs, serves no specific purpose, and messes up franken draft.