### PR TITLE
Franken special draft option to use enums and autocomplete

### DIFF
--- a/src/main/java/ti4/autocomplete/AutoCompleteProvider.java
+++ b/src/main/java/ti4/autocomplete/AutoCompleteProvider.java
@@ -781,12 +781,12 @@ public class AutoCompleteProvider {
             }
             case Constants.DRAFT_MODE -> {
               String enteredValue = event.getFocusedOption().getValue();
-              List<FrankenDraftMode> stats = Arrays.asList(FrankenDraftMode.values());
-              List<Command.Choice> options = stats.stream()
-                  .filter(stat -> stat.search(enteredValue))
+              List<FrankenDraftMode> modes = Arrays.asList(FrankenDraftMode.values());
+              List<Command.Choice> options = modes.stream()
+                  .filter(mode -> mode.search(enteredValue))
                   .limit(25)
                   .sorted(Comparator.comparing(FrankenDraftMode::getAutoCompleteName))
-                  .map(stat -> new Command.Choice(stat.getAutoCompleteName(), stat.toString()))
+                  .map(mode -> new Command.Choice(mode.getAutoCompleteName(), mode.toString()))
                   .collect(Collectors.toList());
               event.replyChoices(options).queue();
           }

--- a/src/main/java/ti4/autocomplete/AutoCompleteProvider.java
+++ b/src/main/java/ti4/autocomplete/AutoCompleteProvider.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import org.apache.commons.lang3.StringUtils;
 import ti4.AsyncTI4DiscordBot;
 import ti4.MessageListener;
+import ti4.commands.franken.StartFrankenDraft.FrankenDraftMode;
 import ti4.commands.game.Undo;
 import ti4.commands.map.Preset;
 import ti4.commands.player.ChangeUnitDecal;
@@ -778,6 +779,17 @@ public class AutoCompleteProvider {
                     .collect(Collectors.toList());
                 event.replyChoices(options).queue();
             }
+            case Constants.DRAFT_MODE -> {
+              String enteredValue = event.getFocusedOption().getValue();
+              List<FrankenDraftMode> stats = Arrays.asList(FrankenDraftMode.values());
+              List<Command.Choice> options = stats.stream()
+                  .filter(stat -> stat.search(enteredValue))
+                  .limit(25)
+                  .sorted(Comparator.comparing(FrankenDraftMode::getAutoCompleteName))
+                  .map(stat -> new Command.Choice(stat.getAutoCompleteName(), stat.toString()))
+                  .collect(Collectors.toList());
+              event.replyChoices(options).queue();
+          }
         }
     }
 

--- a/src/main/java/ti4/commands/franken/StartFrankenDraft.java
+++ b/src/main/java/ti4/commands/franken/StartFrankenDraft.java
@@ -18,8 +18,7 @@ public class StartFrankenDraft extends FrankenSubcommandData {
     public StartFrankenDraft() {
         super(Constants.START_FRANKEN_DRAFT, "Start a franken draft");
         addOptions(new OptionData(OptionType.BOOLEAN, Constants.FORCE, "'True' to forcefully overwrite existing faction setups (Default: False)"));
-        addOptions(new OptionData(OptionType.BOOLEAN, Constants.POWERED, "'True' to add 1 extra faction tech/ability (Default: False)"));
-        addOptions(new OptionData(OptionType.BOOLEAN, Constants.ONEPICK, "'True' to draft 1 item at a time. Default mode is first 3 then 2"));
+        addOptions(new OptionData(OptionType.STRING, Constants.DRAFT_MODE, "Special draft mode").setAutoComplete(true));
     }
 
     @Override
@@ -32,28 +31,61 @@ public class StartFrankenDraft extends FrankenSubcommandData {
             MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
             return;
         }
-        
-        boolean powered = event.getOption(Constants.POWERED, false, OptionMapping::getAsBoolean);
-        boolean onepick = event.getOption(Constants.ONEPICK, false, OptionMapping::getAsBoolean);
-        if (powered && onepick) {
-          MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Choose only one mode, Powered or OnePick, not both.");
+
+        String draftOption = event.getOption(Constants.DRAFT_MODE, "", OptionMapping::getAsString);
+        FrankenDraftMode draftMode = FrankenDraftMode.fromString(draftOption);
+        if (!"".equals(draftOption) && draftMode == null) {
+          MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Invalid draft mode.");
           return;
         }
 
         FrankenDraftHelper.setUpFrankenFactions(game, event, force);
         FrankenDraftHelper.clearPlayerHands(game);
 
-        if (powered) {
-            game.setBagDraft(new PoweredFrankenDraft(game));
-        } else if (onepick) {
-            game.setBagDraft(new OnePickFrankenDraft(game));
-        } else {
-            game.setBagDraft(new FrankenDraft(game));
+        switch (draftMode) {
+          case POWERED -> game.setBagDraft(new PoweredFrankenDraft(game));
+          case ONEPICK -> game.setBagDraft(new OnePickFrankenDraft(game));
+          default -> game.setBagDraft(new FrankenDraft(game));
         }
 
         FrankenDraftHelper.startDraft(game);
         GameSaveLoadManager.saveMap(game, event);
     }
+
+    public enum FrankenDraftMode {
+      POWERED("powered", "Adds 1 extra faction tech/ability to pick from."), 
+      ONEPICK("onepick", "Draft 1 item a time.");
+
+      private final String name;
+      private final String description;
+
+      FrankenDraftMode(String name, String description) {
+          this.name = name;
+          this.description = description;
+      }
+    
+      @Override
+      public String toString() {
+          return super.toString().toLowerCase();
+      }
+
+      public static FrankenDraftMode fromString(String id) {
+          for (FrankenDraftMode mode : values()) {
+              if (id.equals(mode.toString())) {
+                  return mode;
+              }
+          }
+          return null;
+      }
+      public String getAutoCompleteName() {
+          return name + ": " + description;
+      }
+
+      public boolean search(String searchString) {
+          return name.toLowerCase().contains(searchString) || description.toLowerCase().contains(searchString) || toString().contains(searchString);
+      }
+    }
+
 }
 
 

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -875,8 +875,7 @@ public class Constants {
     public static final String PLAYERS_WHO_HIT_PERSISTENT_NO_WHEN = "players_who_hit_persistent_no_when";
     public static final String HACK_ELECTION_STATUS = "hack_election_status";
     public static final String CC_N_PLASTIC_LIMIT = "cc_n_plastic_limit";
-    public static final String POWERED = "powered";
-    public static final String ONEPICK = "onepick";
+    public static final String DRAFT_MODE = "draft_mode";
     public static final String BOT_FACTION_REACTS = "bot_faction_reacts";
     public static final String HAS_HAD_A_STATUS_PHASE = "has_had_a_status_phase";
     public static final String BOT_SHUSHING = "bot_shushing";


### PR DESCRIPTION
Changed /franken start_franken_draft from having multiple special draft options with true/false to use draft_mode option with autocomplete to better support more special draft options later on.