### PR TITLE
Space JSON Serialization with Map-key special logic

### DIFF
--- a/src/main/java/ti4/helpers/Units.java
+++ b/src/main/java/ti4/helpers/Units.java
@@ -70,7 +70,7 @@ public class Units {
             return String.format("%s%s%s", colorID, emdash, asyncID());
         }
 
-        UnitKey(@JsonProperty("unitType") UnitType unitType, @JsonProperty("colorID") String colorID) {
+        public UnitKey(@JsonProperty("unitType") UnitType unitType, @JsonProperty("colorID") String colorID) {
             this.unitType = unitType;
             this.colorID = colorID;
         }

--- a/src/main/java/ti4/json/ObjectMapperFactory.java
+++ b/src/main/java/ti4/json/ObjectMapperFactory.java
@@ -1,0 +1,29 @@
+package ti4.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import ti4.helpers.Units.UnitKey;
+
+final public class ObjectMapperFactory {
+    private ObjectMapperFactory(){}
+
+    /**
+     * Builds the standard Jackson ObjectMapper to be used by the entire application.
+     * 
+     * TODO(Aaron): All instances of ObjectMapper must come from this factory.
+     */
+    public static ObjectMapper build() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // Beacuse UnitKey objects are used as keys within Java maps, we need special
+        // serialization logic for them as JSON map keys can only be strings.
+        // So we must make the "key" a JSON string which we then unwrap when deserializing.
+        SimpleModule simpleMod = new SimpleModule();
+        simpleMod.addKeySerializer(UnitKey.class, new UnitKeyMapKeySerializer());
+        simpleMod.addKeyDeserializer(UnitKey.class, new UnitKeyMapKeyDeserializer());
+        objectMapper.registerModule(simpleMod);
+
+        return objectMapper;
+    }
+}

--- a/src/main/java/ti4/json/UnitKeyMapKeyDeserializer.java
+++ b/src/main/java/ti4/json/UnitKeyMapKeyDeserializer.java
@@ -1,0 +1,22 @@
+package ti4.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ti4.helpers.Units.UnitKey;
+
+/**
+ * UnitKey objects are converted to their literal JSON string representation when they are used as
+ * a map key. This reverts them to their original Java object form by deserializing the string.
+ */
+public class UnitKeyMapKeyDeserializer extends KeyDeserializer {
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+        return mapper.readValue(key, UnitKey.class);
+    }
+}

--- a/src/main/java/ti4/json/UnitKeyMapKeySerializer.java
+++ b/src/main/java/ti4/json/UnitKeyMapKeySerializer.java
@@ -1,0 +1,24 @@
+package ti4.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import ti4.helpers.Units.UnitKey;
+
+/**
+ * JSON map keys can only be strings. So when UnitKey objects are used as Java map keys, we have to
+ * use the literal JSON string as the map key.
+ */
+public class UnitKeyMapKeySerializer extends JsonSerializer<UnitKey> {
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void serialize(UnitKey value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+        gen.writeFieldName(mapper.writeValueAsString(value));
+    }
+}

--- a/src/main/java/ti4/map/UnitHolder.java
+++ b/src/main/java/ti4/map/UnitHolder.java
@@ -2,10 +2,10 @@ package ti4.map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import java.awt.Point;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,11 +17,10 @@ import ti4.generator.Mapper;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "javaClassType")
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = Space.class, name = "space"),
-    @JsonSubTypes.Type(value = Planet.class, name = "planet")
+    @JsonSubTypes.Type(value = Space.class, name = "Space"),
+    @JsonSubTypes.Type(value = Planet.class, name = "Planet")
 })
 abstract public class UnitHolder {
     private final String name;
@@ -80,6 +79,10 @@ abstract public class UnitHolder {
         controlList.remove(cc);
     }
 
+    /**
+     * Adds a variety of tokens from faction effects and other game mechanics (sleeper tokens,
+     * frontier tokens, wormhole tokens, etc).
+     */
     public boolean addToken(String cc) {
         return tokenList.add(cc);
     }
@@ -176,6 +179,7 @@ abstract public class UnitHolder {
         return !getUnits().isEmpty();
     }
 
+    @JsonProperty("unitsDamage")
     public HashMap<UnitKey, Integer> getUnitDamage() {
         return unitsDamage;
     }
@@ -187,6 +191,10 @@ abstract public class UnitHolder {
               .findFirst().map(Entry::getValue).orElse(0);
     }
 
+    /**
+     * Get the Command Counter list.
+     */
+    @JsonProperty("commandCounterList")
     public HashSet<String> getCCList() {
         return ccList;
     }
@@ -209,6 +217,7 @@ abstract public class UnitHolder {
             .collect(Collectors.toMap(entry -> getUnitAliasId(entry.getKey()), Entry::getValue)));
     }
 
+    @JsonIgnore
     public List<String> getUnitColorsOnHolder() {
         return getUnits().keySet().stream()
             .map(this::getUnitColor)
@@ -216,10 +225,12 @@ abstract public class UnitHolder {
             .collect(Collectors.toList());
     }
 
+    @JsonIgnore
     public String getUnitAliasId(UnitKey unitKey) {
         return unitKey.asyncID();
     }
 
+    @JsonIgnore
     public String getUnitColor(UnitKey unitKey) {
         return unitKey.getColorID();
     }

--- a/src/test/java/ti4/map/SpaceTest.java
+++ b/src/test/java/ti4/map/SpaceTest.java
@@ -1,0 +1,96 @@
+package ti4.map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Point;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitType;
+import ti4.testUtils.BaseTi4Test;
+import ti4.testUtils.JsonValidator;
+
+public class SpaceTest extends BaseTi4Test {
+    private final String expectedName = "space";
+    private final Point expectedHolderCenterPosition = new Point(1, 2);
+    private final UnitType expectedUnitType = UnitType.Carrier;
+    private final String expectedColorID = "blu";
+    private final UnitKey expectedUnitKey = new UnitKey(expectedUnitType, expectedColorID);
+    private final int expectedUnitCount = 4;
+    private final int expectedUnitDamage = 1;
+    private final String expectedCommandCounter = "Random Command Counter";
+    private final String expectedControl = "Random Control";
+    private final String expectedToken = "token_frontier.png";
+
+    private Space buildSpace() {
+        Space space = new Space(expectedName, expectedHolderCenterPosition);
+
+        space.addUnit(expectedUnitKey, expectedUnitCount);
+        space.addUnitDamage(expectedUnitKey, expectedUnitDamage);
+        space.addCC(expectedCommandCounter);
+        space.addControl(expectedControl);
+        space.addToken(expectedToken);
+        
+        return space;
+    }
+    
+    @Test
+    public void testSpaceHasNoUnexpectedProperties() throws Exception {
+        // Given        
+        Space space = buildSpace();
+        Set<String> knownJsonAttributes = new HashSet<>(Arrays.asList(
+            "name",
+            "javaClassType",
+            "holderCenterPosition",
+            "units",
+            "unitsDamage",
+            "commandCounterList",
+            "controlList",
+            "tokenList"
+        ));
+
+        // When
+        JsonValidator.assertAvailableJsonAttributes(space, knownJsonAttributes);
+    }
+
+    @Test
+    public void testSpaceIsJacksonSerializable() {
+        JsonValidator.assertIsJacksonSerializable(Space.class);
+    }
+
+    @Test
+    public void testSpaceJsonSaveAndRestore() throws JsonProcessingException {
+        // Given        
+        Space space = buildSpace();
+
+        // When
+        Space restoredSpace = JsonValidator.jsonCycleObject(space, Space.class);
+
+        // Then
+        assertEquals(expectedName, restoredSpace.getName());
+        assertEquals(expectedHolderCenterPosition, restoredSpace.getHolderCenterPosition());
+        HashMap<UnitKey, Integer> restoredUnits = restoredSpace.getUnits();
+        assertEquals(1, restoredUnits.size());
+        assertEquals(expectedUnitCount, restoredUnits.get(expectedUnitKey));
+        HashMap<UnitKey, Integer> restoredUnitsDamaged = restoredSpace.getUnitDamage();
+        assertEquals(1, restoredUnitsDamaged.size());
+        assertEquals(expectedUnitDamage, restoredUnitsDamaged.get(expectedUnitKey));
+        HashSet<String> restoredCCList = restoredSpace.getCCList();
+        assertEquals(1, restoredCCList.size());
+        assertTrue(restoredCCList.contains(expectedCommandCounter));
+        HashSet<String> restoredControlList = restoredSpace.getControlList();
+        assertEquals(1, restoredControlList.size());
+        assertTrue(restoredControlList.contains(expectedControl));
+        HashSet<String> restoredTokenList = restoredSpace.getTokenList();
+        assertEquals(1, restoredTokenList.size());
+        assertTrue(restoredTokenList.contains(expectedToken));
+    }
+}

--- a/src/test/java/ti4/testUtils/JsonValidator.java
+++ b/src/test/java/ti4/testUtils/JsonValidator.java
@@ -10,13 +10,19 @@ import java.util.Set;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import ti4.helpers.Units.UnitKey;
+import ti4.json.ObjectMapperFactory;
+import ti4.json.UnitKeyMapKeyDeserializer;
+import ti4.json.UnitKeyMapKeySerializer;
 
 /**
  * Utility test class that allows us to validate our source files are correctly configured
  * for JSON save/restore.
  */
 public final class JsonValidator<T> {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.build();
     
     private JsonValidator() {}
 


### PR DESCRIPTION
# Description

Because `UnitKey` objects are used as keys within Java maps, we need special serialization logic for them as JSON map keys can only be strings. So we must make the "key" a JSON string which we then unwrap when deserializing.

Before this, Jackson was using `UnitKey.toString()` to convert the object key into a string which is not at all what we want.

I tried getting annotations working to add the key serializers/deserializers but I could never get the deserializer to trigger. Only way I got it working was to attach them to the `ObjectMapper`.

At some point we will need to do a pass and update all `ObjectMapper`'s to use the factory I created. Otherwise they will fail to convert objects.

# Testing

```
docker build -t tibot .
```