### PR TITLE
AddAdjacencyOverrideList to add all adjacencies with one command

### DIFF
--- a/src/main/java/ti4/commands/fow/AddAdjacencyOverrideList.java
+++ b/src/main/java/ti4/commands/fow/AddAdjacencyOverrideList.java
@@ -1,0 +1,54 @@
+package ti4.commands.fow;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.helpers.Constants;
+import ti4.map.Game;
+import ti4.message.MessageHelper;
+
+public class AddAdjacencyOverrideList extends FOWSubcommandData {
+    public AddAdjacencyOverrideList() {
+        super(Constants.ADD_ADJACENCY_OVERRIDE_LIST, "Add Custom Adjacent Tiles as a List. ");
+        addOptions(new OptionData(OptionType.STRING, Constants.ADJACENCY_OVERRIDES_LIST, "Primary:Direction:Secondary 101:nw:202")
+          .setRequired(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game activeGame = getActiveGame();
+        OptionMapping adjacencyList = event.getOption(Constants.ADJACENCY_OVERRIDES_LIST);
+
+        String[] adjacencyListOptions = adjacencyList.getAsString().toLowerCase().split(" ");
+        for (String adjacencyOption : adjacencyListOptions) {
+          String[] adjacencyTile = adjacencyOption.split(":");
+          if (adjacencyTile.length < 3) {
+              MessageHelper.sendMessageToChannel(event.getChannel(), "Invalid Adjacency Settings");
+              return;
+          }
+          
+          String primaryTile = adjacencyTile[0];
+            
+          int direction;
+          switch (adjacencyTile[1]) {
+              case "n" -> direction = 0;
+              case "ne" -> direction = 1;
+              case "se" -> direction = 2;
+              case "s" -> direction = 3;
+              case "sw" -> direction = 4;
+              case "nw" -> direction = 5;
+              default -> direction = -1;
+          } 
+          
+          String secondaryTile = adjacencyTile[2];
+
+          if (primaryTile.isBlank() || secondaryTile.isBlank() || direction == -1) {
+            MessageHelper.sendMessageToChannel(event.getChannel(), "Invalid Adjacency Settings");
+            return;
+          }
+
+          activeGame.addAdjacentTileOverride(primaryTile, direction, secondaryTile);
+        }
+    }
+}

--- a/src/main/java/ti4/commands/fow/FOWCommand.java
+++ b/src/main/java/ti4/commands/fow/FOWCommand.java
@@ -82,6 +82,7 @@ public class FOWCommand implements Command {
         Collection<FOWSubcommandData> subcommands = new HashSet<>();
         subcommands.add(new AddCustomAdjacentTile());
         subcommands.add(new AddAdjacencyOverride());
+        subcommands.add(new AddAdjacencyOverrideList());
         subcommands.add(new AddFogTile());
         subcommands.add(new CheckChannels());
         subcommands.add(new PingActivePlayer());

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -234,6 +234,8 @@ public class Constants {
     public static final String ADD_ADJACENCY_OVERRIDE = "add_adjacency_override";
     public static final String REMOVE_ADJACENCY_OVERRIDE = "remove_adjacency_override";
     public static final String REMOVE_ALL_ADJACENCY_OVERRIDES = "remove_all_adjacency_overrides";
+    public static final String ADD_ADJACENCY_OVERRIDE_LIST = "add_adjacency_override_list";
+    public static final String ADJACENCY_OVERRIDES_LIST = "adjacency_list";
     public static final String REMOVE_FOG_TILE = "remove_fog_tile";
     public static final String REMOVE_CUSTOM_ADJACENT_TILES = "remove_custom_adjacent_tiles";
     public static final String REMOVE_ALL_CUSTOM_ADJACENT_TILES = "remove_all_custom_adjacent_tiles";


### PR DESCRIPTION
When building a lot of maps and using a lot of adjacency overrides, it is a pain to add them one by one. 

Added a command to add all of them at once using pattern "PrimaryTile:Direction:SecondaryTile 101:nw:202 ..."

This also makes it possible for you to store the string and just copy-paste it to add all adjacencies in similar vein of map add_tile_list.