### PR TITLE
Limit visibility of scored objectives in FoW

### DIFF
--- a/src/main/java/ti4/commands/cardsso/ListAllScored.java
+++ b/src/main/java/ti4/commands/cardsso/ListAllScored.java
@@ -4,13 +4,14 @@ import java.util.List;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.helpers.Constants;
+import ti4.helpers.FoWHelper;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
 
 public class ListAllScored extends SOCardsSubcommandData{
     public ListAllScored() {
-        super(Constants.SO_LIST_SCORED, "Displays all scored secret objectives");
+        super(Constants.SO_LIST_SCORED, "Displays scored secret objectives");
     }
 
     @Override
@@ -20,7 +21,9 @@ public class ListAllScored extends SOCardsSubcommandData{
 
         Game game = getActiveGame();
         List<Player> players = game.getPlayers().values().stream().toList();
+        Player currentPlayer = game.getPlayer(getUser().getId());
         for (Player player : players) {
+          if (!game.isFoWMode() || FoWHelper.canSeeStatsOfPlayer(game, player, currentPlayer))
             for (var objective : player.getSecretsScored().keySet()) {
                 sb.append(player.getFactionEmoji()).append(SOInfo.getSecretObjectiveRepresentation(objective));
             }

--- a/src/main/java/ti4/commands/cardsso/ListAllScored.java
+++ b/src/main/java/ti4/commands/cardsso/ListAllScored.java
@@ -23,9 +23,10 @@ public class ListAllScored extends SOCardsSubcommandData{
         List<Player> players = game.getPlayers().values().stream().toList();
         Player currentPlayer = game.getPlayer(getUser().getId());
         for (Player player : players) {
-          if (!game.isFoWMode() || FoWHelper.canSeeStatsOfPlayer(game, player, currentPlayer))
-            for (var objective : player.getSecretsScored().keySet()) {
-                sb.append(player.getFactionEmoji()).append(SOInfo.getSecretObjectiveRepresentation(objective));
+          if (!game.isFoWMode() || FoWHelper.canSeeStatsOfPlayer(game, player, currentPlayer)) {
+              for (String objective : player.getSecretsScored().keySet()) {
+                  sb.append(player.getFactionEmoji()).append(SOInfo.getSecretObjectiveRepresentation(objective));
+                }
             }
         }
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), sb.toString());

--- a/src/main/java/ti4/commands/status/POInfo.java
+++ b/src/main/java/ti4/commands/status/POInfo.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.generator.Mapper;
 import ti4.helpers.Constants;
+import ti4.helpers.FoWHelper;
 import ti4.message.MessageHelper;
 
 public class POInfo extends StatusSubcommandData {
@@ -26,6 +27,7 @@ public class POInfo extends StatusSubcommandData {
             .map(id -> Mapper.getPublicObjective(id.getKey()))
             .toList();
 
+        var currentPlayer = game.getPlayer(getUser().getId());
         var stringBuilder = new StringBuilder();
         stringBuilder.append("__**Current Public Objectives**__\n");
         int publicObjectiveNumber = 1;
@@ -39,6 +41,7 @@ public class POInfo extends StatusSubcommandData {
                 var playersWhoHaveScoredObjective = scoredPublicObjectives.get(publicObjective.getAlias()).stream()
                     .map(player -> game.getPlayer(player))
                     .filter(player -> player != null)
+                    .filter(player -> !game.isFoWMode() || FoWHelper.canSeeStatsOfPlayer(game, player, currentPlayer))
                     .toList();
 
                 if (!playersWhoHaveScoredObjective.isEmpty()) {


### PR DESCRIPTION
FoW checks for
/so list_scored - to only show SOs player can see
/status po_info include_scored: true - to show only faction emojies player can see