### PR TITLE
Fow options command for optional settings

### DIFF
--- a/src/main/java/ti4/commands/agenda/ListVoteCount.java
+++ b/src/main/java/ti4/commands/agenda/ListVoteCount.java
@@ -4,6 +4,7 @@ import java.util.List;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.commands.fow.FOWOptions;
 import ti4.helpers.AgendaHelper;
 import ti4.helpers.Constants;
 import ti4.helpers.Emojis;
@@ -32,7 +33,8 @@ public class ListVoteCount extends AgendaSubcommandData {
         for (Player player : orderList) {
             votes = votes + AgendaHelper.getTotalVoteCount(game, player);
         }
-        StringBuilder sb = new StringBuilder("**__Vote Count (Total votes: " + votes);
+        StringBuilder sb = new StringBuilder("**__Vote Count (Total votes: " 
+          + (Boolean.valueOf(game.getFowOption(FOWOptions.HIDE_TOTAL_VOTES)) ? "???" : votes));
         sb.append("):__**\n");
         int itemNo = 1;
         for (Player player : orderList) {

--- a/src/main/java/ti4/commands/agenda/ListVoteCount.java
+++ b/src/main/java/ti4/commands/agenda/ListVoteCount.java
@@ -34,7 +34,7 @@ public class ListVoteCount extends AgendaSubcommandData {
             votes = votes + AgendaHelper.getTotalVoteCount(game, player);
         }
         StringBuilder sb = new StringBuilder("**__Vote Count (Total votes: " 
-          + (Boolean.valueOf(game.getFowOption(FOWOptions.HIDE_TOTAL_VOTES)) ? "???" : votes));
+          + (Boolean.parseBoolean(game.getFowOption(FOWOptions.HIDE_TOTAL_VOTES)) ? "???" : votes));
         sb.append("):__**\n");
         int itemNo = 1;
         for (Player player : orderList) {

--- a/src/main/java/ti4/commands/custom/CustomizationOptions.java
+++ b/src/main/java/ti4/commands/custom/CustomizationOptions.java
@@ -45,7 +45,6 @@ public class CustomizationOptions extends CustomSubcommandData {
             "Consider People To Pass on SCs if they dont respond with X hours. Set X to 0 to turn off"));
         addOptions(new OptionData(OptionType.STRING, Constants.UNIT_SOURCE,
             "Swap player's owned units to units from another source").setAutoComplete(true));
-        addOptions(new OptionData(OptionType.BOOLEAN, Constants.FOW_OPTION_HIDE_NAMES, "Completely hide player discord names."));
     }
 
     @Override
@@ -165,9 +164,5 @@ public class CustomizationOptions extends CustomSubcommandData {
         String unitSource = event.getOption(Constants.UNIT_SOURCE, null, OptionMapping::getAsString);
         if (unitSource != null && Mapper.getUnitSources().contains(unitSource))
             game.swapInVariantUnits(unitSource);
-
-        Boolean fowHideNames = event.getOption(Constants.FOW_OPTION_HIDE_NAMES, null, OptionMapping::getAsBoolean);
-        if (fowHideNames != null)
-            game.setFowOptionHideNames(fowHideNames);
     }
 }

--- a/src/main/java/ti4/commands/fow/FOWCommand.java
+++ b/src/main/java/ti4/commands/fow/FOWCommand.java
@@ -94,6 +94,7 @@ public class FOWCommand implements Command {
         subcommands.add(new SetFogFilter());
         subcommands.add(new Whisper());
         subcommands.add(new Announce());
+        subcommands.add(new FOWOptions());
         return subcommands;
     }
 

--- a/src/main/java/ti4/commands/fow/FOWOptions.java
+++ b/src/main/java/ti4/commands/fow/FOWOptions.java
@@ -1,0 +1,35 @@
+package ti4.commands.fow;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.helpers.Constants;
+import ti4.map.Game;
+
+public class FOWOptions extends FOWSubcommandData {
+
+    public static final String HIDE_NAMES = "hide_player_names";
+    public static final String HIDE_TOTAL_VOTES = "hide_total_votes";
+
+    public FOWOptions() {
+        super(Constants.FOW_OPTIONS, "Change options for FoW game");
+        addOptions(new OptionData(OptionType.BOOLEAN, HIDE_NAMES, "Completely hide player discord names - Default: false"));
+        addOptions(new OptionData(OptionType.BOOLEAN, HIDE_TOTAL_VOTES, "Don't show total votes amount in agenda - Default: false"));
+    }
+
+     @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getActiveGame();
+
+        Boolean hideNames = event.getOption(HIDE_NAMES, null, OptionMapping::getAsBoolean);
+        if (hideNames != null) {
+            game.setFowOption(HIDE_NAMES, Boolean.toString(hideNames));
+        }
+
+        Boolean hideTotalVotes = event.getOption(HIDE_TOTAL_VOTES, null, OptionMapping::getAsBoolean);
+        if (hideTotalVotes != null) {
+            game.setFowOption(HIDE_TOTAL_VOTES, Boolean.toString(hideTotalVotes));
+        }
+    }
+}

--- a/src/main/java/ti4/commands/game/Info.java
+++ b/src/main/java/ti4/commands/game/Info.java
@@ -1,5 +1,7 @@
 package ti4.commands.game;
 
+import java.util.Map;
+
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -91,6 +93,13 @@ public class Info extends GameSubcommandData {
         if (game.getTableTalkChannel() != null) sb.append("Table Talk Channel: ").append(game.getTableTalkChannel().getAsMention()).append(NEW_LINE);
         if (game.getActionsChannel() != null) sb.append("Actions Channel: ").append(game.getActionsChannel().getAsMention()).append(NEW_LINE);
         if (game.getBotMapUpdatesThread() != null) sb.append("Bot Map Thread: ").append(game.getBotMapUpdatesThread().getAsMention()).append(NEW_LINE);
+        if (game.isFoWMode()) {
+            sb.append("FoW Options:");
+            for (Map.Entry<String, String> entry : game.getFowOptions().entrySet()) {
+                sb.append(" " + entry.getKey() + ":" + entry.getValue());
+            }
+            sb.append(NEW_LINE);
+        }
 
         if (!privateGame) {
             sb.append("### Players: ").append(NEW_LINE);

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -56,6 +56,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.utils.FileUpload;
 import ti4.AsyncTI4DiscordBot;
 import ti4.ResourceHelper;
+import ti4.commands.fow.FOWOptions;
 import ti4.helpers.AliasHandler;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.ButtonHelperAbilities;
@@ -597,7 +598,8 @@ public class MapGenerator {
                 // PAINT AVATAR AND USERNAME
                 StringBuilder userName = new StringBuilder();
                 String playerName = player.getUserName();
-                if (!game.isFowOptionHideNames()) {
+                Boolean fowHidePlayerNames = Boolean.valueOf(game.getFowOption(FOWOptions.HIDE_NAMES));
+                if (!fowHidePlayerNames) {
                     graphics.drawImage(getPlayerDiscordAvatar(player), x, y + 5, null);
                     userName.append(" ").append(playerName.substring(0, Math.min(playerName.length(), 20)));
                 }
@@ -622,7 +624,7 @@ public class MapGenerator {
                     userName.append(" -- AFK");
                 }
 
-                graphics.drawString(userName.toString(), !game.isFowOptionHideNames() ? x + 34 : x, y);
+                graphics.drawString(userName.toString(), !fowHidePlayerNames ? x + 34 : x, y);
                 if (player.getFaction() == null || "null".equals(player.getColor()) || player.getColor() == null) {
                     continue;
                 }
@@ -2787,7 +2789,7 @@ public class MapGenerator {
 
             // PAINT USERNAME
             Point point = PositionMapper.getPlayerStats(Constants.STATS_USERNAME);
-            if (!game.isFowOptionHideNames()) {
+            if (!Boolean.valueOf(game.getFowOption(FOWOptions.HIDE_NAMES))) {
                 graphics.drawString(userName.substring(0, Math.min(userName.length(), 11)), point.x + deltaX,
                     point.y + deltaY);
             }

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -598,7 +598,7 @@ public class MapGenerator {
                 // PAINT AVATAR AND USERNAME
                 StringBuilder userName = new StringBuilder();
                 String playerName = player.getUserName();
-                Boolean fowHidePlayerNames = Boolean.valueOf(game.getFowOption(FOWOptions.HIDE_NAMES));
+                boolean fowHidePlayerNames = Boolean.parseBoolean(game.getFowOption(FOWOptions.HIDE_NAMES));
                 if (!fowHidePlayerNames) {
                     graphics.drawImage(getPlayerDiscordAvatar(player), x, y + 5, null);
                     userName.append(" ").append(playerName.substring(0, Math.min(playerName.length(), 20)));
@@ -2789,7 +2789,7 @@ public class MapGenerator {
 
             // PAINT USERNAME
             Point point = PositionMapper.getPlayerStats(Constants.STATS_USERNAME);
-            if (!Boolean.valueOf(game.getFowOption(FOWOptions.HIDE_NAMES))) {
+            if (!Boolean.parseBoolean(game.getFowOption(FOWOptions.HIDE_NAMES))) {
                 graphics.drawString(userName.substring(0, Math.min(userName.length(), 11)), point.x + deltaX,
                     point.y + deltaY);
             }

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -61,7 +61,7 @@ public class Constants {
     public static final String COMMUNITY_MODE = "community_mode";
     public static final String ALLIANCE_MODE = "alliance_mode";
     public static final String FOW_MODE = "fow_mode";
-    public static final String FOW_OPTION_HIDE_NAMES = "fow_hide_names";
+    public static final String FOW_OPTIONS = "fow_options";
     public static final String BASE_GAME_MODE = "base_game_mode";
     public static final String LIGHT_FOG_MODE = "light_fog_mode";
     public static final String RED_TAPE_MODE = "red_tape_mode";

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -127,8 +127,7 @@ public class Game {
     private boolean homeBrew;
     @ExportableField
     private boolean fowMode;
-    @ExportableField
-    private boolean fowOptionHideNames;
+    private final Map<String, String> fowOptions = new HashMap<>();
     @ExportableField
     private boolean naaluAgent;
     @ExportableField
@@ -719,12 +718,16 @@ public class Game {
         this.fowMode = fowMode;
     }
 
-    public boolean isFowOptionHideNames() {
-        return fowOptionHideNames;
+    public Map<String, String> getFowOptions() {
+        return fowOptions;
     }
 
-    public void setFowOptionHideNames(boolean fowOptionHideNames) {
-        this.fowOptionHideNames = fowOptionHideNames;
+    public String getFowOption(String optionName) {
+        return fowOptions.get(optionName);
+    }
+
+    public void setFowOption(String optionName, String value) {
+        fowOptions.put(optionName, value);
     }
 
     public boolean isLightFogMode() {

--- a/src/main/java/ti4/map/GameSaveLoadManager.java
+++ b/src/main/java/ti4/map/GameSaveLoadManager.java
@@ -1800,7 +1800,7 @@ public class GameSaveLoadManager {
                         // Do nothing
                     }
                 }
-                case "fow_hide_names" -> { //REMOVE THIS AFTER ONE SAVE/LOAD GAMES
+                case "fow_hide_names" -> { //TODO REMOVE THIS AFTER ONE SAVE/LOAD GAMES
                     try {
                         boolean value = Boolean.parseBoolean(info);
                         if (value)

--- a/src/main/java/ti4/map/GameSaveLoadManager.java
+++ b/src/main/java/ti4/map/GameSaveLoadManager.java
@@ -572,7 +572,11 @@ public class GameSaveLoadManager {
         writer.write(System.lineSeparator());
         writer.write(Constants.FOW_MODE + " " + game.isFoWMode());
         writer.write(System.lineSeparator());
-        writer.write(Constants.FOW_OPTION_HIDE_NAMES + " " + game.isFowOptionHideNames());
+        StringBuilder fowOptions = new StringBuilder();
+        for (Map.Entry<String, String> entry : game.getFowOptions().entrySet()) {
+            fowOptions.append(entry.getKey()).append(",").append(entry.getValue()).append(";");
+        }
+        writer.write(Constants.FOW_OPTIONS + " " + fowOptions);
         writer.write(System.lineSeparator());
         writer.write(Constants.NAALU_AGENT + " " + game.getNaaluAgent());
         writer.write(System.lineSeparator());
@@ -1703,6 +1707,15 @@ public class GameSaveLoadManager {
                         }
                     }
                 }
+                case Constants.FOW_OPTIONS -> {
+                  StringTokenizer fowOptions = new StringTokenizer(info, ";");
+                  while (fowOptions.hasMoreTokens()) {
+                      StringTokenizer dataInfo = new StringTokenizer(fowOptions.nextToken(), ",");
+                      String optionName = dataInfo.nextToken();
+                      String optionValue = dataInfo.nextToken();
+                      game.setFowOption(optionName, optionValue);
+                  }
+                }
                 case Constants.GAME_CUSTOM_NAME -> game.setCustomName(info);
                 case Constants.PLAYERS_WHO_HIT_PERSISTENT_NO_AFTER -> game.setPlayersWhoHitPersistentNoAfter(info);
                 case Constants.PLAYERS_WHO_HIT_PERSISTENT_NO_WHEN -> game.setPlayersWhoHitPersistentNoWhen(info);
@@ -1787,10 +1800,11 @@ public class GameSaveLoadManager {
                         // Do nothing
                     }
                 }
-                case Constants.FOW_OPTION_HIDE_NAMES -> {
+                case "fow_hide_names" -> { //REMOVE THIS AFTER ONE SAVE/LOAD GAMES
                     try {
                         boolean value = Boolean.parseBoolean(info);
-                        game.setFowOptionHideNames(value);
+                        if (value)
+                          game.setFowOption("hide_player_names", info);
                     } catch (Exception e) {
                         // Do nothing
                     }


### PR DESCRIPTION
Added a command /fow fow_options to put all fow settings to one place and make it easy to add more if needed in the future.

- Moved the setting to hide player names from /custom customization to /fow fow_options
- Added an option to hide total votes in agenda
- Show set fow options in /game info if game is fow