### PR TITLE
Phase Banner Updates

### DIFF
--- a/src/main/java/ti4/commands/agenda/RevealAgenda.java
+++ b/src/main/java/ti4/commands/agenda/RevealAgenda.java
@@ -62,7 +62,7 @@ public class RevealAgenda extends AgendaSubcommandData {
         }
         game.setStoredValue("agendaCount", aCount + "");
         if (aCount == 1 && game.isShowBanners()) {
-            MapGenerator.drawPhaseBanner("agenda", game.getRound(), event);
+            MapGenerator.drawPhaseBanner("agenda", game.getRound(), game.getActionsChannel());
         }
 
         game.setStoredValue("noWhenThisAgenda", "");

--- a/src/main/java/ti4/commands/player/TurnEnd.java
+++ b/src/main/java/ti4/commands/player/TurnEnd.java
@@ -240,7 +240,7 @@ public class TurnEnd extends PlayerSubcommandData {
     public static void showPublicObjectivesWhenAllPassed(GenericInteractionCreateEvent event, Game game, MessageChannel gameChannel) {
         MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "All players have passed.");
         if (game.isShowBanners()) {
-            MapGenerator.drawPhaseBanner("status", game.getRound(), event);
+            MapGenerator.drawPhaseBanner("status", game.getRound(), game.getActionsChannel());
         }
         String message = "Please score objectives, " + game.getPing() + ".";
 

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -544,7 +544,7 @@ public class MapGenerator {
 
     }
 
-    public static void drawPhaseBanner(String phase, int round, GenericInteractionCreateEvent event) {
+    public static void drawPhaseBanner(String phase, int round, TextChannel channel) {
         BufferedImage bannerImage = new BufferedImage(511, 331, BufferedImage.TYPE_INT_ARGB);
         BufferedImage backgroundImage = ImageHelper.readScaled(ResourceHelper.getInstance().getExtraFile(phase + "banner.png"), 511, 331);
 
@@ -554,34 +554,12 @@ public class MapGenerator {
         bannerG.setColor(Color.WHITE);
         superDrawString(bannerG, phase.toUpperCase() + " PHASE", 255, 110, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke8, Color.BLACK);
         bannerG.setFont(Storage.getFont32());
-        switch (round) {
-            case 1:
-                superDrawString(bannerG, "ROUND ONE", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 2:
-                superDrawString(bannerG, "ROUND TWO", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 3:
-                superDrawString(bannerG, "ROUND THREE", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 4:
-                superDrawString(bannerG, "ROUND FOUR", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 5:
-                superDrawString(bannerG, "ROUND FIVE", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 6:
-                superDrawString(bannerG, "ROUND SIX", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 7:
-                superDrawString(bannerG, "ROUND SEVEN", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 8:
-                superDrawString(bannerG, "ROUND EIGHT", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
-            case 9:
-                superDrawString(bannerG, "ROUND NINE", 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
-                break;
+        if (0 <= round && round <= 20) {
+            String[] numbers = {"ZERO", "ONE", "TWO", "THREE", "FOUR",
+                                "FIVE", "SIX", "SEVEN", "EIGHT", "NINE",
+                                "TEN", "ELEVEN", "TWELVE", "THIRTEEN", "FOURTEEN",
+                                "FIFTEEN", "SIXTEEN", "SEVENTEEN", "EIGHTEEN", "NINETEEN", "TWENTY"};
+            superDrawString(bannerG, "ROUND " + numbers[round], 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
         }
         FileUpload fileUpload = null;
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -603,7 +581,7 @@ public class MapGenerator {
         } catch (IOException e) {
             BotLogger.log("Could not create FileUpload", e);
         }
-        MessageHelper.sendFileUploadToChannel(event.getMessageChannel(), fileUpload);
+        MessageHelper.sendFileUploadToChannel(channel, fileUpload);
 
     }
 

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -54,6 +54,7 @@ import org.jetbrains.annotations.Nullable;
 
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.emoji.CustomEmoji;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
@@ -560,6 +561,8 @@ public class MapGenerator {
                                 "TEN", "ELEVEN", "TWELVE", "THIRTEEN", "FOURTEEN",
                                 "FIFTEEN", "SIXTEEN", "SEVENTEEN", "EIGHTEEN", "NINETEEN", "TWENTY"};
             superDrawString(bannerG, "ROUND " + numbers[round], 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
+        } else {
+            superDrawString(bannerG, "ROUND " + round, 255, 221, Color.WHITE, HorizontalAlign.Center, VerticalAlign.Center, stroke6, Color.BLACK);
         }
         FileUpload fileUpload = null;
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -7224,7 +7224,7 @@ public class ButtonHelper {
         } else {
             MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "All players have picked a strategy card.");
             if (game.isShowBanners()) {
-                MapGenerator.drawPhaseBanner("action", game.getRound(), event);
+                MapGenerator.drawPhaseBanner("action", game.getRound(), game.getActionsChannel());
             }
             ListTurnOrder.turnOrder(event, game);
             if (!msgExtra.isEmpty()) {
@@ -7411,7 +7411,7 @@ public class ButtonHelper {
         }
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Started Round " + round);
         if (game.isShowBanners()) {
-            MapGenerator.drawPhaseBanner("strategy", round, event);
+            MapGenerator.drawPhaseBanner("strategy", round, game.getActionsChannel());
         }
         if (game.getRealPlayers().size() == 6) {
             game.setStrategyCardsPerPlayer(1);


### PR DESCRIPTION
Now the banners should always display in the actions channel, instead of the map updates thread for the Action Phase banner.

Also, the round number will display in words on the banner for rounds zero to twenty inclusive, expanded from round one to nine inclusive. Additionally, the round number will display in digits for outside this range. Imperium Rex happens at the end of round nine RAW, but homebrew might create an extended game, so this will show up in that case.