### PR TITLE
Fix Peek Marker Alignment and Add Peek Marker Indexes

### DIFF
--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -3252,30 +3252,33 @@ public class MapGenerator {
         List<String> unrevealedPublicObjectives,
         Integer objectiveWorth,
         Game activeGame) {
+
+        Integer index = 1;
+
         for (String unRevealed : unrevealedPublicObjectives) {
 
             String name = Mapper.getPublicObjective(unRevealed).getName();
 
             if (activeGame.isRedTapeMode()) {
-                graphics.drawString("(Unrevealed) " + name + " - " + objectiveWorth + " VP", x, y + 23);
+                graphics.drawString(String.format("(%d) <Unrevealed> %s - %d VP", index, name, objectiveWorth), x, y + 23);
             } else {
-                graphics.drawString("(Unrevealed) - " + objectiveWorth + " VP", x, y + 23);
+                graphics.drawString(String.format("(%d) <Unrevealed> - %d VP", index, objectiveWorth), x, y + 23);
             }
 
             graphics.drawRect(x - 4, y - 5, 785, 38);
 
-            List<String> playerIDs;
-            if (activeGame.getPublicObjectives1Peeked().containsKey(unRevealed)) {
-                playerIDs = activeGame.getPublicObjectives1Peeked().get(unRevealed);
-            } else if (activeGame.getPublicObjectives2Peeked().containsKey(unRevealed)) {
-                playerIDs = activeGame.getPublicObjectives2Peeked().get(unRevealed);
-            } else {
-                y += 43;
-                continue;
+            if (activeGame.getPublicObjectives1Peeked().containsKey(unRevealed) || activeGame.getPublicObjectives2Peeked().containsKey(unRevealed)) {
+                List<String> playerIDs;
+                if (activeGame.getPublicObjectives1Peeked().containsKey(unRevealed)) {
+                    playerIDs = activeGame.getPublicObjectives1Peeked().get(unRevealed);
+                } else {
+                    playerIDs = activeGame.getPublicObjectives2Peeked().get(unRevealed);
+                }
+                drawPeekedMarkers(x + 515, y, activeGame.getPlayers(), playerIDs);
             }
 
-            drawPeekedMarkers(x + 515, y, activeGame.getPlayers(), playerIDs);
             y += 43;
+            index++;
         }
         return y;
     }

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -3314,9 +3314,10 @@ public class MapGenerator {
                     int centreCustomTokenVertically = controlTokenImage.getHeight() / 2 - peekMarkerImage.getHeight() / 2;
 
                     graphics.drawImage(peekMarkerImage, x + centreCustomTokenHorizontally + tempX, y + centreCustomTokenVertically, null);
-
-                    tempX += scoreTokenWidth;
                 }
+
+                // This needs to be updated regardless if the player peeked or not to maintain marker alignment with PO score markers.
+                tempX += scoreTokenWidth;
             }
         } catch (Exception e) {
             BotLogger.log("Could not draw peek markers", e);


### PR DESCRIPTION
This addresses the peek markers not aligning with the player's scored objective markers, as well as adding an index to the unrevealed public objectives to make it more obvious what index needs to be provided to peek at a particular objective.

![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/22759216/376f5a06-084f-4353-8ee8-fd4c234ad239)
