### PR TITLE
Correct the tier number for MiltyMod Prototype War Sun I

### DIFF
--- a/src/main/resources/data/units/miltymod.json
+++ b/src/main/resources/data/units/miltymod.json
@@ -157,7 +157,7 @@
         "id": "miltymod_muaat_warsun",
         "baseType": "warsun",
         "asyncId": "ws",
-        "name": "Prototype War Sun II",
+        "name": "Prototype War Sun I",
         "upgradesToUnitId": "miltymod_muaat_warsun2",
         "source": "miltymod",
         "faction": "Muaat",


### PR DESCRIPTION
This erroneously read Prototype War Sun II.