### PR TITLE
Small FOW-mode fixes

### DIFF
--- a/src/main/java/ti4/commands/explore/SendFragments.java
+++ b/src/main/java/ti4/commands/explore/SendFragments.java
@@ -88,7 +88,9 @@ public class SendFragments extends ExploreSubcommandData {
 		String p2 = receiver.getRepresentation();
 		String fragString = count + " " + trait + " " + Emojis.getEmojiFromDiscord(emojiName) + " relic fragments";
 		String message = p1 + " sent " + fragString + " to " + p2;
-		MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(receiver, activeGame), message);
+    if (!activeGame.isFoWMode()) {
+		  MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(receiver, activeGame), message);
+    }
 		if (receiver.getLeaderIDs().contains("kollecccommander") && !receiver.hasLeaderUnlocked("kollecccommander")) {
 			ButtonHelper.commanderUnlockCheck(receiver, activeGame, "kollecc", event);
 		}

--- a/src/main/java/ti4/helpers/FoWHelper.java
+++ b/src/main/java/ti4/helpers/FoWHelper.java
@@ -191,7 +191,7 @@ public class FoWHelper {
 	private static void updatePlayerFogTiles(Game game, Player player) {
 		for (Tile tileToUpdate : game.getTileMap().values()) {
 			if (!tileToUpdate.hasFog(player)) {
-				player.updateFogTile(tileToUpdate, "Round " + game.getRound());
+				player.updateFogTile(tileToUpdate, "Rnd " + game.getRound());
 			}
 		}
 	}


### PR DESCRIPTION
In FOW mode, sending a fragment to another player gives duplicate message to the receiver: 
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/bcb94084-890a-40d4-b2b3-ce9ff29c16d2)
Restricted sending the first message to non-fow-mode since FOW specifc check and message is sent later.

In FOW, when a previously seen tile gets fogged, tile number overlaps with Round 2 (or whatever round you saw the tile last).
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/6ad8d5ad-2248-40db-8fa9-34cdd51b874d)
Shortened Round to Rnd to fix this.
