### PR TITLE
Clever Clever Ssruu

### DIFF
--- a/src/main/java/ti4/buttons/ButtonListener.java
+++ b/src/main/java/ti4/buttons/ButtonListener.java
@@ -738,7 +738,7 @@ public class ButtonListener extends ListenerAdapter {
             }
             MessageChannel channel = ButtonHelper.getSCFollowChannel(activeGame, player, scnum);
             if (buttonID.contains("mahact")) {
-                MessageHelper.sendMessageToChannel(channel, ident + " exhausted Mahact agent to follow SC#" + scnum);
+                MessageHelper.sendMessageToChannel(channel, ident + " exhausted " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent) to follow SC#" + scnum);
                 Leader playerLeader = player.unsafeGetLeader("mahactagent");
                 if (playerLeader != null) {
                     playerLeader.setExhausted(true);
@@ -2631,8 +2631,8 @@ public class ButtonListener extends ListenerAdapter {
                 AddCC.addCC(event, color, tile);
             }
             String message = player.getRepresentation() + " Placed A " + StringUtils.capitalize(color) + "CC In The "
-                + Helper.getPlanetRepresentation(planet, activeGame)
-                + " system due to use of Mahact agent";
+                    + Helper.getPlanetRepresentation(planet, activeGame)
+                    + " system due to use of " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)";
             ButtonHelper.sendMessageToRightStratThread(player, activeGame, message, "construction");
             event.getMessage().delete().queue();
         } else if (buttonID.startsWith("greyfire_")) {
@@ -2910,7 +2910,7 @@ public class ButtonListener extends ListenerAdapter {
             AgendaModel agendaDetails = Mapper.getAgenda(agendaID);
             String agendaName = agendaDetails.getName();
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame),
-                ButtonHelper.getIdentOrColor(player, activeGame) + "discarded " + agendaName + " using Edyn Agent");
+                    ButtonHelper.getIdentOrColor(player, activeGame) + "discarded " + agendaName + " using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Allant (Edyn Agent)");
             event.getMessage().delete().queue();
         } else if (buttonID.startsWith("agendaResolution_")) {
             AgendaHelper.resolveAgenda(activeGame, buttonID, event, actionsChannel);
@@ -5195,14 +5195,15 @@ public class ButtonListener extends ListenerAdapter {
                 if (player.hasUnexhaustedLeader("cymiaeagent")) {
                     List<Button> buttons2 = new ArrayList<>();
                     Button hacanButton = Button
-                        .secondary("exhaustAgent_cymiaeagent_" + player.getFaction(), "Use Cymiae Agent")
-                        .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
+                            .secondary("exhaustAgent_cymiaeagent_" + player.getFaction(),
+							           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
                     buttons2.add(hacanButton);
                     MessageHelper.sendMessageToChannelWithButtons(
-                        ButtonHelper.getCorrectChannel(player, activeGame),
-                        player.getRepresentation(true, true)
-                            + " you can use Cymiae agent to make yourself draw an AC",
-                        buttons2);
+                            ButtonHelper.getCorrectChannel(player, activeGame),
+                            player.getRepresentation(true, true)
+                                    + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent) to make yourself draw an AC",
+                            buttons2);
                 }
 
                 if ("Action".equalsIgnoreCase(Mapper.getActionCard(acID).getWindow())) {
@@ -5417,41 +5418,46 @@ public class ButtonListener extends ListenerAdapter {
                     buttons.add(sarweenButton);
                 }
                 if (player.hasUnexhaustedLeader("winnuagent") && !"muaatagent".equalsIgnoreCase(buttonID)
-                    && !"arboHeroBuild".equalsIgnoreCase(buttonID) && !buttonID.contains("integrated")) {
-                    Button winnuButton = Button.danger("exhaustAgent_winnuagent", "Use Winnu Agent")
-                        .withEmoji(Emoji.fromFormatted(Emojis.Winnu));
+                        && !"arboHeroBuild".equalsIgnoreCase(buttonID) && !buttonID.contains("integrated")) {
+                    Button winnuButton = Button.danger("exhaustAgent_winnuagent",
+					                                   "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Berekar Berekon (Winnu Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.Winnu));
                     buttons.add(winnuButton);
                 }
                 if (player.hasUnexhaustedLeader("gledgeagent") && !"muaatagent".equalsIgnoreCase(buttonID)
                     && !"arboHeroBuild".equalsIgnoreCase(buttonID) && !buttonID.contains("integrated")) {
                     Button winnuButton = Button
-                        .danger("exhaustAgent_gledgeagent_" + player.getFaction(), "Use Gledge Agent")
-                        .withEmoji(Emoji.fromFormatted(Emojis.gledge));
+                            .danger("exhaustAgent_gledgeagent_" + player.getFaction(),
+							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Durran (Gledge Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.gledge));
                     buttons.add(winnuButton);
                 }
                 if (player.hasUnexhaustedLeader("ghotiagent")) {
                     Button winnuButton = Button
-                        .danger("exhaustAgent_ghotiagent_" + player.getFaction(), "Use Ghoti Agent")
-                        .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
+                            .danger("exhaustAgent_ghotiagent_" + player.getFaction(),
+							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
                     buttons.add(winnuButton);
                 }
                 if (player.hasUnexhaustedLeader("mortheusagent")) {
                     Button winnuButton = Button
-                        .danger("exhaustAgent_mortheusagent_" + player.getFaction(), "Use Mortheus Agent")
-                        .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
+                            .danger("exhaustAgent_mortheusagent_" + player.getFaction(),
+							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
                     buttons.add(winnuButton);
                 }
                 if (player.hasUnexhaustedLeader("rohdhnaagent") && !"muaatagent".equalsIgnoreCase(buttonID)
                     && !"arboHeroBuild".equalsIgnoreCase(buttonID)) {
                     Button winnuButton = Button
-                        .danger("exhaustAgent_rohdhnaagent_" + player.getFaction(), "Use Rohdhna Agent")
-                        .withEmoji(Emoji.fromFormatted(Emojis.rohdhna));
+                            .danger("exhaustAgent_rohdhnaagent_" + player.getFaction(),
+							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri’ay (Rohdhna Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.rohdhna));
                     buttons.add(winnuButton);
                 }
                 if (player.hasLeaderUnlocked("hacanhero") && !"muaatagent".equalsIgnoreCase(buttonID)
-                    && !"arboHeroBuild".equalsIgnoreCase(buttonID) && !buttonID.contains("integrated")) {
-                    Button hacanButton = Button.danger("purgeHacanHero", "Purge Hacan Hero")
-                        .withEmoji(Emoji.fromFormatted(Emojis.Hacan));
+                        && !"arboHeroBuild".equalsIgnoreCase(buttonID) && !buttonID.contains("integrated")) {
+                    Button hacanButton = Button.danger("purgeHacanHero", "Purge Harrugh Gefhara (Hacan Hero)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.Hacan));
                     buttons.add(hacanButton);
                 }
                 Button doneExhausting;
@@ -5506,14 +5512,14 @@ public class ButtonListener extends ListenerAdapter {
                 if (player.hasUnexhaustedLeader("celdauriagent")) {
                     List<Button> buttons = new ArrayList<>();
                     Button hacanButton = Button
-                        .secondary("exhaustAgent_celdauriagent_" + player.getFaction(), "Use Celdauri Agent")
-                        .withEmoji(Emoji.fromFormatted(Emojis.celdauri));
+                            .secondary("exhaustAgent_celdauriagent_" + player.getFaction(), "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.celdauri));
                     buttons.add(hacanButton);
                     buttons.add(Button.danger("deleteButtons", "Decline"));
                     MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
-                        player.getRepresentation(true, true)
-                            + " you can use Celdauri agent to place an SD for 2tg/2comm",
-                        buttons);
+                            player.getRepresentation(true, true)
+                                    + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent) to place an SD for 2TGs/2comm",
+                            buttons);
                 }
                 List<Button> systemButtons2 = new ArrayList<>();
                 if (!activeGame.isAbsolMode() && player.getRelics().contains("emphidia")
@@ -5525,14 +5531,14 @@ public class ButtonListener extends ListenerAdapter {
                 }
                 systemButtons2 = new ArrayList<>();
                 if (player.hasUnexhaustedLeader("sardakkagent")) {
-                    String message = trueIdentity + " You can use the button to do sardakk agent";
+                    String message = trueIdentity + " You can use the button to use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "T'ro (N'orr Agent)";
                     systemButtons2.addAll(ButtonHelperAgents.getSardakkAgentButtons(activeGame, player));
                     systemButtons2.add(Button.danger("deleteButtons", "Decline"));
                     MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), message, systemButtons2);
                 }
                 systemButtons2 = new ArrayList<>();
                 if (player.hasUnexhaustedLeader("nomadagentmercer")) {
-                    String message = trueIdentity + " You can use the button to do General Mercer";
+                    String message = trueIdentity + " You can use the button to to use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Field Marshal Mercer (Nomad Agent)";
                     systemButtons2.addAll(ButtonHelperAgents.getMercerAgentInitialButtons(activeGame, player));
                     systemButtons2.add(Button.danger("deleteButtons", "Decline"));
                     MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), message, systemButtons2);

--- a/src/main/java/ti4/buttons/ButtonListener.java
+++ b/src/main/java/ti4/buttons/ButtonListener.java
@@ -5196,7 +5196,7 @@ public class ButtonListener extends ListenerAdapter {
                     List<Button> buttons2 = new ArrayList<>();
                     Button hacanButton = Button
                             .secondary("exhaustAgent_cymiaeagent_" + player.getFaction(),
-							           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
+                                       "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
                     buttons2.add(hacanButton);
                     MessageHelper.sendMessageToChannelWithButtons(
@@ -5420,7 +5420,7 @@ public class ButtonListener extends ListenerAdapter {
                 if (player.hasUnexhaustedLeader("winnuagent") && !"muaatagent".equalsIgnoreCase(buttonID)
                         && !"arboHeroBuild".equalsIgnoreCase(buttonID) && !buttonID.contains("integrated")) {
                     Button winnuButton = Button.danger("exhaustAgent_winnuagent",
-					                                   "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Berekar Berekon (Winnu Agent)")
+                                                       "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Berekar Berekon (Winnu Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.Winnu));
                     buttons.add(winnuButton);
                 }
@@ -5428,21 +5428,21 @@ public class ButtonListener extends ListenerAdapter {
                     && !"arboHeroBuild".equalsIgnoreCase(buttonID) && !buttonID.contains("integrated")) {
                     Button winnuButton = Button
                             .danger("exhaustAgent_gledgeagent_" + player.getFaction(),
-							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Durran (Gledge Agent)")
+                                    "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Durran (Gledge Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.gledge));
                     buttons.add(winnuButton);
                 }
                 if (player.hasUnexhaustedLeader("ghotiagent")) {
                     Button winnuButton = Button
                             .danger("exhaustAgent_ghotiagent_" + player.getFaction(),
-							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
+                                    "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
                     buttons.add(winnuButton);
                 }
                 if (player.hasUnexhaustedLeader("mortheusagent")) {
                     Button winnuButton = Button
                             .danger("exhaustAgent_mortheusagent_" + player.getFaction(),
-							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
+                                    "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
                     buttons.add(winnuButton);
                 }
@@ -5450,7 +5450,7 @@ public class ButtonListener extends ListenerAdapter {
                     && !"arboHeroBuild".equalsIgnoreCase(buttonID)) {
                     Button winnuButton = Button
                             .danger("exhaustAgent_rohdhnaagent_" + player.getFaction(),
-							        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri’ay (Rohdhna Agent)")
+                                    "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri’ay (Rohdhna Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.rohdhna));
                     buttons.add(winnuButton);
                 }

--- a/src/main/java/ti4/buttons/ButtonListener.java
+++ b/src/main/java/ti4/buttons/ButtonListener.java
@@ -5450,7 +5450,7 @@ public class ButtonListener extends ListenerAdapter {
                     && !"arboHeroBuild".equalsIgnoreCase(buttonID)) {
                     Button winnuButton = Button
                             .danger("exhaustAgent_rohdhnaagent_" + player.getFaction(),
-                                    "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri’ay (Rohdhna Agent)")
+                                    "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri'ay (Rohdhna Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.rohdhna));
                     buttons.add(winnuButton);
                 }

--- a/src/main/java/ti4/commands/cardsac/ACInfo.java
+++ b/src/main/java/ti4/commands/cardsac/ACInfo.java
@@ -167,7 +167,7 @@ public class ACInfo extends ACCardsSubcommandData implements InfoThreadCommand {
         acButtons.add(Button.primary("getDiscardButtonsACs", "Discard an AC"));
         if (player.hasUnexhaustedLeader("nekroagent")) {
             Button nekroButton = Button.secondary("exhaustAgent_nekroagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Nekro Malleon (Nekro Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Nekro Malleon (Nekro Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Nekro));
             acButtons.add(nekroButton);
         }
@@ -178,7 +178,7 @@ public class ACInfo extends ACCardsSubcommandData implements InfoThreadCommand {
         }
         if (player.hasUnexhaustedLeader("vaylerianagent")) {
             Button nekroButton = Button.secondary("exhaustAgent_vaylerianagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.vaylerian));
             acButtons.add(nekroButton);
         }
@@ -198,13 +198,13 @@ public class ACInfo extends ACCardsSubcommandData implements InfoThreadCommand {
         }
         if (player.hasUnexhaustedLeader("kolleccagent")) {
             Button nekroButton = Button.secondary("exhaustAgent_kolleccagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Dust (Kollecc Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Dust (Kollecc Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.kollecc));
             acButtons.add(nekroButton);
         }
         if (player.hasUnexhaustedLeader("mykomentoriagent")) {
             Button nekroButton = Button.secondary("exhaustAgent_mykomentoriagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Lactarius Indigo (Myko Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Lactarius Indigo (Myko Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mykomentori));
             acButtons.add(nekroButton);
         }

--- a/src/main/java/ti4/commands/cardsac/ACInfo.java
+++ b/src/main/java/ti4/commands/cardsac/ACInfo.java
@@ -166,7 +166,8 @@ public class ACInfo extends ACCardsSubcommandData implements InfoThreadCommand {
         }
         acButtons.add(Button.primary("getDiscardButtonsACs", "Discard an AC"));
         if (player.hasUnexhaustedLeader("nekroagent")) {
-            Button nekroButton = Button.secondary("exhaustAgent_nekroagent", "Use Nekro Agent")
+            Button nekroButton = Button.secondary("exhaustAgent_nekroagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Nekro Malleon (Nekro Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Nekro));
             acButtons.add(nekroButton);
         }
@@ -176,7 +177,8 @@ public class ACInfo extends ACCardsSubcommandData implements InfoThreadCommand {
             acButtons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("vaylerianagent")) {
-            Button nekroButton = Button.secondary("exhaustAgent_vaylerianagent", "Use Vaylerian Agent")
+            Button nekroButton = Button.secondary("exhaustAgent_vaylerianagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.vaylerian));
             acButtons.add(nekroButton);
         }
@@ -195,12 +197,14 @@ public class ACInfo extends ACCardsSubcommandData implements InfoThreadCommand {
             acButtons.add(ghostButton);
         }
         if (player.hasUnexhaustedLeader("kolleccagent")) {
-            Button nekroButton = Button.secondary("exhaustAgent_kolleccagent", "Use Kollecc Agent")
+            Button nekroButton = Button.secondary("exhaustAgent_kolleccagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Dust (Kollecc Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.kollecc));
             acButtons.add(nekroButton);
         }
         if (player.hasUnexhaustedLeader("mykomentoriagent")) {
-            Button nekroButton = Button.secondary("exhaustAgent_mykomentoriagent", "Use Myko Agent")
+            Button nekroButton = Button.secondary("exhaustAgent_mykomentoriagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Lactarius Indigo (Myko Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mykomentori));
             acButtons.add(nekroButton);
         }

--- a/src/main/java/ti4/commands/cardsac/PlayAC.java
+++ b/src/main/java/ti4/commands/cardsac/PlayAC.java
@@ -696,7 +696,7 @@ public class PlayAC extends ACCardsSubcommandData {
         if (player.hasUnexhaustedLeader("cymiaeagent") && player.getStrategicCC() > 0) {
             List<Button> buttons2 = new ArrayList<>();
             Button hacanButton = Button.secondary("exhaustAgent_cymiaeagent_" + player.getFaction(),
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
             buttons2.add(hacanButton);
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, game),

--- a/src/main/java/ti4/commands/cardsac/PlayAC.java
+++ b/src/main/java/ti4/commands/cardsac/PlayAC.java
@@ -695,12 +695,13 @@ public class PlayAC extends ACCardsSubcommandData {
         }
         if (player.hasUnexhaustedLeader("cymiaeagent") && player.getStrategicCC() > 0) {
             List<Button> buttons2 = new ArrayList<>();
-            Button hacanButton = Button.secondary("exhaustAgent_cymiaeagent_" + player.getFaction(), "Use Cymiae Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
+            Button hacanButton = Button.secondary("exhaustAgent_cymiaeagent_" + player.getFaction(),
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
             buttons2.add(hacanButton);
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, game),
-                player.getRepresentation(true, true) + " you can use Cymiae agent to draw an AC",
-                buttons2);
+                    player.getRepresentation(true, true) + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent) to draw an AC",
+                    buttons2);
         }
 
         ACInfo.sendActionCardInfo(game, player);

--- a/src/main/java/ti4/commands/combat/StartCombat.java
+++ b/src/main/java/ti4/commands/combat/StartCombat.java
@@ -545,7 +545,7 @@ public class StartCombat extends CombatSubcommandData {
         if (!activeGame.isFoWMode() && titans != null && titans.hasUnexhaustedLeader("titansagent")) {
             String finChecker = "FFCC_" + titans.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "exhaustAgent_titansagent",
-			                             "Use " + (titans.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tellurian (Ul Agent)")
+                                         "Use " + (titans.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tellurian (Ul Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Titans)));
         }
         if (p1.hasTechReady("sc") || (!activeGame.isFoWMode() && p2.hasTechReady("sc"))) {
@@ -560,7 +560,7 @@ public class StartCombat extends CombatSubcommandData {
         if (!activeGame.isFoWMode() && ghemina != null && ghemina.hasUnexhaustedLeader("gheminaagent")) {
             String finChecker = "FFCC_" + ghemina.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "exhaustAgent_gheminaagent",
-			                             "Use " + (ghemina.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skarvald & Torvar (Ghemina Agents)")
+                                         "Use " + (ghemina.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skarvald & Torvar (Ghemina Agents)")
                     .withEmoji(Emoji.fromFormatted(Emojis.ghemina)));
         }
 
@@ -568,7 +568,7 @@ public class StartCombat extends CombatSubcommandData {
         if (!activeGame.isFoWMode() && khal != null && khal.hasUnexhaustedLeader("kjalengardagent")) {
             String finChecker = "FFCC_" + khal.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "exhaustAgent_kjalengardagent",
-			                             "Use " + (khal.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Merkismathr Asvand (Kjalengard Agent)")
+                                         "Use " + (khal.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Merkismathr Asvand (Kjalengard Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.kjalengard)));
         }
 
@@ -576,20 +576,20 @@ public class StartCombat extends CombatSubcommandData {
         if (!activeGame.isFoWMode() && sol != null && sol.hasUnexhaustedLeader("solagent") && isGroundCombat) {
             String finChecker = "FFCC_" + sol.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "getAgentSelection_solagent",
-			                             "Use " + (sol.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Evelyn Delouis (Sol Agent)")
+                                         "Use " + (sol.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Evelyn Delouis (Sol Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Sol)));
             buttons.add(Button.secondary(finChecker + "getAgentSelection_solagent",
-			                             (sol.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Evelyn Delouis (Sol Agent)")
+                                         (sol.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Evelyn Delouis (Sol Agent)")
                 .withEmoji(Emoji.fromFormatted(Emojis.Sol)));
         }
         Player kyro = Helper.getPlayerFromUnlockedLeader(activeGame, "kyroagent");
         if (!activeGame.isFoWMode() && kyro != null && kyro.hasUnexhaustedLeader("kyroagent") && isGroundCombat) {
             String finChecker = "FFCC_" + kyro.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "getAgentSelection_kyroagent",
-			                             "Use " + (kyro.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tox (Kyro Agent)")
+                                         "Use " + (kyro.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tox (Kyro Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.blex)));
             buttons.add(Button.secondary(finChecker + "getAgentSelection_kyroagent",
-			                            (kyro.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tox (Kyro Agent)")
+                                        (kyro.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tox (Kyro Agent)")
                 .withEmoji(Emoji.fromFormatted(Emojis.blex)));
         }
 
@@ -598,7 +598,7 @@ public class StartCombat extends CombatSubcommandData {
             && "space".equalsIgnoreCase(groundOrSpace)) {
             String finChecker = "FFCC_" + letnev.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "getAgentSelection_letnevagent",
-			                             "Use " + (letnev.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Viscount Unlenn (Letnev Agent)")
+                                         "Use " + (letnev.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Viscount Unlenn (Letnev Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Letnev)));
         }
 
@@ -607,7 +607,7 @@ public class StartCombat extends CombatSubcommandData {
             && nomad.hasUnexhaustedLeader("nomadagentthundarian")) {
             String finChecker = "FFCC_" + nomad.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "exhaustAgent_nomadagentthundarian",
-			                             "Use " + (nomad.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "The Thundarian (Nomad Agent)")
+                                         "Use " + (nomad.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "The Thundarian (Nomad Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Nomad)));
         }
 
@@ -615,7 +615,7 @@ public class StartCombat extends CombatSubcommandData {
         if ((!activeGame.isFoWMode() || yin == p1) && yin != null && yin.hasUnexhaustedLeader("yinagent")) {
             String finChecker = "FFCC_" + yin.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "yinagent_" + pos,
-			                             "Use " + (yin.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Brother Milor (Yin Agent)")
+                                         "Use " + (yin.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Brother Milor (Yin Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Yin)));
         }
 

--- a/src/main/java/ti4/commands/combat/StartCombat.java
+++ b/src/main/java/ti4/commands/combat/StartCombat.java
@@ -497,7 +497,7 @@ public class StartCombat extends CombatSubcommandData {
 
     /**
      * # of extra rings to show around the tile image
-     * 
+     *
      * @return 0 if no PDS2 nearby, 1 if PDS2 is nearby
      */
     private static int getTileImageContextForPDS2(Game activeGame, Player player1, Tile tile, String spaceOrGround) {
@@ -544,8 +544,9 @@ public class StartCombat extends CombatSubcommandData {
         Player titans = Helper.getPlayerFromUnlockedLeader(activeGame, "titansagent");
         if (!activeGame.isFoWMode() && titans != null && titans.hasUnexhaustedLeader("titansagent")) {
             String finChecker = "FFCC_" + titans.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "exhaustAgent_titansagent", "Titans Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Titans)));
+            buttons.add(Button.secondary(finChecker + "exhaustAgent_titansagent",
+			                             "Use " + (titans.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tellurian (Ul Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Titans)));
         }
         if (p1.hasTechReady("sc") || (!activeGame.isFoWMode() && p2.hasTechReady("sc"))) {
             // TemporaryCombatModifierModel combatModAC =
@@ -558,27 +559,37 @@ public class StartCombat extends CombatSubcommandData {
         Player ghemina = Helper.getPlayerFromUnlockedLeader(activeGame, "gheminaagent");
         if (!activeGame.isFoWMode() && ghemina != null && ghemina.hasUnexhaustedLeader("gheminaagent")) {
             String finChecker = "FFCC_" + ghemina.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "exhaustAgent_gheminaagent", "Ghemina Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.ghemina)));
+            buttons.add(Button.secondary(finChecker + "exhaustAgent_gheminaagent",
+			                             "Use " + (ghemina.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skarvald & Torvar (Ghemina Agents)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.ghemina)));
         }
 
         Player khal = Helper.getPlayerFromUnlockedLeader(activeGame, "kjalengardagent");
         if (!activeGame.isFoWMode() && khal != null && khal.hasUnexhaustedLeader("kjalengardagent")) {
             String finChecker = "FFCC_" + khal.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "exhaustAgent_kjalengardagent", "Kjalengard Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.kjalengard)));
+            buttons.add(Button.secondary(finChecker + "exhaustAgent_kjalengardagent",
+			                             "Use " + (khal.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Merkismathr Asvand (Kjalengard Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.kjalengard)));
         }
 
         Player sol = Helper.getPlayerFromUnlockedLeader(activeGame, "solagent");
         if (!activeGame.isFoWMode() && sol != null && sol.hasUnexhaustedLeader("solagent") && isGroundCombat) {
             String finChecker = "FFCC_" + sol.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "getAgentSelection_solagent", "Sol Agent")
+            buttons.add(Button.secondary(finChecker + "getAgentSelection_solagent",
+			                             "Use " + (sol.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Evelyn Delouis (Sol Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Sol)));
+            buttons.add(Button.secondary(finChecker + "getAgentSelection_solagent",
+			                             (sol.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Evelyn Delouis (Sol Agent)")
                 .withEmoji(Emoji.fromFormatted(Emojis.Sol)));
         }
         Player kyro = Helper.getPlayerFromUnlockedLeader(activeGame, "kyroagent");
         if (!activeGame.isFoWMode() && kyro != null && kyro.hasUnexhaustedLeader("kyroagent") && isGroundCombat) {
             String finChecker = "FFCC_" + kyro.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "getAgentSelection_kyroagent", "Kyro Agent")
+            buttons.add(Button.secondary(finChecker + "getAgentSelection_kyroagent",
+			                             "Use " + (kyro.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tox (Kyro Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.blex)));
+            buttons.add(Button.secondary(finChecker + "getAgentSelection_kyroagent",
+			                            (kyro.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tox (Kyro Agent)")
                 .withEmoji(Emoji.fromFormatted(Emojis.blex)));
         }
 
@@ -586,23 +597,26 @@ public class StartCombat extends CombatSubcommandData {
         if ((!activeGame.isFoWMode() || letnev == p1) && letnev != null && letnev.hasUnexhaustedLeader("letnevagent")
             && "space".equalsIgnoreCase(groundOrSpace)) {
             String finChecker = "FFCC_" + letnev.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "getAgentSelection_letnevagent", "Letnev Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Letnev)));
+            buttons.add(Button.secondary(finChecker + "getAgentSelection_letnevagent",
+			                             "Use " + (letnev.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Viscount Unlenn (Letnev Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Letnev)));
         }
 
         Player nomad = Helper.getPlayerFromUnlockedLeader(activeGame, "nomadagentthundarian");
         if ((!activeGame.isFoWMode() || nomad == p1) && nomad != null
             && nomad.hasUnexhaustedLeader("nomadagentthundarian")) {
             String finChecker = "FFCC_" + nomad.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "exhaustAgent_nomadagentthundarian", "Thundarian")
-                .withEmoji(Emoji.fromFormatted(Emojis.Nomad)));
+            buttons.add(Button.secondary(finChecker + "exhaustAgent_nomadagentthundarian",
+			                             "Use " + (nomad.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "The Thundarian (Nomad Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Nomad)));
         }
 
         Player yin = Helper.getPlayerFromUnlockedLeader(activeGame, "yinagent");
         if ((!activeGame.isFoWMode() || yin == p1) && yin != null && yin.hasUnexhaustedLeader("yinagent")) {
             String finChecker = "FFCC_" + yin.getFaction() + "_";
-            buttons.add(Button.secondary(finChecker + "yinagent_" + pos, "Yin Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Yin)));
+            buttons.add(Button.secondary(finChecker + "yinagent_" + pos,
+			                             "Use " + (yin.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Brother Milor (Yin Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Yin)));
         }
 
         // if (p1.hasAbility("technological_singularity")) {
@@ -633,12 +647,12 @@ public class StartCombat extends CombatSubcommandData {
             && p1.getFragments().size() > 0) {
             String finChecker = "FFCC_" + p2.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "exhaustAgent_kortaliagent_" + p1.getColor(),
-                "Use Kortali Agent To Steal Frag").withEmoji(Emoji.fromFormatted(Emojis.kortali)));
+                    "Use " + (p2.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Queen Lucreia (Kortali Agent) To Steal Frag").withEmoji(Emoji.fromFormatted(Emojis.kortali)));
         }
         if (p1.hasUnexhaustedLeader("kortaliagent") && isGroundCombat && p2.getFragments().size() > 0) {
             String finChecker = "FFCC_" + p1.getFaction() + "_";
             buttons.add(Button.secondary(finChecker + "exhaustAgent_kortaliagent_" + p2.getColor(),
-                "Use Kortali Agent To Steal Frag").withEmoji(Emoji.fromFormatted(Emojis.kortali)));
+                    "Use " + (p1.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Queen Lucreia (Kortali Agent) To Steal Frag").withEmoji(Emoji.fromFormatted(Emojis.kortali)));
         }
 
         // if ((p2.hasAbility("edict") || p2.hasAbility("imperia")) &&

--- a/src/main/java/ti4/commands/explore/ExpPlanet.java
+++ b/src/main/java/ti4/commands/explore/ExpPlanet.java
@@ -195,9 +195,10 @@ public class ExpPlanet extends ExploreSubcommandData {
             ExploreModel exploreModel = Mapper.getExplore(cardID);
             String name1 = exploreModel.getName();
             Button resolveExplore1 = Button.success("lanefirAgentRes_Decline_" + drawColor + "_" + cardID + "_" + planetName, "Choose " + name1);
-            Button resolveExplore2 = Button.success("lanefirAgentRes_Accept_" + drawColor + "_" + planetName, "Use Lanefir Agent");
+            Button resolveExplore2 = Button.success("lanefirAgentRes_Accept_" + drawColor + "_" + planetName,
+			                                        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vassa Hagi (Lanefir Agent)");
             List<Button> buttons = List.of(resolveExplore1, resolveExplore2);
-            String message = player.getRepresentation(true, true) + " You have Lanefir Agent, and thus can decline this explore to draw another one instead.";
+            String message = player.getRepresentation(true, true) + " You have " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vassa Hagi (Lanefir Agent), and thus can decline this explore to draw another one instead.";
             if (!activeGame.isFoWMode() && event.getChannel() != activeGame.getActionsChannel()) {
                 String pF = player.getFactionEmoji();
                 MessageHelper.sendMessageToChannel(activeGame.getActionsChannel(), pF + " found a " + name1 + " on " + planetName);
@@ -259,9 +260,10 @@ public class ExpPlanet extends ExploreSubcommandData {
             for (Player p2 : activeGame.getRealPlayers()) {
                 if (p2.hasUnexhaustedLeader("augersagent")) {
                     List<Button> buttons = new ArrayList<>();
-                    buttons.add(Button.success("exhaustAgent_augersagent_" + player.getFaction(), "Use Augers Agent on " + player.getColor()).withEmoji(Emoji.fromFormatted(Emojis.augers)));
+                    buttons.add(Button.success("exhaustAgent_augersagent_" + player.getFaction(),
+					                           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Clodho (Augers Agent) on " + player.getColor()).withEmoji(Emoji.fromFormatted(Emojis.augers)));
                     buttons.add(Button.danger("deleteButtons", "Decline"));
-                    String msg2 = p2.getRepresentation(true, true) + " you can use Augers Agent on " + ButtonHelper.getIdentOrColor(player, activeGame) + " to give them 2tg";
+                    String msg2 = p2.getRepresentation(true, true) + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Clodho (Augers Agent) on " + ButtonHelper.getIdentOrColor(player, activeGame) + " to give them 2tg";
                     MessageHelper.sendMessageToChannelWithButtons(p2.getCardsInfoThread(), msg2, buttons);
                 }
             }

--- a/src/main/java/ti4/commands/explore/ExpPlanet.java
+++ b/src/main/java/ti4/commands/explore/ExpPlanet.java
@@ -71,7 +71,7 @@ public class ExpPlanet extends ExploreSubcommandData {
             MessageHelper.sendMessageToEventChannel(event, "Cannot determine trait, please specify");
             return;
         }
-        
+
         boolean over = false;
         OptionMapping overRider = event.getOption(Constants.OVERRIDE_EXPLORE_OWNERSHIP_REQ);
         if (overRider != null && "YES".equalsIgnoreCase(overRider.getAsString())) {
@@ -196,7 +196,7 @@ public class ExpPlanet extends ExploreSubcommandData {
             String name1 = exploreModel.getName();
             Button resolveExplore1 = Button.success("lanefirAgentRes_Decline_" + drawColor + "_" + cardID + "_" + planetName, "Choose " + name1);
             Button resolveExplore2 = Button.success("lanefirAgentRes_Accept_" + drawColor + "_" + planetName,
-			                                        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vassa Hagi (Lanefir Agent)");
+                                                    "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vassa Hagi (Lanefir Agent)");
             List<Button> buttons = List.of(resolveExplore1, resolveExplore2);
             String message = player.getRepresentation(true, true) + " You have " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vassa Hagi (Lanefir Agent), and thus can decline this explore to draw another one instead.";
             if (!activeGame.isFoWMode() && event.getChannel() != activeGame.getActionsChannel()) {
@@ -261,7 +261,7 @@ public class ExpPlanet extends ExploreSubcommandData {
                 if (p2.hasUnexhaustedLeader("augersagent")) {
                     List<Button> buttons = new ArrayList<>();
                     buttons.add(Button.success("exhaustAgent_augersagent_" + player.getFaction(),
-					                           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Clodho (Augers Agent) on " + player.getColor()).withEmoji(Emoji.fromFormatted(Emojis.augers)));
+                                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Clodho (Augers Agent) on " + player.getColor()).withEmoji(Emoji.fromFormatted(Emojis.augers)));
                     buttons.add(Button.danger("deleteButtons", "Decline"));
                     String msg2 = p2.getRepresentation(true, true) + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Clodho (Augers Agent) on " + ButtonHelper.getIdentOrColor(player, activeGame) + " to give them 2tg";
                     MessageHelper.sendMessageToChannelWithButtons(p2.getCardsInfoThread(), msg2, buttons);

--- a/src/main/java/ti4/commands/planet/PlanetAdd.java
+++ b/src/main/java/ti4/commands/planet/PlanetAdd.java
@@ -174,7 +174,7 @@ public class PlanetAdd extends PlanetAddRemove {
             && player.hasUnexhaustedLeader("vaylerianagent")) {
             List<Button> buttons = new ArrayList<>();
             buttons.add(Button.success("exhaustAgent_vaylerianagent_" + player.getFaction(),
-			                           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)")
+                                       "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.vaylerian)));
             buttons.add(Button.danger("deleteButtons", "Decline"));
             String msg2 = player.getRepresentation(true, true) + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent) to draw an AC";

--- a/src/main/java/ti4/commands/planet/PlanetAdd.java
+++ b/src/main/java/ti4/commands/planet/PlanetAdd.java
@@ -173,10 +173,11 @@ public class PlanetAdd extends PlanetAddRemove {
         if (activeGame.getActivePlayerID() != null && !("".equalsIgnoreCase(activeGame.getActivePlayerID()))
             && player.hasUnexhaustedLeader("vaylerianagent")) {
             List<Button> buttons = new ArrayList<>();
-            buttons.add(Button.success("exhaustAgent_vaylerianagent_" + player.getFaction(), "Use Vaylerian Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.vaylerian)));
+            buttons.add(Button.success("exhaustAgent_vaylerianagent_" + player.getFaction(),
+			                           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.vaylerian)));
             buttons.add(Button.danger("deleteButtons", "Decline"));
-            String msg2 = player.getRepresentation(true, true) + " you can use Vaylerian Agent to draw an AC";
+            String msg2 = player.getRepresentation(true, true) + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent) to draw an AC";
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame), msg2,
                 buttons);
         }

--- a/src/main/java/ti4/commands/player/SCPlay.java
+++ b/src/main/java/ti4/commands/player/SCPlay.java
@@ -127,7 +127,7 @@ public class SCPlay extends PlayerSubcommandData {
             message.append(" by ").append(player.getRepresentation());
         }
         message.append(".\n\n");
-        
+
         String gamePing = activeGame.getPing();
         if (!gamePing.isEmpty()) {
             message.append(gamePing).append("\n");
@@ -269,7 +269,6 @@ public class SCPlay extends PlayerSubcommandData {
 
         if (!scModel.usesAutomationForSCID("pok1leadership")) {
             Button emelpar = Button.danger("scepterE_follow_" + scToPlay, "Exhaust Scepter of Emelpar");
-            Button mahactA = Button.danger("mahactA_follow_" + scToPlay, "Use Mahact Agent").withEmoji(Emoji.fromFormatted(Emojis.Mahact));
             for (Player player3 : activeGame.getRealPlayers()) {
                 if (player3 == player) {
                     continue;
@@ -284,13 +283,12 @@ public class SCPlay extends PlayerSubcommandData {
                             + " with the scepter of emelpar",
                         empNMahButtons);
                 }
-                if (player3.hasUnexhaustedLeader("mahactagent")
-                    && ButtonHelper.getTilesWithYourCC(player, activeGame, event).size() > 0 && !winnuHero) {
+                if (player3.hasUnexhaustedLeader("mahactagent") && ButtonHelper.getTilesWithYourCC(player, activeGame, event).size() > 0 && !winnuHero) {
+					Button mahactA = Button.danger("mahactA_follow_" + scToPlay,
+					                               "Use " + (player3.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)").withEmoji(Emoji.fromFormatted(Emojis.Mahact));
                     empNMahButtons.add(0, mahactA);
                     MessageHelper.sendMessageToChannelWithButtons(player3.getCardsInfoThread(),
-                        player3.getRepresentation(true, true) + " You can follow SC #" + scToPlay
-                            + " with mahact agent",
-                        empNMahButtons);
+                        player3.getRepresentation(true, true) + " You can follow SC #" + scToPlay + " with " + (player3.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)", empNMahButtons);
                 }
             }
         }

--- a/src/main/java/ti4/commands/player/SCPlay.java
+++ b/src/main/java/ti4/commands/player/SCPlay.java
@@ -284,8 +284,8 @@ public class SCPlay extends PlayerSubcommandData {
                         empNMahButtons);
                 }
                 if (player3.hasUnexhaustedLeader("mahactagent") && ButtonHelper.getTilesWithYourCC(player, activeGame, event).size() > 0 && !winnuHero) {
-					Button mahactA = Button.danger("mahactA_follow_" + scToPlay,
-					                               "Use " + (player3.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)").withEmoji(Emoji.fromFormatted(Emojis.Mahact));
+                    Button mahactA = Button.danger("mahactA_follow_" + scToPlay,
+                                                   "Use " + (player3.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)").withEmoji(Emoji.fromFormatted(Emojis.Mahact));
                     empNMahButtons.add(0, mahactA);
                     MessageHelper.sendMessageToChannelWithButtons(player3.getCardsInfoThread(),
                         player3.getRepresentation(true, true) + " You can follow SC #" + scToPlay + " with " + (player3.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)", empNMahButtons);

--- a/src/main/java/ti4/commands/player/TurnStart.java
+++ b/src/main/java/ti4/commands/player/TurnStart.java
@@ -322,12 +322,12 @@ public class TurnStart extends PlayerSubcommandData {
                 && ButtonHelperAgents.getAttachments(activeGame, player).size() > 0) {
                 startButtons.add(Button
                         .success(finChecker + "exhaustAgent_florzenagent_" + player.getFaction(),
-						         "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Gavda (Florzen Agent)")
+                                 "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Gavda (Florzen Agent)")
                         .withEmoji(Emoji.fromFormatted(Emojis.florzen)));
             }
             if (player.hasUnexhaustedLeader("vadenagent")) {
                 Button chaos = Button.secondary("exhaustAgent_vadenagent_" + player.getFaction(),
-				                                "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yudri Sukhov (Vaden Agent)")
+                                                "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yudri Sukhov (Vaden Agent)")
                         .withEmoji(Emoji.fromFormatted(Emojis.vaden));
                 startButtons.add(chaos);
             }
@@ -343,14 +343,14 @@ public class TurnStart extends PlayerSubcommandData {
             }
             if (player.hasUnexhaustedLeader("kolleccagent")) {
                 Button nekroButton = Button.secondary("exhaustAgent_kolleccagent",
-				                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Dust (Kollecc Agent)")
+                                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Dust (Kollecc Agent)")
                         .withEmoji(Emoji.fromFormatted(Emojis.kollecc));
                 startButtons.add(nekroButton);
             }
         }
         if (player.hasTech("pa") && ButtonHelper.getPsychoTechPlanets(activeGame, player).size() > 1) {
             Button psycho = Button.success(finChecker + "getPsychoButtons",
-			                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Psychoarcheology");
+                                           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Psychoarcheology");
             psycho = psycho.withEmoji(Emoji.fromFormatted(Emojis.BioticTech));
             startButtons.add(psycho);
         }
@@ -361,7 +361,7 @@ public class TurnStart extends PlayerSubcommandData {
         startButtons.add(modify);
         if (player.hasUnexhaustedLeader("hacanagent")) {
             Button hacanButton = Button.secondary("exhaustAgent_hacanagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Carth of Golden Sands (Hacan Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Carth of Golden Sands (Hacan Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Hacan));
             startButtons.add(hacanButton);
         }
@@ -370,7 +370,7 @@ public class TurnStart extends PlayerSubcommandData {
         }
         if (player.hasUnexhaustedLeader("nekroagent") && player.getAc() > 0) {
             Button nekroButton = Button.secondary("exhaustAgent_nekroagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Nekro Malleon (Nekro Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Nekro Malleon (Nekro Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Nekro));
             startButtons.add(nekroButton);
         }

--- a/src/main/java/ti4/commands/player/TurnStart.java
+++ b/src/main/java/ti4/commands/player/TurnStart.java
@@ -321,12 +321,14 @@ public class TurnStart extends PlayerSubcommandData {
             if (player.hasUnexhaustedLeader("florzenagent")
                 && ButtonHelperAgents.getAttachments(activeGame, player).size() > 0) {
                 startButtons.add(Button
-                    .success(finChecker + "exhaustAgent_florzenagent_" + player.getFaction(), "Use Florzen Agent")
-                    .withEmoji(Emoji.fromFormatted(Emojis.florzen)));
+                        .success(finChecker + "exhaustAgent_florzenagent_" + player.getFaction(),
+						         "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Gavda (Florzen Agent)")
+                        .withEmoji(Emoji.fromFormatted(Emojis.florzen)));
             }
             if (player.hasUnexhaustedLeader("vadenagent")) {
-                Button chaos = Button.secondary("exhaustAgent_vadenagent_" + player.getFaction(), "Use Vaden Agent")
-                    .withEmoji(Emoji.fromFormatted(Emojis.vaden));
+                Button chaos = Button.secondary("exhaustAgent_vadenagent_" + player.getFaction(),
+				                                "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yudri Sukhov (Vaden Agent)")
+                        .withEmoji(Emoji.fromFormatted(Emojis.vaden));
                 startButtons.add(chaos);
             }
             if (player.hasAbility("laws_order") && !activeGame.getLaws().isEmpty()) {
@@ -340,13 +342,15 @@ public class TurnStart extends PlayerSubcommandData {
                 startButtons.add(transit);
             }
             if (player.hasUnexhaustedLeader("kolleccagent")) {
-                Button nekroButton = Button.secondary("exhaustAgent_kolleccagent", "Use Kollecc Agent")
-                    .withEmoji(Emoji.fromFormatted(Emojis.kollecc));
+                Button nekroButton = Button.secondary("exhaustAgent_kolleccagent",
+				                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Dust (Kollecc Agent)")
+                        .withEmoji(Emoji.fromFormatted(Emojis.kollecc));
                 startButtons.add(nekroButton);
             }
         }
         if (player.hasTech("pa") && ButtonHelper.getPsychoTechPlanets(activeGame, player).size() > 1) {
-            Button psycho = Button.success(finChecker + "getPsychoButtons", "Use Psychoarcheology");
+            Button psycho = Button.success(finChecker + "getPsychoButtons",
+			                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Psychoarcheology");
             psycho = psycho.withEmoji(Emoji.fromFormatted(Emojis.BioticTech));
             startButtons.add(psycho);
         }
@@ -356,16 +360,18 @@ public class TurnStart extends PlayerSubcommandData {
         Button modify = Button.secondary("getModifyTiles", "Modify Units");
         startButtons.add(modify);
         if (player.hasUnexhaustedLeader("hacanagent")) {
-            Button hacanButton = Button.secondary("exhaustAgent_hacanagent", "Use Hacan Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Hacan));
+            Button hacanButton = Button.secondary("exhaustAgent_hacanagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Carth of Golden Sands (Hacan Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Hacan));
             startButtons.add(hacanButton);
         }
         if (player.hasRelicReady("e6-g0_network")) {
             startButtons.add(Button.success("exhauste6g0network", "Exhaust E6-G0 Network Relic to Draw AC"));
         }
         if (player.hasUnexhaustedLeader("nekroagent") && player.getAc() > 0) {
-            Button nekroButton = Button.secondary("exhaustAgent_nekroagent", "Use Nekro Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Nekro));
+            Button nekroButton = Button.secondary("exhaustAgent_nekroagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Nekro Malleon (Nekro Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Nekro));
             startButtons.add(nekroButton);
         }
 

--- a/src/main/java/ti4/commands/uncategorized/CardsInfo.java
+++ b/src/main/java/ti4/commands/uncategorized/CardsInfo.java
@@ -113,14 +113,14 @@ public class CardsInfo implements Command, InfoThreadCommand {
             buttons.add(augers);
         }
         if (player.hasUnexhaustedLeader("mykomentoriagent")) {
-            Button nekroButton = Button.secondary("exhaustAgent_mykomentoriagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Lactarius Indigo (Myko Agent)")
+            Button nekroButton = Button.secondary("exhaustAgent_mykomentoriagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Lactarius Indigo (Myko Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mykomentori));
             buttons.add(nekroButton);
         }
         if (player.hasUnexhaustedLeader("hacanagent")) {
             Button hacanButton = Button.secondary("exhaustAgent_hacanagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Carth of Golden Sands (Hacan Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Carth of Golden Sands (Hacan Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Hacan));
             buttons.add(hacanButton);
         }
@@ -131,13 +131,13 @@ public class CardsInfo implements Command, InfoThreadCommand {
         }
         if (player.hasUnexhaustedLeader("vadenagent")) {
             Button hacanButton = Button.secondary("getAgentSelection_vadenagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yudri Sukhov (Vaden Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yudri Sukhov (Vaden Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.vaden));
             buttons.add(hacanButton);
         } // olradinagent
         if (player.hasUnexhaustedLeader("olradinagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_olradinagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Baggil Wildpaw (Olradin Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_olradinagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Baggil Wildpaw (Olradin Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.olradin));
             buttons.add(hacanButton);
         }
@@ -148,97 +148,97 @@ public class CardsInfo implements Command, InfoThreadCommand {
         }
         if (player.hasUnexhaustedLeader("celdauriagent")) {
             Button hacanButton = Button.secondary("getAgentSelection_celdauriagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.celdauri));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("cheiranagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_cheiranagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_cheiranagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.cheiran));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("freesystemsagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_freesystemsagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Cordo Haved (Free Systems Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_freesystemsagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Cordo Haved (Free Systems Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.freesystems));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("florzenagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_florzenagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Gavda (Florzen Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_florzenagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Gavda (Florzen Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.florzen));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("nokaragent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_nokaragent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_nokaragent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.nokar));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("zelianagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_zelianagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_zelianagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.zelian));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("mirvedaagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_mirvedaagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Logic Machina (Mirveda Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_mirvedaagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Logic Machina (Mirveda Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mirveda));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("cymiaeagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_cymiaeagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_cymiaeagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("mortheusagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_mortheusagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_mortheusagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("zealotsagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_zealotsagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealot Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_zealotsagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealot Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.zealots));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("rohdhnaagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_rohdhnaagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri'ay (Roh'Dhna Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_rohdhnaagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri'ay (Roh'Dhna Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.rohdhna));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("veldyragent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_veldyragent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Solis Morden (Veldyr Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_veldyragent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Solis Morden (Veldyr Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.veldyr));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("gledgeagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_gledgeagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Durran (Gledge Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_gledgeagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Durran (Gledge Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.gledge));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("khraskagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_khraskagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Udosh B'rtul (Khrask Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_khraskagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Udosh B'rtul (Khrask Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.khrask));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("nivynagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_nivynagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Suldhan Wraeg (Nivyn Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_nivynagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Suldhan Wraeg (Nivyn Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.nivyn));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("ghotiagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_ghotiagent", 
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
+            Button hacanButton = Button.secondary("getAgentSelection_ghotiagent",
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
             buttons.add(hacanButton);
         }

--- a/src/main/java/ti4/commands/uncategorized/CardsInfo.java
+++ b/src/main/java/ti4/commands/uncategorized/CardsInfo.java
@@ -113,12 +113,14 @@ public class CardsInfo implements Command, InfoThreadCommand {
             buttons.add(augers);
         }
         if (player.hasUnexhaustedLeader("mykomentoriagent")) {
-            Button nekroButton = Button.secondary("exhaustAgent_mykomentoriagent", "Use Myko Agent")
+            Button nekroButton = Button.secondary("exhaustAgent_mykomentoriagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Lactarius Indigo (Myko Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mykomentori));
             buttons.add(nekroButton);
         }
         if (player.hasUnexhaustedLeader("hacanagent")) {
-            Button hacanButton = Button.secondary("exhaustAgent_hacanagent", "Use Hacan Agent")
+            Button hacanButton = Button.secondary("exhaustAgent_hacanagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Carth of Golden Sands (Hacan Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Hacan));
             buttons.add(hacanButton);
         }
@@ -128,97 +130,115 @@ public class CardsInfo implements Command, InfoThreadCommand {
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("vadenagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_vadenagent", "Use Vaden Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_vadenagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yudri Sukhov (Vaden Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.vaden));
             buttons.add(hacanButton);
         } // olradinagent
         if (player.hasUnexhaustedLeader("olradinagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_olradinagent", "Use Olradin Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_olradinagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Baggil Wildpaw (Olradin Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.olradin));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("edynagent")) {
-            Button hacanButton2 = Button.secondary("presetEdynAgentStep1", "Preset Edyn Agent")
+            Button hacanButton2 = Button.secondary("presetEdynAgentStep1", "Preset " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Allant (Edyn Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.edyn));
             buttons.add(hacanButton2);
         }
         if (player.hasUnexhaustedLeader("celdauriagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_celdauriagent", "Use Celdauri Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_celdauriagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.celdauri));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("cheiranagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_cheiranagent", "Use Cheiran Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_cheiranagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.cheiran));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("freesystemsagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_freesystemsagent", "Use Free Systems Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_freesystemsagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Cordo Haved (Free Systems Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.freesystems));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("florzenagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_florzenagent", "Use Florzen Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_florzenagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Gavda (Florzen Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.florzen));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("nokaragent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_nokaragent", "Use Nokar Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_nokaragent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.nokar));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("zelianagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_zelianagent", "Use Zelian Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_zelianagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.zelian));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("mirvedaagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_mirvedaagent", "Use Mirveda Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_mirvedaagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Logic Machina (Mirveda Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mirveda));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("cymiaeagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_cymiaeagent", "Use Cymiae Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_cymiaeagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Skhot Unit X-12 (Cymiae Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.cymiae));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("mortheusagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_mortheusagent", "Use Mortheus Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_mortheusagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("zealotsagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_zealotsagent", "Use Zealots Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_zealotsagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealot Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.zealots));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("rohdhnaagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_rohdhnaagent", "Use Rohdhna Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_rohdhnaagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Rond Bri'ay (Roh'Dhna Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.rohdhna));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("veldyragent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_veldyragent", "Use Veldyr Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_veldyragent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Solis Morden (Veldyr Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.veldyr));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("gledgeagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_gledgeagent", "Use Gledge Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_gledgeagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Durran (Gledge Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.gledge));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("khraskagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_khraskagent", "Use Khrask Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_khraskagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Udosh B'rtul (Khrask Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.khrask));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("nivynagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_nivynagent", "Use Nivyn Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_nivynagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Suldhan Wraeg (Nivyn Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.nivyn));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("ghotiagent")) {
-            Button hacanButton = Button.secondary("getAgentSelection_ghotiagent", "Use Ghoti Agent")
+            Button hacanButton = Button.secondary("getAgentSelection_ghotiagent", 
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
             buttons.add(hacanButton);
         }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -597,7 +597,7 @@ public class ButtonHelper {
         if (player.hasUnexhaustedLeader("olradinagent")) {
             Button hacanButton = Button
                     .secondary("exhaustAgent_olradinagent_" + player.getFaction(),
-					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Baggil Wildpaw (Olradin Agent)")
+                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Baggil Wildpaw (Olradin Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.olradin));
             buttons.add(hacanButton);
         }
@@ -614,7 +614,7 @@ public class ButtonHelper {
         if (player.hasUnexhaustedLeader("khraskagent")
                 && (whatIsItFor.contains("inf") || whatIsItFor.contains("both"))) {
             Button release = Button.secondary("exhaustAgent_khraskagent_" + player.getFaction(),
-			                                  "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Udosh B'rtul (Khrask Agent)")
+                                              "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Udosh B'rtul (Khrask Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.getFactionIconFromDiscord("khrask")));
             buttons.add(release);
         }
@@ -860,7 +860,7 @@ public class ButtonHelper {
                 List<Button> buttons = new ArrayList<>();
                 Button hacanButton = Button
                         .secondary("exhaustAgent_mirvedaagent_" + player.getFaction(),
-						           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Logic Machina (Mirveda Agent)")
+                                   "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Logic Machina (Mirveda Agent)")
                         .withEmoji(Emoji.fromFormatted(Emojis.mirveda));
                 buttons.add(hacanButton);
                 MessageHelper.sendMessageToChannelWithButtons(player.getCardsInfoThread(), player
@@ -909,7 +909,7 @@ public class ButtonHelper {
             List<Button> buttons = new ArrayList<>();
             Button hacanButton = Button
                     .secondary("exhaustAgent_zealotsagent_" + player.getFaction(),
-					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealots Agent)")
+                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealots Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.zealots));
             buttons.add(hacanButton);
             MessageHelper.sendMessageToChannelWithButtons(player.getCardsInfoThread(),
@@ -1034,14 +1034,14 @@ public class ButtonHelper {
         }
         if (player.hasExternalAccessToLeader("jolnaragent") || player.hasUnexhaustedLeader("jolnaragent")) {
             Button pT2 = Button.secondary("exhaustAgent_jolnaragent",
-			                              "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Doctor Sucaban (Jol-Nar Agent)")
+                                          "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Doctor Sucaban (Jol-Nar Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Jolnar));
             buttons.add(pT2);
         }
         if (player.hasUnexhaustedLeader("veldyragent")) {
             Button winnuButton = Button
                     .danger("exhaustAgent_veldyragent_" + player.getFaction(),
-					        "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Solis Morden (Veldyr Agent)")
+                            "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Solis Morden (Veldyr Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.veldyr));
             buttons.add(winnuButton);
         }
@@ -3673,14 +3673,14 @@ public class ButtonHelper {
         }
         if (player.hasUnexhaustedLeader("naazagent")) {
             endButtons.add(Button.success(finChecker + "exhaustAgent_naazagent",
-			               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Garv and Gunn (Naaz-Rokha Agents)")
+                           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Garv and Gunn (Naaz-Rokha Agents)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Naaz)));
         }
         if (player.hasUnexhaustedLeader("cheiranagent")
             && ButtonHelperAgents.getCheiranAgentTiles(player, game).size() > 0) {
             endButtons.add(
                     Button.success(finChecker + "exhaustAgent_cheiranagent_" + player.getFaction(),
-					               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)")
+                                   "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)")
                             .withEmoji(Emoji.fromFormatted(Emojis.cheiran)));
         }
 
@@ -3688,7 +3688,7 @@ public class ButtonHelper {
             && ButtonHelperAgents.getAvailableLegendaryAbilities(game).size() > 0) {
             endButtons.add(Button.success(finChecker + "exhaustAgent_freesystemsagent_" + player.getFaction(),
                                           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Cordo Haved (Free Systems Agent)")
-					       .withEmoji(Emoji.fromFormatted(Emojis.freesystems)));
+                           .withEmoji(Emoji.fromFormatted(Emojis.freesystems)));
         }
         if (player.hasRelic("absol_tyrantslament") && !player.hasUnit("tyrantslament")) {
             endButtons.add(Button.success("deployTyrant", "Deploy The Tyrant's Lament")
@@ -3697,7 +3697,7 @@ public class ButtonHelper {
 
         if (player.hasUnexhaustedLeader("lizhoagent")) {
             endButtons.add(Button.success(finChecker + "exhaustAgent_lizhoagent",
-			                              "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vasra Ivo (Li-zho Agent) on Yourself")
+                                          "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vasra Ivo (Li-zho Agent) on Yourself")
                     .withEmoji(Emoji.fromFormatted(Emojis.lizho)));
         }
 
@@ -4442,7 +4442,7 @@ public class ButtonHelper {
 
         if (player.hasUnexhaustedLeader("saaragent")) {
             Button saarButton = Button.secondary("exhaustAgent_saaragent",
-			                                     "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Mendosa (Saar Agent)")
+                                                 "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Mendosa (Saar Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Saar));
             buttons.add(saarButton);
         }
@@ -4460,7 +4460,7 @@ public class ButtonHelper {
         if (player.hasUnexhaustedLeader("ghostagent")
                 && FoWHelper.doesTileHaveWHs(game, game.getActiveSystem())) {
             Button ghostButton = Button.secondary("exhaustAgent_ghostagent",
-			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Emissary Taivra (Creuss Agent)")
+                                                  "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Emissary Taivra (Creuss Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.Ghost));
             buttons.add(ghostButton);
         }
@@ -4757,14 +4757,14 @@ public class ButtonHelper {
         if (player.hasUnexhaustedLeader("nokaragent") && FoWHelper.playerHasShipsInSystem(player, tile)) {
             Button chaos = Button
                     .secondary("exhaustAgent_nokaragent_" + player.getFaction(),
-					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent) To Place A Destroyer")
+                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent) To Place A Destroyer")
                     .withEmoji(Emoji.fromFormatted(Emojis.nokar));
             buttons.add(chaos);
         }
         if (player.hasUnexhaustedLeader("tnelisagent") && FoWHelper.playerHasShipsInSystem(player, tile)
                 && FoWHelper.otherPlayersHaveUnitsInSystem(player, tile, game)) {
             Button chaos = Button.secondary("exhaustAgent_tnelisagent_" + player.getFaction(),
-			                                "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Davish S'Norri (Tnelis Agent)")
+                                            "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Davish S'Norri (Tnelis Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.tnelis));
             buttons.add(chaos);
         }
@@ -4772,7 +4772,7 @@ public class ButtonHelper {
             && tile.getUnitHolders().get("space").getUnitCount(UnitType.Infantry, player.getColor()) > 0) {
             Button chaos = Button
                     .secondary("exhaustAgent_zelianagent_" + player.getFaction(),
-					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent) Yourself")
+                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent) Yourself")
                     .withEmoji(Emoji.fromFormatted(Emojis.zelian));
             buttons.add(chaos);
         }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -596,8 +596,9 @@ public class ButtonHelper {
         }
         if (player.hasUnexhaustedLeader("olradinagent")) {
             Button hacanButton = Button
-                .secondary("exhaustAgent_olradinagent_" + player.getFaction(), "Use Olradin Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.olradin));
+                    .secondary("exhaustAgent_olradinagent_" + player.getFaction(),
+					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Baggil Wildpaw (Olradin Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.olradin));
             buttons.add(hacanButton);
         }
         if (player.hasUnexhaustedLeader("keleresagent") && player.getCommodities() > 1) {
@@ -611,9 +612,10 @@ public class ButtonHelper {
             buttons.add(release);
         }
         if (player.hasUnexhaustedLeader("khraskagent")
-            && (whatIsItFor.contains("inf") || whatIsItFor.contains("both"))) {
-            Button release = Button.secondary("exhaustAgent_khraskagent_" + player.getFaction(), "Exhaust Khrask Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.getFactionIconFromDiscord("khrask")));
+                && (whatIsItFor.contains("inf") || whatIsItFor.contains("both"))) {
+            Button release = Button.secondary("exhaustAgent_khraskagent_" + player.getFaction(),
+			                                  "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Udosh B'rtul (Khrask Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.getFactionIconFromDiscord("khrask")));
             buttons.add(release);
         }
         if (player.hasAbility("diplomats") && ButtonHelperAbilities.getDiplomatButtons(game, player).size() > 0) {
@@ -857,13 +859,14 @@ public class ButtonHelper {
             if (player.hasUnexhaustedLeader("mirvedaagent") && player.getStrategicCC() > 0) {
                 List<Button> buttons = new ArrayList<>();
                 Button hacanButton = Button
-                    .secondary("exhaustAgent_mirvedaagent_" + player.getFaction(), "Use Mirveda Agent")
-                    .withEmoji(Emoji.fromFormatted(Emojis.mirveda));
+                        .secondary("exhaustAgent_mirvedaagent_" + player.getFaction(),
+						           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Logic Machina (Mirveda Agent)")
+                        .withEmoji(Emoji.fromFormatted(Emojis.mirveda));
                 buttons.add(hacanButton);
                 MessageHelper.sendMessageToChannelWithButtons(player.getCardsInfoThread(), player
-                    .getRepresentation(true, true)
-                    + " you can use mirveda agent to spend a CC and research a tech of the same color as a prereq of the tech you just got",
-                    buttons);
+                        .getRepresentation(true, true)
+                        + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Logic Machina (Mirveda Agent) to spend a CC and research a tech of the same color as a prereq of the tech you just got",
+                        buttons);
             }
             if (player.hasAbility("obsessive_designs") && paymentRequired
                 && "action".equalsIgnoreCase(game.getCurrentPhase())) {
@@ -905,13 +908,14 @@ public class ButtonHelper {
         if (player.hasUnexhaustedLeader("zealotsagent")) {
             List<Button> buttons = new ArrayList<>();
             Button hacanButton = Button
-                .secondary("exhaustAgent_zealotsagent_" + player.getFaction(), "Use Zealots Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.zealots));
+                    .secondary("exhaustAgent_zealotsagent_" + player.getFaction(),
+					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealots Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.zealots));
             buttons.add(hacanButton);
             MessageHelper.sendMessageToChannelWithButtons(player.getCardsInfoThread(),
-                player.getRepresentation(true, true)
-                    + " you can use Zealots agent to produce 1 ship at home or in a system where you have a tech skip planet",
-                buttons);
+                    player.getRepresentation(true, true)
+                            + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealots Agent) to produce 1 ship at home or in a system where you have a tech skip planet",
+                    buttons);
         }
         player.addTech(techID);
         ButtonHelperFactionSpecific.resolveResearchAgreementCheck(player, techID, game);
@@ -1029,14 +1033,16 @@ public class ButtonHelper {
             buttons.add(pT2);
         }
         if (player.hasExternalAccessToLeader("jolnaragent") || player.hasUnexhaustedLeader("jolnaragent")) {
-            Button pT2 = Button.secondary("exhaustAgent_jolnaragent", "Exhaust Jol Nar Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Jolnar));
+            Button pT2 = Button.secondary("exhaustAgent_jolnaragent",
+			                              "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Doctor Sucaban (Jol-Nar Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Jolnar));
             buttons.add(pT2);
         }
         if (player.hasUnexhaustedLeader("veldyragent")) {
             Button winnuButton = Button
-                .danger("exhaustAgent_veldyragent_" + player.getFaction(), "Exhaust Veldyr Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.veldyr));
+                    .danger("exhaustAgent_veldyragent_" + player.getFaction(),
+					        "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Solis Morden (Veldyr Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.veldyr));
             buttons.add(winnuButton);
         }
         if (game.playerHasLeaderUnlockedOrAlliance(player, "yincommander")) {
@@ -2716,7 +2722,7 @@ public class ButtonHelper {
                 MessageHelper.sendMessageToChannel(getCorrectChannel(player, game), msg);
             }
             player = game.getPlayerFromColorOrFaction(faction);
-            msg = player.getRepresentation(true, true) + " this is a notice that " + msg + " using Mahact agent";
+            msg = player.getRepresentation(true, true) + " this is a notice that " + msg + " using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)";
         }
 
         if (player == null)
@@ -3666,20 +3672,23 @@ public class ButtonHelper {
             endButtons.add(Button.success(finChecker + "useTech_absol_pa", "Use Psychoarchaeology"));
         }
         if (player.hasUnexhaustedLeader("naazagent")) {
-            endButtons.add(Button.success(finChecker + "exhaustAgent_naazagent", "Use NRA Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Naaz)));
+            endButtons.add(Button.success(finChecker + "exhaustAgent_naazagent",
+			               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Garv and Gunn (Naaz-Rokha Agents)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Naaz)));
         }
         if (player.hasUnexhaustedLeader("cheiranagent")
             && ButtonHelperAgents.getCheiranAgentTiles(player, game).size() > 0) {
             endButtons.add(
-                Button.success(finChecker + "exhaustAgent_cheiranagent_" + player.getFaction(), "Use Cheiran Agent")
-                    .withEmoji(Emoji.fromFormatted(Emojis.cheiran)));
+                    Button.success(finChecker + "exhaustAgent_cheiranagent_" + player.getFaction(),
+					               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)")
+                            .withEmoji(Emoji.fromFormatted(Emojis.cheiran)));
         }
 
         if (player.hasUnexhaustedLeader("freesystemsagent") && player.getReadiedPlanets().size() > 0
             && ButtonHelperAgents.getAvailableLegendaryAbilities(game).size() > 0) {
             endButtons.add(Button.success(finChecker + "exhaustAgent_freesystemsagent_" + player.getFaction(),
-                "Use Free Systems Agent").withEmoji(Emoji.fromFormatted(Emojis.freesystems)));
+                                          "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Cordo Haved (Free Systems Agent)")
+					       .withEmoji(Emoji.fromFormatted(Emojis.freesystems)));
         }
         if (player.hasRelic("absol_tyrantslament") && !player.hasUnit("tyrantslament")) {
             endButtons.add(Button.success("deployTyrant", "Deploy The Tyrant's Lament")
@@ -3687,8 +3696,9 @@ public class ButtonHelper {
         }
 
         if (player.hasUnexhaustedLeader("lizhoagent")) {
-            endButtons.add(Button.success(finChecker + "exhaustAgent_lizhoagent", "Use Lizho Agent on Yourself")
-                .withEmoji(Emoji.fromFormatted(Emojis.lizho)));
+            endButtons.add(Button.success(finChecker + "exhaustAgent_lizhoagent",
+			                              "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vasra Ivo (Li-zho Agent) on Yourself")
+                    .withEmoji(Emoji.fromFormatted(Emojis.lizho)));
         }
 
         endButtons.add(Button.danger("deleteButtons", "Delete these buttons"));
@@ -4035,10 +4045,10 @@ public class ButtonHelper {
                 Button resolveExplore1 = Button.success(
                     "lanefirAgentRes_Decline_frontier_" + cardID + "_" + tile.getPosition(), "Choose " + name1);
                 Button resolveExplore2 = Button.success("lanefirAgentRes_Accept_frontier_" + tile.getPosition(),
-                    "Use Lanefir Agent");
+                        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vassa Hagi (Lanefir Agent)");
                 List<Button> buttons = List.of(resolveExplore1, resolveExplore2);
                 String message = player.getRepresentation(true, true)
-                    + " You have Lanefir Agent, and thus can decline this explore to draw another one instead.";
+                        + " You have " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Vassa Hagi (Lanefir Agent), and thus can decline this explore to draw another one instead.";
                 if (!game.isFoWMode() && event.getChannel() != game.getActionsChannel()) {
                     String pF = player.getFactionEmoji();
                     MessageHelper.sendMessageToChannel(game.getActionsChannel(),
@@ -4431,8 +4441,9 @@ public class ButtonHelper {
         }
 
         if (player.hasUnexhaustedLeader("saaragent")) {
-            Button saarButton = Button.secondary("exhaustAgent_saaragent", "Use Saar Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Saar));
+            Button saarButton = Button.secondary("exhaustAgent_saaragent",
+			                                     "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Mendosa (Saar Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Saar));
             buttons.add(saarButton);
         }
 
@@ -4447,9 +4458,10 @@ public class ButtonHelper {
         }
 
         if (player.hasUnexhaustedLeader("ghostagent")
-            && FoWHelper.doesTileHaveWHs(game, game.getActiveSystem())) {
-            Button ghostButton = Button.secondary("exhaustAgent_ghostagent", "Use Ghost Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.Ghost));
+                && FoWHelper.doesTileHaveWHs(game, game.getActiveSystem())) {
+            Button ghostButton = Button.secondary("exhaustAgent_ghostagent",
+			                                      "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Emissary Taivra (Creuss Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.Ghost));
             buttons.add(ghostButton);
         }
         if (player.hasTech("as")
@@ -4585,10 +4597,10 @@ public class ButtonHelper {
                 if (planet.getUnitCount(inf, colorID) > 0 || planet.getUnitCount(mech, colorID) > 0) {
                     if (player.hasUnexhaustedLeader("dihmohnagent")) {
                         Button dihmohn = Button
-                            .success("exhaustAgent_dihmohnagent_" + unitHolder.getName(),
-                                "Use Dihmohn Agent to land an extra Infantry on "
-                                    + Helper.getPlanetRepresentation(unitHolder.getName(), game))
-                            .withEmoji(Emoji.fromFormatted(Emojis.dihmohn));
+                                .success("exhaustAgent_dihmohnagent_" + unitHolder.getName(),
+                                         "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jgin Faru (Dihmohn Agent) to land an extra Infantry on "
+                                                + Helper.getPlanetRepresentation(unitHolder.getName(), game))
+                                .withEmoji(Emoji.fromFormatted(Emojis.dihmohn));
                         buttons.add(dihmohn);
                     }
                 }
@@ -4744,21 +4756,24 @@ public class ButtonHelper {
         }
         if (player.hasUnexhaustedLeader("nokaragent") && FoWHelper.playerHasShipsInSystem(player, tile)) {
             Button chaos = Button
-                .secondary("exhaustAgent_nokaragent_" + player.getFaction(), "Use Nokar Agent To Place A Destroyer")
-                .withEmoji(Emoji.fromFormatted(Emojis.nokar));
+                    .secondary("exhaustAgent_nokaragent_" + player.getFaction(),
+					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent) To Place A Destroyer")
+                    .withEmoji(Emoji.fromFormatted(Emojis.nokar));
             buttons.add(chaos);
         }
         if (player.hasUnexhaustedLeader("tnelisagent") && FoWHelper.playerHasShipsInSystem(player, tile)
-            && FoWHelper.otherPlayersHaveUnitsInSystem(player, tile, game)) {
-            Button chaos = Button.secondary("exhaustAgent_tnelisagent_" + player.getFaction(), "Use Tnelis Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.tnelis));
+                && FoWHelper.otherPlayersHaveUnitsInSystem(player, tile, game)) {
+            Button chaos = Button.secondary("exhaustAgent_tnelisagent_" + player.getFaction(),
+			                                "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Davish S'Norri (Tnelis Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.tnelis));
             buttons.add(chaos);
         }
         if (player.hasUnexhaustedLeader("zelianagent")
             && tile.getUnitHolders().get("space").getUnitCount(UnitType.Infantry, player.getColor()) > 0) {
             Button chaos = Button
-                .secondary("exhaustAgent_zelianagent_" + player.getFaction(), "Use Zelian Agent Yourself")
-                .withEmoji(Emoji.fromFormatted(Emojis.zelian));
+                    .secondary("exhaustAgent_zelianagent_" + player.getFaction(),
+					           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent) Yourself")
+                    .withEmoji(Emoji.fromFormatted(Emojis.zelian));
             buttons.add(chaos);
         }
         if (player.hasLeaderUnlocked("muaathero") && !"18".equalsIgnoreCase(tile.getTileID())
@@ -8020,65 +8035,57 @@ public class ButtonHelper {
                         String led = "muaatagent";
                         if (p1.hasExternalAccessToLeader(led)) {
                             Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Muaat agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + prefix + "leader_" + led,
+                                            "Use " + leaderName + " as Umbat (Muaat Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(lButton);
                         }
                         led = "naaluagent";
                         if (p1.hasExternalAccessToLeader(led)) {
                             Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Naalu agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + prefix + "leader_" + led,
+                                            "Use " + leaderName + " as Z'eu (Naalu Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(lButton);
                         }
                         led = "arborecagent";
                         if (p1.hasExternalAccessToLeader(led)) {
                             Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Arborec agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + prefix + "leader_" + led,
+                                            "Use " + leaderName + " as Letani Ospha (Arborec Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(lButton);
                         }
                         led = "bentoragent";
                         if (p1.hasExternalAccessToLeader(led)) {
                             Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Bentor agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + prefix + "leader_" + led,
+                                            "Use " + leaderName + " as C.O.O. Mgur (Bentor Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(lButton);
                         }
                         led = "kolumeagent";
                         if (p1.hasExternalAccessToLeader(led)) {
                             Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Kolume agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + prefix + "leader_" + led,
+                                            "Use " + leaderName + " as Disciple Fran (Kolume Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(lButton);
                         }
                         led = "axisagent";
                         if (p1.hasExternalAccessToLeader(led)) {
                             Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Axis agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + prefix + "leader_" + led,
+                                            "Use " + leaderName + " as Shipmonger Zsknck (Axis Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(lButton);
                         }
                         led = "xxchaagent";
                         if (p1.hasExternalAccessToLeader(led)) {
                             Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Xxcha agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
-                            compButtons.add(lButton);
-                        }
-                        led = "fogallianceagent";
-                        if (p1.hasExternalAccessToLeader(led)) {
-                            Button lButton = Button
-                                .secondary(finChecker + prefix + "leader_" + led,
-                                    "Use " + leaderName + " as Fog Alliance agent")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + prefix + "leader_" + led,
+                                            "Use " + leaderName + " as Ggrocuto Rinn (Xxcha Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(lButton);
                         }
                         led = "yssarilagent";
@@ -8089,9 +8096,9 @@ public class ButtonHelper {
                         compButtons.add(lButton);
                         if (ButtonHelperFactionSpecific.doesAnyoneElseHaveJr(game, p1)) {
                             Button jrButton = Button
-                                .secondary(finChecker + "yssarilAgentAsJr",
-                                    "Use " + leaderName + " The Relic/Agent JR")
-                                .withEmoji(Emoji.fromFormatted(factionEmoji));
+                                    .secondary(finChecker + "yssarilAgentAsJr",
+                                            "Use " + leaderName + " JR-XS455-O (Relic Agent)")
+                                    .withEmoji(Emoji.fromFormatted(factionEmoji));
                             compButtons.add(jrButton);
                         }
 

--- a/src/main/java/ti4/helpers/ButtonHelperAbilities.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAbilities.java
@@ -632,29 +632,29 @@ public class ButtonHelperAbilities {
             if (player.hasUnexhaustedLeader("mentakagent")) {
                 List<Button> buttons = new ArrayList<>();
                 Button winnuButton = Button
-                    .success(
-                        "FFCC_" + player.getFaction() + "_" + "exhaustAgent_mentakagent_"
-                            + pillaged.getFaction(),
-                        "Use Mentak Agent To Draw ACs for you and pillaged player")
-                    .withEmoji(Emoji.fromFormatted(Emojis.Mentak));
+                        .success(
+                                "FFCC_" + player.getFaction() + "_" + "exhaustAgent_mentakagent_"
+                                        + pillaged.getFaction(),
+                                "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Suffi An (Mentak Agent) To Draw ACs for you and pillaged player")
+                        .withEmoji(Emoji.fromFormatted(Emojis.Mentak));
                 buttons.add(winnuButton);
                 buttons.add(Button.danger("deleteButtons", "Done"));
-                MessageHelper.sendMessageToChannelWithButtons(channel2, "Wanna use Mentak Agent?", buttons);
+                MessageHelper.sendMessageToChannelWithButtons(channel2, "Wanna use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Suffi An (Mentak Agent)?", buttons);
             }
             for (Player p2 : activeGame.getRealPlayers()) {
                 if (p2 != pillaged && p2 != player && p2.hasUnexhaustedLeader("yssarilagent")
                     && player.hasLeader("mentakagent")) {
                     List<Button> buttons = new ArrayList<>();
                     Button winnuButton = Button
-                        .success(
-                            "FFCC_" + p2.getFaction() + "_" + "exhaustAgent_mentakagent_"
-                                + pillaged.getFaction(),
-                            "Use Mentak Agent To Draw ACs for you and pillaged player")
-                        .withEmoji(Emoji.fromFormatted(Emojis.Mentak));
+                            .success(
+                                    "FFCC_" + p2.getFaction() + "_" + "exhaustAgent_mentakagent_"
+                                            + pillaged.getFaction(),
+                                    "Use " + (p2.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Suffi An (Mentak Agent) To Draw ACs for you and pillaged player")
+                            .withEmoji(Emoji.fromFormatted(Emojis.Mentak));
                     buttons.add(winnuButton);
                     buttons.add(Button.danger("deleteButtons", "Done"));
                     MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(p2, activeGame),
-                        p2.getRepresentation() + " Wanna use Mentak Agent?", buttons);
+                            p2.getRepresentation() + "Wanna use " + (p2.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Suffi An (Mentak Agent)?", buttons);
                 }
             }
         }

--- a/src/main/java/ti4/helpers/ButtonHelperAgents.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAgents.java
@@ -75,7 +75,7 @@ public class ButtonHelperAgents {
                     + ButtonHelper.getIdentOrColor(p2, activeGame) + " who has "
                     + p2.getCommoditiesTotal() + " commodities";
                 buttons.add(Button.success("exhaustAgent_cabalagent_startCabalAgent_" + p2.getFaction(),
-				                           "Use " + (cabal.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + " The Stillness of Stars (Vuil'raith Agent)"));
+                                           "Use " + (cabal.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + " The Stillness of Stars (Vuil'raith Agent)"));
                 buttons.add(Button.danger("deleteButtons", "Decline"));
                 MessageHelper.sendMessageToChannelWithButtons(cabal.getCardsInfoThread(), msg, buttons);
             }
@@ -155,11 +155,11 @@ public class ButtonHelperAgents {
                 "Unable to resolve player, please resolve manually.");
             return;
         }
-		Integer commodities = p2.getCommodities();
+        Integer commodities = p2.getCommodities();
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, activeGame),
             p2.getRepresentation(true, true) + " a " + unit
                 + " of yours has been captured by " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "The Stillness of Stars (Vuil'Raith Agent). "
-				+ "Rejoice, for your " + commodities.toString() + " commodities been washed.");
+                + "Rejoice, for your " + commodities.toString() + " commodities been washed.");
         p2.setTg(p2.getTg() + commodities);
         p2.setCommodities(0);
         ButtonHelperFactionSpecific.cabalEatsUnit(p2, activeGame, player, 1, unit, event, true);
@@ -464,7 +464,7 @@ public class ButtonHelperAgents {
             }
         }
         unitButtons.add(Button.danger("deleteButtons_spitItOut",
-		                              "Done Using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Trillossa Aun Mirik (Argent Agent)"));
+                                      "Done Using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Trillossa Aun Mirik (Argent Agent)"));
         MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
             player.getRepresentation(true, true) + " use buttons to place ground forces via " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Trillossa Aun Mirik (Argent Agent)",
             unitButtons);
@@ -505,28 +505,28 @@ public class ButtonHelperAgents {
         playerLeader.setExhausted(true);
 
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), Emojis.getFactionLeaderEmoji(playerLeader));
-		String ssruu = "";
+        String ssruu = "";
         if ("yssarilagent".equalsIgnoreCase(playerLeader.getId())) {
             ssruu = "Clever Clever ";
         }
         if ("nomadagentartuno".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Artuno the Betrayer (Nomad Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             playerLeader.setTgCount(Integer.parseInt(rest.split("_")[1]));
             String messageText = player.getRepresentation() + " placed " + rest.split("_")[1] + " " + Emojis.getTGorNomadCoinEmoji(activeGame)
                 + " on top of " + ssruu + "Artuno the Betrayer (Nomad Agent)";
-			MessageHelper.sendMessageToChannel(channel2, messageText);
+            MessageHelper.sendMessageToChannel(channel2, messageText);
         }
         if ("naazagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Garv and Gunn (Naaz-Rokha Agents)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             List<Button> buttons = ButtonHelper.getButtonsToExploreAllPlanets(player, activeGame);
             MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), "Use buttons to explore", buttons);
         }
 
         if ("augersagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Clodho (Augers Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             Player p2 = activeGame.getPlayerFromColorOrFaction(rest.split("_")[1]);
             int oldTg = p2.getTg();
             p2.setTg(oldTg + 2);
@@ -543,7 +543,7 @@ public class ButtonHelperAgents {
 
         if ("vaylerianagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Yvin Korduul (Vaylerian Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             if (rest.contains("_")) {
                 Player p2 = activeGame.getPlayerFromColorOrFaction(rest.split("_")[1]);
                 String message = ButtonHelper.resolveACDraw(p2, activeGame, event);
@@ -560,7 +560,7 @@ public class ButtonHelperAgents {
         }
         if ("kjalengardagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Merkismathr Asvand (Kjalengard Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             Player activePlayer = activeGame.getActivePlayer();
             if (activePlayer != null) {
                 int oldComms = activePlayer.getCommodities();
@@ -581,18 +581,18 @@ public class ButtonHelperAgents {
                 MessageHelper.sendMessageToChannel(event.getMessageChannel(),
                     ButtonHelper.getIdent(player)
                         + " there were no glory tokens on the board to move. Go win some battles and earn some, or your ancestors will laugh at ya when "
-						+ (ThreadLocalRandom.current().nextInt(20) == 0 ? "(if) " : "") + "you reach Valhalla");
+                        + (ThreadLocalRandom.current().nextInt(20) == 0 ? "(if) " : "") + "you reach Valhalla");
 
             }
         }
         if ("cabalagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "The Stillness of Stars (Vuil'Raith Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             startCabalAgent(player, activeGame, rest.replace("cabalagent_", ""), event);
         }
         if ("jolnaragent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Doctor Sucaban (Jol-Nar Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String msg = player.getRepresentation(true, true) + " you can use the buttons to remove infantry.";
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame), msg,
                 getJolNarAgentButtons(player, activeGame));
@@ -600,7 +600,7 @@ public class ButtonHelperAgents {
 
         if ("empyreanagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Acamar (Empyrean Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             List<Button> buttons = ButtonHelper.getGainCCButtons(player);
             String message2 = trueIdentity + "! Your current CCs are " + player.getCCRepresentation()
                 + ". Use buttons to gain CCs";
@@ -609,12 +609,12 @@ public class ButtonHelperAgents {
         }
         if ("mykomentoriagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Lactarius Indigo (Myko-Mentori Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             ButtonHelperAbilities.offerOmenDiceButtons(activeGame, player);
         }
         if ("gledgeagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Durran (Gledge Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -623,7 +623,7 @@ public class ButtonHelperAgents {
         }
         if ("khraskagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Udosh B'rtul (Khrask Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -632,7 +632,7 @@ public class ButtonHelperAgents {
         }
         if ("rohdhnaagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Rond Bri'ay (Roh'Dhna Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -648,7 +648,7 @@ public class ButtonHelperAgents {
         }
         if ("veldyragent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Solis Morden (Veldyr Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -657,12 +657,12 @@ public class ButtonHelperAgents {
         }
         if ("winnuagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Berekar Berekon (Winnu Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             player.addSpentThing("Exhausted " + ssruu + "Berekar Berekon (Winnu Agent) for 2 resources");
         }
         if ("lizhoagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Vasra Ivo (Li-Zho Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             List<Button> buttons = new ArrayList<>(
                 Helper.getTileWithShipsPlaceUnitButtons(player, activeGame, "2ff", "placeOneNDone_skipbuild"));
             String message = "Use buttons to put 2 fighters with your ships";
@@ -672,14 +672,14 @@ public class ButtonHelperAgents {
 
         if ("nekroagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Nekro Malleon (Nekro Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String message = trueIdentity + " select faction you wish to use " + ssruu + "Nekro Malleon (Nekro Agent) on";
             List<Button> buttons = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "nekroAgentRes", null);
             MessageHelper.sendMessageToChannelWithButtons(channel2, message, buttons);
         }
         if ("kolleccagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Captain Dust (Kollecc Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String message = trueIdentity + " select faction you wish to use " + ssruu + "Captain Dust (Kollecc Agent) on";
             List<Button> buttons = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "kolleccAgentRes", null);
             MessageHelper.sendMessageToChannelWithButtons(channel2, message, buttons);
@@ -687,7 +687,7 @@ public class ButtonHelperAgents {
 
         if ("hacanagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Carth of Golden Sands (Hacan Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String message = trueIdentity + " select faction you wish to use " + ssruu + "Carth of Golden Sands (Hacan Agent) on";
             List<Button> buttons = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "hacanAgentRefresh", null);
             MessageHelper.sendMessageToChannelWithButtons(channel2, message, buttons);
@@ -698,7 +698,7 @@ public class ButtonHelperAgents {
 
         if ("xxchaagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Ggrocuto Rinn (Xxcha Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("xxchaagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             String message = " Use buttons to ready a planet. Removing the infantry is not automated but is an option for you to do.";
@@ -713,7 +713,7 @@ public class ButtonHelperAgents {
 
         if ("yinagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Brother Milor (Yin Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNFaction = rest.replace("yinagent_", "");
             String pos = posNFaction.split("_")[0];
             String faction = posNFaction.split("_")[1];
@@ -727,7 +727,7 @@ public class ButtonHelperAgents {
 
         if ("naaluagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Z'eu (Naalu Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("naaluagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -748,14 +748,14 @@ public class ButtonHelperAgents {
 
         if ("olradinagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Baggil Wildpaw (Olradin Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             resolveOlradinAgentStep2(activeGame, p2);
         }
         if ("solagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Evelyn Delouis (Sol Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             MessageHelper.sendMessageToChannel(event.getMessageChannel(), ButtonHelper.getIdentOrColor(p2, activeGame) + " will receive " + ssruu + "Evelyn Delouis (Sol Agent) on their next roll");
@@ -763,7 +763,7 @@ public class ButtonHelperAgents {
         }
         if ("letnevagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Viscount Unlenn (Letnev Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             MessageHelper.sendMessageToChannel(event.getMessageChannel(), ButtonHelper.getIdentOrColor(p2, activeGame) + " will receive " + ssruu + "Viscount Unlenn (Letnev Agent) on their next roll");
@@ -772,7 +772,7 @@ public class ButtonHelperAgents {
 
         if ("cymiaeagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Skhot Unit X-12 (Cymiae Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -803,7 +803,7 @@ public class ButtonHelperAgents {
 
         if ("mentakagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Suffi An (Mentak Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("mentakagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -856,7 +856,7 @@ public class ButtonHelperAgents {
 
         if ("sardakkagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "T'ro An (N'orr Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNPlanet = rest.replace("sardakkagent_", "");
             String pos = posNPlanet.split("_")[0];
             String planetName = posNPlanet.split("_")[1];
@@ -868,14 +868,14 @@ public class ButtonHelperAgents {
         }
         if ("argentagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Trillossa Aun Mirik (Argent Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String pos = rest.replace("argentagent_", "");
             Tile tile = activeGame.getTileByPosition(pos);
             addArgentAgentButtons(tile, player, activeGame);
         }
         if ("nomadagentmercer".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Field Marshal Mercer (Nomad Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNPlanet = rest.replace("nomadagentmercer_", "");
             String planetName = posNPlanet.split("_")[1];
             List<Button> buttons = ButtonHelper.getButtonsForMovingGroundForcesToAPlanet(activeGame, planetName,
@@ -887,7 +887,7 @@ public class ButtonHelperAgents {
         }
         if ("l1z1xagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "I48S (L1Z1X Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNPlanet = rest.replace("l1z1xagent_", "");
             String pos = posNPlanet.split("_")[0];
             String planetName = posNPlanet.split("_")[1];
@@ -902,7 +902,7 @@ public class ButtonHelperAgents {
 
         if ("muaatagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Umbat (Muaat Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("muaatagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -921,17 +921,17 @@ public class ButtonHelperAgents {
         }
         if ("bentoragent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "C.O.O. Mgur (Bentor Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveBentorAgentStep2(player, activeGame, event, rest);
         }
         if ("kortaliagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Queen Lucreia (Kortali Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveKortaliAgentStep2(player, activeGame, event, rest);
         }
         if ("mortheusagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Walik (Mortheus Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             List<Button> buttons = new ArrayList<>();
@@ -943,22 +943,22 @@ public class ButtonHelperAgents {
         }
         if ("cheiranagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Operator Kkavras (Cheiran Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveCheiranAgentStep1(player, activeGame, event, rest);
         }
         if ("freesystemsagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Cordo Haved (Free Systems Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveFreeSystemsAgentStep1(player, activeGame, event, rest);
         }
         if ("florzenagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Sal Gavda (Florzen Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveFlorzenAgentStep1(player, activeGame, event, rest);
         }
         if ("dihmohnagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Jgin Faru (Dih-Mohn Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String planet = rest.split("_")[1];
             new AddUnits().unitParsing(event, player.getColor(), activeGame.getTileFromPlanet(planet),
                 "1 inf " + planet, activeGame);
@@ -968,12 +968,12 @@ public class ButtonHelperAgents {
         }
         if ("vadenagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Yudri Sukhov (Vaden Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveVadenAgentStep2(player, activeGame, event, rest);
         }
         if ("celdauriagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "George Nobin (Muaat Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveCeldauriAgentStep2(player, activeGame, event, rest);
         }
         // if ("celdauriagent".equalsIgnoreCase(agent)) {
@@ -981,22 +981,22 @@ public class ButtonHelperAgents {
         // }
         if ("zealotsagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Priestess Tuh (Zealots Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveZealotsAgentStep2(player, activeGame, event, rest);
         }
         if ("nokaragent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Sal Sparrow (Nokar Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveNokarAgentStep2(player, activeGame, event, rest);
         }
         if ("zelianagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Zelian A (Zelian Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveZelianAgentStep2(player, activeGame, event, rest);
         }
         if ("mirvedaagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Logic Machina (Mirveda  Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2.getStrategicCC() < 1) {
@@ -1019,7 +1019,7 @@ public class ButtonHelperAgents {
         }
         if ("ghotiagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Becece (Ghoti Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             Button getTech = Button.success("ghotiATG", "Use it for a ");
@@ -1035,7 +1035,7 @@ public class ButtonHelperAgents {
 
         if ("arborecagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Letani Ospha (Arborec Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("arborecagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -1047,7 +1047,7 @@ public class ButtonHelperAgents {
         }
         if ("kolumeagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Disciple Fran (Kolume Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("kolumeagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -1065,7 +1065,7 @@ public class ButtonHelperAgents {
         }
         if ("axisagent".equalsIgnoreCase(agent)) {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Shipmonger Zsknck (Axis Agent)";
-			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("axisagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -1119,7 +1119,7 @@ public class ButtonHelperAgents {
                 buttons2.add(Button.danger("deleteButtons", "Decline"));
                 String msg = p2.getRepresentation(true, true)
                     + " you have the opportunity to exhaust your TCS tech to ready " + agent
-					+ " and potentially resolve a transaction.";
+                    + " and potentially resolve a transaction.";
                 MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(p2, activeGame), msg,
                     buttons2);
             }
@@ -1671,7 +1671,7 @@ public class ButtonHelperAgents {
         String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " place a destroyer in "
             + tile.getRepresentationForButtons(activeGame, player)
             + " due to " + (bentor.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent). "
-			+ "A transaction can be done with transaction buttons.";
+            + "A transaction can be done with transaction buttons.";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg);
         if (activeGame.isFoWMode() && bentor != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(bentor, activeGame), msg);
@@ -1701,7 +1701,7 @@ public class ButtonHelperAgents {
         new AddUnits().unitParsing(event, player.getColor(), tile, "1 mech", activeGame);
         String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " replace an inf with a mech in "
             + tile.getRepresentationForButtons(activeGame, player)
-			+ " due to " + (bentor.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent).";
+            + " due to " + (bentor.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent).";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg);
         if (activeGame.isFoWMode() && bentor != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(bentor, activeGame), msg);
@@ -2130,7 +2130,7 @@ public class ButtonHelperAgents {
         if (player.hasUnexhaustedLeader("nomadagentartuno")) {
             List<Button> buttons = new ArrayList<>();
             buttons.add(Button.success("exhaustAgent_nomadagentartuno_" + tg,
-			                           "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Artuno the Betrayer (Nomad Agent) With " + tg + " TGs"));
+                                       "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Artuno the Betrayer (Nomad Agent) With " + tg + " TGs"));
             buttons.add(Button.danger("deleteButtons", "Decline"));
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
                 player.getRepresentation(true, true)

--- a/src/main/java/ti4/helpers/ButtonHelperAgents.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAgents.java
@@ -155,7 +155,7 @@ public class ButtonHelperAgents {
                 "Unable to resolve player, please resolve manually.");
             return;
         }
-		int commodities = p2.getCommodities();
+		Integer commodities = p2.getCommodities();
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, activeGame),
             p2.getRepresentation(true, true) + " a " + unit
                 + " of yours has been captured by " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "The Stillness of Stars (Vuil'Raith Agent). "
@@ -477,7 +477,7 @@ public class ButtonHelperAgents {
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, activeGame), message);
         if (activeGame.isFoWMode()) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame),
-                ButtonHelper.getIdentOrColor(p2, activeGame) + " gained an AC from using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)"");
+                ButtonHelper.getIdentOrColor(p2, activeGame) + " gained an AC from using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)");
         }
         event.getMessage().delete().queue();
     }

--- a/src/main/java/ti4/helpers/ButtonHelperAgents.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAgents.java
@@ -71,10 +71,11 @@ public class ButtonHelperAgents {
             }
             if (cabal.hasUnexhaustedLeader("cabalagent")) {
                 List<Button> buttons = new ArrayList<>();
-                String msg = cabal.getRepresentation(true, true) + " you have the ability to use cabal agent on "
+                String msg = cabal.getRepresentation(true, true) + " you have the ability to use " + (cabal.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + " The Stillness of Stars (Vuil'raith Agent) on "
                     + ButtonHelper.getIdentOrColor(p2, activeGame) + " who has "
                     + p2.getCommoditiesTotal() + " commodities";
-                buttons.add(Button.success("exhaustAgent_cabalagent_startCabalAgent_" + p2.getFaction(), "Use Agent"));
+                buttons.add(Button.success("exhaustAgent_cabalagent_startCabalAgent_" + p2.getFaction(),
+				                           "Use " + (cabal.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + " The Stillness of Stars (Vuil'raith Agent)"));
                 buttons.add(Button.danger("deleteButtons", "Decline"));
                 MessageHelper.sendMessageToChannelWithButtons(cabal.getCardsInfoThread(), msg, buttons);
             }
@@ -154,10 +155,12 @@ public class ButtonHelperAgents {
                 "Unable to resolve player, please resolve manually.");
             return;
         }
+		int commodities = p2.getCommodities();
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, activeGame),
             p2.getRepresentation(true, true) + " a " + unit
-                + " of yours has been captured by a cabal agent. Any comms you had have been washed.");
-        p2.setTg(p2.getTg() + p2.getCommodities());
+                + " of yours has been captured by " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "The Stillness of Stars (Vuil'Raith Agent). "
+				+ "Rejoice, for your " + commodities.toString() + " commodities been washed.");
+        p2.setTg(p2.getTg() + commodities);
         p2.setCommodities(0);
         ButtonHelperFactionSpecific.cabalEatsUnit(p2, activeGame, player, 1, unit, event, true);
         event.getMessage().delete().queue();
@@ -298,7 +301,7 @@ public class ButtonHelperAgents {
         ButtonHelperAbilities.pillageCheck(p2, activeGame);
         resolveArtunoCheck(p2, activeGame, 2);
         String msg2 = ButtonHelper.getIdentOrColor(player, activeGame) + " selected "
-            + ButtonHelper.getIdentOrColor(p2, activeGame) + " as user of Nekro agent";
+            + ButtonHelper.getIdentOrColor(p2, activeGame) + " as user of " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Nekro Malleon (Nekro Agent)";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg2);
         String message = p2.getRepresentation(true, true) + " increased your tgs by 2 (" + (p2.getTg() - 2) + "->"
             + p2.getTg()
@@ -332,7 +335,7 @@ public class ButtonHelperAgents {
         String faction = buttonID.split("_")[1];
         Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
         String msg2 = ButtonHelper.getIdentOrColor(player, activeGame) + " selected "
-            + ButtonHelper.getIdentOrColor(p2, activeGame) + " as user of Kollecc agent";
+            + ButtonHelper.getIdentOrColor(p2, activeGame) + " as user of " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Captain Dust (Kollecc Agent)";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg2);
         List<Button> buttons = getKolleccAgentButtons(activeGame, p2);
         MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
@@ -383,7 +386,7 @@ public class ButtonHelperAgents {
             cabalAgentInitiation(activeGame, p2);
             message = "Refreshed " + ButtonHelper.getIdentOrColor(p2, activeGame) + "'s commodities";
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, activeGame),
-                p2.getRepresentation(true, true) + " your commodities were refreshed by hacan agent");
+                p2.getRepresentation(true, true) + " your commodities were refreshed by " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Carth of Golden Sands (Hacan Agent)");
         }
         if (p2.hasAbility("military_industrial_complex")
             && ButtonHelperAbilities.getBuyableAxisOrders(p2, activeGame).size() > 1) {
@@ -460,9 +463,10 @@ public class ButtonHelperAgents {
                 }
             }
         }
-        unitButtons.add(Button.danger("deleteButtons_spitItOut", "Done Using Argent Agent"));
+        unitButtons.add(Button.danger("deleteButtons_spitItOut",
+		                              "Done Using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Trillossa Aun Mirik (Argent Agent)"));
         MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
-            player.getRepresentation(true, true) + " use buttons to place ground forces via argent agent",
+            player.getRepresentation(true, true) + " use buttons to place ground forces via " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Trillossa Aun Mirik (Argent Agent)",
             unitButtons);
     }
 
@@ -473,7 +477,7 @@ public class ButtonHelperAgents {
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, activeGame), message);
         if (activeGame.isFoWMode()) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame),
-                ButtonHelper.getIdentOrColor(p2, activeGame) + " gained an AC due to agent usage");
+                ButtonHelper.getIdentOrColor(p2, activeGame) + " gained an AC from using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yvin Korduul (Vaylerian Agent)"");
         }
         event.getMessage().delete().queue();
     }
@@ -501,39 +505,45 @@ public class ButtonHelperAgents {
         playerLeader.setExhausted(true);
 
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), Emojis.getFactionLeaderEmoji(playerLeader));
-        String messageText = player.getRepresentation() +
-            " exhausted " + Helper.getLeaderFullRepresentation(playerLeader);
+		String ssruu = "";
         if ("yssarilagent".equalsIgnoreCase(playerLeader.getId())) {
-            messageText = messageText + "\n" + "Yssaril agent was used as a "
-                + StringUtils.capitalize(agent.replace("agent", "")) + " agent";
+            ssruu = "Clever Clever ";
         }
         if ("nomadagentartuno".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Artuno the Betrayer (Nomad Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             playerLeader.setTgCount(Integer.parseInt(rest.split("_")[1]));
-            messageText = messageText + "\n" + rest.split("_")[1] + " " + Emojis.getTGorNomadCoinEmoji(activeGame)
-                + " was placed on top of the leader";
+            String messageText = player.getRepresentation() + " placed " + rest.split("_")[1] + " " + Emojis.getTGorNomadCoinEmoji(activeGame)
+                + " on top of " + ssruu + "Artuno the Betrayer (Nomad Agent)";
+			MessageHelper.sendMessageToChannel(channel2, messageText);
         }
-        MessageHelper.sendMessageToChannel(channel2, messageText);
         if ("naazagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Garv and Gunn (Naaz-Rokha Agents)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             List<Button> buttons = ButtonHelper.getButtonsToExploreAllPlanets(player, activeGame);
             MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), "Use buttons to explore", buttons);
         }
 
         if ("augersagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Clodho (Augers Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             Player p2 = activeGame.getPlayerFromColorOrFaction(rest.split("_")[1]);
             int oldTg = p2.getTg();
             p2.setTg(oldTg + 2);
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, activeGame),
-                ButtonHelper.getIdentOrColor(player, activeGame) + " gained 2tg due to Augers Agent being used ("
+                ButtonHelper.getIdentOrColor(player, activeGame) + " gained 2TGs from " + ssruu + "Clodho (Augers Agent) being used ("
                     + oldTg + "->" + p2.getTg() + ")");
             if (activeGame.isFoWMode()) {
                 MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame),
-                    ButtonHelper.getIdentOrColor(p2, activeGame) + " gained 2tg due to agent usage");
+                    ButtonHelper.getIdentOrColor(p2, activeGame) + " gained 2TGs due to agent usage");
             }
             ButtonHelperAbilities.pillageCheck(p2, activeGame);
             resolveArtunoCheck(p2, activeGame, 2);
         }
 
         if ("vaylerianagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Yvin Korduul (Vaylerian Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             if (rest.contains("_")) {
                 Player p2 = activeGame.getPlayerFromColorOrFaction(rest.split("_")[1]);
                 String message = ButtonHelper.resolveACDraw(p2, activeGame, event);
@@ -543,12 +553,14 @@ public class ButtonHelperAgents {
                         ButtonHelper.getIdentOrColor(p2, activeGame) + " gained an AC due to agent usage");
                 }
             } else {
-                String message = trueIdentity + " select faction you wish to use your agent on";
+                String message = trueIdentity + " select faction you wish to use " + ssruu + "Yvin Korduul (Vaylerian Agent) on";
                 List<Button> buttons = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "vaylerianAgent", null);
                 MessageHelper.sendMessageToChannelWithButtons(channel2, message, buttons);
             }
         }
         if ("kjalengardagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Merkismathr Asvand (Kjalengard Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             Player activePlayer = activeGame.getActivePlayer();
             if (activePlayer != null) {
                 int oldComms = activePlayer.getCommodities();
@@ -559,7 +571,7 @@ public class ButtonHelperAgents {
                 activePlayer.setCommodities(newComms);
                 MessageHelper.sendMessageToChannel(event.getMessageChannel(),
                     ButtonHelper.getIdent(player)
-                        + " exhausted kjal agent to potentially move a glory token into the system. "
+                        + " exhausted " + ssruu + "Merkismathr Asvand (Kjalengard Agent) to potentially move a glory token into the system. "
                         + ButtonHelper.getIdent(activePlayer) + " comms went from " + oldComms + " -> "
                         + newComms + ".");
             }
@@ -568,20 +580,27 @@ public class ButtonHelperAgents {
             } else {
                 MessageHelper.sendMessageToChannel(event.getMessageChannel(),
                     ButtonHelper.getIdent(player)
-                        + " there were no glory tokens on the board to move. Go win some battles and earn some, or your ancestors will laugh at ya when you reach Valhalla");
+                        + " there were no glory tokens on the board to move. Go win some battles and earn some, or your ancestors will laugh at ya when "
+						+ (ThreadLocalRandom.current().nextInt(20) == 0 ? "(if) " : "") + "you reach Valhalla");
 
             }
         }
         if ("cabalagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "The Stillness of Stars (Vuil'Raith Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             startCabalAgent(player, activeGame, rest.replace("cabalagent_", ""), event);
         }
         if ("jolnaragent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Doctor Sucaban (Jol-Nar Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String msg = player.getRepresentation(true, true) + " you can use the buttons to remove infantry.";
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame), msg,
                 getJolNarAgentButtons(player, activeGame));
         }
 
         if ("empyreanagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Acamar (Empyrean Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             List<Button> buttons = ButtonHelper.getGainCCButtons(player);
             String message2 = trueIdentity + "! Your current CCs are " + player.getCCRepresentation()
                 + ". Use buttons to gain CCs";
@@ -589,28 +608,36 @@ public class ButtonHelperAgents {
             activeGame.setStoredValue("originalCCsFor" + player.getFaction(), player.getCCRepresentation());
         }
         if ("mykomentoriagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Lactarius Indigo (Myko-Mentori Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             ButtonHelperAbilities.offerOmenDiceButtons(activeGame, player);
         }
         if ("gledgeagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Durran (Gledge Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
                 return;
-            p2.addSpentThing("Exhausted Gledge Agent for +3 Production Capacity");
+            p2.addSpentThing("Exhausted " + ssruu + "Durran (Gledge Agent) for +3 Production Capacity");
         }
         if ("khraskagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Udosh B'rtul (Khrask Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
                 return;
-            p2.addSpentThing("Exhausted Khrask Agent to spend 1 non-Home planets Resources as Influence");
+            p2.addSpentThing("Exhausted " + ssruu + "Udosh B'rtul (Khrask Agent) to spend 1 non-home planet's Resources as additional Influence");
         }
         if ("rohdhnaagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Rond Bri'ay (Roh'Dhna Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
                 return;
-            p2.addSpentThing("Exhausted Rohdna Agent for a CC");
+            p2.addSpentThing("Exhausted " + ssruu + "Rond Bri'ay (Roh'Dhna Agent) for a CC");
             List<Button> buttons = ButtonHelper.getGainCCButtons(player);
             String trueIdentity2 = p2.getRepresentation(true, true);
             String message2 = trueIdentity2 + "! Your current CCs are " + p2.getCCRepresentation()
@@ -620,16 +647,22 @@ public class ButtonHelperAgents {
                 buttons);
         }
         if ("veldyragent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Solis Morden (Veldyr Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
                 return;
-            p2.addSpentThing("Exhausted Veldyr Agent to pay with one planets influence instead of resources");
+            p2.addSpentThing("Exhausted " + ssruu + "Solis Morden (Veldyr Agent) to pay with one planets influence instead of resources");
         }
         if ("winnuagent".equalsIgnoreCase(agent)) {
-            player.addSpentThing("Exhausted Winnu Agent for 2 resources");
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Berekar Berekon (Winnu Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            player.addSpentThing("Exhausted " + ssruu + "Berekar Berekon (Winnu Agent) for 2 resources");
         }
         if ("lizhoagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Vasra Ivo (Li-Zho Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             List<Button> buttons = new ArrayList<>(
                 Helper.getTileWithShipsPlaceUnitButtons(player, activeGame, "2ff", "placeOneNDone_skipbuild"));
             String message = "Use buttons to put 2 fighters with your ships";
@@ -638,18 +671,24 @@ public class ButtonHelperAgents {
         }
 
         if ("nekroagent".equalsIgnoreCase(agent)) {
-            String message = trueIdentity + " select faction you wish to use your agent on";
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Nekro Malleon (Nekro Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            String message = trueIdentity + " select faction you wish to use " + ssruu + "Nekro Malleon (Nekro Agent) on";
             List<Button> buttons = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "nekroAgentRes", null);
             MessageHelper.sendMessageToChannelWithButtons(channel2, message, buttons);
         }
         if ("kolleccagent".equalsIgnoreCase(agent)) {
-            String message = trueIdentity + " select faction you wish to use your agent on";
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Captain Dust (Kollecc Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            String message = trueIdentity + " select faction you wish to use " + ssruu + "Captain Dust (Kollecc Agent) on";
             List<Button> buttons = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "kolleccAgentRes", null);
             MessageHelper.sendMessageToChannelWithButtons(channel2, message, buttons);
         }
 
         if ("hacanagent".equalsIgnoreCase(agent)) {
-            String message = trueIdentity + " select faction you wish to use your agent on";
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Carth of Golden Sands (Hacan Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
+            String message = trueIdentity + " select faction you wish to use " + ssruu + "Carth of Golden Sands (Hacan Agent) on";
             List<Button> buttons = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "hacanAgentRefresh", null);
             MessageHelper.sendMessageToChannelWithButtons(channel2, message, buttons);
         }
@@ -658,6 +697,8 @@ public class ButtonHelperAgents {
         }
 
         if ("xxchaagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Ggrocuto Rinn (Xxcha Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("xxchaagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             String message = " Use buttons to ready a planet. Removing the infantry is not automated but is an option for you to do.";
@@ -671,6 +712,8 @@ public class ButtonHelperAgents {
         }
 
         if ("yinagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Brother Milor (Yin Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNFaction = rest.replace("yinagent_", "");
             String pos = posNFaction.split("_")[0];
             String faction = posNFaction.split("_")[1];
@@ -678,11 +721,13 @@ public class ButtonHelperAgents {
             if (p2 == null)
                 return;
             MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(),
-                p2.getRepresentation(true, true) + " Use buttons to resolve yin agent",
+                p2.getRepresentation(true, true) + " Use buttons to resolve " + ssruu + "Brother Milor (Yin Agent)",
                 getYinAgentButtons(p2, activeGame, pos));
         }
 
         if ("naaluagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Z'eu (Naalu Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("naaluagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -697,37 +742,43 @@ public class ButtonHelperAgents {
             List<Button> ringButtons = ButtonHelper.getPossibleRings(p2, activeGame);
             activeGame.resetCurrentMovedUnitsFrom1TacticalAction();
             MessageHelper.sendMessageToChannelWithButtons(channel, p2.getRepresentation(true, true)
-                + " Use buttons to resolve tactical action from Naalu agent. Reminder it is not legal to do a tactical action in a home system.\n"
+                + " Use buttons to resolve tactical action from " + ssruu + "Z'eu (Naalu Agent). Reminder it is not legal to do a tactical action in a home system.\n"
                 + message, ringButtons);
         }
 
         if ("olradinagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Baggil Wildpaw (Olradin Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             resolveOlradinAgentStep2(activeGame, p2);
         }
         if ("solagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Evelyn Delouis (Sol Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
-            MessageHelper.sendMessageToChannel(event.getMessageChannel(),
-                ButtonHelper.getIdentOrColor(p2, activeGame) + " will receive Sol agent on their next roll");
-            activeGame.setStoredValue("solagent", p2.getFaction());
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), ButtonHelper.getIdentOrColor(p2, activeGame) + " will receive " + ssruu + "Evelyn Delouis (Sol Agent) on their next roll");
+            activeGame.setCurrentReacts("solagent", p2.getFaction());
         }
         if ("letnevagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Viscount Unlenn (Letnev Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
-            MessageHelper.sendMessageToChannel(event.getMessageChannel(),
-                ButtonHelper.getIdentOrColor(p2, activeGame) + " will receive Letnev agent on their next roll");
-            activeGame.setStoredValue("letnevagent", p2.getFaction());
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), ButtonHelper.getIdentOrColor(p2, activeGame) + " will receive " + ssruu + "Viscount Unlenn (Letnev Agent) on their next roll");
+            activeGame.setCurrentReacts("letnevagent", p2.getFaction());
         }
 
         if ("cymiaeagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Skhot Unit X-12 (Cymiae Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
                 return;
             String message = "";
-            String successMessage2 = ButtonHelper.getIdent(p2) + " drew an AC due to Cymiae Agent.";
+            String successMessage2 = ButtonHelper.getIdent(p2) + " drew an AC due to " + ssruu + "Skhot Unit X-12 (Cymiae Agent).";
             if (p2.hasAbility("scheming")) {
                 activeGame.drawActionCard(p2.getUserID());
                 successMessage2 += " Drew another AC for scheming. Please discard 1";
@@ -739,7 +790,7 @@ public class ButtonHelperAgents {
                 activeGame.drawActionCard(p2.getUserID());
             }
             ButtonHelper.checkACLimit(activeGame, event, p2);
-            String headerText2 = p2.getRepresentation(true, true) + " you got an AC due to Cymiae Agent";
+            String headerText2 = p2.getRepresentation(true, true) + " you got an AC due to " + ssruu + "Skhot Unit X-12 (Cymiae Agent)";
             MessageHelper.sendMessageToPlayerCardsInfoThread(p2, activeGame, headerText2);
             ACInfo.sendActionCardInfo(activeGame, p2);
             if (p2.hasAbility("scheming")) {
@@ -751,6 +802,8 @@ public class ButtonHelperAgents {
         }
 
         if ("mentakagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Suffi An (Mentak Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("mentakagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -781,10 +834,10 @@ public class ButtonHelperAgents {
 
             ButtonHelper.checkACLimit(activeGame, event, player);
             ButtonHelper.checkACLimit(activeGame, event, p2);
-            String headerText = player.getRepresentation(true, true) + " you got an AC from Mentak Agent";
+            String headerText = player.getRepresentation(true, true) + " you got an AC from " + ssruu + "Suffi An (Mentak Agent)";
             MessageHelper.sendMessageToPlayerCardsInfoThread(player, activeGame, headerText);
             ACInfo.sendActionCardInfo(activeGame, player);
-            String headerText2 = p2.getRepresentation(true, true) + " you got an AC from Mentak Agent";
+            String headerText2 = p2.getRepresentation(true, true) + " you got an AC from " + ssruu + "Suffi An (Mentak Agent)";
             MessageHelper.sendMessageToPlayerCardsInfoThread(p2, activeGame, headerText2);
             ACInfo.sendActionCardInfo(activeGame, p2);
             if (p2.hasAbility("scheming")) {
@@ -802,31 +855,39 @@ public class ButtonHelperAgents {
         }
 
         if ("sardakkagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "T'ro An (N'orr Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNPlanet = rest.replace("sardakkagent_", "");
             String pos = posNPlanet.split("_")[0];
             String planetName = posNPlanet.split("_")[1];
             new AddUnits().unitParsing(event, player.getColor(), activeGame.getTileByPosition(pos),
-                "2 gf " + planetName, activeGame);
+                "2 GFs " + planetName, activeGame);
             String successMessage = ident + " placed 2 " + Emojis.infantry + " on "
                 + Helper.getPlanetRepresentation(planetName, activeGame) + ".";
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), successMessage);
         }
         if ("argentagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Trillossa Aun Mirik (Argent Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String pos = rest.replace("argentagent_", "");
             Tile tile = activeGame.getTileByPosition(pos);
             addArgentAgentButtons(tile, player, activeGame);
         }
         if ("nomadagentmercer".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Field Marshal Mercer (Nomad Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNPlanet = rest.replace("nomadagentmercer_", "");
             String planetName = posNPlanet.split("_")[1];
             List<Button> buttons = ButtonHelper.getButtonsForMovingGroundForcesToAPlanet(activeGame, planetName,
                 player);
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
                 player.getRepresentation(true, true)
-                    + " use buttons to resolve move of mercer units to this planet",
+                    + " use buttons to resolve move of ground forces to this planet with" + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Field Marshal Mercer (Nomad Agent)",
                 buttons);
         }
         if ("l1z1xagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "I48S (L1Z1X Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String posNPlanet = rest.replace("l1z1xagent_", "");
             String pos = posNPlanet.split("_")[0];
             String planetName = posNPlanet.split("_")[1];
@@ -840,12 +901,14 @@ public class ButtonHelperAgents {
         }
 
         if ("muaatagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Umbat (Muaat Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("muaatagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
                 return;
             MessageChannel channel = ButtonHelper.getCorrectChannel(p2, activeGame);
-            String message = "Use buttons to select which tile to Umbat in";
+            String message = "Use buttons to select which tile to " + ssruu + "Umbat (Muaat Agent) in";
             List<Tile> tiles = ButtonHelper.getTilesOfPlayersSpecificUnits(activeGame, p2, UnitType.Warsun,
                 UnitType.Flagship);
             List<Button> buttons = new ArrayList<>();
@@ -857,12 +920,18 @@ public class ButtonHelperAgents {
             MessageHelper.sendMessageToChannelWithButtons(channel, p2.getRepresentation(true, true) + message, buttons);
         }
         if ("bentoragent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "C.O.O. Mgur (Bentor Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveBentorAgentStep2(player, activeGame, event, rest);
         }
         if ("kortaliagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Queen Lucreia (Kortali Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveKortaliAgentStep2(player, activeGame, event, rest);
         }
         if ("mortheusagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Walik (Mortheus Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             List<Button> buttons = new ArrayList<>();
@@ -873,42 +942,61 @@ public class ButtonHelperAgents {
                 buttons);
         }
         if ("cheiranagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Operator Kkavras (Cheiran Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveCheiranAgentStep1(player, activeGame, event, rest);
         }
         if ("freesystemsagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Cordo Haved (Free Systems Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveFreeSystemsAgentStep1(player, activeGame, event, rest);
         }
         if ("florzenagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Sal Gavda (Florzen Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveFlorzenAgentStep1(player, activeGame, event, rest);
         }
         if ("dihmohnagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Jgin Faru (Dih-Mohn Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String planet = rest.split("_")[1];
             new AddUnits().unitParsing(event, player.getColor(), activeGame.getTileFromPlanet(planet),
                 "1 inf " + planet, activeGame);
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame),
                 ButtonHelper.getIdent(player) + " landed an extra infantry on "
-                    + Helper.getPlanetRepresentation(planet, activeGame)
-                    + " using Dihmohn agent [Note, you need to commit something else to the planet besides this extra infantry in order to use this agent]");
+                    + Helper.getPlanetRepresentation(planet, activeGame) + " using " + ssruu + "Jgin Faru (Dih-Mohn Agent) [Note, you need to commit something else to the planet besides this extra infantry in order to use this agent]");
         }
         if ("vadenagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Yudri Sukhov (Vaden Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveVadenAgentStep2(player, activeGame, event, rest);
         }
         if ("celdauriagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "George Nobin (Muaat Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveCeldauriAgentStep2(player, activeGame, event, rest);
         }
         // if ("celdauriagent".equalsIgnoreCase(agent)) {
         // resolveCeldauriAgentStep2(player, activeGame, event, rest);
         // }
         if ("zealotsagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Priestess Tuh (Zealots Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveZealotsAgentStep2(player, activeGame, event, rest);
         }
         if ("nokaragent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Sal Sparrow (Nokar Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveNokarAgentStep2(player, activeGame, event, rest);
         }
         if ("zelianagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Zelian A (Zelian Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             resolveZelianAgentStep2(player, activeGame, event, rest);
         }
         if ("mirvedaagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Logic Machina (Mirveda  Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2.getStrategicCC() < 1) {
@@ -923,37 +1011,43 @@ public class ButtonHelperAgents {
             MessageChannel channel = ButtonHelper.getCorrectChannel(p2, activeGame);
             ButtonHelperCommanders.resolveMuaatCommanderCheck(p2, activeGame, event);
             String message0 = p2.getRepresentation(true, true)
-                + "A CC has been subtracted from your strat pool due to use of mirveda agent. You can add it back if you didnt agree to the agent";
+                + "A cc has been subtracted from your strat pool due to use of " + ssruu + "Logic Machina (Mirveda  Agent). You can add it back if you didn't agree to the agent";
             String message = p2.getRepresentation(true, true)
                 + " Use buttons to get a tech of a color which matches one of the unit upgrades pre-reqs";
             MessageHelper.sendMessageToChannel(channel, message0);
             MessageHelper.sendMessageToChannelWithButtons(channel, message, buttons);
         }
         if ("ghotiagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Becece (Ghoti Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.split("_")[1];
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             Button getTech = Button.success("ghotiATG", "Use it for a ");
             List<Button> buttons = new ArrayList<>();
-            buttons.add(Button.success("ghotiATG", "Use to get Tg"));
+            buttons.add(Button.success("ghotiATG", "Use to get TG"));
             buttons.add(Button.secondary("ghotiAProd", "Use to produce +2 units"));
             buttons.add(Button.danger("deleteButtons", "Delete This"));
             MessageChannel channel = ButtonHelper.getCorrectChannel(p2, activeGame);
             String message = p2.getRepresentation(true, true)
-                + " Use buttons to decide to get a tg or to get to produce 2 more units";
+                + " Use buttons to decide to get a TG or to get to produce 2 more units";
             MessageHelper.sendMessageToChannelWithButtons(channel, message, buttons);
         }
 
         if ("arborecagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Letani Ospha (Arborec Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("arborecagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
                 return;
             MessageChannel channel = ButtonHelper.getCorrectChannel(p2, activeGame);
-            String message = "Use buttons to select which tile to use arborec agent in";
+            String message = "Use buttons to select which tile to use " + ssruu + "Letani Ospha (Arborec Agent) in";
             List<Button> buttons = getTilesToArboAgent(p2, activeGame, event);
             MessageHelper.sendMessageToChannelWithButtons(channel, p2.getRepresentation(true, true) + message, buttons);
         }
         if ("kolumeagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Disciple Fran (Kolume Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("kolumeagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -966,10 +1060,12 @@ public class ButtonHelperAgents {
             redistributeButton.add(deleButton);
             MessageHelper.sendMessageToChannelWithButtons(channel,
                 p2.getRepresentation(true, true)
-                    + " use buttons to redistribute 1 CC (the bot allows more but the agent is restricted to 1)",
+                    + " use buttons to redistribute 1 CC (the bot allows more but " + ssruu + "Disciple Fran (Kolume Agent) is restricted to 1)",
                 redistributeButton);
         }
         if ("axisagent".equalsIgnoreCase(agent)) {
+            String exhaustText = player.getRepresentation() + " has exhausted " + ssruu + "Shipmonger Zsknck (Axis Agent)";
+			MessageHelper.sendMessageToChannel(channel2, exhaustText);
             String faction = rest.replace("axisagent_", "");
             Player p2 = activeGame.getPlayerFromColorOrFaction(faction);
             if (p2 == null)
@@ -1023,7 +1119,7 @@ public class ButtonHelperAgents {
                 buttons2.add(Button.danger("deleteButtons", "Decline"));
                 String msg = p2.getRepresentation(true, true)
                     + " you have the opportunity to exhaust your TCS tech to ready " + agent
-                    + " and potentially resolve a transaction.";
+					+ " and potentially resolve a transaction.";
                 MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(p2, activeGame), msg,
                     buttons2);
             }
@@ -1083,7 +1179,7 @@ public class ButtonHelperAgents {
                     List<Button> buttons = TurnStart.getStartOfTurnButtons(newActivePlayer, activeGame, true, event);
                     MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(newActivePlayer, activeGame),
                         newActivePlayer.getRepresentation(true, true)
-                            + " you can take 1 action now due to Edyn Agent",
+                            + " you can take 1 action now due to " + (edyn.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Allant (Edyn Agent)",
                         buttons);
                     return true;
                 }
@@ -1316,7 +1412,7 @@ public class ButtonHelperAgents {
         new PlanetRefresh().doAction(p2, planetName, activeGame);
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame),
             ButtonHelper.getIdent(player) + " readied " + Helper.getPlanetRepresentation(planetName, activeGame)
-                + " with Olradin Agent");
+                + " with " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Baggil Wildpaw (Olradin Agent)");
         event.getMessage().delete();
 
     }
@@ -1390,7 +1486,7 @@ public class ButtonHelperAgents {
         new PlanetExhaustAbility().doAction(player, planet, activeGame, false);
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame),
             ButtonHelper.getIdent(player) + " chose to use " + Helper.getPlanetRepresentation(planet, activeGame)
-                + " ability. This did not exhaust the ability since it was done with free systems agent.");
+                + " ability. This did not exhaust the ability since it was done with " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Cordo Haved (Free Systems Agent).");
         event.getMessage().delete().queue();
     }
 
@@ -1400,8 +1496,8 @@ public class ButtonHelperAgents {
         Tile origTile = activeGame.getTileByPosition(pos);
         RemoveCC.removeCC(event, player.getColor(), origTile, activeGame);
         MessageHelper.sendMessageToChannel(event.getMessageChannel(),
-            ButtonHelper.getIdent(player) + " removed a CC from "
-                + origTile.getRepresentationForButtons(activeGame, player) + " using Cheiran Agent");
+            ButtonHelper.getIdent(player) + " removed a cc from "
+                + origTile.getRepresentationForButtons(activeGame, player) + " using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)");
         List<Button> buttons = new ArrayList<>();
         for (Tile tile : getAdjacentTilesWithStructuresInThem(player, activeGame, origTile)) {
             buttons.add(Button.success("cheiranAgentStep3_" + tile.getPosition(),
@@ -1422,8 +1518,8 @@ public class ButtonHelperAgents {
         Tile origTile = activeGame.getTileByPosition(pos);
         AddCC.addCC(event, player.getColor(), origTile, true);
         MessageHelper.sendMessageToChannel(event.getMessageChannel(),
-            ButtonHelper.getIdent(player) + " placed a CC in "
-                + origTile.getRepresentationForButtons(activeGame, player) + " using Cheiran Agent");
+            ButtonHelper.getIdent(player) + " placed a cc in "
+                + origTile.getRepresentationForButtons(activeGame, player) + " using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Operator Kkavras (Cheiran Agent)");
         event.getMessage().delete().queue();
     }
 
@@ -1445,14 +1541,14 @@ public class ButtonHelperAgents {
         player.setTg(fTG);
         ButtonHelperAbilities.pillageCheck(player, activeGame);
         resolveArtunoCheck(player, activeGame, 1);
-        String msg = "Used Ghoti Agent to gain a tg (" + cTG + "->" + fTG + "). ";
+        String msg = "Used " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent) to gain a TG (" + cTG + "->" + fTG + "). ";
         player.addSpentThing(msg);
         event.getMessage().delete().queue();
     }
 
     public static void ghotiAgentForProduction(String buttonID, ButtonInteractionEvent event, Game activeGame,
         Player player) {
-        String msg = "Used Ghoti Agent to gain the ability to produce 2 more units. ";
+        String msg = "Used " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent) to gain the ability to produce 2 more units. ";
         player.addSpentThing(msg);
         event.getMessage().delete().queue();
     }
@@ -1484,7 +1580,7 @@ public class ButtonHelperAgents {
         player.setCommodities(player.getCommodities() + commGain);
         String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " max influence planet had " + count
             + " influence, so they gained " + commGain + " comms (" + oldComm + "->"
-            + player.getCommodities() + ") due to Vaden agent";
+            + player.getCommodities() + ") due to " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Yudri Sukhov (Vaden Agent)";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg);
         if (activeGame.isFoWMode() && bentor != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(bentor, activeGame), msg);
@@ -1512,7 +1608,7 @@ public class ButtonHelperAgents {
         bentor.addFragment(frag);
         ExploreModel cardInfo = Mapper.getExplore(frag);
         String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " lost a " + cardInfo.getName() + " to "
-            + ButtonHelper.getIdentOrColor(bentor, activeGame) + " due to Kortali agent";
+            + ButtonHelper.getIdentOrColor(bentor, activeGame) + " due to " + (bentor.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Queen Lucreia (Kortali Agent)";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg);
         if (activeGame.isFoWMode() && bentor != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(bentor, activeGame), msg);
@@ -1545,7 +1641,7 @@ public class ButtonHelperAgents {
             }
         }
         String msg = ButtonHelper.getIdentOrColor(player, activeGame)
-            + " can produce a unit in their HS or in a system with a tech skip planet due to Zealots agent";
+            + " can produce a unit in their HS or in a system with a tech skip planet due to " + (zealots.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Priestess Tuh (Zealots Agent)";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg, buttons);
         if (activeGame.isFoWMode() && zealots != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(zealots, activeGame), msg);
@@ -1574,7 +1670,8 @@ public class ButtonHelperAgents {
         new AddUnits().unitParsing(event, player.getColor(), tile, "1 destroyer", activeGame);
         String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " place a destroyer in "
             + tile.getRepresentationForButtons(activeGame, player)
-            + " due to Nokar agent. A transaction can be done with transaction buttons.";
+            + " due to " + (bentor.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Sal Sparrow (Nokar Agent). "
+			+ "A transaction can be done with transaction buttons.";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg);
         if (activeGame.isFoWMode() && bentor != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(bentor, activeGame), msg);
@@ -1603,7 +1700,8 @@ public class ButtonHelperAgents {
         new RemoveUnits().unitParsing(event, player.getColor(), tile, "1 inf", activeGame);
         new AddUnits().unitParsing(event, player.getColor(), tile, "1 mech", activeGame);
         String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " replace an inf with a mech in "
-            + tile.getRepresentationForButtons(activeGame, player) + " due to Zelian agent.";
+            + tile.getRepresentationForButtons(activeGame, player)
+			+ " due to " + (bentor.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Zelian A (Zelian Agent).";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg);
         if (activeGame.isFoWMode() && bentor != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(bentor, activeGame), msg);
@@ -1627,7 +1725,7 @@ public class ButtonHelperAgents {
                 "Could not resolve target player, please resolve manually.");
             return;
         }
-        String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " replenished comms due to Kyro agent.";
+        String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " replenished comms due to " + (kyro.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Tox (Kyro Agent).";
         Player p2 = player;
         p2.setCommodities(p2.getCommoditiesTotal());
         ButtonHelper.resolveMinisterOfCommerceCheck(activeGame, p2, event);
@@ -1698,7 +1796,7 @@ public class ButtonHelperAgents {
         String buttonID) {
         String planet = buttonID.split("_")[1];
         String msg = ButtonHelper.getIdent(player) + " put a space dock on "
-            + Helper.getPlanetRepresentation(planet, activeGame) + " using Celdauri Agent";
+            + Helper.getPlanetRepresentation(planet, activeGame) + " using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)";
         new AddUnits().unitParsing(event, player.getColor(), activeGame.getTileFromPlanet(planet), "1 sd " + planet,
             activeGame);
         if (player.getCommodities() > 1) {
@@ -1747,7 +1845,7 @@ public class ButtonHelperAgents {
 
         player.setTg(oldTg + tgGain);
         String msg = ButtonHelper.getIdentOrColor(player, activeGame) + " gained " + tgGain + "tg (" + oldTg + "->"
-            + player.getTg() + ") and " + commGain + " commodities due to bentor agent";
+            + player.getTg() + ") and " + commGain + " commodities due to " + (bentor.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "C.O.O. Mgur (Bentor Agent)";
         MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(player, activeGame), msg);
         if (activeGame.isFoWMode() && bentor != player) {
             MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(bentor, activeGame), msg);
@@ -1885,7 +1983,7 @@ public class ButtonHelperAgents {
                 String planetRepresentation = Helper.getPlanetRepresentation(planetId, activeGame);
                 buttons.add(Button
                     .success("exhaustAgent_sardakkagent_" + activeGame.getActiveSystem() + "_" + planetId,
-                        "Use Sardakk Agent on " + planetRepresentation)
+                        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "T'ro (N'orr Agent) on " + planetRepresentation)
                     .withEmoji(Emoji.fromFormatted(Emojis.Sardakk)));
             }
         }
@@ -1908,7 +2006,7 @@ public class ButtonHelperAgents {
                 String planetRepresentation = Helper.getPlanetRepresentation(planetId, activeGame);
                 buttons.add(Button
                     .success("exhaustAgent_nomadagentmercer_" + activeGame.getActiveSystem() + "_" + planetId,
-                        "Use Nomad Agent General Mercer on " + planetRepresentation)
+                        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Field Marshal Mercer (Nomad Agent) on " + planetRepresentation)
                     .withEmoji(Emoji.fromFormatted(Emojis.Nomad)));
             }
         }
@@ -1931,7 +2029,7 @@ public class ButtonHelperAgents {
                 String planetRepresentation = Helper.getPlanetRepresentation(planetId, activeGame);
                 buttons.add(Button
                     .success("exhaustAgent_l1z1xagent_" + activeGame.getActiveSystem() + "_" + planetId,
-                        "Use L1Z1X Agent on " + planetRepresentation)
+                        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "I48S (L1Z1X Agent) on " + planetRepresentation)
                     .withEmoji(Emoji.fromFormatted(Emojis.L1Z1X)));
             }
         }
@@ -2012,13 +2110,13 @@ public class ButtonHelperAgents {
         String message;
         if ("cruiser".equalsIgnoreCase(buttonID.split("_")[1])) {
             MessageHelper.sendMessageToChannel(event.getChannel(),
-                ButtonHelper.getIdent(player) + " Chose to place 1 cruiser with their ships from Axis Agent");
+                ButtonHelper.getIdent(player) + " Chose to place 1 cruiser with their ships from " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Shipmonger Zsknck (Axis Agent)");
             buttons.addAll(
                 Helper.getTileWithShipsPlaceUnitButtons(player, activeGame, "cruiser", "placeOneNDone_skipbuild"));
             message = " Use buttons to put 1 cruiser with your ships";
         } else {
             MessageHelper.sendMessageToChannel(event.getChannel(),
-                ButtonHelper.getIdent(player) + " Chose to place 1 destroyer with their ships from Axis Agent");
+                ButtonHelper.getIdent(player) + " Chose to place 1 destroyer with their ships from " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Shipmonger Zsknck (Axis Agent)");
             buttons.addAll(
                 Helper.getTileWithShipsPlaceUnitButtons(player, activeGame, "cruiser", "placeOneNDone_skipbuild"));
             message = " Use buttons to put 1 destroyer with your ships";
@@ -2031,11 +2129,12 @@ public class ButtonHelperAgents {
     public static void resolveArtunoCheck(Player player, Game activeGame, int tg) {
         if (player.hasUnexhaustedLeader("nomadagentartuno")) {
             List<Button> buttons = new ArrayList<>();
-            buttons.add(Button.success("exhaustAgent_nomadagentartuno_" + tg, "Exhaust Artuno with " + tg + " tg"));
+            buttons.add(Button.success("exhaustAgent_nomadagentartuno_" + tg,
+			                           "Exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Artuno the Betrayer (Nomad Agent) With " + tg + " TGs"));
             buttons.add(Button.danger("deleteButtons", "Decline"));
             MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
                 player.getRepresentation(true, true)
-                    + " you have the opportunity to exhaust your agent Artuno and place " + tg + " tg on her.",
+                    + " you have the opportunity to exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Artuno the Betrayer (Nomad Agent) and place " + tg + " TGs on her.",
                 buttons);
         }
     }
@@ -2044,7 +2143,7 @@ public class ButtonHelperAgents {
         String ident, String trueIdentity) {
         List<Button> buttons = ButtonHelper.getButtonsForAgentSelection(activeGame, buttonID);
         MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(),
-            trueIdentity + " Use buttons to select faction to give agent to.", buttons);
+            trueIdentity + " Use buttons to select faction to give " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Brother Milor (Yin Agent) to.", buttons);
         String exhaustedMessage = event.getMessage().getContentRaw();
         if (exhaustedMessage.length() < 1) {
             exhaustedMessage = "Combat";
@@ -2089,7 +2188,7 @@ public class ButtonHelperAgents {
         }
         MessageHelper.sendMessageToChannel(event.getChannel(),
             ButtonHelper.getIdent(player) + " removed 1 infantry from "
-                + ButtonHelper.getUnitHolderRep(unitHolder, tile, activeGame) + " using Jol Nar agent");
+                + ButtonHelper.getUnitHolderRep(unitHolder, tile, activeGame) + " using " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Doctor Sucaban (Jol-Nar Agent)");
         new RemoveUnits().unitParsing(event, player.getColor(), tile, "1 infantry " + unitHName, activeGame);
         if (unitHolder.getUnitCount(UnitType.Infantry, player.getColor()) < 1) {
             ButtonHelper.deleteTheOneButton(event);

--- a/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
+++ b/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
@@ -236,9 +236,9 @@ public class ButtonHelperFactionSpecific {
         List<Button> buttons2 = AgendaHelper.getPlayerOutcomeButtons(activeGame, null, "jrResolution", null);
         player.getLeader("yssarilagent").get().setExhausted(true);
         MessageHelper.sendMessageToChannel(event.getMessageChannel(),
-            player.getFactionEmoji() + " is using yssaril agent as JR");
+                player.getFactionEmoji() + " is using Clever Clever JR-XS455-O (Relic Agent)");
         MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(),
-            "Use buttons to decide who to use JR on", buttons2);
+                "Use buttons to decide who to use Clever Clever JR-XS455-O (Relic Agent) on", buttons2);
         event.getMessage().delete().queue();
         String message = "Use buttons to end turn or do another action.";
         List<Button> systemButtons = TurnStart.getStartOfTurnButtons(player, activeGame, true, event);

--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -1853,14 +1853,14 @@ public class ButtonHelperModifyUnits {
         }
         if (player.hasUnexhaustedLeader("ghotiagent")) {
             Button winnuButton = Button.danger("exhaustAgent_ghotiagent_" + player.getFaction(),
-			                                   "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
+                                               "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
             buttons.add(winnuButton);
         }
         if (player.hasUnexhaustedLeader("mortheusagent")) {
             Button winnuButton = Button
                     .danger("exhaustAgent_mortheusagent_" + player.getFaction(),
-					        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
+                            "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
                     .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
             buttons.add(winnuButton);
         }

--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -1562,8 +1562,8 @@ public class ButtonHelperModifyUnits {
                     finsFactionCheckerPrefix + "reinforcements_cc_placement_" + planetName,
                     "Place A CC From Reinforcements In The System.");
                 Button placeConstructionCCInSystem = Button.secondary(
-                    finsFactionCheckerPrefix + "placeHolderOfConInSystem_" + planetName,
-                    "Place A CC Of The Construction Holder's because you used Mahact Agent");
+                        finsFactionCheckerPrefix + "placeHolderOfConInSystem_" + planetName,
+                        "Place A CC Of The Construction Holder's because you used " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Jae Mir Kan (Mahact Agent)");
                 Button NoDontWantTo = Button.primary(finsFactionCheckerPrefix + "deleteButtons",
                     "Don't Place A CC In The System.");
                 List<Button> buttons = List.of(placeCCInSystem, placeConstructionCCInSystem, NoDontWantTo);
@@ -1852,14 +1852,16 @@ public class ButtonHelperModifyUnits {
             buttons.add(sarweenButton);
         }
         if (player.hasUnexhaustedLeader("ghotiagent")) {
-            Button winnuButton = Button.danger("exhaustAgent_ghotiagent_" + player.getFaction(), "Use Ghoti Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
+            Button winnuButton = Button.danger("exhaustAgent_ghotiagent_" + player.getFaction(),
+			                                   "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Becece (Ghoti Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.ghoti));
             buttons.add(winnuButton);
         }
         if (player.hasUnexhaustedLeader("mortheusagent")) {
             Button winnuButton = Button
-                .danger("exhaustAgent_mortheusagent_" + player.getFaction(), "Use Mortheus Agent")
-                .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
+                    .danger("exhaustAgent_mortheusagent_" + player.getFaction(),
+					        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Walik (Mortheus Agent)")
+                    .withEmoji(Emoji.fromFormatted(Emojis.mortheus));
             buttons.add(winnuButton);
         }
         Button DoneExhausting;

--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -297,20 +297,21 @@ public class ButtonHelperTacticalAction {
             if (player.hasUnexhaustedLeader("celdauriagent")) {
                 List<Button> buttons = new ArrayList<>();
                 Button hacanButton = Button
-                    .secondary("exhaustAgent_celdauriagent_" + player.getFaction(), "Use Celdauri Agent")
-                    .withEmoji(Emoji.fromFormatted(Emojis.celdauri));
+                        .secondary("exhaustAgent_celdauriagent_" + player.getFaction(),
+						           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)")
+                        .withEmoji(Emoji.fromFormatted(Emojis.celdauri));
                 buttons.add(hacanButton);
                 buttons.add(Button.danger("deleteButtons", "Decline"));
                 MessageHelper.sendMessageToChannelWithButtons(ButtonHelper.getCorrectChannel(player, activeGame),
-                    player.getRepresentation(true, true)
-                        + " you can use Celdauri agent to place an SD for 2tg/2comm",
-                    buttons);
+                        player.getRepresentation(true, true)
+                                + " you can use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent) to place an SD for 2tg/2comm",
+                        buttons);
             }
         }
 
         if (!activeGame.isAbsolMode() && player.getRelics().contains("emphidia")
-            && !player.getExhaustedRelics().contains("emphidia")) {
-            String message = player.getRepresentation() + " You can use the button to explore using crown of emphidia";
+                && !player.getExhaustedRelics().contains("emphidia")) {
+            String message = player.getRepresentation() + " You can use the button to explore using the crown of emphidia";
             List<Button> systemButtons2 = new ArrayList<>();
             systemButtons2.add(Button.success("crownofemphidiaexplore", "Use Crown To Explore a Planet"));
             MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), message, systemButtons2);
@@ -389,13 +390,14 @@ public class ButtonHelperTacticalAction {
             }
             List<Button> empyButtons = new ArrayList<>();
             if (!activeGame.getMovedUnitsFromCurrentActivation().isEmpty()
-                && (tile.getPlanetUnitHolders().size() == 0) && player.hasUnexhaustedLeader("empyreanagent")) {
-                Button empyButton = Button.secondary("exhaustAgent_empyreanagent", "Use Empyrean Agent")
-                    .withEmoji(Emoji.fromFormatted(Emojis.Empyrean));
+                    && (tile.getUnitHolders().values().size() == 1) && player.hasUnexhaustedLeader("empyreanagent")) {
+                Button empyButton = Button.secondary("exhaustAgent_empyreanagent",
+				                                     "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Acamar (Empyrean Agent)")
+                        .withEmoji(Emoji.fromFormatted(Emojis.Empyrean));
                 empyButtons.add(empyButton);
                 empyButtons.add(Button.danger("deleteButtons", "Delete These Buttons"));
                 MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(),
-                    player.getRepresentation(true, true) + " use button to exhaust Empy agent", empyButtons);
+                        player.getRepresentation(true, true) + " use button to exhaust " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Acamar (Empyrean Agent)", empyButtons);
             }
             if (!activeGame.getMovedUnitsFromCurrentActivation().isEmpty()
                 && (tile.getUnitHolders().values().size() == 1) && player.getPlanets().contains("ghoti")) {
@@ -646,7 +648,7 @@ public class ButtonHelperTacticalAction {
 
         List<Button> button3 = ButtonHelperAgents.getL1Z1XAgentButtons(activeGame, player);
         if (player.hasUnexhaustedLeader("l1z1xagent") && !button3.isEmpty() && !activeGame.getL1Hero()) {
-            String msg = player.getRepresentation(true, true) + " You can use buttons to resolve L1 Agent if you want";
+            String msg = player.getRepresentation(true, true) + " You can use buttons to resolve " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "I48S (L1Z1Z Agent) if you want";
             MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), msg, button3);
         }
         Tile tile = activeGame.getTileByPosition(pos);

--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -298,7 +298,7 @@ public class ButtonHelperTacticalAction {
                 List<Button> buttons = new ArrayList<>();
                 Button hacanButton = Button
                         .secondary("exhaustAgent_celdauriagent_" + player.getFaction(),
-						           "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)")
+                                   "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "George Nobin (Celdauri Agent)")
                         .withEmoji(Emoji.fromFormatted(Emojis.celdauri));
                 buttons.add(hacanButton);
                 buttons.add(Button.danger("deleteButtons", "Decline"));
@@ -392,7 +392,7 @@ public class ButtonHelperTacticalAction {
             if (!activeGame.getMovedUnitsFromCurrentActivation().isEmpty()
                     && (tile.getUnitHolders().values().size() == 1) && player.hasUnexhaustedLeader("empyreanagent")) {
                 Button empyButton = Button.secondary("exhaustAgent_empyreanagent",
-				                                     "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Acamar (Empyrean Agent)")
+                                                     "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Acamar (Empyrean Agent)")
                         .withEmoji(Emoji.fromFormatted(Emojis.Empyrean));
                 empyButtons.add(empyButton);
                 empyButtons.add(Button.danger("deleteButtons", "Delete These Buttons"));

--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -1774,8 +1774,8 @@ public class Helper {
 
             if (player.hasUnexhaustedLeader("argentagent")) {
                 Button argentButton = Button.success(
-                    "FFCC_" + player.getFaction() + "_" + "exhaustAgent_argentagent_" + tile.getPosition(),
-                    "Use Argent Agent");
+                        "FFCC_" + player.getFaction() + "_" + "exhaustAgent_argentagent_" + tile.getPosition(),
+                        "Use " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "") + "Trillossa Aun Mirik (Argent Agent)");
                 argentButton = argentButton.withEmoji(Emoji.fromFormatted(Emojis.Argent));
                 unitButtons.add(argentButton);
             }

--- a/src/main/java/ti4/map/Player.java
+++ b/src/main/java/ti4/map/Player.java
@@ -1459,7 +1459,7 @@ public class Player {
      * @param leaderID
      * @return whether a player has access to this leader, typically by way of
      *         Yssaril Agent
-     */
+    */
     public boolean hasExternalAccessToLeader(String leaderID) {
         if (!hasLeader(leaderID) && leaderID.contains("agent") && getLeaderIDs().contains("yssarilagent")) {
             return getGame().isLeaderInGame(leaderID);


### PR DESCRIPTION
This update names all of the agents in the game everywhere (mostly?) they are used, in the form e.g. "Carth of Golden Sands (Hacan Agent)". More importantly, when Yssaril copies an agent, it will prefix "Clever Clever" to the agent name e.g. "Clever Clever Carth of Golden Sands (Hacan Agent)", to make it clear that it is a copy being used.
The code uses `player.hasUnexhaustedLeader("yssarilagent")`. This may cause weirdness in Franken if somebody has both Ssruu and The Company. In addition, if the agent is referenced in a multi-step process, and Ssruu is exhausted in one of the first steps, then the prefix will be dropped for the later steps. Furthermore, there's a few functions where the owner of the agent isn't explicitly passed as an argument, especially for a few of the three-way abilities ("A allows B to do something to C"), especially DS agents (e.g. Queen Lucreia). A few of these use the actor ("B") as a proxy for the owner ("A"), assuming that the Yssaril player would use the ability on themselves more often than not.