### PR TITLE
Fix Checks and Balances to not reveal player info in FoW

### DIFF
--- a/src/main/java/ti4/commands/player/SCPick.java
+++ b/src/main/java/ti4/commands/player/SCPick.java
@@ -176,8 +176,13 @@ public class SCPick extends PlayerSubcommandData {
         int scpick = Integer.parseInt(scPicked);
         String factionPicked = buttonID.split("_")[2];
         Player p2 = game.getPlayerFromColorOrFaction(factionPicked);
-        boolean pickSuccessful = Stats.secondHalfOfPickSC(event, game, p2, scpick);
-        MessageHelper.sendMessageToChannel(ButtonHelper.getCorrectChannel(p2, game), p2.getRepresentation(true, true) + " was given SC #" + scpick + " by " + player.getFactionEmoji());
+
+        Stats.secondHalfOfPickSC(event, game, p2, scpick);
+        
+        String recipientMessage = p2.getRepresentation(true, true) + " was given SC #" + scpick 
+            + (!game.isFoWMode() ? " by " + player.getFactionEmoji() : "");
+        MessageHelper.sendMessageToChannel(p2.getCorrectChannel(), recipientMessage);
+
         if (game.isFoWMode()) {
             MessageHelper.sendMessageToChannel(player.getCorrectChannel(), p2.getColor() + " was given SC #" + scpick);
 

--- a/src/main/java/ti4/commands/player/Stats.java
+++ b/src/main/java/ti4/commands/player/Stats.java
@@ -396,11 +396,11 @@ public class Stats extends PlayerSubcommandData {
 		Integer tgCount = scTradeGoods.get(scNumber);
 		String msg = player.getRepresentation(true, true) +
 			"\n> Picked: " + Helper.getSCRepresentation(game, scNumber);
-		MessageHelper.sendMessageToChannel(event.getMessageChannel(), msg);
+		MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);
 		if (tgCount != null && tgCount != 0) {
 			int tg = player.getTg();
 			tg += tgCount;
-			MessageHelper.sendMessageToChannel((MessageChannel) event.getChannel(),
+			MessageHelper.sendMessageToChannel(player.getCorrectChannel(),
 				player.getRepresentation() + " gained " + tgCount + " tgs from picking SC #" + scNumber);
 			if (game.isFoWMode()) {
 				String messageToSend = Emojis.getColorEmojiWithName(player.getColor()) + " gained " + tgCount


### PR DESCRIPTION
Checks and Balances reveals player information in FoW.

It told the player selecting the SC the name of the player they were giving it to.

It told the receiving player the faction emoji of player doing the selection.
