### PR TITLE
Fow improvements

### DIFF
--- a/src/main/java/ti4/MessageListener.java
+++ b/src/main/java/ti4/MessageListener.java
@@ -897,7 +897,7 @@ public class MessageListener extends ListenerAdapter {
                     game.setStoredValue("futureMessageFor" + player.getFaction(), previousThoughts + messageContent);
                     MessageHelper.sendMessageToChannel(event.getChannel(), player.getFactionEmoji() + " sent themselves a future message");
                 } else if (endOfRoundSummary) {
-                    RoundSummaryHelper.storeEndOfRoundSummary(game, player, messageBeginning, messageContent, true);
+                    RoundSummaryHelper.storeEndOfRoundSummary(game, player, messageBeginning, messageContent, true, event.getChannel());
                 } else {
                     String factionColor = StringUtils.substringBefore(messageLowerCase, " ").substring(8);
                     factionColor = AliasHandler.resolveFaction(factionColor);

--- a/src/main/java/ti4/MessageListener.java
+++ b/src/main/java/ti4/MessageListener.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.entities.channel.unions.IThreadContainerUnion;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -182,6 +183,18 @@ public class MessageListener extends ListenerAdapter {
 
         String gameID = StringUtils.substringBefore(channelName, "-");
         boolean gameExists = mapList.contains(gameID);
+        
+        boolean isThreadEnabledSubcommand = 
+            (Constants.COMBAT.equals(eventName) && Constants.COMBAT_ROLL.equals(subCommandName));
+        if (!gameExists && channel instanceof ThreadChannel && isThreadEnabledSubcommand) {
+            IThreadContainerUnion parentChannel = ((ThreadChannel) channel).getParentChannel();
+            if (parentChannel != null) {
+                channelName = parentChannel.getName();
+                gameID = StringUtils.substringBefore(channelName, "-");
+                gameExists = mapList.contains(gameID);
+            }
+        }
+
         boolean isUnprotectedCommand = eventName.contains(Constants.SHOW_GAME)
             || eventName.contains(Constants.BOTHELPER) || eventName.contains(Constants.ADMIN)
             || eventName.contains(Constants.DEVELOPER);

--- a/src/main/java/ti4/commands/game/GameEnd.java
+++ b/src/main/java/ti4/commands/game/GameEnd.java
@@ -40,6 +40,7 @@ import ti4.helpers.PlayerTitleHelper;
 import ti4.helpers.Storage;
 import ti4.helpers.TIGLHelper;
 import ti4.helpers.WebHelper;
+import ti4.helpers.async.RoundSummaryHelper;
 import ti4.map.Game;
 import ti4.map.GameManager;
 import ti4.map.GameSaveLoadManager;
@@ -260,10 +261,10 @@ public class GameEnd extends GameSubcommandData {
 
         for (int x = 1; x < game.getRound() + 1; x++) {
             String summary = "";
-            for (Player player : game.getRealPlayers()) {
-                String summaryKey = "endofround" + x + player.getFaction();
+            for (Player player : game.getPlayers().values()) {
+                String summaryKey = RoundSummaryHelper.resolveRoundSummaryKey(player, String.valueOf(x));
                 if (!game.getStoredValue(summaryKey).isEmpty()) {
-                    summary += player.getFactionEmoji() + ": " + game.getStoredValue(summaryKey) + "\n";
+                    summary += RoundSummaryHelper.resolvePlayerEmoji(player) + ": " + game.getStoredValue(summaryKey) + "\n";
                 }
             }
             if (!summary.isEmpty()) {

--- a/src/main/java/ti4/commands/relic/RelicSendFragments.java
+++ b/src/main/java/ti4/commands/relic/RelicSendFragments.java
@@ -45,7 +45,7 @@ public class RelicSendFragments extends RelicSubcommandData {
 			return;
 		}
 		String trait = event.getOption(Constants.TRAIT, null, OptionMapping::getAsString);
-		int count = event.getOption(Constants.COUNT, 3, OptionMapping::getAsInt);
+		int count = event.getOption(Constants.COUNT, 1, OptionMapping::getAsInt);
 		ButtonHelperAbilities.pillageCheck(sender, game);
 		ButtonHelperAbilities.pillageCheck(receiver, game);
 		sendFrags(event, sender, receiver, trait, count, game);

--- a/src/main/java/ti4/helpers/async/RoundSummaryHelper.java
+++ b/src/main/java/ti4/helpers/async/RoundSummaryHelper.java
@@ -12,8 +12,9 @@ import net.dv8tion.jda.api.interactions.components.text.TextInput;
 import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
 import net.dv8tion.jda.api.interactions.modals.Modal;
 import net.dv8tion.jda.api.interactions.modals.ModalMapping;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import ti4.buttons.Buttons;
-import ti4.helpers.ButtonHelper;
+import ti4.helpers.Emojis;
 import ti4.helpers.RegexHelper;
 import ti4.listeners.annotations.ButtonHandler;
 import ti4.listeners.annotations.ModalHandler;
@@ -24,15 +25,16 @@ import ti4.message.MessageHelper;
 public class RoundSummaryHelper {
 
     @ButtonHandler("editEndOfRoundSummaries")
-    public static void serveEditSummaryButtons(Game game, Player player) {
+    public static void serveEditSummaryButtons(Game game, Player player, MessageChannel eventChannel) {
         List<Button> buttons = new ArrayList<>();
         for (int x = 1; x <= game.getRound(); x++)
             buttons.add(editSummaryButton(game, player, x));
-        MessageHelper.sendMessageToChannelWithButtons(player.getCardsInfoThread(), "Choose a round summary to view/edit/create:", buttons);
+        MessageChannel playerChannel = player.isRealPlayer() ? player.getCardsInfoThread() : eventChannel;
+        MessageHelper.sendMessageToChannelWithButtons(playerChannel, "Choose a round summary to view/edit/create:", buttons);
     }
 
     public static Button editSummaryButton(Game game, Player player, int round) {
-        String roundSummary = game.getStoredValue("endofround" + round + player.getFaction());
+        String roundSummary = game.getStoredValue(resolveRoundSummaryKey(player, String.valueOf(round)));
         String buttonID = "editRoundSummary_" + round + "~MDL";
         if (roundSummary.isEmpty()) {
             return Buttons.green(buttonID, "Create round " + round + " summary");
@@ -46,7 +48,7 @@ public class RoundSummaryHelper {
         String roundNum = buttonID.replace("editRoundSummary_", "").replace("~MDL", "");
 
         String modalId = "finishEditRoundSummary_" + roundNum;
-        String currentSummary = game.getStoredValue("endofround" + roundNum + player.getFaction());
+        String currentSummary = game.getStoredValue(resolveRoundSummaryKey(player, roundNum));
         if (currentSummary.isBlank()) currentSummary = null;
 
         String fieldID = "summary";
@@ -66,13 +68,13 @@ public class RoundSummaryHelper {
         if (matcher.matches()) {
             ModalMapping mapping = event.getValue("summary");
             String thoughts = mapping.getAsString();
-            storeEndOfRoundSummary(game, player, matcher.group("round"), thoughts, false);
+            storeEndOfRoundSummary(game, player, matcher.group("round"), thoughts, false, event.getChannel());
         }
     }
 
-    public static void storeEndOfRoundSummary(Game game, Player player, String roundNum, String thoughts, boolean append) {
+    public static void storeEndOfRoundSummary(Game game, Player player, String roundNum, String thoughts, boolean append, MessageChannel eventChannel) {
         roundNum = roundNum.replaceAll("[^0-9]", ""); // I only want the digits
-        String roundKey = "endofround" + roundNum + player.getFaction();
+        String roundKey = resolveRoundSummaryKey(player, roundNum);
         String previousThoughts = "";
         if (append && !game.getStoredValue(roundKey).isEmpty()) {
             previousThoughts = game.getStoredValue(roundKey);
@@ -80,7 +82,17 @@ public class RoundSummaryHelper {
         }
         game.setStoredValue(roundKey, previousThoughts + thoughts);
 
-        MessageHelper.sendMessageToChannelWithButton(player.getCardsInfoThread(), player.getFactionEmoji() + " stored an end of round summary", Buttons.EDIT_SUMMARIES);
+        MessageChannel playerChannel = player.isRealPlayer() ? player.getCardsInfoThread() : eventChannel;
+        MessageHelper.sendMessageToChannelWithButton(playerChannel, resolvePlayerEmoji(player) + " stored an end of round summary", Buttons.EDIT_SUMMARIES);
         MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "Someone stored an end of round summary");
+    }
+
+    public static String resolveRoundSummaryKey(Player player, String roundNum) {
+        String keySuffix = player.isRealPlayer() ? player.getFaction() : player.getUserName();
+        return "endofround" + roundNum + keySuffix;
+    }
+
+    public static String resolvePlayerEmoji(Player player) {
+        return player.isRealPlayer() ? player.getFactionEmoji() : Emojis.getRandomGoodDog(player.getUserID());
     }
 }


### PR DESCRIPTION
* Added a check for existing spectator thread, so spectating space combat followed by invasion uses the same thread like it does for the actual combat thread. Currently it was creating a new one for invasion.


* Allow non-players to create EndOfRound summaries. So basically GM can use `endofround1 Message` to save the first summary. Buttons to add/modify them are given in reply so after the first one, they can use the buttons too. 
  * Used UserName instead of Faction for the key to save them
  * Used Good Doggos instead of Faction Emoji


* Allowed the use of `/combat combat_roll` in channels not starting with the game name. If it is used in a thread and the parent channel name is valid game, then it's allowed.
  * Helps a lot in FoW if player-to-player private threads can run that to do PDS throws.

