### PR TITLE
SetHomeSystemPosition command to set HS explicitly in Franken

### DIFF
--- a/src/main/java/ti4/commands/franken/FrankenCommand.java
+++ b/src/main/java/ti4/commands/franken/FrankenCommand.java
@@ -109,6 +109,7 @@ public class FrankenCommand implements Command {
         subcommands.add(new ShowFrankenHand());
         subcommands.add(new FrankenViewCard());
         subcommands.add(new ApplyDraftBags());
+        subcommands.add(new SetHomeSystemPosition());
         return subcommands;
     }
 

--- a/src/main/java/ti4/commands/franken/SetHomeSystemPosition.java
+++ b/src/main/java/ti4/commands/franken/SetHomeSystemPosition.java
@@ -1,0 +1,46 @@
+package ti4.commands.franken;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.helpers.Constants;
+import ti4.helpers.Helper;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.map.Tile;
+import ti4.message.MessageHelper;
+
+public class SetHomeSystemPosition extends FrankenSubcommandData {
+
+    public SetHomeSystemPosition() {
+        super(Constants.SET_HOMESYSTEM_POS, "Set home system position to override other checks.");
+        addOptions(new OptionData(OptionType.STRING, Constants.HS_TILE_POSITION, "Home system tile. Enter 'none' to reset to default.").setRequired(true));
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Faction or Color").setAutoComplete(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getActiveGame();
+        Player player = game.getPlayer(getUser().getId());
+        player = Helper.getPlayer(game, player, event);
+        if (player == null) {
+            MessageHelper.sendMessageToEventChannel(event, "Player could not be found");
+            return;
+        }
+
+        String hsTileString = event.getOption(Constants.HS_TILE_POSITION, null, OptionMapping::getAsString);
+        if ("none".equalsIgnoreCase(hsTileString)) {
+            player.setHomeSystemPosition(null);
+            MessageHelper.sendMessageToEventChannel(event, "Home system reset");
+        } else {
+            Tile hsTile = game.getTileByPosition(hsTileString);
+            if (hsTile == null) {
+                MessageHelper.sendMessageToEventChannel(event, "Invalid tile position.");
+            } else {
+                player.setHomeSystemPosition(hsTileString);
+                MessageHelper.sendMessageToEventChannel(event, "Home system set to " + hsTile.getRepresentation() + " for " + player.getRepresentation());
+            }
+        }
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1030,6 +1030,7 @@ public class Constants {
     public static final String FACTION_IMAGE_URL = "faction_image_url";
     public static final String SET_FACTION_ICON = "set_faction_icon";
     public static final String SET_FACTION_DISPLAY_NAME = "set_faction_display_name";
+    public static final String SET_HOMESYSTEM_POS = "set_hs_position";
     public static final String FRANKEN_FACTION_NAME = "franken_faction_suffix";
     public static final String FORCE = "force";
     public static final String REVEAL_SPECIFIC = "reveal_specific";

--- a/src/main/java/ti4/map/GameSaveLoadManager.java
+++ b/src/main/java/ti4/map/GameSaveLoadManager.java
@@ -734,6 +734,9 @@ public class GameSaveLoadManager {
             writer.write(Constants.STATS_ANCHOR_LOCATION + " " + player.getPlayerStatsAnchorPosition());
             writer.write(System.lineSeparator());
 
+            writer.write(Constants.HS_TILE_POSITION + " " + player.getHomeSystemPosition());
+            writer.write(System.lineSeparator());
+
             writer.write(Constants.ALLIANCE_MEMBERS + " " + player.getAllianceMembers());
             writer.write(System.lineSeparator());
 
@@ -2167,6 +2170,7 @@ public class GameSaveLoadManager {
                 case Constants.COLOR -> player.setColor(tokenizer.nextToken());
                 case Constants.DECAL_SET -> player.setDecalSet(tokenizer.nextToken());
                 case Constants.STATS_ANCHOR_LOCATION -> player.setPlayerStatsAnchorPosition(tokenizer.nextToken());
+                case Constants.HS_TILE_POSITION -> player.setHomeSystemPosition(tokenizer.nextToken());
                 case Constants.ALLIANCE_MEMBERS -> player.setAllianceMembers(tokenizer.nextToken());
                 case Constants.AFK_HOURS -> player.setHoursThatPlayerIsAFK(tokenizer.nextToken());
                 case Constants.ROLE_FOR_COMMUNITY -> player.setRoleIDForCommunity(tokenizer.nextToken());

--- a/src/main/java/ti4/map/Player.java
+++ b/src/main/java/ti4/map/Player.java
@@ -91,6 +91,8 @@ public class Player {
 
     @Setter
     private String playerStatsAnchorPosition;
+    @Setter
+    private String homeSystemPosition;
     private String allianceMembers = "";
     private String hoursThatPlayerIsAFK = "";
     private String color;
@@ -2504,6 +2506,13 @@ public class Player {
         return playerStatsAnchorPosition;
     }
 
+    public String getHomeSystemPosition() {
+        if ("null".equals(homeSystemPosition)) {
+          return null;
+        }
+        return homeSystemPosition;
+    }
+
     public boolean hasOlradinPolicies() {
         return (hasAbility("policies"))
             || (hasAbility("policy_the_people_connect"))
@@ -2824,6 +2833,13 @@ public class Player {
     @JsonIgnore
     public Tile getHomeSystemTile() {
         Game game = getGame();
+        if (getHomeSystemPosition() != null) {
+            Tile frankenHs = game.getTileByPosition(getHomeSystemPosition());
+            if (frankenHs != null) {
+                return frankenHs;
+            }
+        }
+
         if (hasAbility("mobile_command")) {
             if (ButtonHelper.getTilesOfPlayersSpecificUnits(game, this, UnitType.Flagship).isEmpty()) {
                 return null;


### PR DESCRIPTION
An override setting to explicitly set home system position in Franken. 

Default behaviour persists unless homeSystemPosition is set. In that case use that one.

![image](https://github.com/AsyncTI4/TI4_map_generator_bot/assets/13619922/a12298b3-c0a2-4fea-8dc2-f31f85aaa2f2)

This allows moving stats_anchors to better locations so player information won't overlap the map mainly in Franken-FoW where they can't be moved atm due to visibility checks based on HS. Currently an issue for example in my fow180.
