### PR TITLE
fix: updated Absol's space docks to account for ignoring non-fighter ships in fleet pool checks

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -2503,7 +2503,12 @@ public class ButtonHelper {
         if (player.hasTech("dsghotg") && tile == player.getHomeSystemTile()) {
             armadaValue = armadaValue + 3;
         }
-        int fleetCap = (player.getFleetCC() + armadaValue + player.getMahactCC().size()) * 2;
+        int fleetCap = (
+            player.getFleetCC() 
+            + armadaValue 
+            + player.getMahactCC().size() 
+            + tile.getFleetSupplyBonusForPlayer(player)
+        ) * 2; // fleetCap is double to more easily deal with half-capacity, e.g., Naalu Fighter II
         if (player.getLeader("letnevhero").map(Leader::isActive).orElse(false)) {
             fleetCap += 1000;
         }
@@ -2575,7 +2580,6 @@ public class ButtonHelper {
             }
             if (capChecker.getUnitCount(UnitType.PlenaryOrbital, player.getColor()) > 0) {
                 fightersIgnored += 8;
-                fleetCap = fleetCap + 4;
             }
         }
         // System.out.println(fightersIgnored);
@@ -2657,7 +2661,7 @@ public class ButtonHelper {
         if (fleetSupplyViolated) {
             message += " You are violating fleet supply in tile " + tile.getRepresentation()
                 + ". Specifically, you have " + fleetCap / 2
-                + " fleet supply, and that you currently are filling "
+                + " fleet supply in this system, and you currently are filling "
                 + (numFighter2sFleet + numOfCapitalShips + 1) / 2
                 + " of that. ";
         }

--- a/src/main/java/ti4/map/Tile.java
+++ b/src/main/java/ti4/map/Tile.java
@@ -603,6 +603,18 @@ public class Tile {
         return false;
     }
 
+    @JsonIgnore
+    public int getFleetSupplyBonusForPlayer(final Player player) {
+        return getUnitHolders().values().stream()
+            .flatMap(unitHolder -> unitHolder.getUnits().entrySet().stream())
+            .filter(entry -> entry.getValue() > 0 && player.unitBelongsToPlayer(entry.getKey()))
+            .map(Map.Entry::getKey)
+            .map(player::getUnitFromUnitKey)
+            .filter(Objects::nonNull)
+            .mapToInt(unit -> unit.getFleetSupplyBonus())
+            .sum();
+    }
+
     public static Predicate<Tile> tileHasPlayerShips(Player player) {
         return tile -> tile.containsPlayersUnitsWithModelCondition(player, UnitModel::getIsShip);
     }

--- a/src/main/java/ti4/model/UnitModel.java
+++ b/src/main/java/ti4/model/UnitModel.java
@@ -28,6 +28,7 @@ public class UnitModel implements ModelInterface, EmbeddableModel {
     private int moveValue;
     private int productionValue;
     private int capacityValue;
+    private int fleetSupplyBonus;
     private int capacityUsed;
     private float cost;
     private int combatHitsOn;

--- a/src/main/resources/data/units/absol.json
+++ b/src/main/resources/data/units/absol.json
@@ -7,6 +7,7 @@
         "source": "absol",
         "productionValue": 10,
         "capacityValue": 8,
+        "fleetSupplyBonus": 2,
         "planetaryShield": true,
         "isStructure": true,
         "ability": "Deploy: After you activate a system, attach this card to a non-home planet other than Mecatol Rex you control in that system that does not contain a space dock. The planet this card is attached to contains this unit. Up to 8 fighters in this system do not count against your ships' capacity. Up to 2 non-fighter ships in the system do not count against your fleet pool.  This unit cannot be affected by opponent's action cards.  When this unit is destroyed or removed, purge this card."
@@ -153,6 +154,7 @@
         "source": "absol",
         "productionValue": "+4",
         "capacityValue": 5,
+        "fleetSupplyBonus": 1,
         "isStructure": true,
         "homebrewReplacesID": "spacedock2"
     },
@@ -435,6 +437,7 @@
         "moveValue": 2,
         "productionValue": 7,
         "capacityValue": 6,
+        "fleetSupplyBonus": 1,
         "isStructure": true,
         "ability": "This unit is placed in the space area instead of on a planet. This unit can move and retreat as if it were a ship. If this unit is blockaded, it is destroyed. 1 non-fighter ship in this system does not count against your fleet pool.",
         "homebrewReplacesID": "saar_spacedock2"
@@ -529,8 +532,9 @@
         "source": "absol",
         "faction": "cabal",
         "productionValue": 7,
+        "fleetSupplyBonus": 1,
         "isStructure": true,
-        "ability": "This system is a gravity rift; your ships do not roll for this gravity rift. Place a dimensional tear token beneath this unit as a reminder. Up to 12 fighters in this system do not count against your ships' capacity.",
+        "ability": "This system is a gravity rift; your ships do not roll for this gravity rift. Place a dimensional tear token beneath this unit as a reminder. Up to 10 fighters in this system do not count against your ships' capacity. 1 non-fighter ship in this system does not count against your fleet pool.",
         "homebrewReplacesID": "cabal_spacedock2"
     },
     {


### PR DESCRIPTION
Absol's mod's space dock upgrades allow the player to ignore some number of non-fighter ships when 
checking fleet pool size.

This commit allows that feature to be added to any unit by adding the `fleetSupplyBonus` to the unit's 
JSON model definition.X
