### PR TITLE
Support for multiple tiles for add/remove token

### DIFF
--- a/src/main/java/ti4/commands/tokens/AddRemoveToken.java
+++ b/src/main/java/ti4/commands/tokens/AddRemoveToken.java
@@ -56,24 +56,32 @@ abstract public class AddRemoveToken implements Command {
                 colors.add(player.getColor());
 
             }
-            OptionMapping tileOption = event.getOption(Constants.TILE_NAME);
-            if (tileOption != null) {
-                String tileID = AliasHandler.resolveTile(tileOption.getAsString().toLowerCase());
+            String tileOptions = event.getOption(Constants.TILE_NAME, null, OptionMapping::getAsString);
+            if (tileOptions != null) {
+                List<Tile> tiles = new ArrayList<>();
+                String tileString = tileOptions.toLowerCase().replace(" ", "");
+                StringTokenizer tileTokenizer = new StringTokenizer(tileString, ",");
+                while (tileTokenizer.hasMoreTokens()) {
+                    String tileID = AliasHandler.resolveTile(tileTokenizer.nextToken());
 
-                if (game.isTileDuplicated(tileID)) {
-                    MessageHelper.replyToMessage(event, "Duplicate tile name found, please use position coordinates");
-                    return;
-                }
-                Tile tile = game.getTile(tileID);
-                if (tile == null) {
-                    tile = game.getTileByPosition(tileID);
-                }
-                if (tile == null) {
-                    MessageHelper.replyToMessage(event, "Tile in map not found");
-                    return;
+                    if (game.isTileDuplicated(tileID)) {
+                        MessageHelper.replyToMessage(event, "Duplicate tile name found, please use position coordinates");
+                        return;
+                    }
+                    Tile tile = game.getTile(tileID);
+                    if (tile == null) {
+                        tile = game.getTileByPosition(tileID);
+                    }
+                    if (tile == null) {
+                        MessageHelper.replyToMessage(event, "Tile in map not found");
+                        return;
+                    }
+                    tiles.add(tile);
                 }
 
-                parsingForTile(event, colors, tile, game);
+                for (Tile tile : tiles) {
+                  parsingForTile(event, colors, tile, game);
+                }
                 GameSaveLoadManager.saveMap(game, event);
                 ShowGame.simpleShowGame(game, event);
             } else {


### PR DESCRIPTION
As this already supports multiple players, added similar support for multiple tiles. Did a lot of testing, but since several commands extend this one and this affects all of them, I'd like a review to confirm this is ok to do. :)

Main benefit for custom maps to be able to add all custom wormholes at once, 
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/da418dc7-9aae-4d0f-96a4-d6b0bfd690c4)
or to remove them
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/1ed1a0bb-37b2-46dc-b635-2bc0c48fe847)

But works with any token.

Also allows adding or removing multiple ccs if there is a reason to
![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/42de3d1f-b160-4acb-99b3-9e42338d7657)


