### PR TITLE
Tile Positions In Gravity Rift Rift Loss Messages

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -457,7 +457,7 @@ public class ButtonHelper {
             damaged = true;
         }
         Die d1 = new Die(4);
-        String msg = Emojis.getEmojiFromDiscord(unit.toLowerCase()) + " in tile " tile.getPosition()  + " rolled a " + d1.getResult();
+        String msg = Emojis.getEmojiFromDiscord(unit.toLowerCase()) + " in tile " + tile.getPosition()  + " rolled a " + d1.getResult();
         if (damaged) {
             msg = "A damaged " + msg;
         }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -457,7 +457,7 @@ public class ButtonHelper {
             damaged = true;
         }
         Die d1 = new Die(4);
-        String msg = Emojis.getEmojiFromDiscord(unit.toLowerCase()) + " rolled a " + d1.getResult();
+        String msg = Emojis.getEmojiFromDiscord(unit.toLowerCase()) + " in tile " tile.getPosition()  + " rolled a " + d1.getResult();
         if (damaged) {
             msg = "A damaged " + msg;
         }

--- a/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
+++ b/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
@@ -1544,7 +1544,7 @@ public class ButtonHelperFactionSpecific {
         GenericInteractionCreateEvent event, boolean cabalAgent) {
         String msg = cabal.getRepresentation(true, true) + " has failed to eat " + amount + " of the " + unit
             + "s owned by "
-            + player.getRepresentation() + " because they were blockaded. Wah-wah.";
+            + player.getRepresentation() + " because they were blockaded. Womp Womp.";
         String unitP = AliasHandler.resolveUnit(unit);
         if (unitP.contains("sd") || unitP.contains("pd")
             || (cabal.getAllianceMembers().contains(player.getFaction()) && !cabalAgent)) {

--- a/src/main/java/ti4/helpers/ButtonHelperHeroes.java
+++ b/src/main/java/ti4/helpers/ButtonHelperHeroes.java
@@ -1125,7 +1125,7 @@ public class ButtonHelperHeroes {
 
         for (Tile tile : adjTiles) {
             empties.add(Button.primary(finChecker + "cabalHeroTile_" + tile.getPosition(),
-                "Roll for units in " + tile.getRepresentationForButtons(game, player)));
+                "Roll For Units In " + tile.getRepresentationForButtons(game, player)));
         }
         return empties;
     }
@@ -1145,7 +1145,7 @@ public class ButtonHelperHeroes {
                 && ButtonHelperFactionSpecific.isCabalBlockadedByPlayer(p2, game, player)) {
                 String msg = player.getRepresentation(true, true) + " has failed to eat units owned by "
                     + p2.getRepresentation()
-                    + " because they were blockaded. Wah-wah.";
+                    + " because they were blockaded. Womp Womp.";
                 MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);
             }
         }


### PR DESCRIPTION
This adds the tile position to the gravity rift rolling messages. The main motivation behind this is that it will trigger on the Vuil'raith hero. At the moment, after all the buttons have been pressed, there's just a list of ships. Somebody who was not online at the time would have a hard time knowing where the lost ships were previously located.