### PR TITLE
absol tech fixes 14oct24

### DIFF
--- a/src/main/java/ti4/buttons/ButtonListener.java
+++ b/src/main/java/ti4/buttons/ButtonListener.java
@@ -1046,15 +1046,19 @@ public class ButtonListener extends ListenerAdapter {
             ButtonHelper.deleteMessage(event);
         } else if (buttonID.startsWith("getAllTechOfType_")) {
             String techType = buttonID.replace("getAllTechOfType_", "");
-            boolean noPay = false;
+            String payType = null;
             if (techType.contains("_")) {
-                techType = techType.split("_")[0];
-                noPay = true;
+                final String[] split = techType.split("_");
+                techType = split[0];
+                payType = split[1];
             }
             List<TechnologyModel> techs = Helper.getAllTechOfAType(game, techType, player);
-            List<Button> buttons = Helper.getTechButtons(techs, techType, player);
-            if (noPay) {
-                buttons = Helper.getTechButtons(techs, player, "nekro");
+
+            List<Button> buttons;
+            if (payType == null) {
+                buttons = Helper.getTechButtons(techs, player);
+            } else{
+                buttons = Helper.getTechButtons(techs, player, payType);
             }
 
             if (game.isComponentAction()) {
@@ -2800,6 +2804,7 @@ public class ButtonListener extends ListenerAdapter {
                     ButtonHelper.deleteMessage(event);
                 }
                 case "acquireATech" -> ButtonHelper.acquireATech(player, game, event, messageID, false);
+                case "acquireATechWithInf" -> ButtonHelper.acquireATech(player, game, event, messageID, false, "inf");
                 case "acquireATechWithSC" -> ButtonHelper.acquireATech(player, game, event, messageID, true);
                 case Constants.SO_NO_SCORING -> {
                     String message = player.getRepresentation()

--- a/src/main/java/ti4/buttons/ButtonListener.java
+++ b/src/main/java/ti4/buttons/ButtonListener.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -2804,7 +2805,7 @@ public class ButtonListener extends ListenerAdapter {
                     ButtonHelper.deleteMessage(event);
                 }
                 case "acquireATech" -> ButtonHelper.acquireATech(player, game, event, messageID, false);
-                case "acquireATechWithInf" -> ButtonHelper.acquireATech(player, game, event, messageID, false, "inf");
+                case "acquireAUnitTechWithInf" -> ButtonHelper.acquireATech(player, game, event, messageID, false, Set.of(Constants.UNIT), "inf");
                 case "acquireATechWithSC" -> ButtonHelper.acquireATech(player, game, event, messageID, true);
                 case Constants.SO_NO_SCORING -> {
                     String message = player.getRepresentation()

--- a/src/main/java/ti4/buttons/Buttons.java
+++ b/src/main/java/ti4/buttons/Buttons.java
@@ -12,6 +12,7 @@ import ti4.message.BotLogger;
 
 public class Buttons {
     public static final Button GET_A_TECH = green("acquireATech", "Get a Tech");
+    public static final Button GET_A_TECH_WITH_INF = green("acquireATechWithInf", "Get a Tech");
     public static final Button GET_A_FREE_TECH = green("acquireAFreeTech", "Get a Tech");
     public static final Button REDISTRIBUTE_CCs = green("redistributeCCButtons", "Redistribute CCs");
     public static final Button DONE_DELETE_BUTTONS = gray("deleteButtons", "Done");

--- a/src/main/java/ti4/buttons/Buttons.java
+++ b/src/main/java/ti4/buttons/Buttons.java
@@ -12,7 +12,7 @@ import ti4.message.BotLogger;
 
 public class Buttons {
     public static final Button GET_A_TECH = green("acquireATech", "Get a Tech");
-    public static final Button GET_A_TECH_WITH_INF = green("acquireATechWithInf", "Get a Tech");
+    public static final Button GET_A_UNIT_TECH_WITH_INF = green("acquireAUnitTechWithInf", "Get a Unit Tech");
     public static final Button GET_A_FREE_TECH = green("acquireAFreeTech", "Get a Tech");
     public static final Button REDISTRIBUTE_CCs = green("redistributeCCButtons", "Redistribute CCs");
     public static final Button DONE_DELETE_BUTTONS = gray("deleteButtons", "Done");

--- a/src/main/java/ti4/commands/player/Pass.java
+++ b/src/main/java/ti4/commands/player/Pass.java
@@ -53,7 +53,7 @@ public class Pass extends PlayerSubcommandData {
                 MessageHelper.sendMessageToChannelWithButtons(
                     player.getCorrectChannel(),
                     player.getRepresentation(true, true) + " you may use the button to get your tech.",
-                    Collections.singletonList(Buttons.GET_A_TECH));
+                    Collections.singletonList(Buttons.GET_A_TECH_WITH_INF));
             } else {
                 List<Button> buttons = ButtonHelper.getGainCCButtons(player);
                 String message2 = player.getRepresentation() + "! Your current CCs are " + player.getCCRepresentation() + ". Use buttons to gain CCs";

--- a/src/main/java/ti4/commands/player/Pass.java
+++ b/src/main/java/ti4/commands/player/Pass.java
@@ -53,7 +53,7 @@ public class Pass extends PlayerSubcommandData {
                 MessageHelper.sendMessageToChannelWithButtons(
                     player.getCorrectChannel(),
                     player.getRepresentation(true, true) + " you may use the button to get your tech.",
-                    Collections.singletonList(Buttons.GET_A_TECH_WITH_INF));
+                    Collections.singletonList(Buttons.GET_A_UNIT_TECH_WITH_INF));
             } else {
                 List<Button> buttons = ButtonHelper.getGainCCButtons(player);
                 String message2 = player.getRepresentation() + "! Your current CCs are " + player.getCCRepresentation() + ". Use buttons to gain CCs";

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -6575,13 +6575,26 @@ public class ButtonHelper {
         deleteMessage(event);
     }
 
-    public static void acquireATech(Player player, Game game, ButtonInteractionEvent event, String messageID,
-    boolean sc) {
-        ButtonHelper.acquireATech(player, game, event, messageID, sc, "res");
+    public static void acquireATech(Player player, Game game, ButtonInteractionEvent event, String messageID, 
+            boolean sc) {
+        ButtonHelper.acquireATech(
+            player, game, event, messageID, sc, 
+            Set.of(Constants.PROPULSION, Constants.BIOTIC, Constants.CYBERNETIC, Constants.WARFARE, Constants.UNIT), 
+            "res"
+        );
+    }
+
+    public static void acquireATech(Player player, Game game, ButtonInteractionEvent event, String messageID, 
+            boolean sc, final String payType) {
+        ButtonHelper.acquireATech(
+            player, game, event, messageID, sc, 
+            Set.of(Constants.PROPULSION, Constants.BIOTIC, Constants.CYBERNETIC, Constants.WARFARE, Constants.UNIT), 
+            payType
+        );
     }
 
     public static void acquireATech(Player player, Game game, ButtonInteractionEvent event, String messageID,
-        boolean sc, String payType) {
+            boolean sc, final Set<String> techTypes, final String payType) {
         String finsFactionCheckerPrefix = player.getFinsFactionCheckerPrefix();
         List<Button> buttons = new ArrayList<>();
         if (sc) {
@@ -6602,30 +6615,42 @@ public class ButtonHelper {
         } else {
             game.setComponentAction(true);
         }
-        Button propulsionTech = Buttons.blue(finsFactionCheckerPrefix + "getAllTechOfType_propulsion_" + payType,
-            "Get a Blue Tech");
-        propulsionTech = propulsionTech.withEmoji(Emoji.fromFormatted(Emojis.PropulsionTech));
-        buttons.add(propulsionTech);
 
-        Button bioticTech = Buttons.green(finsFactionCheckerPrefix + "getAllTechOfType_biotic_" + payType, 
-            "Get a Green Tech");
-        bioticTech = bioticTech.withEmoji(Emoji.fromFormatted(Emojis.BioticTech));
-        buttons.add(bioticTech);
+        if (techTypes.contains(Constants.PROPULSION)) {
+            Button propulsionTech = Buttons.blue(finsFactionCheckerPrefix + "getAllTechOfType_propulsion_" + payType,
+                "Get a Blue Tech");
+            propulsionTech = propulsionTech.withEmoji(Emoji.fromFormatted(Emojis.PropulsionTech));
+            buttons.add(propulsionTech);
+        }
 
-        Button cyberneticTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_cybernetic_" + payType,
-            "Get a Yellow Tech");
-        cyberneticTech = cyberneticTech.withEmoji(Emoji.fromFormatted(Emojis.CyberneticTech));
-        buttons.add(cyberneticTech);
+        if (techTypes.contains(Constants.BIOTIC)) {
+            Button bioticTech = Buttons.green(finsFactionCheckerPrefix + "getAllTechOfType_biotic_" + payType, 
+                "Get a Green Tech");
+            bioticTech = bioticTech.withEmoji(Emoji.fromFormatted(Emojis.BioticTech));
+            buttons.add(bioticTech);
+        }
 
-        Button warfareTech = Buttons.red(finsFactionCheckerPrefix + "getAllTechOfType_warfare_" + payType, 
-                "Get a Red Tech");
-        warfareTech = warfareTech.withEmoji(Emoji.fromFormatted(Emojis.WarfareTech));
-        buttons.add(warfareTech);
+        if (techTypes.contains(Constants.CYBERNETIC)) {
+            Button cyberneticTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_cybernetic_" + payType,
+                "Get a Yellow Tech");
+            cyberneticTech = cyberneticTech.withEmoji(Emoji.fromFormatted(Emojis.CyberneticTech));
+            buttons.add(cyberneticTech);
+        }
 
-        Button unitupgradesTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_unitupgrade_" + payType,
-            "Get A Unit Upgrade Tech");
-        unitupgradesTech = unitupgradesTech.withEmoji(Emoji.fromFormatted(Emojis.UnitUpgradeTech));
-        buttons.add(unitupgradesTech);
+        if (techTypes.contains(Constants.WARFARE)) {
+            Button warfareTech = Buttons.red(finsFactionCheckerPrefix + "getAllTechOfType_warfare_" + payType, 
+                    "Get a Red Tech");
+            warfareTech = warfareTech.withEmoji(Emoji.fromFormatted(Emojis.WarfareTech));
+            buttons.add(warfareTech);
+        }
+
+        if (techTypes.contains(Constants.UNIT)) {
+            Button unitupgradesTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_unitupgrade_" + payType,
+                "Get A Unit Upgrade Tech");
+            unitupgradesTech = unitupgradesTech.withEmoji(Emoji.fromFormatted(Emojis.UnitUpgradeTech));
+            buttons.add(unitupgradesTech);
+        }
+
         ButtonHelperCommanders.yinCommanderSummary(player, game);
         String message = player.getRepresentation() + " What type of tech would you want?";
         MessageHelper.sendMessageToChannelWithButtons(player.getCardsInfoThread(), message, buttons);

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -6576,7 +6576,12 @@ public class ButtonHelper {
     }
 
     public static void acquireATech(Player player, Game game, ButtonInteractionEvent event, String messageID,
-        boolean sc) {
+    boolean sc) {
+        ButtonHelper.acquireATech(player, game, event, messageID, sc, "res");
+    }
+
+    public static void acquireATech(Player player, Game game, ButtonInteractionEvent event, String messageID,
+        boolean sc, String payType) {
         String finsFactionCheckerPrefix = player.getFinsFactionCheckerPrefix();
         List<Button> buttons = new ArrayList<>();
         if (sc) {
@@ -6597,25 +6602,27 @@ public class ButtonHelper {
         } else {
             game.setComponentAction(true);
         }
-        Button propulsionTech = Buttons.blue(finsFactionCheckerPrefix + "getAllTechOfType_propulsion",
+        Button propulsionTech = Buttons.blue(finsFactionCheckerPrefix + "getAllTechOfType_propulsion_" + payType,
             "Get a Blue Tech");
         propulsionTech = propulsionTech.withEmoji(Emoji.fromFormatted(Emojis.PropulsionTech));
         buttons.add(propulsionTech);
 
-        Button bioticTech = Buttons.green(finsFactionCheckerPrefix + "getAllTechOfType_biotic", "Get a Green Tech");
+        Button bioticTech = Buttons.green(finsFactionCheckerPrefix + "getAllTechOfType_biotic_" + payType, 
+            "Get a Green Tech");
         bioticTech = bioticTech.withEmoji(Emoji.fromFormatted(Emojis.BioticTech));
         buttons.add(bioticTech);
 
-        Button cyberneticTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_cybernetic",
+        Button cyberneticTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_cybernetic_" + payType,
             "Get a Yellow Tech");
         cyberneticTech = cyberneticTech.withEmoji(Emoji.fromFormatted(Emojis.CyberneticTech));
         buttons.add(cyberneticTech);
 
-        Button warfareTech = Buttons.red(finsFactionCheckerPrefix + "getAllTechOfType_warfare", "Get a Red Tech");
+        Button warfareTech = Buttons.red(finsFactionCheckerPrefix + "getAllTechOfType_warfare_" + payType, 
+                "Get a Red Tech");
         warfareTech = warfareTech.withEmoji(Emoji.fromFormatted(Emojis.WarfareTech));
         buttons.add(warfareTech);
 
-        Button unitupgradesTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_unitupgrade",
+        Button unitupgradesTech = Buttons.gray(finsFactionCheckerPrefix + "getAllTechOfType_unitupgrade_" + payType,
             "Get A Unit Upgrade Tech");
         unitupgradesTech = unitupgradesTech.withEmoji(Emoji.fromFormatted(Emojis.UnitUpgradeTech));
         buttons.add(unitupgradesTech);

--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -1299,10 +1299,8 @@ public class Helper {
         String msg = player.getFactionEmoji() + " exhausted the following: \n";
         int res = 0;
         int inf = 0;
-        //boolean tech = false;
         if (resOrInfOrBoth.contains("tech")) {
             resOrInfOrBoth = resOrInfOrBoth.replace("tech", "");
-            //tech = true;
         }
         int tg = player.getSpentTgsThisWindow();
         boolean xxcha = player.hasLeaderUnlocked("xxchahero");
@@ -2565,7 +2563,7 @@ public class Helper {
         }
     }
 
-    public static List<Button> getTechButtons(List<TechnologyModel> techs, String techType, Player player) {
+    public static List<Button> getTechButtons(List<TechnologyModel> techs, Player player) {
         return getTechButtons(techs, player, "nope");
     }
 
@@ -2578,10 +2576,12 @@ public class Helper {
             String techName = tech.getName();
             String techID = tech.getAlias();
             String buttonID;
-            if ("nope".equalsIgnoreCase(buttonPrefixType)) { // default
+            if ("nope".equalsIgnoreCase(buttonPrefixType) || "res".equalsIgnoreCase(buttonPrefixType)) { // default
                 buttonID = "FFCC_" + player.getFaction() + "_getTech_" + techID;
             } else if ("nekro".equalsIgnoreCase(buttonPrefixType)) {
                 buttonID = "FFCC_" + player.getFaction() + "_getTech_" + techID + "__noPay";
+            } else if ("inf".equalsIgnoreCase(buttonPrefixType)) {
+                buttonID = "FFCC_" + player.getFaction() + "_getTech_" + techID + "__inf";
             } else {
                 buttonID = "FFCC_" + player.getFaction() + "_swapTechs__" + buttonPrefixType + "__" + techID;
             }

--- a/src/main/java/ti4/map/Player.java
+++ b/src/main/java/ti4/map/Player.java
@@ -543,7 +543,7 @@ public class Player {
     @JsonIgnore
     public boolean hasWarsunTech() {
         return getTechs().contains("pws2") || getTechs().contains("dsrohdws") || getTechs().contains("ws")
-            || getTechs().contains("absol_ws")
+            || getTechs().contains("absol_ws") || getTechs().contains("absol_pws2")
             || hasUnit("muaat_warsun") || hasUnit("rohdhna_warsun");
     }
 

--- a/src/main/resources/data/technologies/absol.json
+++ b/src/main/resources/data/technologies/absol.json
@@ -921,7 +921,7 @@
         "types": [
             "UNITUPGRADE"
         ],
-        "requirements": "GGG",
+        "requirements": "GG",
         "faction": "mahact",
         "baseUpgrade": "absol_inf2",
         "source": "absol",


### PR DESCRIPTION
- **fix: missing War Sun button on production for Muaat players on Absol's Techs & Mechs**
- **fix: incorrect tech requirement's for Absol's Mahact Crimson Legionnaire II**
- **fix: bug where Absol's AI Development Algorithm's post-pass tech research is paid for with Resources instead of Influence**
- **fix: bug where Absol's AI Development Algorithm post-pass ability provided buttons for all tech types instead of just units**
