### PR TITLE
Remove relic AFTER resolving it to fix Dynamis Core

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -9178,9 +9178,6 @@ public class ButtonHelper {
                     MessageHelper.sendMessageToChannelWithButtons(getCorrectChannel(p2, game), msg, buttons3);
                 }
             }
-        } else { // PURGE THE RELIC
-            player.removeRelic(relicID);
-            player.removeExhaustedRelic(relicID);
         }
 
         RelicModel relicModel = Mapper.getRelic(relicID);
@@ -9226,6 +9223,11 @@ public class ButtonHelper {
                 //handled above
             }
             default -> MessageHelper.sendMessageToChannel(event.getChannel(), "This Relic is not tied to any automation. Please resolve manually.");
+        }
+
+        if ("Purged".equals(purgeOrExhaust)) {
+            player.removeRelic(relicID);
+            player.removeExhaustedRelic(relicID);
         }
     }
 


### PR DESCRIPTION
Relic was removed before resolving it, which made absol Dynamis Core to first reduce total commodities and thus giving wrong number of TGs.