### PR TITLE
Spectator specific thread for FoW combats

### DIFF
--- a/src/main/java/ti4/MessageListener.java
+++ b/src/main/java/ti4/MessageListener.java
@@ -805,21 +805,22 @@ public class MessageListener extends ListenerAdapter {
                     MessageChannel pChannel = player.getPrivateChannel();
                     TextChannel pChan = (TextChannel) pChannel;
                     if (pChan != null) {
-                        String newMessage = player.getRepresentation(true, true) + " Someone said: " + messageText;
+                        String threadName = event.getChannel().getName();
+                        boolean combatParticipant = threadName.contains("-" + player.getColor() + "-");
+                        String newMessage = player.getRepresentation(true, combatParticipant) + " Someone said: " + messageText;
                         if (event.getAuthor().isBot() && messageText.contains("Total hits ")) {
                             String hits = StringUtils.substringAfter(messageText, "Total hits ");
                             String location = StringUtils.substringAfter(messageText, "rolls for ");
                             location = StringUtils.substringBefore(location, " Combat");
-                            newMessage = player.getRepresentation(true, true) + " Someone rolled dice for " + location
+                            newMessage = player.getRepresentation(true, combatParticipant) + " Someone rolled dice for " + location
                                 + " and got a total of **" + hits + " hit" + (hits.equals("1") ? "" : "s");
                         }
                         if (!event.getAuthor().isBot() && player3 != null && player3.isRealPlayer()) {
-                            newMessage = player.getRepresentation(true, true) + " "
+                            newMessage = player.getRepresentation(true, combatParticipant) + " "
                                 + StringUtils.capitalize(player3.getColor()) + " said: " + messageText;
                         }
 
                         newMessage = newMessage.replace("Total hits", "");
-                        String threadName = event.getChannel().getName();
                         List<ThreadChannel> threadChannels = pChan.getThreadChannels();
                         for (ThreadChannel threadChannel_ : threadChannels) {
                             if (threadChannel_.getName().contains(threadName) && threadChannel_ != event.getChannel()) {

--- a/src/main/java/ti4/commands/combat/StartCombat.java
+++ b/src/main/java/ti4/commands/combat/StartCombat.java
@@ -167,8 +167,7 @@ public class StartCombat extends CombatSubcommandData {
                 if (!tile.getRepresentationForButtons(game, player3).contains("(")) {
                     continue;
                 }
-                findOrCreateCombatThread(game, player3.getPrivateChannel(), player3, player3,
-                    threadName, tile, event, "space", "space");
+                createSpectatorThread(game, player3.getPrivateChannel(), player3, threadName, tile, event);
             }
         }
     }
@@ -207,8 +206,7 @@ public class StartCombat extends CombatSubcommandData {
                 if (!tile.getRepresentationForButtons(game, player3).contains("(")) {
                     continue;
                 }
-                StartCombat.findOrCreateCombatThread(game, player3.getPrivateChannel(), player3, player3,
-                    threadName, tile, event, "ground", unitHolder.getName());
+                createSpectatorThread(game, player3.getPrivateChannel(), player3, threadName, tile, event);
             }
         }
     }
@@ -334,6 +332,26 @@ public class StartCombat extends CombatSubcommandData {
             List<Button> lanefirATSButtons = ButtonHelperFactionSpecific.getLanefirATSButtons(player1, player2);
             MessageHelper.sendMessageToChannelWithButtons(threadChannel, "Buttons to remove commodities from ATS Armaments:", lanefirATSButtons);
         }
+    }
+
+    private static void createSpectatorThread(Game game, MessageChannel channel, Player player, String threadName, Tile tile, 
+        GenericInteractionCreateEvent event) {
+        Helper.checkThreadLimitAndArchive(event.getGuild());
+        FileUpload systemWithContext = GenerateTile.getInstance().saveImage(game, 0, tile.getPosition(),
+            event, player);
+
+        channel.sendMessage("Spectate Combat in this thread:").queue(m -> {
+            ThreadChannelAction threadChannel = ((TextChannel) channel).createThreadChannel(threadName, m.getId());
+            threadChannel = threadChannel.setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_3_DAYS);
+            threadChannel.queue(tc -> {
+                StringBuilder message = new StringBuilder();
+                message.append(player.getRepresentation(true, true));
+                message.append(" Please spectate the interaction here.\n");
+                message.append("\nImage of System:");
+                MessageHelper.sendMessageWithFile(tc, systemWithContext, message.toString(), false);
+                sendGeneralCombatButtonsToThread(tc, game, player, player, tile, "justPicture", event);
+            });
+        });
     }
 
     public static void sendSpaceCannonButtonsToThread(MessageChannel threadChannel, Game game,

--- a/src/main/java/ti4/commands/combat/StartCombat.java
+++ b/src/main/java/ti4/commands/combat/StartCombat.java
@@ -167,7 +167,7 @@ public class StartCombat extends CombatSubcommandData {
                 if (!tile.getRepresentationForButtons(game, player3).contains("(")) {
                     continue;
                 }
-                createSpectatorThread(game, player3.getPrivateChannel(), player3, threadName, tile, event);
+                createSpectatorThread(game, player3, threadName, tile, event);
             }
         }
     }
@@ -206,7 +206,7 @@ public class StartCombat extends CombatSubcommandData {
                 if (!tile.getRepresentationForButtons(game, player3).contains("(")) {
                     continue;
                 }
-                createSpectatorThread(game, player3.getPrivateChannel(), player3, threadName, tile, event);
+                createSpectatorThread(game, player3, threadName, tile, event);
             }
         }
     }
@@ -334,12 +334,13 @@ public class StartCombat extends CombatSubcommandData {
         }
     }
 
-    private static void createSpectatorThread(Game game, MessageChannel channel, Player player, String threadName, Tile tile, 
+    private static void createSpectatorThread(Game game, Player player, String threadName, Tile tile, 
         GenericInteractionCreateEvent event) {
         Helper.checkThreadLimitAndArchive(event.getGuild());
         FileUpload systemWithContext = GenerateTile.getInstance().saveImage(game, 0, tile.getPosition(),
             event, player);
 
+        MessageChannel channel = player.getPrivateChannel();
         channel.sendMessage("Spectate Combat in this thread:").queue(m -> {
             ThreadChannelAction threadChannel = ((TextChannel) channel).createThreadChannel(threadName, m.getId());
             threadChannel = threadChannel.setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_3_DAYS);
@@ -347,6 +348,7 @@ public class StartCombat extends CombatSubcommandData {
                 StringBuilder message = new StringBuilder();
                 message.append(player.getRepresentation(true, true));
                 message.append(" Please spectate the interaction here.\n");
+                message.append("\nPlease note, that although you can see the combat participants' messages, you cannot communicate with them.\n");
                 message.append("\nImage of System:");
                 MessageHelper.sendMessageWithFile(tc, systemWithContext, message.toString(), false);
                 sendGeneralCombatButtonsToThread(tc, game, player, player, tile, "justPicture", event);


### PR DESCRIPTION
Constantly players who see the combat, but are not participants of it, are confused about the combat thread created for them in FoW to spectate the interaction.

So for spectators, create a thread without combat buttons nor steps-for-combat -message.

![image](https://github.com/user-attachments/assets/7e02bf9b-18b9-461d-a495-64418d9ea530)

![image](https://github.com/user-attachments/assets/c8369905-cfc5-4496-902c-e45f2b62f034)
