### PR TITLE
Use blue dice for J.N.S. Hylarim critical hits

### DIFF
--- a/src/main/java/ti4/helpers/CombatMessageHelper.java
+++ b/src/main/java/ti4/helpers/CombatMessageHelper.java
@@ -85,8 +85,13 @@ public class CombatMessageHelper {
             .collect(Collectors.joining(" "));
 
         String unitEmoji = unitModel.getUnitEmoji();
-
+        
         String resultRollsString = "[" + resultRolls.stream().map(Die::getRedDieIfSuccessOrGrayDieIfFailure).collect(Collectors.joining("")) + "]";
+        if ("jolnar_flagship".equals(unitModel.getId()))
+        {
+            resultRollsString = resultRollsString.replace(Emojis.d10red_9, Emojis.d10blue_9).replace(Emojis.d10red_0, Emojis.d10blue_0);
+        }
+        
         return String.format("> `%sx`%s %s %s - %s hit%s\n", unitQuantity, unitEmoji, optionalText, resultRollsString, numHit, hitsSuffix);
     }
 


### PR DESCRIPTION
This will show a blue dice whenever the J.N.S. Hylarim rolls a 9 or 10, and thus triggers its ability to produce two additional hits. In theory, if the Jol-Nar player has an additional -2 beyond FRAGILE, a 9 will still show as grey ¯\\\_(ツ)\_/¯.