### PR TITLE
Ping on next turn

### DIFF
--- a/src/main/java/ti4/commands2/player/SCPick.java
+++ b/src/main/java/ti4/commands2/player/SCPick.java
@@ -34,6 +34,7 @@ import ti4.service.info.ListTurnOrderService;
 import ti4.service.player.PlayerStatsService;
 import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
+import ti4.settings.users.UserSettingsManager;
 
 class SCPick extends GameStateSubcommand {
 
@@ -260,7 +261,8 @@ class SCPick extends GameStateSubcommand {
                     if (nextPlayer == player) {
                         text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
                     } else {
-                        text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                        String ping = UserSettingsManager.get(nextPlayer.getUserID()).isPingOnNextTurn() ? nextPlayer.getRepresentationUnfogged() : nextPlayer.getRepresentationNoPing();
+                        text += "\n-# " + ping + " will start their turn once you've ended yours.";
                     }
                 }
                 MessageHelper.sendMessageToChannel(game.getMainGameChannel(), text);

--- a/src/main/java/ti4/commands2/user/SetPingOnNextTurn.java
+++ b/src/main/java/ti4/commands2/user/SetPingOnNextTurn.java
@@ -1,0 +1,21 @@
+package ti4.commands2.user;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import ti4.commands2.Subcommand;
+import ti4.service.player.PingOnNextTurn;
+
+class SetPingOnNextTurn extends Subcommand {
+
+    public SetPingOnNextTurn() {
+        super("set_ping_on_next_turn", "Set whether to ping you when the player before you starts their turn");
+        addOption(OptionType.BOOLEAN, "ping", "True to ping you, false to not", true);
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        boolean ping = event.getOption("ping", false, OptionMapping::getAsBoolean);
+        PingOnNextTurn.set(event, ping);
+    }
+}

--- a/src/main/java/ti4/commands2/user/UserCommand.java
+++ b/src/main/java/ti4/commands2/user/UserCommand.java
@@ -14,6 +14,7 @@ public class UserCommand implements ParentCommand {
                     new ShowUserSettings(),
                     new SetPreferredColourList(),
                     new SetPersonalPingInterval(),
+                    new SetPingOnNextTurn(),
                     new OfferAFKTimeOptions())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -98,6 +98,7 @@ import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.RemoveUnitService;
+import ti4.settings.users.UserSettingsManager;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -5692,7 +5693,8 @@ public class ButtonHelper {
             if (nextPlayer == player) {
                 msgExtra += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
             } else if (nextPlayer != null) {
-                msgExtra += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                String ping = UserSettingsManager.get(nextPlayer.getUserID()).isPingOnNextTurn() ? nextPlayer.getRepresentationUnfogged() : nextPlayer.getRepresentationNoPing();
+                msgExtra += "\n-# " + ping + " will start their turn once you've ended yours.";
             }
             MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
 

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -46,6 +46,7 @@ import ti4.service.info.ListPlayerInfoService;
 import ti4.service.info.ListTurnOrderService;
 import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
+import ti4.settings.users.UserSettingsManager;
 
 @UtilityClass
 public class StartPhaseService {
@@ -581,7 +582,8 @@ public class StartPhaseService {
             if (nextNextPlayer == nextPlayer) {
                 msgExtra += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
             } else if (nextNextPlayer != null) {
-                msgExtra += "\n-# " + nextNextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                String ping = UserSettingsManager.get(nextNextPlayer.getUserID()).isPingOnNextTurn() ? nextNextPlayer.getRepresentationUnfogged() : nextNextPlayer.getRepresentationNoPing();
+                msgExtra += "\n-# " + ping + " will start their turn once you've ended yours.";
             }
             MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msgExtra);
 

--- a/src/main/java/ti4/service/player/PingOnNextTurn.java
+++ b/src/main/java/ti4/service/player/PingOnNextTurn.java
@@ -1,0 +1,27 @@
+package ti4.service.player;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import ti4.message.MessageHelper;
+import ti4.settings.users.UserSettings;
+import ti4.settings.users.UserSettingsManager;
+
+@UtilityClass
+public class PingOnNextTurn {
+
+    public static void set(GenericInteractionCreateEvent event, UserSettings settings, boolean ping) {
+        settings.setPingOnNextTurn(ping);
+        UserSettingsManager.save(settings);
+        
+        if (event == null) {
+            return;
+        }
+        String message = "Set `Ping On Next Turn` to: `" + ping + "`.";
+        MessageHelper.sendMessageToEventChannel(event, message);
+    }
+
+    public static void set(GenericInteractionCreateEvent event, boolean ping) {
+        UserSettings userSettings = UserSettingsManager.get(event.getUser().getId());
+        set(event, userSettings, ping);
+    }
+}

--- a/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
@@ -61,7 +61,7 @@ class WinningPathsStatisticsService {
 
         AtomicInteger atomicInteger = new AtomicInteger();
         StringBuilder sb = new StringBuilder();
-        sb.append("__**Winning Paths With SftT Count:**__").append("\n");
+        sb.append("__**Winning Paths Holding Support for the Throne Count:**__").append("\n");
         supportWinCount.entrySet().stream()
             .sorted(Map.Entry.<Integer, Integer>comparingByValue().reversed())
             .forEach(entry -> sb.append(atomicInteger.getAndIncrement() + 1)
@@ -71,9 +71,9 @@ class WinningPathsStatisticsService {
                 .append(Math.round(100 * entry.getValue() / (double) gameWithWinnerCount.get()))
                 .append("%)` ")
                 .append(entry.getKey())
-                .append(" SftT wins")
+                .append(" Support for the Throne wins")
                 .append("\n"));
-        MessageHelper.sendMessageToThread((MessageChannelUnion) event.getMessageChannel(), "SftT wins", sb.toString());
+        MessageHelper.sendMessageToThread((MessageChannelUnion) event.getMessageChannel(), "Support for the Throne wins", sb.toString());
     }
 
     private static void getWinsWithSupport(Game game, Map<Integer, Integer> supportWinCount, AtomicInteger gameWithWinnerCount) {

--- a/src/main/java/ti4/service/strategycard/PickStrategyCardService.java
+++ b/src/main/java/ti4/service/strategycard/PickStrategyCardService.java
@@ -27,6 +27,7 @@ import ti4.message.MessageHelper;
 import ti4.service.info.ListTurnOrderService;
 import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
+import ti4.settings.users.UserSettingsManager;
 
 @UtilityClass
 public class PickStrategyCardService {
@@ -191,7 +192,8 @@ public class PickStrategyCardService {
                 if (nextPlayer == privatePlayer) {
                     text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
                 } else if (nextPlayer != null) {
-                    text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                    String ping = UserSettingsManager.get(nextPlayer.getUserID()).isPingOnNextTurn() ? nextPlayer.getRepresentationUnfogged() : nextPlayer.getRepresentationNoPing();
+                    text += "\n-# " + ping + " will start their turn once you've ended yours.";
                 }
                 MessageHelper.sendMessageToChannel(game.getMainGameChannel(), text);
                 if (privatePlayer.getGenSynthesisInfantry() > 0) {

--- a/src/main/java/ti4/service/tech/PlayerTechService.java
+++ b/src/main/java/ti4/service/tech/PlayerTechService.java
@@ -44,6 +44,7 @@ import ti4.service.leader.CommanderUnlockCheckService;
 import ti4.service.turn.EndTurnService;
 import ti4.service.turn.StartTurnService;
 import ti4.service.unit.AddUnitService;
+import ti4.settings.users.UserSettingsManager;
 
 @UtilityClass
 public class PlayerTechService {
@@ -479,7 +480,8 @@ public class PlayerTechService {
                 if (nextPlayer == player) {
                     text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
                 } else {
-                    text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                    String ping = UserSettingsManager.get(nextPlayer.getUserID()).isPingOnNextTurn() ? nextPlayer.getRepresentationUnfogged() : nextPlayer.getRepresentationNoPing();
+                    text += "\n-# " + ping + " will start their turn once you've ended yours.";
                 }
             }
             String buttonText = "Use buttons to do your turn. ";

--- a/src/main/java/ti4/service/turn/StartTurnService.java
+++ b/src/main/java/ti4/service/turn/StartTurnService.java
@@ -39,6 +39,7 @@ import ti4.service.fow.FowCommunicationThreadService;
 import ti4.service.fow.WhisperService;
 import ti4.service.info.CardsInfoService;
 import ti4.service.leader.CommanderUnlockCheckService;
+import ti4.settings.users.UserSettingsManager;
 
 @UtilityClass
 public class StartTurnService {
@@ -80,7 +81,8 @@ public class StartTurnService {
             if (nextPlayer == player) {
                 text += "\n-# All other players are passed; you will take consecutive turns until you pass, ending the action phase.";
             } else {
-                text += "\n-# " + nextPlayer.getRepresentationNoPing() + " will start their turn once you've ended yours.";
+                String ping = UserSettingsManager.get(nextPlayer.getUserID()).isPingOnNextTurn() ? nextPlayer.getRepresentationUnfogged() : nextPlayer.getRepresentationNoPing();
+                text += "\n-# " + ping + " will start their turn once you've ended yours.";
             }
         }
         

--- a/src/main/java/ti4/settings/users/UserSettings.java
+++ b/src/main/java/ti4/settings/users/UserSettings.java
@@ -21,6 +21,7 @@ public class UserSettings {
     private boolean prefersDistanceBasedTacticalActions;
     private String afkHours;
     private LocalDateTime lockedFromCreatingGamesUntil;
+    private boolean pingOnNextTurn;
 
     UserSettings() {} // needed for ObjectMapper
 


### PR DESCRIPTION
Adds a `/user set_ping_on_next_turn` command, which if set true, will ping a player when the player before them starts their turn.