### PR TITLE
Command to view FoW as specific player

### DIFF
--- a/src/main/java/ti4/commands/fow/FOWCommand.java
+++ b/src/main/java/ti4/commands/fow/FOWCommand.java
@@ -93,6 +93,7 @@ public class FOWCommand implements Command {
         subcommands.add(new Whisper());
         subcommands.add(new Announce());
         subcommands.add(new FOWOptions());
+        subcommands.add(new ShowGameAsPlayer());
         return subcommands;
     }
 

--- a/src/main/java/ti4/commands/fow/ShowGameAsPlayer.java
+++ b/src/main/java/ti4/commands/fow/ShowGameAsPlayer.java
@@ -1,0 +1,54 @@
+package ti4.commands.fow;
+
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.commands.uncategorized.ShowGame;
+import ti4.helpers.Constants;
+import ti4.helpers.Helper;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.message.MessageHelper;
+
+public class ShowGameAsPlayer extends FOWSubcommandData {
+
+    public ShowGameAsPlayer() {
+        super(Constants.SHOW_GAME_AS_PLAYER, "Shows map as the specified player sees it.");
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Faction or Color to which to show the map as").setAutoComplete(true).setRequired(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getActiveGame();
+        Player player = game.getPlayer(getUser().getId());
+        player = Helper.getGamePlayer(game, player, event, null);
+
+        if (player == null) {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), "You're not a player of this game");
+            return;
+        }
+
+        Player showMapAsPlayer = Helper.getPlayer(game, null, event);
+        if (showMapAsPlayer == null) {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Player could not be found");
+            return;
+        }
+
+        ShowGame.simpleShowGame(game, new SlashCommandCustomUserWrapper(event, showMapAsPlayer.getUser()));
+    }
+
+    public class SlashCommandCustomUserWrapper extends SlashCommandInteractionEvent {
+        private User overriddenUser;
+        
+        public SlashCommandCustomUserWrapper(SlashCommandInteractionEvent event, User overriddenUser) {
+            super(event.getJDA(), event.getResponseNumber(), event.getInteraction());
+            this.overriddenUser = overriddenUser;
+        }
+
+        @Override
+        public User getUser() {
+            return overriddenUser;
+        }
+    }
+}

--- a/src/main/java/ti4/generator/MapGenerator.java
+++ b/src/main/java/ti4/generator/MapGenerator.java
@@ -66,6 +66,7 @@ import net.dv8tion.jda.api.utils.FileUpload;
 import ti4.AsyncTI4DiscordBot;
 import ti4.ResourceHelper;
 import ti4.commands.fow.FOWOptions;
+import ti4.commands.fow.ShowGameAsPlayer;
 import ti4.helpers.AliasHandler;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.ButtonHelperAbilities;
@@ -388,7 +389,9 @@ public class MapGenerator {
         if (debug)
             debugStartTime = System.nanoTime();
         if (game.isFowMode() && event != null) {
-            if (event.getMessageChannel().getName().endsWith(Constants.PRIVATE_CHANNEL)) {
+            if (event.getMessageChannel().getName().endsWith(Constants.PRIVATE_CHANNEL) 
+                || event instanceof ShowGameAsPlayer.SlashCommandCustomUserWrapper) {
+
                 isFoWPrivate = true;
                 Player player = getFowPlayer(event);
 

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -895,6 +895,7 @@ public class Constants {
     public static final String INCLUDE_OPTIONS = "include_options";
     public static final String CARDS_INFO = "cards_info";
     public static final String FRANKEN = "franken";
+    public static final String SHOW_GAME_AS_PLAYER = "show_game_as";
 
     //DRAFTS
     public static final String BAG_DRAFT = "bag_draft";


### PR DESCRIPTION
A suggestion for a command to view FoW as a specific player. 

Don't like the way to extend SlashCommandInteractionEvent to override getUser, but this seemed the most clean way. Didn't want to invent a whole new way to pass the User to MapGenerator just for this feature.



