### PR TITLE
Change Start-Of-Turn Message

### DIFF
--- a/src/main/java/ti4/commands2/player/SCPick.java
+++ b/src/main/java/ti4/commands2/player/SCPick.java
@@ -256,11 +256,12 @@ class SCPick extends GameStateSubcommand {
                 String text = player.getRepresentationUnfogged() + ", it is now your turn (your " 
                     + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
                 Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
-                if (nextPlayer == null || game.isFowMode()) {
-                } else if (nextPlayer == player) {
-                    text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
-                } else {
-                    text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                if (nextPlayer != null && !game.isFowMode()) {
+                    if (nextPlayer == player) {
+                        text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+                    } else {
+                        text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                    }
                 }
                 MessageHelper.sendMessageToChannel(game.getMainGameChannel(), text);
                 if (privatePlayer.getGenSynthesisInfantry() > 0) {

--- a/src/main/java/ti4/commands2/player/SCPick.java
+++ b/src/main/java/ti4/commands2/player/SCPick.java
@@ -25,12 +25,14 @@ import ti4.helpers.Constants;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
 import ti4.helpers.PromissoryNoteHelper;
+import ti4.helpers.StringHelper;
 import ti4.image.BannerGenerator;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
 import ti4.service.info.ListTurnOrderService;
 import ti4.service.player.PlayerStatsService;
+import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
 
 class SCPick extends GameStateSubcommand {
@@ -181,7 +183,7 @@ class SCPick extends GameStateSubcommand {
 
             //INFORM FIRST PLAYER IS UP FOR ACTION
             if (nextPlayer != null) {
-                msgExtra += " " + nextPlayer.getRepresentation() + " is up for an action";
+                msgExtra += "\n" + nextPlayer.getRepresentation() + " is first in initiative order.";
                 privatePlayer = nextPlayer;
                 game.updateActivePlayer(nextPlayer);
                 ButtonHelperFactionSpecific.resolveMilitarySupportCheck(nextPlayer, game);
@@ -201,7 +203,9 @@ class SCPick extends GameStateSubcommand {
         //SEND EXTRA MESSAGE
         if (isFowPrivateGame) {
             if (allPicked) {
-                msgExtra = privatePlayer.getRepresentationUnfogged() + " UP NEXT";
+                BannerGenerator.drawPhaseBanner("action", game.getRound(), game.getActionsChannel());
+                msgExtra = privatePlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
+                    + StringHelper.ordinal(privatePlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
             }
             String fail = "User for next faction not found. Report to ADMIN";
             String success = "The next player has been notified";
@@ -216,7 +220,7 @@ class SCPick extends GameStateSubcommand {
                 if (game.isShowBanners()) {
                     BannerGenerator.drawFactionBanner(privatePlayer);
                 }
-                MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getPrivateChannel(), msgExtra + "\n Use Buttons to do turn.",
+                MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getPrivateChannel(), "Use buttons to do turn.",
                     StartTurnService.getStartOfTurnButtons(privatePlayer, game, false, event));
                 if (privatePlayer.getGenSynthesisInfantry() > 0) {
                     if (!ButtonHelper.getPlaceStatusInfButtons(game, privatePlayer).isEmpty()) {
@@ -234,21 +238,31 @@ class SCPick extends GameStateSubcommand {
             }
 
         } else {
-            if (allPicked) {
-                ListTurnOrderService.turnOrder(event, game);
-            }
             if (!allPicked) {
                 game.updateActivePlayer(privatePlayer);
                 MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), msgExtra + "\nUse buttons to pick your strategy card.", Helper.getRemainingSCButtons(game, privatePlayer));
                 game.setPhaseOfGame("strategy");
             } else {
                 MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
+                if (game.isShowBanners()) {
+                    BannerGenerator.drawPhaseBanner("action", game.getRound(), game.getActionsChannel());
+                }
+                game.setPhaseOfGame("action");
+                ListTurnOrderService.turnOrder(event, game);
                 privatePlayer.setInRoundTurnCount(privatePlayer.getInRoundTurnCount() + 1);
                 if (game.isShowBanners()) {
                     BannerGenerator.drawFactionBanner(privatePlayer);
                 }
-                MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), "\n Use Buttons to do turn.",
-                    StartTurnService.getStartOfTurnButtons(privatePlayer, game, false, event));
+                String text = player.getRepresentationUnfogged() + ", it is now your turn (your " 
+                    + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
+                Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
+                if (nextPlayer == null || game.isFowMode()) {
+                } else if (nextPlayer == player) {
+                    text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+                } else {
+                    text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                }
+                MessageHelper.sendMessageToChannel(game.getMainGameChannel(), text);
                 if (privatePlayer.getGenSynthesisInfantry() > 0) {
                     if (!ButtonHelper.getPlaceStatusInfButtons(game, privatePlayer).isEmpty()) {
                         MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getCorrectChannel(),
@@ -261,7 +275,8 @@ class SCPick extends GameStateSubcommand {
 
                     }
                 }
-                game.setPhaseOfGame("action");
+                MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), "Use buttons to do turn.",
+                    StartTurnService.getStartOfTurnButtons(privatePlayer, game, false, event));
             }
         }
         if (allPicked) {

--- a/src/main/java/ti4/commands2/player/SCUnpick.java
+++ b/src/main/java/ti4/commands2/player/SCUnpick.java
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.commands2.GameStateSubcommand;
 import ti4.helpers.Constants;
 import ti4.helpers.FoWHelper;
+import ti4.helpers.StringHelper;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
@@ -104,7 +105,8 @@ class SCUnpick extends GameStateSubcommand {
         //SEND EXTRA MESSAGE
         if (isFowPrivateGame) {
             if (allPicked) {
-                msgExtra = privatePlayer.getRepresentationUnfogged() + " UP NEXT";
+                msgExtra = privatePlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
+                    + StringHelper.ordinal(privatePlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
             }
             String fail = "User for next faction not found. Report to ADMIN";
             String success = "The next player has been notified";

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -5687,10 +5687,9 @@ public class ButtonHelper {
             String msgExtra = player.getRepresentationUnfogged() + ", it is now your turn (your " 
                     + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
             Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
-            if (nextPlayer == null) {
-            } else if (nextPlayer == player) {
+            if (nextPlayer == player) {
                 msgExtra += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
-            } else {
+            } else if (nextPlayer != null) {
                 msgExtra += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
             }
             MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -44,9 +44,11 @@ import ti4.commands2.tokens.AddTokenCommand;
 import ti4.helpers.DiceHelper.Die;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
+import ti4.image.BannerGenerator;
 import ti4.image.MapRenderPipeline;
 import ti4.image.Mapper;
 import ti4.image.PositionMapper;
+import ti4.helpers.StringHelper;
 import ti4.image.TileGenerator;
 import ti4.image.TileHelper;
 import ti4.listeners.annotations.ButtonHandler;
@@ -91,6 +93,7 @@ import ti4.service.planet.AddPlanetService;
 import ti4.service.planet.FlipTileService;
 import ti4.service.tech.ShowTechDeckService;
 import ti4.service.transaction.SendDebtService;
+import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.RemoveUnitService;
@@ -5632,12 +5635,9 @@ public class ButtonHelper {
 
     public static void startMyTurn(GenericInteractionCreateEvent event, Game game, Player player) {
         boolean isFowPrivateGame = FoWHelper.isPrivateGame(game, event);
-        String msg;
-        String msgExtra = "";
 
         // INFORM FIRST PLAYER IS UP FOR ACTION
         if (player != null) {
-            msgExtra += "# " + player.getRepresentation() + " is up for an action";
             game.updateActivePlayer(player);
             if (game.isFowMode()) {
                 FoWHelper.pingAllPlayersWithFullStats(game, event, player, "started turn");
@@ -5646,16 +5646,17 @@ public class ButtonHelper {
             ButtonHelperFactionSpecific.resolveKolleccAbilities(player, game);
 
             game.setPhaseOfGame("action");
+        } else {
+            BotLogger.log(event, "`ButtonHelper.startMyTurn` player is null");
+            return;
         }
 
-        msg = "";
-        MessageHelper.sendMessageToChannel(event.getMessageChannel(), msg);
         if (isFowPrivateGame) {
-            if (player == null) {
-                BotLogger.log(event, "`ButtonHelper.startMyTurn` privatePlayer is null");
-                return;
+            if (game.isShowBanners()) {
+                BannerGenerator.drawFactionBanner(player);
             }
-            msgExtra = player.getRepresentationUnfogged() + " UP NEXT";
+            String msgExtra = player.getRepresentationUnfogged() + ", it is now your turn (your " 
+                    + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
             String fail = "User for next faction not found. Report to ADMIN";
             String success = "The next player has been notified";
             MessageHelper.sendPrivateMessageToPlayer(player, game, event, msgExtra, fail, success);
@@ -5679,29 +5680,37 @@ public class ButtonHelper {
 
                 }
             }
-
         } else {
-            if (!msgExtra.isEmpty()) {
-                MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
-                MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(),
-                    "\n Use Buttons to do turn.",
-                    StartTurnService.getStartOfTurnButtons(player, game, false, event));
+            if (game.isShowBanners()) {
+                BannerGenerator.drawFactionBanner(player);
+            }
+            String msgExtra = player.getRepresentationUnfogged() + ", it is now your turn (your " 
+                    + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
+            Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
+            if (nextPlayer == null) {
+            } else if (nextPlayer == player) {
+                msgExtra += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+            } else {
+                msgExtra += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+            }
+            MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
 
-                if (player.getGenSynthesisInfantry() > 0) {
-                    if (!getPlaceStatusInfButtons(game, player).isEmpty()) {
-                        MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(),
-                            "Use buttons to revive infantry. You have " + player.getGenSynthesisInfantry()
-                                + " infantry left to revive.",
-                            getPlaceStatusInfButtons(game, player));
-                    } else {
-                        player.setStasisInfantry(0);
-                        MessageHelper.sendMessageToChannel(player.getCorrectChannel(), player
-                            .getRepresentation()
-                            + ", you had infantry II to be revived, but the bot couldn't any planets you control own in your home system to place them on, so per the rules they now disappear into the ether.");
+            if (player.getGenSynthesisInfantry() > 0) {
+                if (!getPlaceStatusInfButtons(game, player).isEmpty()) {
+                    MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(),
+                        "Use buttons to revive infantry. You have " + player.getGenSynthesisInfantry()
+                            + " infantry left to revive.",
+                        getPlaceStatusInfButtons(game, player));
+                } else {
+                    player.setStasisInfantry(0);
+                    MessageHelper.sendMessageToChannel(player.getCorrectChannel(), player
+                        .getRepresentation()
+                        + ", you had infantry II to be revived, but the bot couldn't any planets you control own in your home system to place them on, so per the rules they now disappear into the ether.");
 
-                    }
                 }
             }
+            MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(),
+                "Use buttons to do turn.", StartTurnService.getStartOfTurnButtons(player, game, false, event));
         }
     }
 

--- a/src/main/java/ti4/helpers/ButtonHelperActionCards.java
+++ b/src/main/java/ti4/helpers/ButtonHelperActionCards.java
@@ -1789,15 +1789,17 @@ public class ButtonHelperActionCards {
             }
         }
         String adjective = "";
-        if (amount > 3) {
+        if (amount >= 5) {
             if (hits == 0) {
                 adjective = "n inconsequential";
             } else if (hits == amount) {
                 adjective = " catastrophic";
             } else if (hits <= amount / 3) {
                 adjective = " minor";
-            } else if (hits <= 2 * amount / 3) {
+            } else if (hits >= 2 * (amount+1) / 3) {
                 adjective = " major";
+            } else if (hits * 2 == amount) {
+                adjective = " typical";
             }
         }
         if (game.isFowMode())

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -380,18 +380,6 @@ public class MessageHelper {
 							Game game = managedGame.getGame();
 							game.setLatestTransactionMsg(complete.getId());
 						}
-
-						if (false && message.toLowerCase().contains("up next")) { // disabled due to change in start-of-turn message
-							Game game = managedGame.getGame();
-							if (game.getLatestUpNextMsg() != null && !"".equalsIgnoreCase(game.getLatestUpNextMsg())) {
-								String id = game.getLatestUpNextMsg().split("_")[0];
-								String msg = game.getLatestUpNextMsg().substring(game.getLatestUpNextMsg().indexOf("_") + 1);
-								msg = msg.replace("UP NEXT", "started their turn");
-								game.getActionsChannel().editMessageById(id, msg).queue(null,
-									error -> BotLogger.log(getRestActionFailureMessage(channel, "Error editing message", messageCreateData, error)));
-							}
-							game.setLatestUpNextMsg(complete.getId() + "_" + message);
-						}
 					}
 
 					// RUN SUPPLIED ACTION

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -381,7 +381,7 @@ public class MessageHelper {
 							game.setLatestTransactionMsg(complete.getId());
 						}
 
-						if (message.toLowerCase().contains("up next")) {
+						if (false && message.toLowerCase().contains("up next")) { // disabled due to change in start-of-turn message
 							Game game = managedGame.getGame();
 							if (game.getLatestUpNextMsg() != null && !"".equalsIgnoreCase(game.getLatestUpNextMsg())) {
 								String id = game.getLatestUpNextMsg().split("_")[0];

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -532,10 +532,9 @@ public class StartPhaseService {
             String msgExtra = nextPlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
                 + StringHelper.ordinal(nextPlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
             Player nextNextPlayer = EndTurnService.findNextUnpassedPlayer(game, nextPlayer);
-            if (nextNextPlayer == null) {
-            } else if (nextNextPlayer == nextPlayer) {
+            if (nextNextPlayer == nextPlayer) {
                 msgExtra += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
-            } else {
+            } else if (nextNextPlayer != null) {
                 msgExtra += "\n-# " + nextNextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
             }
             MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -23,6 +23,7 @@ import ti4.helpers.GameLaunchThreadHelper;
 import ti4.helpers.Helper;
 import ti4.helpers.PlayerTitleHelper;
 import ti4.helpers.PromissoryNoteHelper;
+import ti4.helpers.StringHelper;
 import ti4.image.BannerGenerator;
 import ti4.image.MapRenderPipeline;
 import ti4.image.Mapper;
@@ -456,9 +457,6 @@ public class StartPhaseService {
         String msg;
         game.setStoredValue("willRevolution", "");
         game.setPhaseOfGame("action");
-        String msgExtra = "";
-        boolean allPicked = true;
-        Player privatePlayer = null;
         Collection<Player> activePlayers = game.getPlayers().values().stream()
             .filter(Player::isRealPlayer)
             .toList();
@@ -488,73 +486,73 @@ public class StartPhaseService {
             }
         }
 
-        // INFORM FIRST PLAYER IS UP FOR ACTION
-        if (nextPlayer != null) {
-            msgExtra += " " + nextPlayer.getRepresentation() + " is up for an action";
-            privatePlayer = nextPlayer;
-            game.updateActivePlayer(nextPlayer);
-            if (game.isFowMode()) {
-                FoWHelper.pingAllPlayersWithFullStats(game, event, nextPlayer, "started turn");
-            }
-            ButtonHelperFactionSpecific.resolveMilitarySupportCheck(nextPlayer, game);
-
-            game.setPhaseOfGame("action");
+        game.setPhaseOfGame("action");
+        if (nextPlayer == null) {
+            return;
         }
+        game.updateActivePlayer(nextPlayer);
+        if (game.isFowMode()) {
+            FoWHelper.pingAllPlayersWithFullStats(game, event, nextPlayer, "started turn");
+        }
+        ButtonHelperFactionSpecific.resolveMilitarySupportCheck(nextPlayer, game);
 
-        msg = "";
-        MessageHelper.sendMessageToChannel(nextPlayer.getCorrectChannel(), msg);
         if (isFowPrivateGame) {
-            msgExtra = "Start phase command run";
+            String msgExtra = "Start phase command run";
             String fail = "User for next faction not found. Report to ADMIN";
             String success = "The next player has been notified";
-            MessageHelper.sendPrivateMessageToPlayer(privatePlayer, game, event, msgExtra, fail, success);
-            if (privatePlayer == null)
-                return;
-            msgExtra = privatePlayer.getRepresentationUnfogged() + " UP NEXT";
-            game.updateActivePlayer(privatePlayer);
+            MessageHelper.sendPrivateMessageToPlayer(nextPlayer, game, event, msgExtra, fail, success);
+            msgExtra = nextPlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
+                + StringHelper.ordinal(nextPlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
+            game.updateActivePlayer(nextPlayer);
 
-            if (!allPicked) {
-                game.setPhaseOfGame("strategy");
-                MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getPrivateChannel(), "Use buttons to pick a strategy card.", Helper.getRemainingSCButtons(game, privatePlayer));
-            } else {
+            MessageHelper.sendMessageToChannelWithButtons(nextPlayer.getPrivateChannel(), msgExtra + "\n Use buttons to do turn.", StartTurnService.getStartOfTurnButtons(nextPlayer, game, false, event));
 
-                MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getPrivateChannel(), msgExtra + "\n Use Buttons to do turn.", StartTurnService.getStartOfTurnButtons(privatePlayer, game, false, event));
-
-                if (privatePlayer.getGenSynthesisInfantry() > 0) {
-                    if (!ButtonHelper.getPlaceStatusInfButtons(game, privatePlayer).isEmpty()) {
-                        MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getCorrectChannel(),
-                            "Use buttons to revive infantry. You have " + privatePlayer.getGenSynthesisInfantry() + " infantry left to revive.",
-                            ButtonHelper.getPlaceStatusInfButtons(game, privatePlayer));
-                    } else {
-                        privatePlayer.setStasisInfantry(0);
-                        MessageHelper.sendMessageToChannel(privatePlayer.getCorrectChannel(), privatePlayer.getRepresentation()
-                            + ", you had infantry II to be revived, but the bot couldn't find any planets you control in your home system to place them on, so per the rules they now disappear into the ether.");
-                    }
+            if (nextPlayer.getGenSynthesisInfantry() > 0) {
+                if (!ButtonHelper.getPlaceStatusInfButtons(game, nextPlayer).isEmpty()) {
+                    MessageHelper.sendMessageToChannelWithButtons(nextPlayer.getCorrectChannel(),
+                        "Use buttons to revive infantry. You have " + nextPlayer.getGenSynthesisInfantry() + " infantry left to revive.",
+                        ButtonHelper.getPlaceStatusInfButtons(game, nextPlayer));
+                } else {
+                    nextPlayer.setStasisInfantry(0);
+                    MessageHelper.sendMessageToChannel(nextPlayer.getCorrectChannel(), nextPlayer.getRepresentation()
+                        + ", you had infantry II to be revived, but the bot couldn't find any planets you control in your home system to place them on, so per the rules they now disappear into the ether.");
                 }
             }
 
         } else {
-            MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "All players have picked a strategy card.");
+            MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "All players have picked a strategy card.\n"
+                + nextPlayer.getRepresentation() + " is first in initiative order.");
             if (game.isShowBanners()) {
                 BannerGenerator.drawPhaseBanner("action", game.getRound(), game.getActionsChannel());
             }
             ListTurnOrderService.turnOrder(event, game);
-            if (!msgExtra.isEmpty()) {
-                MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
-                MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), "\n Use Buttons to do turn.", StartTurnService.getStartOfTurnButtons(privatePlayer, game, false, event));
+            if (game.isShowBanners()) {
+                BannerGenerator.drawFactionBanner(nextPlayer);
+            }
+            String msgExtra = nextPlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
+                + StringHelper.ordinal(nextPlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
+            Player nextNextPlayer = EndTurnService.findNextUnpassedPlayer(game, nextPlayer);
+            if (nextNextPlayer == null) {
+            } else if (nextNextPlayer == nextPlayer) {
+                msgExtra += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+            } else {
+                msgExtra += "\n-# " + nextNextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+            }
+            MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
 
-                if (privatePlayer.getGenSynthesisInfantry() > 0) {
-                    if (!ButtonHelper.getPlaceStatusInfButtons(game, privatePlayer).isEmpty()) {
-                        MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getCorrectChannel(),
-                            "Use buttons to revive infantry. You have " + privatePlayer.getGenSynthesisInfantry() + " infantry left to revive.",
-                            ButtonHelper.getPlaceStatusInfButtons(game, privatePlayer));
-                    } else {
-                        privatePlayer.setStasisInfantry(0);
-                        MessageHelper.sendMessageToChannel(privatePlayer.getCorrectChannel(), privatePlayer.getRepresentation()
-                            + ", you had infantry II to be revived, but the bot couldn't find any planets you control in your home system to place them on, so per the rules they now disappear into the ether.");
-                    }
+            if (nextPlayer.getGenSynthesisInfantry() > 0) {
+                if (!ButtonHelper.getPlaceStatusInfButtons(game, nextPlayer).isEmpty()) {
+                    MessageHelper.sendMessageToChannelWithButtons(nextPlayer.getCorrectChannel(),
+                        "Use buttons to revive infantry. You have " + nextPlayer.getGenSynthesisInfantry() + " infantry left to revive.",
+                        ButtonHelper.getPlaceStatusInfButtons(game, nextPlayer));
+                } else {
+                    nextPlayer.setStasisInfantry(0);
+                    MessageHelper.sendMessageToChannel(nextPlayer.getCorrectChannel(), nextPlayer.getRepresentation()
+                        + ", you had infantry II to be revived, but the bot couldn't find any planets you control in your home system to place them on, so per the rules they now disappear into the ether.");
                 }
             }
+            MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), "Use buttons to do turn.",
+                StartTurnService.getStartOfTurnButtons(nextPlayer, game, false, event));
         }
         for (Player p2 : game.getRealPlayers()) {
             List<Button> buttons = new ArrayList<>();

--- a/src/main/java/ti4/service/strategycard/PickStrategyCardService.java
+++ b/src/main/java/ti4/service/strategycard/PickStrategyCardService.java
@@ -19,11 +19,13 @@ import ti4.helpers.ButtonHelperFactionSpecific;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
 import ti4.helpers.PromissoryNoteHelper;
+import ti4.helpers.StringHelper;
 import ti4.image.BannerGenerator;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
 import ti4.service.info.ListTurnOrderService;
+import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
 
 @UtilityClass
@@ -114,7 +116,7 @@ public class PickStrategyCardService {
 
             //INFORM FIRST PLAYER IS UP FOR ACTION
             if (nextPlayer != null) {
-                msgExtra += " " + nextPlayer.getRepresentation() + " is up for an action";
+                msgExtra += "\n" + nextPlayer.getRepresentation() + " is first in initiative order.";
                 privatePlayer = nextPlayer;
                 game.updateActivePlayer(nextPlayer);
                 ButtonHelperFactionSpecific.resolveMilitarySupportCheck(nextPlayer, game);
@@ -134,7 +136,8 @@ public class PickStrategyCardService {
         //SEND EXTRA MESSAGE
         if (isFowPrivateGame) {
             if (allPicked) {
-                msgExtra = privatePlayer.getRepresentationUnfogged() + " UP NEXT";
+                msgExtra = privatePlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
+                    + StringHelper.ordinal(privatePlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
             }
             String fail = "User for next faction not found. Report to ADMIN";
             String success = "The next player has been notified";
@@ -167,21 +170,31 @@ public class PickStrategyCardService {
             }
 
         } else {
-            if (allPicked) {
-                ListTurnOrderService.turnOrder(event, game);
-            }
             if (!allPicked) {
                 game.updateActivePlayer(privatePlayer);
                 MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), msgExtra + "\nUse buttons to pick your strategy card.", Helper.getRemainingSCButtons(game, privatePlayer));
                 game.setPhaseOfGame("strategy");
             } else {
                 MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
+                if (game.isShowBanners()) {
+                    BannerGenerator.drawPhaseBanner("action", game.getRound(), game.getActionsChannel());
+                }
+                game.setPhaseOfGame("action");
+                ListTurnOrderService.turnOrder(event, game);
                 privatePlayer.setInRoundTurnCount(privatePlayer.getInRoundTurnCount() + 1);
                 if (game.isShowBanners()) {
                     BannerGenerator.drawFactionBanner(privatePlayer);
                 }
-                MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), "\n Use Buttons to do turn.",
-                    StartTurnService.getStartOfTurnButtons(privatePlayer, game, false, event));
+                String text = privatePlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
+                    + StringHelper.ordinal(privatePlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
+                Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, privatePlayer);
+                if (nextPlayer == null) {
+                } else if (nextPlayer == privatePlayer) {
+                    text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+                } else {
+                    text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                }
+                MessageHelper.sendMessageToChannel(game.getMainGameChannel(), text);
                 if (privatePlayer.getGenSynthesisInfantry() > 0) {
                     if (!ButtonHelper.getPlaceStatusInfButtons(game, privatePlayer).isEmpty()) {
                         MessageHelper.sendMessageToChannelWithButtons(privatePlayer.getCorrectChannel(),
@@ -194,7 +207,8 @@ public class PickStrategyCardService {
 
                     }
                 }
-                game.setPhaseOfGame("action");
+                MessageHelper.sendMessageToChannelWithButtons(game.getMainGameChannel(), "Use buttons to do turn.",
+                    StartTurnService.getStartOfTurnButtons(privatePlayer, game, false, event));
             }
         }
         if (allPicked) {

--- a/src/main/java/ti4/service/strategycard/PickStrategyCardService.java
+++ b/src/main/java/ti4/service/strategycard/PickStrategyCardService.java
@@ -188,10 +188,9 @@ public class PickStrategyCardService {
                 String text = privatePlayer.getRepresentationUnfogged() + ", it is now your turn (your " 
                     + StringHelper.ordinal(privatePlayer.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
                 Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, privatePlayer);
-                if (nextPlayer == null) {
-                } else if (nextPlayer == privatePlayer) {
+                if (nextPlayer == privatePlayer) {
                     text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
-                } else {
+                } else if (nextPlayer != null) {
                     text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
                 }
                 MessageHelper.sendMessageToChannel(game.getMainGameChannel(), text);

--- a/src/main/java/ti4/service/tech/PlayerTechService.java
+++ b/src/main/java/ti4/service/tech/PlayerTechService.java
@@ -24,6 +24,7 @@ import ti4.helpers.DiceHelper;
 import ti4.helpers.DiscordantStarsHelper;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
+import ti4.helpers.StringHelper;
 import ti4.helpers.Units;
 import ti4.helpers.ignis_aurora.IgnisAuroraHelperTechs;
 import ti4.image.Mapper;
@@ -40,6 +41,7 @@ import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.ExploreEmojis;
 import ti4.service.emoji.FactionEmojis;
 import ti4.service.leader.CommanderUnlockCheckService;
+import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
 import ti4.service.unit.AddUnitService;
 
@@ -470,7 +472,15 @@ public class PlayerTechService {
                     // Block of code to handle errors
                 }
             }
-            String text = player.getRepresentationUnfogged() + " UP NEXT";
+            String text = player.getRepresentationUnfogged() + ", it is now your turn (your " 
+                + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
+            Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
+            if (nextPlayer == null || game.isFowMode()) {
+            } else if (nextPlayer == player) {
+                text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+            } else {
+                text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+            }
             String buttonText = "Use buttons to do your turn. ";
             if (game.getName().equalsIgnoreCase("pbd1000") || game.getName().equalsIgnoreCase("pbd100two")) {
                 buttonText = buttonText + "Your SC number is #" + player.getSCs().toArray()[0];

--- a/src/main/java/ti4/service/tech/PlayerTechService.java
+++ b/src/main/java/ti4/service/tech/PlayerTechService.java
@@ -475,11 +475,12 @@ public class PlayerTechService {
             String text = player.getRepresentationUnfogged() + ", it is now your turn (your " 
                 + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
             Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
-            if (nextPlayer == null || game.isFowMode()) {
-            } else if (nextPlayer == player) {
-                text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
-            } else {
-                text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+            if (nextPlayer != null && !game.isFowMode()) {
+                if (nextPlayer == player) {
+                    text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+                } else {
+                    text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                }
             }
             String buttonText = "Use buttons to do your turn. ";
             if (game.getName().equalsIgnoreCase("pbd1000") || game.getName().equalsIgnoreCase("pbd100two")) {

--- a/src/main/java/ti4/service/turn/StartTurnService.java
+++ b/src/main/java/ti4/service/turn/StartTurnService.java
@@ -20,6 +20,7 @@ import ti4.helpers.ButtonHelperFactionSpecific;
 import ti4.helpers.ComponentActionHelper;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
+import ti4.helpers.StringHelper;
 import ti4.image.BannerGenerator;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -72,7 +73,16 @@ public class StartTurnService {
                 goingToPass = true;
             }
         }
-        String text = player.getRepresentationUnfogged() + " UP NEXT (Turn #" + player.getInRoundTurnCount() + ")";
+        String text = player.getRepresentationUnfogged() + ", it is now your turn (your " 
+            + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
+        Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
+        if (nextPlayer == null || game.isFowMode()) {
+        } else if (nextPlayer == player) {
+            text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+        } else {
+            text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+        }
+        
         String buttonText = "Use buttons to do your turn. ";
         if (game.getName().equalsIgnoreCase("pbd1000") || game.getName().equalsIgnoreCase("pbd100two")) {
             buttonText = buttonText + "Your SC number is #" + player.getSCs().toArray()[0];
@@ -126,9 +136,6 @@ public class StartTurnService {
                 BannerGenerator.drawFactionBanner(player);
             }
             MessageHelper.sendMessageToChannel(gameChannel, text);
-            if (!goingToPass) {
-                MessageHelper.sendMessageToChannelWithButtons(gameChannel, buttonText, buttons);
-            }
             if (getMissedSCFollowsText(game, player) != null
                 && !"".equalsIgnoreCase(getMissedSCFollowsText(game, player))) {
                 MessageHelper.sendMessageToChannel(gameChannel, getMissedSCFollowsText(game, player));
@@ -144,6 +151,9 @@ public class StartTurnService {
                         + ", you had infantry II to be revived, but the bot couldn't find any planets you control in your home system to place them on, so per the rules they now disappear into the ether.");
 
                 }
+            }
+            if (!goingToPass) {
+                MessageHelper.sendMessageToChannelWithButtons(gameChannel, buttonText, buttons);
             }
             ButtonHelperFactionSpecific.resolveMykoMechCheck(player, game);
             ButtonHelperFactionSpecific.resolveKolleccAbilities(player, game);

--- a/src/main/java/ti4/service/turn/StartTurnService.java
+++ b/src/main/java/ti4/service/turn/StartTurnService.java
@@ -76,11 +76,12 @@ public class StartTurnService {
         String text = player.getRepresentationUnfogged() + ", it is now your turn (your " 
             + StringHelper.ordinal(player.getInRoundTurnCount()) + " turn of round " + game.getRound() + ").";
         Player nextPlayer = EndTurnService.findNextUnpassedPlayer(game, player);
-        if (nextPlayer == null || game.isFowMode()) {
-        } else if (nextPlayer == player) {
-            text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
-        } else {
-            text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+        if (nextPlayer != null && !game.isFowMode()) {
+            if (nextPlayer == player) {
+                text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
+            } else {
+                text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+            }
         }
         
         String buttonText = "Use buttons to do your turn. ";


### PR DESCRIPTION
Currently, the bot says `[player] is UP NEXT` at the start of their turn. However, on the map, the active player is marked `ACTIVE` and the next player in initiative order is marked `NEXT UP`. This change primarily changes the former message to be more explicit that it is the player's turn *now*.

The player who is next in initiative order is also shown in the start of turn message (if not fog-of-war), but they are not pinged. The message changes if all other players have passed. In addition, the buttons for doing the turn action are moved below the pending strategy cards etc, so that the message can be resolved top-to-bottom (though in the example below, the strategy cards were popped in initiative order, so ideally Leadership would be up the top).

![image](https://github.com/user-attachments/assets/191aabb8-0e2d-4327-9d45-c4d8c55a8d60)
