### PR TITLE
Prevent accidental end of turns in FoW

### DIFF
--- a/src/main/java/ti4/buttons/ButtonListener.java
+++ b/src/main/java/ti4/buttons/ButtonListener.java
@@ -4735,6 +4735,11 @@ public class ButtonListener extends ListenerAdapter {
                     playerUsedSC.put(messageID, players);
                 }
                 case "turnEnd" -> {
+                    if (activeGame.isFoWMode() && !player.equals(activeGame.getActivePlayer())) {
+                      MessageHelper.sendMessageToChannel(event.getMessageChannel(), "You are not the active player. Force End Turn with /player turn_end.");
+                      return;
+                    }
+
                     TurnEnd.pingNextPlayer(event, activeGame, player);
                     event.getMessage().delete().queue();
 


### PR DESCRIPTION
Added checks for End of Turn in FoW.

If pressing End Turn button out of turn:
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/2c8b6d18-366e-4736-82b6-f1e699522dc0)

Trying to End Turn with a command:
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/c8297728-6bba-4f40-b5ff-fcf04e33a9c2)

Added End of Turn message (I've been asked how does one know they've ended their turn, and I've had to answer "if you see double ping message followed by next player notification, then that means you've ended your turn"). This is more clear. 
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/2e008140-634a-45ad-8f03-80e4adcee088)
