### PR TITLE
Fix Log Spam

### DIFF
--- a/src/main/java/ti4/draft/DraftItem.java
+++ b/src/main/java/ti4/draft/DraftItem.java
@@ -2,6 +2,8 @@ package ti4.draft;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.items.AbilityDraftItem;
 import ti4.draft.items.AgentDraftItem;
 import ti4.draft.items.BlueTileDraftItem;
@@ -105,8 +107,10 @@ public abstract class DraftItem implements ModelInterface {
         ItemId = itemId;
     }
 
+    @JsonIgnore
     public abstract String getShortDescription();
 
+    @JsonIgnore
     public String getLongDescription() {
         StringBuilder sb = new StringBuilder(getLongDescriptionImpl());
         if (Errata != null) {
@@ -132,8 +136,10 @@ public abstract class DraftItem implements ModelInterface {
         return sb.toString();
     }
 
+    @JsonIgnore
     protected abstract String getLongDescriptionImpl();
 
+    @JsonIgnore
     public abstract String getItemEmoji();
 
     public boolean isDraftable(Player player) {

--- a/src/main/java/ti4/draft/FrankenDraft.java
+++ b/src/main/java/ti4/draft/FrankenDraft.java
@@ -38,7 +38,7 @@ public class FrankenDraft extends BagDraft {
     public static List<FactionModel> getDraftableFactionsForGame(Game activeGame) {
         List<FactionModel> factionSet = getAllFrankenLegalFactions();
         if (!activeGame.isDiscordantStarsMode()) {
-            factionSet.removeIf(factionModel -> factionModel.getSource().isDs());
+            factionSet.removeIf(factionModel -> factionModel.getSource().isDs() && !factionModel.getSource().isPok());
         }
         return factionSet;
     }

--- a/src/main/java/ti4/draft/items/AbilityDraftItem.java
+++ b/src/main/java/ti4/draft/items/AbilityDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.map.Faction;
@@ -15,11 +16,13 @@ public class AbilityDraftItem extends DraftItem {
         super(Category.ABILITY, itemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return getAbilityModel().getName();
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         AbilityModel abilityModel = getAbilityModel();
@@ -31,11 +34,13 @@ public class AbilityDraftItem extends DraftItem {
         return "";
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return getAbilityModel().getFactionEmoji();
     }
 
+    @JsonIgnore
     private AbilityModel getAbilityModel() {
         return Mapper.getAbility(ItemId);
     }

--- a/src/main/java/ti4/draft/items/AgentDraftItem.java
+++ b/src/main/java/ti4/draft/items/AgentDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -17,10 +18,12 @@ public class AgentDraftItem extends DraftItem {
         super(Category.AGENT, itemId);
     }
 
+    @JsonIgnore
     private LeaderModel getLeader() {
         return Mapper.getLeader(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         LeaderModel leader = getLeader();
@@ -31,6 +34,7 @@ public class AgentDraftItem extends DraftItem {
         return "Agent - " + leader.getName();
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         LeaderModel leader = getLeader();
@@ -40,6 +44,7 @@ public class AgentDraftItem extends DraftItem {
         return "";
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         LeaderModel leader = getLeader();

--- a/src/main/java/ti4/draft/items/BlueTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/BlueTileDraftItem.java
@@ -3,6 +3,7 @@ package ti4.draft.items;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.commands.milty.MiltyDraftManager;
 import ti4.commands.milty.MiltyDraftTile;
 import ti4.draft.DraftItem;
@@ -18,11 +19,13 @@ public class BlueTileDraftItem extends DraftItem {
         super(Category.BLUETILE, itemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return TileHelper.getTile(ItemId).getName() + " (" + ItemId + ")";
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         TileModel tile = TileHelper.getTile(ItemId);
@@ -73,6 +76,7 @@ public class BlueTileDraftItem extends DraftItem {
         };
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.SemLor;

--- a/src/main/java/ti4/draft/items/CommanderDraftItem.java
+++ b/src/main/java/ti4/draft/items/CommanderDraftItem.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -17,10 +18,12 @@ public class CommanderDraftItem extends DraftItem {
         super(Category.COMMANDER, itemId);
     }
 
+    @JsonIgnore
     private LeaderModel getLeader() {
         return Mapper.getLeader(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         LeaderModel leader = getLeader();
@@ -30,6 +33,7 @@ public class CommanderDraftItem extends DraftItem {
         }return "Commander - " + getLeader().getName();
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         LeaderModel leader = getLeader();
@@ -39,6 +43,7 @@ public class CommanderDraftItem extends DraftItem {
         return "";
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         LeaderModel leader = getLeader();

--- a/src/main/java/ti4/draft/items/CommoditiesDraftItem.java
+++ b/src/main/java/ti4/draft/items/CommoditiesDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -20,17 +21,21 @@ public class CommoditiesDraftItem extends DraftItem {
         }
         return Mapper.getFaction(ItemId);
     }
+
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return getFaction().getFactionName() + " Commodities";
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         int comms = getFaction().getCommodities();
         return comms + " Commodities";
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.comm;

--- a/src/main/java/ti4/draft/items/FlagshipDraftItem.java
+++ b/src/main/java/ti4/draft/items/FlagshipDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -16,10 +17,12 @@ public class FlagshipDraftItem extends DraftItem {
         super(Category.FLAGSHIP, itemId);
     }
 
+    @JsonIgnore
     private UnitModel getUnit() {
         return Mapper.getUnit(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         UnitModel unit = getUnit();
@@ -29,6 +32,7 @@ public class FlagshipDraftItem extends DraftItem {
         return "Flagship - " + unit.getName();
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         UnitModel unit = getUnit();
@@ -61,6 +65,7 @@ public class FlagshipDraftItem extends DraftItem {
         return sb.toString();
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.flagship;

--- a/src/main/java/ti4/draft/items/HeroDraftItem.java
+++ b/src/main/java/ti4/draft/items/HeroDraftItem.java
@@ -3,6 +3,8 @@ package ti4.draft.items;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -15,10 +17,12 @@ public class HeroDraftItem extends DraftItem {
         super(Category.HERO, itemId);
     }
 
+    @JsonIgnore
     private LeaderModel getLeader() {
         return Mapper.getLeader(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         LeaderModel leader = getLeader();
@@ -29,6 +33,7 @@ public class HeroDraftItem extends DraftItem {
         return "Hero - " + leader.getName().replace("\n", "");
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         LeaderModel leader = getLeader();
@@ -38,6 +43,7 @@ public class HeroDraftItem extends DraftItem {
         return "";
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
 

--- a/src/main/java/ti4/draft/items/HomeSystemDraftItem.java
+++ b/src/main/java/ti4/draft/items/HomeSystemDraftItem.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.generator.TileHelper;
@@ -15,11 +16,13 @@ public class HomeSystemDraftItem extends DraftItem {
         super(Category.HOMESYSTEM, itemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return Mapper.getFaction(ItemId).getFactionName() + " Home System";
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         if ("ghost".equals(ItemId)) {
@@ -46,6 +49,7 @@ public class HomeSystemDraftItem extends DraftItem {
         sb.append(") ");
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.getFactionIconFromDiscord(ItemId);

--- a/src/main/java/ti4/draft/items/MechDraftItem.java
+++ b/src/main/java/ti4/draft/items/MechDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -20,11 +21,13 @@ public class MechDraftItem extends DraftItem {
         return Mapper.getUnit(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return "Mech - " + getUnit().getName();
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         UnitModel unit = getUnit();
@@ -55,6 +58,7 @@ public class MechDraftItem extends DraftItem {
         return sb.toString();
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.mech;

--- a/src/main/java/ti4/draft/items/PNDraftItem.java
+++ b/src/main/java/ti4/draft/items/PNDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -15,22 +16,26 @@ public class PNDraftItem extends DraftItem {
         super(Category.PN, itemId);
     }
 
+    @JsonIgnore
     private PromissoryNoteModel getPn() {
         return Mapper.getPromissoryNoteByID(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         PromissoryNoteModel pn = getPn();
         return "Promissory Note - " + pn.getName();
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         PromissoryNoteModel pn = getPn();
         return pn.getText();
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.PN;

--- a/src/main/java/ti4/draft/items/RedTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/RedTileDraftItem.java
@@ -3,6 +3,7 @@ package ti4.draft.items;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.commands.milty.MiltyDraftManager;
 import ti4.commands.milty.MiltyDraftTile;
 import ti4.draft.DraftItem;
@@ -18,11 +19,13 @@ public class RedTileDraftItem extends DraftItem {
         super(Category.REDTILE, itemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return TileHelper.getTile(ItemId).getName() + " (" + ItemId + ")";
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         TileModel tile = TileHelper.getTile(ItemId);
@@ -76,6 +79,7 @@ public class RedTileDraftItem extends DraftItem {
         };
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.Supernova;

--- a/src/main/java/ti4/draft/items/SpeakerOrderDraftItem.java
+++ b/src/main/java/ti4/draft/items/SpeakerOrderDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.helpers.Emojis;
 import ti4.map.Game;
@@ -13,11 +14,13 @@ public class SpeakerOrderDraftItem extends DraftItem {
         super(Category.DRAFTORDER, itemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return "Table Position " + ItemId;
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         if ("1".equals(ItemId)) {
@@ -26,6 +29,7 @@ public class SpeakerOrderDraftItem extends DraftItem {
         return "Table Position " + ItemId;
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         if ("1".equals(ItemId)) {

--- a/src/main/java/ti4/draft/items/StartingFleetDraftItem.java
+++ b/src/main/java/ti4/draft/items/StartingFleetDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
@@ -18,20 +19,24 @@ public class StartingFleetDraftItem extends DraftItem {
     }
 
 
+    @JsonIgnore
     private FactionModel getFaction() {
         return Mapper.getFaction(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return getFaction().getFactionName() + " Starting Fleet";
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         return Helper.getUnitListEmojis(getFaction().getStartingFleet());
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.NonUnitTechSkip;

--- a/src/main/java/ti4/draft/items/StartingTechDraftItem.java
+++ b/src/main/java/ti4/draft/items/StartingTechDraftItem.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -16,6 +17,7 @@ public class StartingTechDraftItem extends DraftItem {
         super(Category.STARTINGTECH, itemId);
     }
 
+    @JsonIgnore
     private FactionModel getFaction() {
         if ("keleres".equals(ItemId)) {
             return Mapper.getFaction("keleresa");
@@ -23,6 +25,7 @@ public class StartingTechDraftItem extends DraftItem {
         return Mapper.getFaction(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return getFaction().getFactionName() + " Starting Tech";
@@ -46,6 +49,9 @@ public class StartingTechDraftItem extends DraftItem {
             Map.entry("tnelis", "Choose 2 of the following: :Biotictech: Neural Motivator, :Propulsiontech: Antimass Deflectors, :Warfaretech: Plasma Scoring."),
             Map.entry("vaden", "Choose 2 of the following: :Biotictech: Neural Motivator, :Propulsiontech: Antimass Deflectors, :Cybernetictech: Sarween Tools.")
     );
+
+
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         if (selectableStartingTechs.containsKey(ItemId)) {
@@ -73,6 +79,7 @@ public class StartingTechDraftItem extends DraftItem {
         return getFaction().getStartingTech();
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         return Emojis.UnitTechSkip;

--- a/src/main/java/ti4/draft/items/TechDraftItem.java
+++ b/src/main/java/ti4/draft/items/TechDraftItem.java
@@ -1,5 +1,6 @@
 package ti4.draft.items;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import ti4.draft.DraftItem;
 import ti4.generator.Mapper;
 import ti4.helpers.Emojis;
@@ -15,6 +16,7 @@ public class TechDraftItem extends DraftItem {
         super(Category.TECH, itemId);
     }
 
+    @JsonIgnore
     @Override
     public String getShortDescription() {
         return getTech().getName();
@@ -24,11 +26,13 @@ public class TechDraftItem extends DraftItem {
         return Mapper.getTech(ItemId);
     }
 
+    @JsonIgnore
     @Override
     public String getLongDescriptionImpl() {
         return getTech().getText() + " " + getTech().getRequirementsEmoji();
     }
 
+    @JsonIgnore
     @Override
     public String getItemEmoji() {
         TechnologyModel model = getTech();


### PR DESCRIPTION
A recent update to Franken caused a bunch of log spam when saving to JSON. This adds JSONIgnore to a bunch of methods so they don't get serialized.