### PR TITLE
Fow fixes

### DIFF
--- a/src/main/java/ti4/commands/cardsac/PlayAC.java
+++ b/src/main/java/ti4/commands/cardsac/PlayAC.java
@@ -261,13 +261,13 @@ public class PlayAC extends ACCardsSubcommandData {
             if (actionCardTitle.contains(codedName)) {
                 codedButtons.add(Button.success("autoresolve_manual",
                     "Resolve " + codedName));
-                MessageHelper.sendMessageToChannelWithButtons(channel2, codedMessage + codedName, codedButtons);
+                sendResolveMsgToMainChannel(codedMessage + codedName, codedButtons, player, game);
             }
             codedName = "Confusing Legal Text";
             if (actionCardTitle.contains(codedName)) {
                 codedButtons.add(Button.success("autoresolve_manual",
                     "Resolve " + codedName));
-                MessageHelper.sendMessageToChannelWithButtons(channel2, codedMessage + codedName, codedButtons);
+                sendResolveMsgToMainChannel(codedMessage + codedName, codedButtons, player, game);
             }
 
             codedName = "Reveal Prototype";
@@ -730,8 +730,7 @@ public class PlayAC extends ACCardsSubcommandData {
             if (actionCardTitle.contains(codedName)) {
                 codedButtons.add(
                     Button.primary(player.getFinsFactionCheckerPrefix() + "resolveVeto", "Reveal next Agenda"));
-                MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), codedMessage + codedName,
-                    codedButtons);
+                sendResolveMsgToMainChannel(codedMessage + codedName, codedButtons, player, game);
             }
 
             codedName = "Fighter Conscription";
@@ -839,4 +838,11 @@ public class PlayAC extends ACCardsSubcommandData {
         ACInfo.sendActionCardInfo(game, player);
         return null;
     }
+
+    private static void sendResolveMsgToMainChannel(String message, List<Button> buttons, Player player, Game game) {
+      if (game.isFowMode()) {
+          message = message.replace(player.getRepresentation(), "");
+      }
+      MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), message, buttons);
+  }
 }

--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -1750,7 +1750,7 @@ public class AgendaHelper {
 
         }
 
-        event.getChannel().sendMessage(voteMessage).queue();
+        player.getCorrectChannel().sendMessage(voteMessage).queue();
         // event.getMessage().delete().queue();
     }
 


### PR DESCRIPTION
Agenda related AC resolve buttons need to be sent to main channel in fow. If they are resolved in private threads, next agenda is fliped in the private thread.