### PR TITLE
Allow /fow remove_fog_tile to remove multiple tiles at once for another player

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -359,6 +359,7 @@ public class AsyncTI4DiscordBot {
         adminRoles.add(jda.getRoleById("1215451631622164610")); // Sigma's Server
         adminRoles.add(jda.getRoleById("1225597324206800996")); // ForlornGeas's Server
         adminRoles.add(jda.getRoleById("1226068025464197160")); // Rintsi's Server
+        adminRoles.add(jda.getRoleById("1226805374007640095")); // Solax's Server
         adminRoles.removeIf(Objects::isNull);
 
         //DEVELOPER ROLES
@@ -372,6 +373,7 @@ public class AsyncTI4DiscordBot {
         developerRoles.add(jda.getRoleById("1215453013154734130")); // Sigma's Server
         developerRoles.add(jda.getRoleById("1225597362186223746")); // ForlornGeas's Server
         developerRoles.add(jda.getRoleById("1226068105071956058")); // Rintsi's Server
+        developerRoles.add(jda.getRoleById("1226805601422676069")); // Solax's Server
         developerRoles.removeIf(Objects::isNull);
 
         //BOTHELPER ROLES
@@ -389,6 +391,7 @@ public class AsyncTI4DiscordBot {
         bothelperRoles.add(jda.getRoleById("1131925041219653714")); // Jonjo's Server
         bothelperRoles.add(jda.getRoleById("1215450829096624129")); // Sigma's Server
         bothelperRoles.add(jda.getRoleById("1226068245010710558")); // Rintsi's Server
+        bothelperRoles.add(jda.getRoleById("1226805674046914560")); // Solax's Server
         bothelperRoles.removeIf(Objects::isNull);
     }
 

--- a/src/main/java/ti4/commands/fow/RemoveFogTile.java
+++ b/src/main/java/ti4/commands/fow/RemoveFogTile.java
@@ -13,8 +13,9 @@ import ti4.message.MessageHelper;
 
 public class RemoveFogTile extends FOWSubcommandData {
     public RemoveFogTile() {
-        super(Constants.REMOVE_FOG_TILE, "Remove a Fog of War tile from the map.");
-        addOptions(new OptionData(OptionType.STRING, Constants.POSITION, "Tile position on map").setRequired(true));
+        super(Constants.REMOVE_FOG_TILE, "Remove Fog of War tiles from the map.");
+        addOptions(new OptionData(OptionType.STRING, Constants.POSITION, "Tile positions on map").setRequired(true));
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Faction or Color to remove from").setAutoComplete(true));
     }
 
     @Override
@@ -35,14 +36,22 @@ public class RemoveFogTile extends FOWSubcommandData {
             return;
         }
 
-        String position = positionMapping.getAsString().toLowerCase();
-        if (!PositionMapper.isTilePositionValid(position)) {
-            MessageHelper.replyToMessage(event, "Tile position is not allowed");
+        Player targetPlayer = Helper.getPlayer(activeGame, player, event);
+        if (targetPlayer == null) {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Player to remove tiles from was not found.");
             return;
         }
 
-        //remove the custom tile from the player
-        player.removeFogTile(position);
+        String[] positions = positionMapping.getAsString().split(" ");
+        for (String position : positions) {
+          if (!PositionMapper.isTilePositionValid(position)) {
+              MessageHelper.replyToMessage(event, "Tile position is not allowed");
+              return;
+          }
+
+          //remove the custom tile from the player
+          targetPlayer.removeFogTile(position);
+        }
         GameSaveLoadManager.saveMap(activeGame, event);
     }
 }


### PR DESCRIPTION
When 💩 hits the fan in FoW and a player sees more than they are supposed to, it is a pain to remove shown tiles one by one. Also, GM can't do that for the player. They have to do it.

Changed RemoveFogTile so that multiple tiles can be removed at once. And allow the command to be used for someone else.