### PR TITLE
Basic JSON serialization tests for `UnitKey`

### DIFF
--- a/src/main/java/ti4/helpers/Units.java
+++ b/src/main/java/ti4/helpers/Units.java
@@ -1,6 +1,10 @@
 package ti4.helpers;
 
 import java.util.concurrent.ThreadLocalRandom;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Data;
 import lombok.Getter;
 
@@ -8,11 +12,23 @@ public class Units {
 
     private static final String emdash = "—";
 
+    /**
+     * <H3>
+     * DO NOT ADD NEW VALUES TO THIS OBJECT.
+     * </H3>
+     * 
+     * <p>
+     * It is being used as a key in some major hashmaps which causes issues when we attempt to 
+     * save/restore from JSON as JSON map keys have to be strings, not JSON objects. This forces
+     * us to use custom mappers to resolve.
+     * </p>
+     */
     @Data
     public static class UnitKey {
         private UnitType unitType;
         private String colorID;
 
+        @JsonIgnore
         public String getColor() {
             return AliasHandler.resolveColor(colorID);
         }
@@ -29,6 +45,7 @@ public class Units {
             return unitType.getUnitTypeEmoji();
         }
 
+        @JsonIgnore
         public String getFileName() {
             if (unitType == UnitType.Destroyer && ThreadLocalRandom.current().nextInt(Constants.EYE_CHANCE) == 0) {
                 return String.format("%s_dd_eyes.png", colorID);
@@ -40,6 +57,7 @@ public class Units {
             return String.format("%s_%s.png", colorID, asyncID());
         }
 
+        @JsonIgnore
         public String getOldUnitID() {
             return String.format("%s_%s.png", colorID, asyncID());
         }
@@ -52,7 +70,7 @@ public class Units {
             return String.format("%s%s%s", colorID, emdash, asyncID());
         }
 
-        UnitKey(UnitType unitType, String colorID) {
+        UnitKey(@JsonProperty("unitType") UnitType unitType, @JsonProperty("colorID") String colorID) {
             this.unitType = unitType;
             this.colorID = colorID;
         }

--- a/src/test/java/ti4/helpers/UnitsTest.java
+++ b/src/test/java/ti4/helpers/UnitsTest.java
@@ -1,0 +1,63 @@
+package ti4.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitType;
+import ti4.testUtils.JsonValidator;
+
+public class UnitsTest {
+    
+    @Nested
+    class UnitKeyTest {
+        private final UnitType expectedUnitType = UnitType.Carrier;
+        private final String expectedColorId = "blu";
+
+        private UnitKey buildUnitKey() {
+            return new UnitKey(expectedUnitType, expectedColorId);
+        }
+
+        @Test
+        public void testUnitKeyHasNoUnexpectedProperties() throws Exception {
+            // Given        
+            UnitKey unitKey = buildUnitKey();
+            // DO NOT ADD NEW JSON KEYS TO THIS OBJECT.
+            // This object is being used as a key in maps which causes issues when we
+            // try to conver the Java map to a JSON map (as maps only allow for string keys).
+            Set<String> knownJsonAttributes = new HashSet<>(Arrays.asList(
+                "unitType",
+                "colorID"
+            ));
+
+            // When
+            JsonValidator.assertAvailableJsonAttributes(unitKey, knownJsonAttributes);
+        }
+
+        @Test
+        public void testUnitKeyIsJacksonSerializable() {
+            JsonValidator.assertIsJacksonSerializable(UnitKey.class);
+        }
+
+        @Test
+        public void testUnitKeyJsonSaveAndRestore() throws JsonProcessingException {
+            // Given        
+            UnitKey unitKey = buildUnitKey();
+
+            // When
+            UnitKey restoredUnitKey = JsonValidator.jsonCycleObject(unitKey, UnitKey.class);
+
+            // Then
+            assertEquals(expectedColorId, restoredUnitKey.getColorID());
+            assertEquals(expectedUnitType, restoredUnitKey.getUnitType());
+        }
+    }
+}

--- a/src/test/java/ti4/map/LeaderTest.java
+++ b/src/test/java/ti4/map/LeaderTest.java
@@ -1,23 +1,18 @@
 package ti4.map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
-import java.util.Map.Entry;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ti4.testUtils.JsonValidator;
 
 public class LeaderTest {
-    private ObjectMapper objectMapper = new ObjectMapper();
-
     private final String expectedId = "testId";
     private final  String expectedType = "testType";
     private final int expectedTgCount = 1;
@@ -25,11 +20,14 @@ public class LeaderTest {
     private final boolean expectedLocked = true;
     private final boolean expectedActive = false;
 
+    private Leader buildLeader() {
+        return new Leader(expectedId, expectedType, expectedTgCount, expectedExhausted, expectedLocked, expectedActive);
+    }
     
     @Test
     public void testLeaderHasNoUnexpectedProperties() throws Exception {
         // Given        
-        Leader leader = new Leader(expectedId, expectedType, expectedTgCount, expectedExhausted, expectedLocked, expectedActive);
+        Leader leader = buildLeader();
         Set<String> knownJsonAttributes = new HashSet<>(Arrays.asList(
             "id",
             "type",
@@ -40,33 +38,21 @@ public class LeaderTest {
         ));
 
         // When
-        JsonNode json = objectMapper.valueToTree(leader);
-
-        // Then
-        Iterator<Entry<String, JsonNode>> fields = json.fields();
-        while (fields.hasNext()) {
-            Entry<String, JsonNode> field = fields.next();
-            if (!knownJsonAttributes.remove(field.getKey())) {
-                throw new Exception("Untested JSON property found in class. Please update tests to validate this new field is JSON safe. Field: " + field.getKey());
-            }
-        }
-
-        assertEquals(0, knownJsonAttributes.size(), "JSON field was expected to be seen on object but was never observed");
+        JsonValidator.assertAvailableJsonAttributes(leader, knownJsonAttributes);
     }
 
     @Test
     public void testLeaderIsJacksonSerializable() {
-        assertTrue(objectMapper.canSerialize(Leader.class), "Jackson doesn't think it can serialize this class");
+        JsonValidator.assertIsJacksonSerializable(Leader.class);
     }
 
     @Test
     public void testLeaderJsonSaveAndRestore() throws JsonProcessingException {
         // Given        
-        Leader leader = new Leader(expectedId, expectedType, expectedTgCount, expectedExhausted, expectedLocked, expectedActive);
+        Leader leader = buildLeader();
 
         // When
-        String json = objectMapper.writeValueAsString(leader);
-        Leader restoredLeader = objectMapper.readValue(json, Leader.class);
+        Leader restoredLeader = JsonValidator.jsonCycleObject(leader, Leader.class);
 
         // Then
         assertEquals(expectedId, restoredLeader.getId());

--- a/src/test/java/ti4/testUtils/JacksonConfigurationException.java
+++ b/src/test/java/ti4/testUtils/JacksonConfigurationException.java
@@ -1,0 +1,12 @@
+package ti4.testUtils;
+
+/**
+ * If thrown, a test case has discovered an issue with how our source code is configured
+ * for Jackson, our JSON serializer convering java classes into JSON files. Do not ignore
+ * this exception as it likely means you will break our save/restore cycles for game state.
+ */
+public class JacksonConfigurationException extends Exception {
+    JacksonConfigurationException(String msg) {
+        super(msg);
+    }
+}

--- a/src/test/java/ti4/testUtils/JsonValidator.java
+++ b/src/test/java/ti4/testUtils/JsonValidator.java
@@ -1,0 +1,65 @@
+package ti4.testUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Utility test class that allows us to validate our source files are correctly configured
+ * for JSON save/restore.
+ */
+public final class JsonValidator<T> {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    
+    private JsonValidator() {}
+
+    /**
+     * Subjects the provided object to a save/restore JSON loop where we serialize the object to
+     * a JSON string and then re-consistue it. Allows tests to confirm no data is lost in this
+     * process.
+     */
+    public static <T> T jsonCycleObject(T obj, Class<T> clazz) throws JsonProcessingException {
+        String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (Exception e) {
+            System.err.println("JSON which failed to be restored:");
+            System.err.println(json);
+            throw e;
+        }
+    }
+
+    /**
+     * Scans an object and confirms we only see attributes in the JSON output that we expect to see.
+     * 
+     * Any any missing attributes or unknown attributes will cause an exception to be thrown.
+     */
+    public static void assertAvailableJsonAttributes(Object obj, Set<String> knownJsonAttributes) throws JacksonConfigurationException {
+        JsonNode json = objectMapper.valueToTree(obj);
+
+        // Validate all fields we expect to be present in JSON output are accounted for with no extras.
+        Iterator<Entry<String, JsonNode>> fields = json.fields();
+        while (fields.hasNext()) {
+            Entry<String, JsonNode> field = fields.next();
+            if (!knownJsonAttributes.remove(field.getKey())) {
+                throw new JacksonConfigurationException("Untested JSON property found in class. Please update tests to validate this new field is JSON safe. Field: " + field.getKey());
+            }
+        }
+
+        assertEquals(0, knownJsonAttributes.size(), "JSON field was expected to be seen on object but was never observed");
+    }
+
+    /**
+     * Runs any tests we can on the entire class to determine if Jackson things this class can be successfully serialized.
+     */
+    public static void assertIsJacksonSerializable(Class<?> clazz) {
+        assertTrue(objectMapper.canSerialize(clazz), "Jackson doesn't think it can serialize this class");
+    }
+}


### PR DESCRIPTION
# Description

More serialization tests, this time for `UnitKey`.

`UnitKey` is causing us issues as it's being used as a key in Java maps which messes up serialization. JSON only allows map keys to be strings, causing issues we we attempt to deserialize back to a Java map.

This ensures we can at least serialize UnitKey which was taking on tons of extra fields that I had to drop.

Next step will be to modify the serialization process to get this working when `UnitKey` is used as a map key.

# Testing

```
docker build -t tibot .
```