### PR TITLE
Add flavor text for explore cards

### DIFF
--- a/src/main/java/ti4/model/ExploreModel.java
+++ b/src/main/java/ti4/model/ExploreModel.java
@@ -19,6 +19,7 @@ public class ExploreModel implements ModelInterface, EmbeddableModel {
     private String resolution;
     private String text;
     private String attachmentId;
+    private String flavorText;
     private ComponentSource source;
     private List<String> searchTags = new ArrayList<>();
 

--- a/src/main/resources/data/explores/explores.json
+++ b/src/main/resources/data/explores/explores.json
@@ -5,6 +5,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "You may produce 1 unit in this system. You may spend influence as if it were resources to produce this unit.",
+        "flavorText": "*The Vexis Howelers were well-equipped with transports, powered armor, and even logistical support—everything a fledgling outpost needed to survive.*",
         "source": "pok"
     },
     {
@@ -13,6 +14,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "You may produce 1 unit in this system. You may spend influence as if it were resources to produce this unit.",
+        "flavorText": "*As part of the annexation agreement, local artisans would be well paid to lay the groundwork for military installations in the newly acquired territories.*",
         "source": "pok"
     },
     {
@@ -21,6 +23,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "You may produce 1 unit in this system. You may spend influence as if it were resources to produce this unit.",
+        "flavorText": "*Overseer Flix was known for hiring hundreds of freelancers and then \"forgetting\" to pay them once the bulk of the work was complete.*",
         "source": "pok"
     },
     {
@@ -29,6 +32,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "You may place 1 infantry from your reinforcements on this planet.",
+        "flavorText": "*\"My mates and I used to be 4th Air Legion, but we figured we could make more money working freelance.\"*",
         "source": "pok"
     },
     {
@@ -37,6 +41,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "You may place 1 infantry from your reinforcements on this planet.",
+        "flavorText": "*The bar was full of scarred and dirty individuals from a dozen different species. But each one had a weapon, and looked completely comfortable with it.*",
         "source": "pok"
     },
     {
@@ -45,6 +50,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "You may place 1 infantry from your reinforcements on this planet.",
+        "flavorText": "*\"Morse's Marauders are the most affordable soldiers of fortune on-planet. And trust me, you get exactly what you pay for.\"*",
         "source": "pok"
     },
     {
@@ -53,6 +59,7 @@
         "type": "Cultural",
         "resolution": "Token",
         "text": "Place a gamma wormhole token in this system. Then, purge this card.",
+        "flavorText": "*The gravic sensors howled a warning. Ahead of the ship was a ring of twisted starlight, surrounding a sphere of utter darkness.*",
         "attachmentId": "gamma",
         "source": "pok"
     },
@@ -170,6 +177,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, gain 1 command token.",
+        "flavorText": "*It turned out that the continuous lightning storms were an unlimited source of power, which was little consolation to those assigned to build the collection towers.*",
         "source": "pok"
     },
     {
@@ -178,6 +186,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, gain 1 command token.",
+        "flavorText": "*Only by using retrofitted Scavenger walkers could they mine the radioactive Nyx crystals safely.*",
         "source": "pok"
     },
     {
@@ -186,6 +195,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, gain 1 command token.",
+        "flavorText": "*\"With the extra fuel refined from the plasma clouds, our fleet can continue operations for months.\"*",
         "source": "pok"
     },
     {
@@ -194,6 +204,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, ready this planet.",
+        "flavorText": "*\"These cave networks stretch for hundreds of kilometers. It may take months to properly map them.\"*",
         "source": "pok"
     },
     {
@@ -202,6 +213,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, ready this planet.",
+        "flavorText": "*\"We've lost two companies of scouts to whatever is in those canyons.\"*",
         "source": "pok"
     },
     {
@@ -210,6 +222,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, ready this planet.",
+        "flavorText": "*The Eidolon screamed through the atmosphere, corrosive rain streaming harmlessly off the hull as it began its survey sweep.*",
         "source": "pok"
     },
     {
@@ -218,6 +231,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, gain 1 trade good.",
+        "flavorText": "*\"If we don't seal it now, this mine is going to erupt and spew those metals you want so badly across the entire continent!\"*",
         "source": "pok"
     },
     {
@@ -226,6 +240,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, gain 1 trade good.",
+        "flavorText": "*The borehole was over a kilometer across. It seemed to stretch down forever, but Ilan could see a faint orange glow in its depths.*",
         "source": "pok"
     },
     {
@@ -234,6 +249,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, gain 1 trade good.",
+        "flavorText": "*The borehole was over a kilometer across. It seemed to stretch down forever, but Ilan could see a faint orange glow in its depths.*",
         "source": "pok"
     },
     {
@@ -334,6 +350,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 2 commodities, or you may convert up to 2 of your commodities to trade goods.",
+        "flavorText": "*\"Looks like some smuggler hid their shipment of gerr root here and forgot to pick it up.\"*",
         "source": "pok"
     },
     {
@@ -342,6 +359,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 2 commodities, or you may convert up to 2 of your commodities to trade goods.",
+        "flavorText": "*Suffi An drifted into the derelict orbital and brushed her suited hand across the inner hatch controls. A light glowed, and she smiled. The statis seals were still operational.*",
         "source": "pok"
     },
     {
@@ -350,6 +368,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 2 commodities, or you may convert up to 2 of your commodities to trade goods.",
+        "flavorText": "*The storage silos had been half buried in sand dunes, sealed enviro-doors hiding the stockpiles within.*",
         "source": "pok"
     },
     {
@@ -358,6 +377,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 2 commodities, or you may convert up to 2 of your commodities to trade goods.",
+        "flavorText": "*Far beneath the storm-wracked seas, vast storage tanks drifted in the lightless depths.*",
         "source": "pok"
     },
     {
@@ -366,6 +386,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to draw 1 action card.",
+        "flavorText": "*The Imperial Survey Corp outpost had been adandoned since the Twilight Wars, but the facilities had been built to last for millennia.*",
         "source": "pok"
     },
     {
@@ -374,6 +395,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to draw 1 action card.",
+        "flavorText": "*The orbital distribution station proved easy to integrate into the fleet's growing logistical operation.*",
         "source": "pok"
     },
     {
@@ -382,6 +404,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to draw 1 action card.",
+        "flavorText": "*The local defense forces abandoned their fortress as the first troop transports made planetfall, leaving it open to occupation.*",
         "source": "pok"
     },
     {
@@ -390,6 +413,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to draw 1 action card.",
+        "flavorText": "*\"Yes commander, the base appears completely abandoned. No sign of what happened to the garrison.\"*",
         "source": "pok"
     },
     {
@@ -398,6 +422,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to place 1 mech from your reinforcements on this planet.",
+        "flavorText": "*Edict 281: All indigenous production facilities are placed under control of the occupational authorities until further notice.*",
         "source": "pok"
     },
     {
@@ -406,6 +431,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to place 1 mech from your reinforcements on this planet.",
+        "flavorText": "*\"These people's autofactories can turn out a new starfighter in less time than it takes me to order it!\"*",
         "source": "pok"
     },
     {
@@ -414,6 +440,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to place 1 mech from your reinforcements on this planet.",
+        "flavorText": "*Though sub-standard, the locally produced munitions were enough to turn the tide of the war.*",
         "source": "pok"
     },
     {
@@ -422,6 +449,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to place 1 mech from your reinforcements on this planet.",
+        "flavorText": "*Within months, bulk transports were arriving from the homeworld, reviving the local economy.*",
         "source": "pok"
     },
     {
@@ -497,6 +525,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Draw 1 secret objective.",
+        "flavorText": "The flickering ion storm illuminated the hulk, its hull rent and torn apart by some monstrous force.",
         "source": "pok"
     },
     {
@@ -505,6 +534,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Draw 1 secret objective.",
+        "flavorText": "*Missing for fifty years, the* Errasthua *was found drifting off the Celder Nebula with her drive dead and every crewmember vanished.*",
         "source": "pok"
     },
     {
@@ -513,6 +543,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Place this card faceup in your play area. Action: You may spend 6 resource and purge this card to research 1 technology.",
+        "flavorText": "*A needle longer than a dreadnought but no wider than a landcar flew through the void, its surface glowing with a pale violet light.*",
         "source": "pok"
     },
     {
@@ -521,6 +552,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Place this card faceup in your play area. Action: You may spend 6 resource and purge this card to research 1 technology.",
+        "flavorText": "*The silver pinwheel spun slowly in the midst of the nebula, each kilometer-long blade glittering faintly with reflected starlight.*",
         "source": "pok"
     },
     {
@@ -530,6 +562,7 @@
         "resolution": "Token",
         "text": "Place a gamma wormhole token in this system. Then, purge this card.",
         "attachmentId": "gamma",
+        "flavorText": "*Old spacers would tell stories of a black gateway in the deep space beyond the outer Oort Cloud.*",
         "source": "pok"
     },
     {
@@ -547,6 +580,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Draw 2 action cards.",
+        "flavorText": "*\"Mayday, mayday...this is the free trader* Hrothgar*...losing pressure fast...abandoning ship... Mayday...\"*",
         "source": "pok"
     },
     {
@@ -555,6 +589,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Draw 2 action cards.",
+        "flavorText": "*Only two survivors were found aboard the derelict, and they had a harrowing tale to tell their saviors.*",
         "source": "pok"
     },
     {
@@ -563,6 +598,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "You may replenish your commodities, or you may convert your commodities to trade goods.",
+        "flavorText": "*The deep space freeports tend to be infamous dens of criminals, but also valuable nodes in the interplanetary trade networks.*",
         "source": "pok"
     },
     {
@@ -571,6 +607,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "You may replenish your commodities, or you may convert your commodities to trade goods.",
+        "flavorText": "*\"Unidentified vessel, this is Freeport Canopus. State your intentions before approaching.\"*",
         "source": "pok"
     },
     {
@@ -579,6 +616,7 @@
         "type": "Frontier",
         "resolution": "Token",
         "text": "Place the Mirage planet token in this system. Gain the Mirage planet card and ready it. Then, purge this card.",
+        "flavorText": "*The star wasn't supposed to have a habitable planet, but one lay directly in the cruiser's path. And a cloud of starfighters was rising from the world's surface to greet it.*",
         "attachmentId": "mirage",
         "source": "pok"
     },

--- a/src/main/resources/data/explores/explores.json
+++ b/src/main/resources/data/explores/explores.json
@@ -650,6 +650,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Gain 1 command token and 1 trade good.",
+        "flavorText": "*After the Naaz-Rokha's discoveries in the wake of the Acheron event, various enterprising corporations quickly sought to stake their claims in areas well suited to entropic field harvesting.*",
         "source": "codex3"
     },
     {
@@ -658,6 +659,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Gain 1 command token and 2 trade goods.",
+        "flavorText": "*Several destroyers, a light cruiser, and even a pair of Eidolons patrolled the field during major extraction operations. One could never be too careful.*",
         "source": "codex3"
     },
     {
@@ -666,6 +668,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Gain 1 command token and 3 trade goods.",
+        "flavorText": "Jaset had worked the field for several months before the dreams began to bleed into waking hours. Voices. Flashes of red. Dust-filled caverns that went deep into the planet's core. He'd blink and rub his eyes and carry on with his work. Exhaustion, he told himself. Nothing more.",
         "source": "codex3"
     },
     {
@@ -674,6 +677,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Gain 2 command tokens.",
+        "flavorText": "*The stranded Keleres were grateful for the resupply, and offered to assist the research team in any way that they could.*",
         "source": "codex3"
     },
     {
@@ -682,6 +686,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Gain 2 command tokens.",
+        "flavorText": "*The* Hinterlight *moved steadily toward the distress beacon, broadcasting their own response on all channels.*",
         "source": "codex3"
     },
     {
@@ -690,6 +695,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Draw 1 relic.",
+        "flavorText": "*The* Best Guess *drifted through the debris. Layers of rock and...metal? It was all being held together by some kind of electric field—the same field that had hidden it from their scanners. With a growing sense of unease, they hastened their salvage.*",
         "source": "codex3"
     },
     {

--- a/src/main/resources/data/explores/explores.json
+++ b/src/main/resources/data/explores/explores.json
@@ -736,6 +736,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "For each planet in this system, gain 1 trade good.",
+        "flavorText": "*\"Oh, thank the stars!\" the merchant gushed over comms. \"We haven't had fresh food in weeks!\"*",
         "source": "ds"
     },
     {
@@ -744,6 +745,7 @@
         "type": "Cultural",
         "resolution": "Instant",
         "text": "Redistribute up to 1 command token, or spend 1 influence to gain 1 command token.",
+        "flavorText": "*\"Very well,\" said the old Celdauri officer. \"Let's take a look at these plans.\"*",
         "source": "ds"
     },
     {
@@ -761,6 +763,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, ready your agent or draw 1 action card.",
+        "flavorText": "*There are safer places to find a merc, but that sort of place doesn't attract the sort of operation the Emoress had tasked Za-trè with recruiting.*",
         "source": "ds"
     },
     {
@@ -769,6 +772,7 @@
         "type": "Hazardous",
         "resolution": "Instant",
         "text": "If you have at least 1 mech on this planet, or if you remove 1 infantry from this planet, place 1 mech or 2 infantry from your reinforcements on this planet.",
+        "flavorText": "*Magma spurted through cracks in the surface, but the exploratory team knew the risk was worth the reward.*",
         "source": "ds"
     },
     {
@@ -786,6 +790,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "Explore the frontier deck in this system.",
+        "flavorText": "*Hadd Halftail hadn't been searching for a laboratorym but was happy to claim the secrets she had stumbled upon.*",
         "source": "ds"
     },
     {
@@ -794,6 +799,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "Place up to 1 cruiser from your reinforcements in this system if it contains no other players' ships.",
+        "flavorText": "*Alva was pleased to discover the cruiser's systems were still operational. \"A grand welcome awaits us,\" she said to her twin.*",
         "source": "ds"
     },
     {
@@ -811,6 +817,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Place 1 command token from your reinforcements in your fleet pool and move any number of your units in this system to the space area of another system that contains no other players' ships.",
+        "flavorText": "*Captain Kask ordered the fleet through the scintilating gate. There was no path back, but at least they'd be with allies.*",
         "source": "ds"
     },
     {
@@ -819,6 +826,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Choose 2 other players, each of those players must give you 1 promissory note from their hand.",
+        "flavorText": "*The abandoned ships provided a trove of compromising diplomatic communications.*",
         "source": "ds"
     },
     {
@@ -827,6 +835,7 @@
         "type": "Frontier",
         "resolution": "Instant",
         "text": "Look at the top card of each exploration deck, discard any number of those cards and explore up to 1 planet you control. Then, shuffle each exploration deck.",
+        "flavorText": "*If you stare too long into the voids between the stars, you may find that the voids begin to whisper.*",
         "source": "ds"
     },
     {


### PR DESCRIPTION
For no particular reason.

Covers PoK, codex 3, and Discordant Stars.

The field is unused at the moment.