### PR TITLE
Fix typos in Absol's Relics

### DIFF
--- a/src/main/resources/data/relics/absol.json
+++ b/src/main/resources/data/relics/absol.json
@@ -67,7 +67,7 @@
         "name": "Shard of the Throne (1)",
         "text": "When you gain this card, gain 1 victory point. When you lose this card, lose 1 victory point. When you cast votes during the agenda phase, you cast 2 additional votes. When a player gains control of a legendary planet you control or a planet you control in your home system, that player gains one Shard of the Throne from your play area.",
         "source": "absol",
-        "flavourText": "''What power does a broken piece of the Throne of Emperors hold? To me, none. But to everyone else...''"
+        "flavourText": "\"What power does a broken piece of the Throne of Emperors hold? To me, none. But to everyone else...\""
     },
     {
         "alias": "absol_shardofthethrone2",

--- a/src/main/resources/data/relics/absol.json
+++ b/src/main/resources/data/relics/absol.json
@@ -32,7 +32,7 @@
         "name": "Maw of Worlds",
         "text": "When you would exhaust a technology or legendary planet card, you may exhaust this card instead.\nAt the start of the agenda phase, you may purge this card and exhaust any number of your planets to gain a technology with the same number of prerequisites.",
         "source": "absol",
-        "flavourText": "No larger than a carrier, the spherical lattice held a captive singularity at its heart. As they dumped the planet's entire energy grid into its core, the black hole began to spin, the complex logic-circuitry along the lattic slowly coming to life."
+        "flavourText": "No larger than a carrier, the spherical lattice held a captive singularity at its heart. As they dumped the planet's entire energy grid into its core, the black hole began to spin, the complex logic-circuitry along the lattice slowly coming to life."
     },
     {
         "alias": "absol_nanoforge",
@@ -57,7 +57,7 @@
     },
     {
         "alias": "absol_emelpar",
-        "name": "Sceptar of Emelpar",
+        "name": "Scepter of Emelpar",
         "text": "When you would spend a token from your strategy pool, you may exhaust this card to spend a token from your reinforcements instead.\nACTION: Purge this card to ready your strategy card.",
         "source": "absol",
         "flavourText": "As the hilt began to fuse with the flesh of her hand, she worried that she should set the scepter aside. But the whispered suggestions in her mind were too valuable and insightful to seriously consider such a rash and illogical act."


### PR DESCRIPTION
Scepter was misspelled, lattice was misspelled, the quotation marks in Shard Of The Throne 1 were odd.

I checked these against some card images in an attempt to confirm that the errors were here and not in the source.