### PR TITLE
Ability Linebreaks

### DIFF
--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -215,7 +215,6 @@ public class MapGenerator implements AutoCloseable {
                 displayTypeBasic = DisplayType.all;
                 width = mapWidth;
         }
-        System.out.println(displayType);
         allEyesOnMe = this.displayType.equals(DisplayType.googly);
         mainImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         graphics = mainImage.getGraphics();
@@ -1564,7 +1563,14 @@ public class MapGenerator implements AutoCloseable {
             } else {
                 drawFactionIconImage(g2, abilityModel.getFaction(), x + deltaX - 1, y, 42, 42);
                 g2.setFont(Storage.getFont16());
-                drawTwoLinesOfTextVertically(g2, abilityModel.getShortName(), x + deltaX + 6, y + 144, 130);
+                if (abilityModel.getShortName().charAt(0) == '\n')
+                {
+                    drawTextVertically(g2, abilityModel.getShortName().substring(1).toUpperCase(), x + deltaX + 17, y + 144, Storage.getFont16());
+                }
+                else
+                {
+                    drawTwoLinesOfTextVertically(g2, abilityModel.getShortName(), x + deltaX + 9, y + 144, 130);
+                }
                 drawRectWithOverlay(g2, x + deltaX - 2, y - 2, 44, 152, abilityModel);
             }
 

--- a/src/main/resources/data/abilities/base.json
+++ b/src/main/resources/data/abilities/base.json
@@ -6,21 +6,24 @@
         "permanentEffect": "Your space docks cannot produce infantry",
         "window": "At the start of the status phase",
         "windowEffect": "Place 1 infantry from your reinforcements on any planet you control.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nMitosis"
     },
     {
         "id": "creuss_gate",
         "name": "Creuss Gate",
         "faction": "ghost",
         "permanentEffect": "When you create the game board, place the Creuss Gate (tile 17) where your home system would normally be placed. The Creuss Gate system is not a home system. Then, place your home system (tile 51) in your play area.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Creuss\nGate"
     },
     {
         "id": "quantum_entanglement",
         "name": "Quantum Entanglement",
         "faction": "ghost",
         "permanentEffect": "You treat all systems that contain either an alpha or beta wormhole as adjacent to each other. Game effects cannot prevent you from using this ability.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Quantum\nEntanglem'nt"
     },
     {
         "id": "slipstream",
@@ -28,28 +31,32 @@
         "faction": "ghost",
         "window": "During your tactical actions",
         "windowEffect": "Apply +1 to the move value of each of your ships that starts its movement in your home system or in a system that contains either an alpha or beta wormhole.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nSlipstream"
     },
     {
         "id": "arbiters",
         "name": "Arbiters",
         "faction": "hacan",
         "permanentEffect": "When you are negotiating a transaction, action cards can be exchanged as part of that transaction.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nArbiters"
     },
     {
         "id": "guild_ships",
         "name": "Guild Ships",
         "faction": "hacan",
         "permanentEffect": "You can negotiate transactions with players who are not your neighbor.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Guild\nShips"
     },
     {
         "id": "master_of_trade",
         "name": "Masters of Trade",
         "faction": "hacan",
         "permanentEffect": "You do not have to spend a command token to resolve the secondary ability of the \"Trade\" strategy card.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Masters\nof Trade"
     },
     {
         "id": "analytical",
@@ -57,7 +64,8 @@
         "faction": "jolnar",
         "window": "When you research a technology that is not a unit upgrade technology",
         "windowEffect": "You may ignore 1 prerequisite.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nAnalytical"
     },
     {
         "id": "brilliant",
@@ -65,14 +73,16 @@
         "faction": "jolnar",
         "window": "When you spend a command token to resolve the secondary ability of the \"Technology\" strategy card",
         "windowEffect": "You may resolve the primary ability instead.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nBrilliant"
     },
     {
         "id": "fragile",
         "name": "Fragile",
         "faction": "jolnar",
         "permanentEffect": "Apply -1 to the result of each of your unit's combat rolls.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nFragile"
     },
     {
         "id": "assimilate",
@@ -80,7 +90,8 @@
         "faction": "l1z1x",
         "window": "When you gain control of a planet",
         "windowEffect": "Replace each PDS and space dock that is on that planet with a matching unit from your reinforcements.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nAssimilate"
     },
     {
         "id": "harrow",
@@ -88,14 +99,16 @@
         "faction": "l1z1x",
         "window": "At the end of each round of ground combat",
         "windowEffect": "Your ships in the active system may use their Bombardment abilities against your opponent's ground forces on the planet.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nHarrow"
     },
     {
         "id": "armada",
         "name": "Armada",
         "faction": "letnev",
         "permanentEffect": "The maximum number of non-fighter ships you can have in each system is equal to 2 more than the number of tokens in your fleet pool",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nArmada"
     },
     {
         "id": "munitions",
@@ -103,7 +116,8 @@
         "faction": "letnev",
         "window": "At the start of each round of space combat",
         "windowEffect": "You may spend 2 trade goods to re-roll any number of your dice during that combat round.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Munitions\nReserves"
     },
     {
         "id": "ambush",
@@ -111,7 +125,8 @@
         "faction": "mentak",
         "window": "At the start of a space combat",
         "windowEffect": "You may roll 1 die for each of up to 2 of your cruisers or destroyers in the system. For each result equal to or greater than that ship's combat value, produce 1 hit; your opponent must assign it to 1 of their ships.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nAmbush"
     },
     {
         "id": "pillage",
@@ -119,14 +134,16 @@
         "faction": "mentak",
         "window": "After 1 of your neighbors gains trade goods or resolves a transaction",
         "windowEffect": "If they have 3 or more trade goods, you may take 1 of their trade goods or commodities.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nPillage"
     },
     {
         "id": "gashlai_physiology",
         "name": "Gashlai Physiology",
         "faction": "muaat",
         "permanentEffect": "Your ships can move through supernovas",
-        "source": "base"
+        "source": "base",
+        "shortName": "Gashlai\nPhysiology"
     },
     {
         "id": "star_forge",
@@ -134,7 +151,8 @@
         "faction": "muaat",
         "window": "ACTION",
         "windowEffect": "Spend 1 token from your strategy pool to place either 2 fighters or 1 destroyer from your reinforcements in a system that contains 1 or more of your war suns.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Star\nForge"
     },
     {
         "id": "foresight",
@@ -142,7 +160,8 @@
         "faction": "naalu",
         "window": "After another player moves ships into a system that contains 1 or more of your ships",
         "windowEffect": "You may place 1 token from your strategy pool in an adjacent system that does not contain another player's ships; move your ships from the active system into that system.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nForesight"
     },
     {
         "id": "telepathic",
@@ -150,7 +169,8 @@
         "faction": "naalu",
         "window": "At the end of the strategy phase",
         "windowEffect": "Place the Naalu \"0\" token on your strategy card; you are first in initiative order.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nTelepathic"
     },
     {
         "id": "galactic_threat",
@@ -159,7 +179,8 @@
         "permanentEffect": "You cannot vote on agendas",
         "window": "Once per agenda phase, after an agenda is revealed",
         "windowEffect": "You may predict aloud the outcome of that agenda. If your prediction is correct, gain 1 technology that is owned by a player who voted how you predicted.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Galactic\nThreat"
     },
     {
         "id": "propagation",
@@ -168,7 +189,8 @@
         "permanentEffect": "You cannot research technology",
         "window": "When you would research a technology",
         "windowEffect": "Gain 3 command tokens instead.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nPropagation"
     },
     {
         "id": "technological_singularity",
@@ -176,14 +198,16 @@
         "faction": "nekro",
         "window": "Once per combat, after 1 of your opponent's units is destroyed",
         "windowEffect": "You may gain 1 technology that is owned by that player.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Techno-\nSingularity"
     },
     {
         "id": "nomadic",
         "name": "Nomadic",
         "faction": "saar",
         "permanentEffect": "You can score objectives even if you do not control the planets in your home system.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nNomadic"
     },
     {
         "id": "scavenge",
@@ -191,14 +215,16 @@
         "faction": "saar",
         "window": "After you gain control of a planet",
         "windowEffect": "Gain 1 trade good.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nScavenge"
     },
     {
         "id": "unrelenting",
         "name": "Unrelenting",
         "faction": "sardakk",
         "permanentEffect": "Apply +1 to the result of each of your unit's combat rolls.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nUnrelenting"
     },
     {
         "id": "orbital_drop",
@@ -206,7 +232,8 @@
         "faction": "sol",
         "window": "ACTION",
         "windowEffect": "Spend 1 token from your strategy pool to place 2 infantry from your reinforcements on 1 planet you control.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Orbital\nDrop"
     },
     {
         "id": "versatile",
@@ -214,14 +241,16 @@
         "faction": "sol",
         "window": "When you gain command tokens during the status phase",
         "windowEffect": "Gain 1 additional command token.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nVersatile"
     },
     {
         "id": "blood_ties",
         "name": "Blood Ties",
         "faction": "winnu",
         "permanentEffect": "You do not have to spend influence to remove the custodians token from Mecatol Rex.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Blood\nTies"
     },
     {
         "id": "reclamation",
@@ -229,7 +258,8 @@
         "faction": "winnu",
         "window": "After you resolve a tactical action during which you gained control of Mecatol Rex",
         "windowEffect": "You may place 1 PDS and 1 space dock from your reinforcements on Mecatol Rex.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nReclamation"
     },
     {
         "id": "peace_accords",
@@ -237,7 +267,8 @@
         "faction": "xxcha",
         "window": "After you resolve the primary or secondary ability of the \"Diplomacy\" strategy card",
         "windowEffect": "You may gain control of 1 planet other than Mecatol Rex that does not contain any units and is in a system that is adjacent to a planet you control.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Peace\nAccords"
     },
     {
         "id": "quash",
@@ -245,7 +276,8 @@
         "faction": "xxcha",
         "window": "When an agenda is revealed",
         "windowEffect": "You may spend 1 token from your strategy pool to discard that agenda and reveal 1 agenda from the top of the deck. Players vote on this agenda instead.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nQuash"
     },
     {
         "id": "devotion",
@@ -253,7 +285,8 @@
         "faction": "yin",
         "window": "After each space battle round",
         "windowEffect": "You may destroy 1 of your cruisers or destroyers in the active system to produce 1 hit and assign it to 1 of your opponent's ships in that system.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nDevotion"
     },
     {
         "id": "indoctrination",
@@ -261,14 +294,16 @@
         "faction": "yin",
         "window": "At the start of a ground combat",
         "windowEffect": "You may spend 2 influence to replace 1 of your opponent's participating infantry with 1 infantry from your reinforcements.",
-        "source": "base"
+        "source": "base",
+        "shortName": "Indoctri\n-nation"
     },
     {
         "id": "crafty",
         "name": "Crafty",
         "faction": "yssaril",
         "permanentEffect": "You can have any number of action cards in your hand. Game effects cannot prevent you from using this ability.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nCrafty"
     },
     {
         "id": "scheming",
@@ -276,7 +311,8 @@
         "faction": "yssaril",
         "window": "When you draw 1 or more action cards",
         "windowEffect": "Draw 1 additional action card. Then, choose and discard 1 action card from your hand.",
-        "source": "base"
+        "source": "base",
+        "shortName": "\nScheming"
     },
     {
         "id": "stall_tactics",
@@ -284,6 +320,7 @@
         "faction": "yssaril",
         "window": "ACTION",
         "windowEffect": "Discard 1 action card from your hand",
-        "source": "base"
+        "source": "base",
+        "shortName": "Stall\nTactics"
     }
 ]

--- a/src/main/resources/data/abilities/pok.json
+++ b/src/main/resources/data/abilities/pok.json
@@ -5,7 +5,8 @@
         "faction": "argent",
         "window": "When 1 or more of your units uses ANTI-FIGHTER BARRAGE",
         "windowEffect": "for each hit produced in excess of your opponent's fighters, choose 1 of your opponent's ships that has SUSTAIN DAMAGE to become damaged.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "Raid\nFormation"
     },
     {
         "id": "zeal",
@@ -14,7 +15,8 @@
         "permanentEffect": "You always vote first during the agenda phase",
         "window": "When you cast at least 1 vote",
         "windowEffect": "cast 1 additional vote for each player in the game including you.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nZeal"
     },
     {
         "id": "amalgamation",
@@ -22,14 +24,16 @@
         "faction": "cabal",
         "window": "When you produce a unit",
         "windowEffect": "You may return 1 captured unit of that type to produce that unit without spending resources.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "Amalga\n-mation"
     },
     {
         "id": "devour",
         "name": "Devour",
         "faction": "cabal",
         "permanentEffect": "Capture your opponent's non-structure units that are destroyed during combat.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nDevour"
     },
     {
         "id": "riftmeld",
@@ -37,7 +41,8 @@
         "faction": "cabal",
         "window": "When you research a unit upgrade technology",
         "windowEffect": "You may return 1 captured unit of that type to ignore all of the technology's prerequisites.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nRiftmeld"
     },
     {
         "id": "aetherpassage",
@@ -45,21 +50,24 @@
         "faction": "empyrean",
         "window": "After a player activates a system",
         "windowEffect": "You may allow that player to move their ships through systems that contain your ships.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "Aether-\npassage"
     },
     {
         "id": "dark_whispers",
         "name": "Dark Whispers",
         "faction": "empyrean",
         "permanentEffect": "During setup, take the additional Empyrean faction promissory note; you have 2 faction promissory notes",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "Dark\nWhispers"
     },
     {
         "id": "voidborn",
         "name": "Voidborn",
         "faction": "empyrean",
         "permanentEffect": "Nebulae do not affect your ships' movement",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nVoidborn"
     },
     {
         "id": "edict",
@@ -68,21 +76,24 @@
         "permanentEffect": "Other player's tokens in your fleet pool increase your fleet limit but cannot be redistributed.",
         "window": "When you win a combat",
         "windowEffect": "Place 1 command token from your opponent's reinforcements in your fleet pool if it does not already contain 1 of that player's tokens.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nEdict"
     },
     {
         "id": "hubris",
         "name": "Hubris",
         "faction": "mahact",
         "permanentEffect": "During setup, purge your \"Alliance\" promissory note. Other players cannot give you their 'Alliance\" promissory note.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nHubris"
     },
     {
         "id": "imperia",
         "name": "Imperia",
         "faction": "mahact",
         "permanentEffect": "While another player's command token is in your fleet pool, you can use the ability of that player's commander, if it is unlocked.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nImperia"
     },
     {
         "id": "distant_suns",
@@ -90,7 +101,8 @@
         "faction": "naaz",
         "window": "When you explore a planet that contains 1 of your mechs",
         "windowEffect": "You may draw 1 additional card; choose 1 to resolve and discard the rest.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "Distant\nSuns"
     },
     {
         "id": "fabrication",
@@ -98,7 +110,8 @@
         "faction": "naaz",
         "window": "ACTION",
         "windowEffect": "Either purge 2 of your relic fragments of the same type to gain 1 relic; or purge 1 of your relic fragments to gain 1 command token.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nFabrication"
     },
     {
         "id": "future_sight",
@@ -106,14 +119,16 @@
         "faction": "nomad",
         "window": "During the Agenda phase, after an outcome that you voted for or predicted is resolved",
         "windowEffect": "Gain 1 trade good",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "Future\nSight"
     },
     {
         "id": "the_company",
         "name": "The Company",
         "faction": "nomad",
         "permanentEffect": "During setup, take the 2 additional Nomad faction agents and place them next to your faction sheet; you have 3 agents",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nThe Company"
     },
     {
         "id": "awaken",
@@ -121,14 +136,16 @@
         "faction": "titans",
         "window": "After you activate a system that contains 1 or more of your sleeper tokens",
         "windowEffect": "You may replace each of those tokens with 1 PDS from your reinforcements.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nAwaken"
     },
     {
         "id": "coalescence",
         "name": "Coalescence",
         "faction": "titans",
         "permanentEffect": "If your flagship or your AWAKEN faction ability places your units into the same space area or onto the same planet as another player's units, your units must participate in combat during \"Space Combat\" or \"Ground Combat\" steps.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "\nCoalescence"
     },
     {
         "id": "terragenesis",
@@ -136,6 +153,7 @@
         "faction": "titans",
         "window": "After you explore a planet that does not have a sleeper token",
         "windowEffect": "You may place or move 1 sleeper token onto that planet.",
-        "source": "pok"
+        "source": "pok",
+        "shortName": "Terra-\ngenesis"
     }
 ]


### PR DESCRIPTION
Adds linebreaks to ability names (not homebrew) so that they appear nicely in the player areas on the game map.
![image](https://github.com/user-attachments/assets/2dbb31d5-345d-4fd4-a741-67aaec06d463)
