### PR TITLE
Franken draft mode to pick 1 at a time

### DIFF
--- a/src/main/java/ti4/commands/franken/StartFrankenDraft.java
+++ b/src/main/java/ti4/commands/franken/StartFrankenDraft.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.draft.FrankenDraft;
+import ti4.draft.OnePickFrankenDraft;
 import ti4.draft.PoweredFrankenDraft;
 import ti4.helpers.Constants;
 import ti4.helpers.FrankenDraftHelper;
@@ -16,8 +17,9 @@ import ti4.message.MessageHelper;
 public class StartFrankenDraft extends FrankenSubcommandData {
     public StartFrankenDraft() {
         super(Constants.START_FRANKEN_DRAFT, "Start a franken draft");
-        addOptions(new OptionData(OptionType.BOOLEAN, Constants.POWERED, "'True' to add 1 extra faction tech/ability (Default: False)"));
         addOptions(new OptionData(OptionType.BOOLEAN, Constants.FORCE, "'True' to forcefully overwrite existing faction setups (Default: False)"));
+        addOptions(new OptionData(OptionType.BOOLEAN, Constants.POWERED, "'True' to add 1 extra faction tech/ability (Default: False)"));
+        addOptions(new OptionData(OptionType.BOOLEAN, Constants.ONEPICK, "'True' to draft 1 item at a time. Default mode is first 3 then 2"));
     }
 
     @Override
@@ -30,13 +32,21 @@ public class StartFrankenDraft extends FrankenSubcommandData {
             MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
             return;
         }
+        
+        boolean powered = event.getOption(Constants.POWERED, false, OptionMapping::getAsBoolean);
+        boolean onepick = event.getOption(Constants.ONEPICK, false, OptionMapping::getAsBoolean);
+        if (powered && onepick) {
+          MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Choose only one mode, Powered or OnePick, not both.");
+          return;
+        }
 
         FrankenDraftHelper.setUpFrankenFactions(game, event, force);
         FrankenDraftHelper.clearPlayerHands(game);
 
-        boolean powered = event.getOption(Constants.POWERED, false, OptionMapping::getAsBoolean);
         if (powered) {
             game.setBagDraft(new PoweredFrankenDraft(game));
+        } else if (onepick) {
+            game.setBagDraft(new OnePickFrankenDraft(game));
         } else {
             game.setBagDraft(new FrankenDraft(game));
         }

--- a/src/main/java/ti4/draft/BagDraft.java
+++ b/src/main/java/ti4/draft/BagDraft.java
@@ -24,6 +24,8 @@ public abstract class BagDraft {
             return new FrankenDraft(game);
         } else if ("powered_franken".equals(draftType)) {
             return new PoweredFrankenDraft(game);
+        } else if ("onepick_franken".equals(draftType)) {
+            return new OnePickFrankenDraft(game);
         }
 
         return null;
@@ -40,6 +42,14 @@ public abstract class BagDraft {
     public abstract List<DraftBag> generateBags(Game game);
 
     public abstract int getBagSize();
+
+    public int getPicksFromFirstBag() {
+      return 3;
+    }
+
+    public int getPicksFromNextBags() {
+      return 2;
+    }
 
     public boolean isDraftStageComplete() {
         List<Player> players = owner.getRealPlayers();

--- a/src/main/java/ti4/draft/OnePickFrankenDraft.java
+++ b/src/main/java/ti4/draft/OnePickFrankenDraft.java
@@ -1,0 +1,25 @@
+package ti4.draft;
+
+import ti4.map.Game;
+
+public class OnePickFrankenDraft extends FrankenDraft {
+
+    public OnePickFrankenDraft(Game owner) {
+        super(owner);
+    }
+
+    @Override
+    public int getPicksFromFirstBag() {
+      return 1;
+    }
+
+    @Override
+    public int getPicksFromNextBags() {
+      return 1;
+    }
+
+    @Override
+    public String getSaveString() {
+        return "onepick_franken";
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -876,6 +876,7 @@ public class Constants {
     public static final String HACK_ELECTION_STATUS = "hack_election_status";
     public static final String CC_N_PLASTIC_LIMIT = "cc_n_plastic_limit";
     public static final String POWERED = "powered";
+    public static final String ONEPICK = "onepick";
     public static final String BOT_FACTION_REACTS = "bot_faction_reacts";
     public static final String HAS_HAD_A_STATUS_PHASE = "has_had_a_status_phase";
     public static final String BOT_SHUSHING = "bot_shushing";

--- a/src/main/java/ti4/helpers/FrankenDraftHelper.java
+++ b/src/main/java/ti4/helpers/FrankenDraftHelper.java
@@ -143,7 +143,7 @@ public class FrankenDraftHelper {
 
         int draftQueueCount = player.getDraftQueue().Contents.size();
         boolean isFirstDraft = player.getDraftHand().Contents.isEmpty();
-        boolean isQueueFull = draftQueueCount >= 2 && !isFirstDraft || draftQueueCount >= 3;
+        boolean isQueueFull = draftQueueCount >= draft.getPicksFromNextBags() && !isFirstDraft || draftQueueCount >= draft.getPicksFromFirstBag();
         if (draftables.isEmpty()) {
             MessageHelper.sendMessageToChannel(bagChannel, player.getRepresentation(true, true) + " you cannot legally draft anything from this bag right now.");
         } else if (!isQueueFull) {
@@ -262,7 +262,8 @@ public class FrankenDraftHelper {
     }
 
     public static void startDraft(Game game) {
-        List<DraftBag> bags = game.getActiveBagDraft().generateBags(game);
+        BagDraft draft = game.getActiveBagDraft();
+        List<DraftBag> bags = draft.generateBags(game);
         Collections.shuffle(bags);
         List<Player> realPlayers = game.getRealPlayers();
         for (int i = 0; i < realPlayers.size(); i++) {
@@ -274,10 +275,12 @@ public class FrankenDraftHelper {
         }
         game.setBagDraftStatusMessageID(null); // Clear the status message so it will be regenerated
 
+        int first = draft.getPicksFromFirstBag();
+        int next = draft.getPicksFromNextBags();
         String message = "# " + game.getPing() + " Franken Draft has started!\n" +
-            "> As a reminder, for the first bag you pick 3 items, and for all the bags after that you pick 2 items.\n" +
+            "> As a reminder, for the first bag you pick " + first + " item(s), and for all the bags after that you pick " + next + " item(s).\n" +
             "> After each pick, the draft thread will be recreated. Sometimes discord will lag while sending long messages, so the buttons may take a few seconds to show up\n" +
-            "> Once you have made your 2 picks (3 in the first bag), the bags will automatically be passed once everyone is ready.";
+            "> Once you have made your " + next + " pick(s) (" + first + " in the first bag), the bags will automatically be passed once everyone is ready.";
 
         MessageHelper.sendMessageToChannel(game.getMainGameChannel(), message);
         GameSaveLoadManager.saveMap(game);


### PR DESCRIPTION
Our group thinks picking 3 from the first bag is unbalanced and we want to pick only 1 at a time.

Ideally would've like to make it a choice of how many to pick from first bag and how many from the following bags, but as we currently only save the draft name and not any options for it, felt this is more convenient solution at the moment.

Also don't really like that command has two options which only one can used (powred or onepick). More futureproof could've been /franken start_franken_draft mode: default/powered/onepick. But then tooltip about the mode woudn't be visible.

Thoughts?