### PR TITLE
Add missing unit upgrade ability text

### DIFF
--- a/src/main/resources/data/units/absol.json
+++ b/src/main/resources/data/units/absol.json
@@ -296,7 +296,8 @@
         "disablesPlanetaryShield": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "homebrewReplacesID": "warsun"
+        "homebrewReplacesID": "warsun",
+        "ability": "Other players' units in this system lose PLANETARY SHIELD."
     },
     {
         "id": "absol_sol_carrier2",

--- a/src/main/resources/data/units/absol.json
+++ b/src/main/resources/data/units/absol.json
@@ -275,7 +275,8 @@
         "sustainDamage": true,
         "canBeDirectHit": false,
         "isShip": true,
-        "homebrewReplacesID": "dreadnought2"
+        "homebrewReplacesID": "dreadnought2",
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards."
     },
     {
         "id": "absol_warsun",
@@ -353,7 +354,7 @@
         "bombardDieCount": 2,
         "sustainDamage": true,
         "isShip": true,
-        "ability": "After a round of space combat, you may destroy this unit to destroy up to 2 ships in the system.",
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards. After a round of space combat, you may destroy this unit to destroy up to 2 ships in the system.",
         "homebrewReplacesID": "sardakk_dreadnought2"
     },
     {
@@ -375,7 +376,8 @@
         "bombardDieCount": 1,
         "sustainDamage": true,
         "isShip": true,
-        "homebrewReplacesID": "l1z1x_dreadnought2"
+        "homebrewReplacesID": "l1z1x_dreadnought2",
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards."
     },
     {
         "id": "absol_naalu_fighter2",

--- a/src/main/resources/data/units/absol.json
+++ b/src/main/resources/data/units/absol.json
@@ -393,7 +393,8 @@
         "isShip": true,
         "combatHitsOn": 7,
         "combatDieCount": 1,
-        "homebrewReplacesID": "naalu_fighter2"
+        "homebrewReplacesID": "naalu_fighter2",
+        "ability": "This unit may move without being transported. Each fighter in excess of your ships' capacity counts as 1/2 of a ship against your fleet pool."
     },
     {
         "id": "absol_muaat_warsun2",

--- a/src/main/resources/data/units/ds.json
+++ b/src/main/resources/data/units/ds.json
@@ -210,7 +210,7 @@
         "bombardDieCount": 1,
         "sustainDamage": true,
         "isShip": true,
-        "ability": "When this unit is destroyed, you may place 1 fighter or 1 destroyer from your reinforcements in this system's space area."
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards. When this unit is destroyed, you may place 1 fighter or 1 destroyer from your reinforcements in this system's space area."
     },
     {
         "id": "cheiran_flagship",
@@ -1718,7 +1718,8 @@
         "spaceCannonHitsOn": 5,
         "spaceCannonDieCount": 1,
         "sustainDamage": true,
-        "isShip": true
+        "isShip": true,
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards."
     },
     {
         "id": "veldyr_flagship",

--- a/src/main/resources/data/units/ds.json
+++ b/src/main/resources/data/units/ds.json
@@ -605,7 +605,8 @@
         "cost": 3,
         "combatHitsOn": 9,
         "combatDieCount": 1,
-        "isShip": true
+        "isShip": true,
+        "ability": "You may reroll 1 of your unit's combat dice during each round of ground combat on a planet in this system that contains 2 or fewer of your infantry."
     },
     {
         "id": "ghoti_flagship",

--- a/src/main/resources/data/units/miltymod.json
+++ b/src/main/resources/data/units/miltymod.json
@@ -227,7 +227,8 @@
         "isShip": true,
         "combatHitsOn": 7,
         "combatDieCount": 1,
-        "homebrewReplacesID": "naalu_fighter2"
+        "homebrewReplacesID": "naalu_fighter2",
+        "ability": "This unit may move without being transported. Each fighter in excess of your ships' capacity counts as 1/2 of a ship against your fleet pool."
     },
     {
         "id": "miltymod_saar_spacedock",

--- a/src/main/resources/data/units/miltymod.json
+++ b/src/main/resources/data/units/miltymod.json
@@ -608,7 +608,8 @@
         "disablesPlanetaryShield": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "homebrewReplacesID": "warsun"
+        "homebrewReplacesID": "warsun",
+        "ability": "Other players' units in this system lose PLANETARY SHIELD."
     },
     {
         "id": "miltymod_carrier",

--- a/src/main/resources/data/units/units.json
+++ b/src/main/resources/data/units/units.json
@@ -640,7 +640,8 @@
         "capacityUsed": 1,
         "isShip": true,
         "combatHitsOn": 7,
-        "combatDieCount": 1
+        "combatDieCount": 1,
+        "ability": "This unit may move without being transported. Each fighter in excess of your ships' capacity counts as 1/2 of a ship against your fleet pool."
     },
     {
         "id": "naalu_flagship",

--- a/src/main/resources/data/units/units.json
+++ b/src/main/resources/data/units/units.json
@@ -1582,7 +1582,8 @@
         "sustainDamage": true,
         "disablesPlanetaryShield": true,
         "canBeDirectHit": true,
-        "isShip": true
+        "isShip": true,
+        "ability": "Other player's units in this system lose PLANETARY SHIELD."
     },
     {
         "id": "mech",

--- a/src/main/resources/data/units/units.json
+++ b/src/main/resources/data/units/units.json
@@ -367,7 +367,8 @@
         "bombardHitsOn": 4,
         "bombardDieCount": 1,
         "sustainDamage": true,
-        "isShip": true
+        "isShip": true,
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards."
     },
     {
         "id": "l1z1x_flagship",
@@ -929,7 +930,7 @@
         "bombardDieCount": 2,
         "sustainDamage": true,
         "isShip": true,
-        "ability": "After a round of space combat, you may destroy this unit to destroy up to 2 ships in the system."
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards. After a round of space combat, you may destroy this unit to destroy up to 2 ships in the system."
     },
     {
         "id": "sardakk_flagship",
@@ -1438,7 +1439,8 @@
         "bombardDieCount": 1,
         "sustainDamage": true,
         "canBeDirectHit": false,
-        "isShip": true
+        "isShip": true,
+        "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards."
     },
     {
         "id": "fighter",


### PR DESCRIPTION
Adds ability text for Dreadnought II variants, Naalu Fighter II, and War Sun.

~~Only addresses the base game & PoK units. The various mods have at least some of the same problems, but i don't know where to find authoritative sources for those yet. i'll get those in another pass hopefully.~~

Includes MiltyMod, Absol, and Discordant Stars variants, where applicable.

Also adds the Ghemina Raiders' Combat Transport II's ability, which was also missing.