### PR TITLE
Leader.java Jackson Serialization Tests

### DIFF
--- a/src/test/java/ti4/map/LeaderTest.java
+++ b/src/test/java/ti4/map/LeaderTest.java
@@ -1,0 +1,79 @@
+package ti4.map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Map.Entry;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class LeaderTest {
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String expectedId = "testId";
+    private final  String expectedType = "testType";
+    private final int expectedTgCount = 1;
+    private final boolean expectedExhausted = false;
+    private final boolean expectedLocked = true;
+    private final boolean expectedActive = false;
+
+    
+    @Test
+    public void testLeaderHasNoUnexpectedProperties() throws Exception {
+        // Given        
+        Leader leader = new Leader(expectedId, expectedType, expectedTgCount, expectedExhausted, expectedLocked, expectedActive);
+        Set<String> knownJsonAttributes = new HashSet<>(Arrays.asList(
+            "id",
+            "type",
+            "tgCount",
+            "exhausted",
+            "locked",
+            "active"
+        ));
+
+        // When
+        JsonNode json = objectMapper.valueToTree(leader);
+
+        // Then
+        Iterator<Entry<String, JsonNode>> fields = json.fields();
+        while (fields.hasNext()) {
+            Entry<String, JsonNode> field = fields.next();
+            if (!knownJsonAttributes.remove(field.getKey())) {
+                throw new Exception("Untested JSON property found in class. Please update tests to validate this new field is JSON safe. Field: " + field.getKey());
+            }
+        }
+
+        assertEquals(0, knownJsonAttributes.size(), "JSON field was expected to be seen on object but was never observed");
+    }
+
+    @Test
+    public void testLeaderIsJacksonSerializable() {
+        assertTrue(objectMapper.canSerialize(Leader.class), "Jackson doesn't think it can serialize this class");
+    }
+
+    @Test
+    public void testLeaderJsonSaveAndRestore() throws JsonProcessingException {
+        // Given        
+        Leader leader = new Leader(expectedId, expectedType, expectedTgCount, expectedExhausted, expectedLocked, expectedActive);
+
+        // When
+        String json = objectMapper.writeValueAsString(leader);
+        Leader restoredLeader = objectMapper.readValue(json, Leader.class);
+
+        // Then
+        assertEquals(expectedId, restoredLeader.getId());
+        assertEquals(expectedType, restoredLeader.getType());
+        assertEquals(expectedTgCount, restoredLeader.getTgCount());
+        assertEquals(expectedExhausted, restoredLeader.isExhausted());
+        assertEquals(expectedLocked, restoredLeader.isLocked());
+        assertEquals(expectedActive, restoredLeader.isActive());
+    }
+}


### PR DESCRIPTION
# Description

This is an example Jackson serialization tests which will ensure `Leader` is always serializable. I intend to spread this pattern into all objects which eventually get serialized to bring stability to our save/restore process.

In these series of tests, I confirm that object data survives a save/restore cycle and the tests will automatically fail should anyone add new fields which suddenly appear in the JSON model.

Validated that tests fail when I add a new property or function which causes a field to be added to the JSON model. Also confirmed null values are caught by the field detection logic.


# Tests

Ran build and new tests:

```
docker build -t tibot .
```