### PR TITLE
Updates

### DIFF
--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -4940,11 +4940,11 @@ public class MapGenerator {
                 } else {
                     Point position = unitTokenPosition.getPosition(tokenID);
                     boolean isMirage = unitHolder.getName().equals(Constants.MIRAGE);
-
                     if (isMirage) {
                         if (tile.getPlanetUnitHolders().size() == 3+1)
                         {
-                            position = Constants.MIRAGE_TRIPLE_POSITION;
+                            position.x += Constants.MIRAGE_TRIPLE_POSITION.x;
+                            position.y += Constants.MIRAGE_TRIPLE_POSITION.y;
                         }
                         else if (position == null)
                         {

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -4672,9 +4672,16 @@ public class MapGenerator {
                 boolean isMirage = unitHolder.getName().equals(Constants.MIRAGE);
                 Point position = unitTokenPosition.getPosition(controlID);
                 if (isMirage) {
-                    if (position == null) {
-                        position = new Point(Constants.MIRAGE_POSITION.x, Constants.MIRAGE_POSITION.y);
-                    } else {
+                    if (tile.getPlanetUnitHolders().size() == 3+1)
+                    {
+                        position = Constants.MIRAGE_TRIPLE_POSITION;
+                    }
+                    else if (position == null)
+                    {
+                        position = Constants.MIRAGE_POSITION;
+                    }
+                    else
+                    {
                         position.x += Constants.MIRAGE_POSITION.x;
                         position.y += Constants.MIRAGE_POSITION.y;
                     }
@@ -4722,6 +4729,11 @@ public class MapGenerator {
         Function<String, Boolean> isValid, Game game) {
         BufferedImage tokenImage;
         Point centerPosition = unitHolder.getHolderCenterPosition();
+        if (unitHolder.getName().equalsIgnoreCase("mirage") && (tile.getPlanetUnitHolders().size() == 3+1))
+        {
+            centerPosition = new Point(Constants.MIRAGE_TRIPLE_POSITION.x + Constants.MIRAGE_CENTER_POSITION.x,
+                Constants.MIRAGE_TRIPLE_POSITION.y + Constants.MIRAGE_CENTER_POSITION.y);
+        }
         List<String> tokenList = new ArrayList<>(unitHolder.getTokenList());
         tokenList.remove(null);
         tokenList.sort((o1, o2) -> {
@@ -4930,9 +4942,16 @@ public class MapGenerator {
                     boolean isMirage = unitHolder.getName().equals(Constants.MIRAGE);
 
                     if (isMirage) {
-                        if (position == null) {
-                            position = new Point(Constants.MIRAGE_POSITION.x, Constants.MIRAGE_POSITION.y);
-                        } else {
+                        if (tile.getPlanetUnitHolders().size() == 3+1)
+                        {
+                            position = Constants.MIRAGE_TRIPLE_POSITION;
+                        }
+                        else if (position == null)
+                        {
+                            position = Constants.MIRAGE_POSITION;
+                        }
+                        else
+                        {
                             position.x += Constants.MIRAGE_POSITION.x;
                             position.y += Constants.MIRAGE_POSITION.y;
                         }
@@ -4987,7 +5006,7 @@ public class MapGenerator {
         float mirageDragRatio = 2.0f/3;
         int mirageDragX = Math.round((345/8 + TILE_PADDING) * (1-mirageDragRatio));
         int mirageDragY = Math.round((3*300/4 + TILE_PADDING) * (1-mirageDragRatio));
-        boolean hasMirage = tokenList.stream().anyMatch(tok -> tok.contains("mirage"));
+        boolean hasMirage = tokenList.stream().anyMatch(tok -> tok.contains("mirage")) && (tile.getPlanetUnitHolders().size() != 3+1);
         List<Point> spaceTokenPositions = PositionMapper.getSpaceTokenPositions(tile.getTileID());
         if (spaceTokenPositions.isEmpty()) {
             x = centerPosition.x;
@@ -5006,8 +5025,16 @@ public class MapGenerator {
                 return;
 
             if (tokenPath.contains(Constants.MIRAGE)) {
-                tileGraphics.drawImage(tokenImage, TILE_PADDING + Constants.MIRAGE_POSITION.x,
-                    TILE_PADDING + Constants.MIRAGE_POSITION.y, null);
+                if (tile.getPlanetUnitHolders().size() == 3+1)
+                {
+                    tileGraphics.drawImage(tokenImage, TILE_PADDING + Constants.MIRAGE_TRIPLE_POSITION.x,
+                        TILE_PADDING + Constants.MIRAGE_TRIPLE_POSITION.y, null);
+                }
+                else
+                {
+                    tileGraphics.drawImage(tokenImage, TILE_PADDING + Constants.MIRAGE_POSITION.x,
+                        TILE_PADDING + Constants.MIRAGE_POSITION.y, null);
+                }
             } else if (tokenPath.contains(Constants.SLEEPER)) {
                 tileGraphics.drawImage(tokenImage, TILE_PADDING + centerPosition.x - (tokenImage.getWidth() / 2),
                     TILE_PADDING + centerPosition.y - (tokenImage.getHeight() / 2), null);
@@ -5031,8 +5058,12 @@ public class MapGenerator {
                 }
                 if (hasMirage)
                 {
+                    drawX += (tokenImage.getWidth() / 2);
+                    drawY += (tokenImage.getHeight() / 2);
                     drawX = Math.round(mirageDragRatio * drawX) + mirageDragX;
                     drawY = Math.round(mirageDragRatio * drawY) + mirageDragY;
+                    drawX -= (tokenImage.getWidth() / 2);
+                    drawY -= (tokenImage.getHeight() / 2);
                 }
                 tileGraphics.drawImage(tokenImage, drawX, drawY, null);
 
@@ -5079,7 +5110,8 @@ public class MapGenerator {
         if (isSpace)
         {
             Set<String> tokenList = unitHolder.getTokenList();
-            hasMirage = tokenList.stream().anyMatch(tok -> tok.contains("mirage"));
+            hasMirage = tokenList.stream().anyMatch(tok -> tok.contains("mirage"))
+                && (tile.getPlanetUnitHolders().size() != 3+1);
         }
 
         boolean isCabalJail = "s11".equals(tile.getTileID());
@@ -5265,13 +5297,25 @@ public class MapGenerator {
                 int imageY = position != null ? position.y : yOriginal - (unitImage.getHeight() / 2);
                 imageY += TILE_PADDING;
                 if (isMirage) {
-                    imageX += Constants.MIRAGE_POSITION.x;
-                    imageY += Constants.MIRAGE_POSITION.y;
+                    if (tile.getPlanetUnitHolders().size() == 3+1)
+                    {
+                        imageX += Constants.MIRAGE_TRIPLE_POSITION.x;
+                        imageY += Constants.MIRAGE_TRIPLE_POSITION.y;
+                    }
+                    else
+                    {
+                        imageX += Constants.MIRAGE_POSITION.x;
+                        imageY += Constants.MIRAGE_POSITION.y;
+                    }
                 }
-                if (hasMirage)
+                else if (hasMirage)
                 {
+                    imageX += (unitImage.getWidth() / 2);
+                    imageY += (unitImage.getHeight() / 2);
                     imageX = Math.round(mirageDragRatio * imageX) + mirageDragX + (fighterOrInfantry ? 60 : 0);
                     imageY = Math.round(mirageDragRatio * imageY) + mirageDragY;
+                    imageX -= (unitImage.getWidth() / 2);
+                    imageY -= (unitImage.getHeight() / 2);
                 }
 
                 tileGraphics.drawImage(unitImage, imageX, imageY, null);

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -4984,6 +4984,10 @@ public class MapGenerator {
         int y = 0;
         int deltaX = 80;
         int deltaY = 0;
+        float mirageDragRatio = 2.0f/3;
+        int mirageDragX = Math.round((345/8 + TILE_PADDING) * (1-mirageDragRatio));
+        int mirageDragY = Math.round((3*300/4 + TILE_PADDING) * (1-mirageDragRatio));
+        boolean hasMirage = tokenList.stream().anyMatch(tok -> tok.contains("mirage"));
         List<Point> spaceTokenPositions = PositionMapper.getSpaceTokenPositions(tile.getTileID());
         if (spaceTokenPositions.isEmpty()) {
             x = centerPosition.x;
@@ -5025,6 +5029,11 @@ public class MapGenerator {
                     deltaX += 30;
                     deltaY += 30;
                 }
+                if (hasMirage)
+                {
+                    drawX = Math.round(mirageDragRatio * drawX) + mirageDragX;
+                    drawY = Math.round(mirageDragRatio * drawY) + mirageDragY;
+                }
                 tileGraphics.drawImage(tokenImage, drawX, drawY, null);
 
                 // add icons to wormholes for agendas
@@ -5062,6 +5071,16 @@ public class MapGenerator {
         Map<UnitKey, Integer> units = new LinkedHashMap<>();
         HashMap<String, Point> unitOffset = new HashMap<>();
         boolean isSpace = unitHolder.getName().equals(Constants.SPACE);
+        
+        float mirageDragRatio = 2.0f/3;
+        int mirageDragX = Math.round((345/8 + TILE_PADDING) * (1-mirageDragRatio));
+        int mirageDragY = Math.round((3*300/4 + TILE_PADDING) * (1-mirageDragRatio));
+        boolean hasMirage = false;
+        if (isSpace)
+        {
+            Set<String> tokenList = unitHolder.getTokenList();
+            hasMirage = tokenList.stream().anyMatch(tok -> tok.contains("mirage"));
+        }
 
         boolean isCabalJail = "s11".equals(tile.getTileID());
         boolean isNekroJail = "s12".equals(tile.getTileID());
@@ -5242,26 +5261,33 @@ public class MapGenerator {
                 int xOriginal = centerPosition.x + x;
                 int yOriginal = centerPosition.y + y;
                 int imageX = position != null ? position.x : xOriginal - (unitImage.getWidth() / 2);
+                imageX += TILE_PADDING;
                 int imageY = position != null ? position.y : yOriginal - (unitImage.getHeight() / 2);
+                imageY += TILE_PADDING;
                 if (isMirage) {
                     imageX += Constants.MIRAGE_POSITION.x;
                     imageY += Constants.MIRAGE_POSITION.y;
                 }
+                if (hasMirage)
+                {
+                    imageX = Math.round(mirageDragRatio * imageX) + mirageDragX + (fighterOrInfantry ? 60 : 0);
+                    imageY = Math.round(mirageDragRatio * imageY) + mirageDragY;
+                }
 
-                tileGraphics.drawImage(unitImage, TILE_PADDING + imageX, TILE_PADDING + imageY, null);
+                tileGraphics.drawImage(unitImage, imageX, imageY, null);
                 if (unitKey.getUnitType() == UnitType.Mech && (ButtonHelper.isLawInPlay(game, "articles_war") || ButtonHelper.isLawInPlay(game, "absol_articleswar"))) {
                     BufferedImage mechTearImage = ImageHelper.read(ResourceHelper.getInstance().getTokenFile("agenda_articles_of_war" + getBlackWhiteFileSuffix(unitKey.getColorID())));
-                    tileGraphics.drawImage(mechTearImage, TILE_PADDING + imageX, TILE_PADDING + imageY, null);
+                    tileGraphics.drawImage(mechTearImage, imageX, imageY, null);
                 }
                 else if (unitKey.getUnitType() == UnitType.Warsun && ButtonHelper.isLawInPlay(game, "schematics")) {
                     BufferedImage wsCrackImage = ImageHelper.read(ResourceHelper.getInstance().getTokenFile("agenda_publicize_weapon_schematics" + getBlackWhiteFileSuffix(unitKey.getColorID())));
-                    tileGraphics.drawImage(wsCrackImage, TILE_PADDING + imageX, TILE_PADDING + imageY, null);
+                    tileGraphics.drawImage(wsCrackImage, imageX, imageY, null);
                 }
                 if (!List.of(UnitType.Fighter, UnitType.Infantry).contains(unitKey.getUnitType())) {
-                    tileGraphics.drawImage(decal, TILE_PADDING + imageX, TILE_PADDING + imageY, null);
+                    tileGraphics.drawImage(decal, imageX, imageY, null);
                 }
                 if (spoopy != null) {
-                    tileGraphics.drawImage(spoopy, TILE_PADDING + imageX, TILE_PADDING + imageY, null);
+                    tileGraphics.drawImage(spoopy, imageX, imageY, null);
                 }
 
                 // UNIT TAGS
@@ -5275,15 +5301,15 @@ public class MapGenerator {
                             .read(ResourceHelper.getInstance().getUnitFile("unittags_plaquette.png"));
                         Point plaquetteOffset = getUnitTagLocation(id);
 
-                        tileGraphics.drawImage(plaquette, TILE_PADDING + imageX + plaquetteOffset.x,
-                            TILE_PADDING + imageY + plaquetteOffset.y, null);
-                        drawPlayerFactionIconImage(tileGraphics, player, TILE_PADDING + imageX + plaquetteOffset.x,
-                            TILE_PADDING + imageY + plaquetteOffset.y, 32, 32);
+                        tileGraphics.drawImage(plaquette, imageX + plaquetteOffset.x,
+                            imageY + plaquetteOffset.y, null);
+                        drawPlayerFactionIconImage(tileGraphics, player, imageX + plaquetteOffset.x,
+                            imageY + plaquetteOffset.y, 32, 32);
 
                         tileGraphics.setColor(Color.WHITE);
                         drawCenteredString(tileGraphics, factionTag,
-                            new Rectangle(TILE_PADDING + imageX + plaquetteOffset.x + 25,
-                                TILE_PADDING + imageY + plaquetteOffset.y + 17, 40, 13),
+                            new Rectangle(imageX + plaquetteOffset.x + 25,
+                                imageY + plaquetteOffset.y + 17, 40, 13),
                             Storage.getFont13());
                     }
                 }
@@ -5299,8 +5325,8 @@ public class MapGenerator {
                         scaledNumberPositionY = scaledNumberPositionY + 5;
                     }
                     tileGraphics.drawString(Integer.toString(bulkUnitCount),
-                        TILE_PADDING + imageX + scaledNumberPositionX,
-                        TILE_PADDING + imageY + scaledNumberPositionY);
+                        imageX + scaledNumberPositionX,
+                        imageY + scaledNumberPositionY);
                 }
 
                 if (unitDamageCount != null && unitDamageCount > 0 && dmgImage != null) {
@@ -5314,8 +5340,8 @@ public class MapGenerator {
                         ? position.y + (unitImage.getHeight() / 2) - (dmgImage.getHeight() / 2)
                         : yOriginal - (dmgImage.getHeight() / 2);
                     if (isMirage) {
-                        imageDmgX = imageX;
-                        imageDmgY = imageY;
+                        imageDmgX = imageX - TILE_PADDING;
+                        imageDmgY = imageY - TILE_PADDING;
                     } else if (unitKey.getUnitType() == UnitType.Mech) {
                         imageDmgX = position != null ? position.x : xOriginal - (dmgImage.getWidth());
                         imageDmgY = position != null ? position.y : yOriginal - (dmgImage.getHeight());

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -313,7 +313,8 @@ public class Constants {
     public static final int RADIUS = 45;
     public static final Point SPACE_CENTER_POSITION = new Point(172, 150);
     public static final Point MIRAGE_POSITION = new Point(172, 33); // 55, 5
-    public static final Point MIRAGE_CENTER_POSITION = new Point(71, 69);
+    public static final Point MIRAGE_TRIPLE_POSITION = new Point(38, 178);
+    public static final Point MIRAGE_CENTER_POSITION = new Point(71, 59);
     public static final String MIRAGE = "mirage";
     public static final String SLEEPER = "sleeper";
     public static final String DMZ = "dmz";

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -312,7 +312,7 @@ public class Constants {
     public static final int SPACE_RADIUS = 115;
     public static final int RADIUS = 45;
     public static final Point SPACE_CENTER_POSITION = new Point(172, 150);
-    public static final Point MIRAGE_POSITION = new Point(172, 43); // 55, 5
+    public static final Point MIRAGE_POSITION = new Point(172, 33); // 55, 5
     public static final Point MIRAGE_CENTER_POSITION = new Point(71, 69);
     public static final String MIRAGE = "mirage";
     public static final String SLEEPER = "sleeper";

--- a/src/main/java/ti4/model/ShipPositionModel.java
+++ b/src/main/java/ti4/model/ShipPositionModel.java
@@ -20,7 +20,7 @@ public class ShipPositionModel {
                 case TYPE05 -> "dd 126,138; ca 51,158; cv 186,80; dn 60,227; fs 207,5; ws 24,86; sd 164,5; mf 192,254; tkn_gf 270,115; tkn_gf 240,115; tkn_ff 270,150; tkn_ff 240,150";
                 case TYPE06 -> "dd 44,196; ca 55,233; cv 124,129; dn 62,31; fs 115,222; ws 113,71; sd 122,5; mf 259,203; tkn_gf 270,115; tkn_gf 240,115; tkn_ff 270,150; tkn_ff 240,150";
                 case TYPE07 -> "dd 115,25; ca 115,85; cv 180,115; dn 210,190; fs 40,85; ws 60,35; sd 210,245; mf 220,55; tkn_gf 270,115; tkn_gf 240,115; tkn_ff 270,150; tkn_ff 240,150";
-                case TYPE08 -> "dd 210,80; ca 210,195; cv 60,210; dn 115,150; fs 20,110; ws 175,235; sd 130,255; mf 180,15; tkn_gf 270,115; tkn_gf 240,115; tkn_ff 270,150; tkn_ff 240,150";
+                case TYPE08 -> "dd 140,80; ca 210,195; cv 60,210; dn 115,150; fs 20,110; ws 175,235; sd 130,255; mf 180,15; tkn_gf 270,115; tkn_gf 240,115; tkn_ff 270,150; tkn_ff 240,150";
                 case TYPE09 -> "dd 35,205; ca 65,250; cv 135,295; dn 290,180; fs 160,240; ws 230,235; sd 295,255; mf 65,65; tkn_gf 60,115; tkn_gf 30,115; tkn_ff 60,150; tkn_ff 30,150";
                 case TYPE10 -> "dd 60,35; ca 160,220; cv 140,20; dn 70,215; fs 225,30; ws 185,70; sd 35,90; mf 235,195; tkn_gf 270,115; tkn_gf 240,115; tkn_ff 270,150; tkn_ff 240,150";
                 case TYPE11 -> "dd 60,65; ca 65,130; cv 130,190; dn 160,215; fs 180,155; ws 20,105; sd 170,250; mf 225,225; tkn_gf 270,115; tkn_gf 240,115; tkn_ff 270,150; tkn_ff 240,150";


### PR DESCRIPTION
This change will compress anything on a tile with Mirage towards the bottom left edge (except Mirage itself), which should prevent/reduce Mirage overlapping something important. It also moves the destroyer to the left on a `TYPE08` (blank) tile.  
Without Mirage:  
![image](https://github.com/user-attachments/assets/9c410bad-6485-4e54-b391-ca7440ca6ac3)  
With Mirage:  
![image-1](https://github.com/user-attachments/assets/89adadd7-34d4-4ac4-bcd4-6df6cacc13bd)  
Corner case: Planet Stellar Converted then Empyrean Hero then Mirage:  
![image](https://github.com/user-attachments/assets/b905e313-0007-46fc-8d9f-a9039374f6df)  
