### PR TITLE
Don't check for private channels for non-real players in FoW

### DIFF
--- a/src/main/java/ti4/buttons/ButtonListener.java
+++ b/src/main/java/ti4/buttons/ButtonListener.java
@@ -193,7 +193,7 @@ public class ButtonListener extends ListenerAdapter {
             activeGame.increaseButtonPressCount();
 
             if (activeGame.isFoWMode()) {
-                if (player != null && player.getPrivateChannel() == null) {
+                if (player != null && player.isRealPlayer() && player.getPrivateChannel() == null) {
                     MessageHelper.sendMessageToChannel(event.getChannel(),
                         "Private channels are not set up for this game. Messages will be suppressed.");
                     privateChannel = null;


### PR DESCRIPTION
Every time GM presses buttons in FoW, this gets shown:
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/a1ec6b87-934d-471f-8fb1-afd3cfb65229)
Set the gm-room channel as the private channel for GM.

If GM is also a player, then this gets replaced when player private channels are setup.