### PR TITLE
Duranium Armor summary fix & repair order automation

### DIFF
--- a/src/main/java/ti4/helpers/ShipRepairComparator.java
+++ b/src/main/java/ti4/helpers/ShipRepairComparator.java
@@ -1,0 +1,22 @@
+package ti4.helpers;
+
+import java.util.Comparator;
+import ti4.helpers.Units.UnitKey;
+
+public class ShipRepairComparator implements Comparator<UnitKey> {
+
+    @Override
+    public int compare(UnitKey o1, UnitKey o2) {
+        return Integer.compare(getAssignedValue(o1), getAssignedValue(o2));
+    }
+
+    private int getAssignedValue(UnitKey ship) {
+        return switch (ship.getUnitType()) {
+            case Units.UnitType.Cruiser -> 4;       // SE2 can have sustained damage
+            case Units.UnitType.Dreadnought -> 3;
+            case Units.UnitType.Flagship -> 2;
+            case Units.UnitType.Warsun -> 1;
+            default -> 0;
+        };
+    }
+}

--- a/src/test/java/ti4/helpers/ButtonHelperModifyUnitsTest.java
+++ b/src/test/java/ti4/helpers/ButtonHelperModifyUnitsTest.java
@@ -1,0 +1,385 @@
+package ti4.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import ti4.helpers.Units.UnitKey;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.map.Tile;
+import ti4.testUtils.BaseTi4Test;
+
+public class ButtonHelperModifyUnitsTest extends BaseTi4Test {
+    private final Game game = new Game();
+    private Tile tile = new Tile("tile 1", null, null, null, null);
+    @Test
+    void testAutoAssignSpaceCombatHits_SpaceCombat_DuraniumArmor() {
+
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 1, null, true, true);
+
+        assertFalse(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_Summarizing_DuraniumArmor_NoUnitDamage() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 2, null, true, false);
+
+        assertFalse(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_Summarizing_DuraniumArmor_NoUnitDamage_MultipleTypesOfDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        UnitKey warsunUnitKey = new UnitKey(Units.UnitType.Warsun, "red");
+        tile.addUnit(Constants.SPACE, warsunUnitKey, 1);
+
+        UnitKey flagshipUnitKey = new UnitKey(Units.UnitType.Flagship, "red");
+        tile.addUnit(Constants.SPACE, flagshipUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, true, false);
+
+        assertFalse(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_Summarizing_DuraniumArmor_UnitDamage_AutoAssignNoneToDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 1, null, true, false);
+
+        assertTrue(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_Summarizing_DuraniumArmor_UnitDamage_AutoAssignSomeToDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 2, null, true, false);
+
+        assertTrue(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+    
+    @Test
+    void testAutoAssignSpaceCombatHits_Summarizing_DuraniumArmor_UnitDamage_AutoAssignAllDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, true, false);
+
+        assertFalse(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_Summarizing_DuraniumArmor_UnitDamage_MultipleTypesOfDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        UnitKey warsunUnitKey = new UnitKey(Units.UnitType.Warsun, "red");
+        tile.addUnit(Constants.SPACE, warsunUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, warsunUnitKey, 1);
+
+        UnitKey flagshipUnitKey = new UnitKey(Units.UnitType.Flagship, "red");
+        tile.addUnit(Constants.SPACE, flagshipUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, flagshipUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, true, false);
+
+        assertTrue(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+        
+    @Disabled("Need a way to mock emoji's to prove actual message string")
+    @Test
+    void testAutoAssignSpaceCombatHits_Summarizing_DuraniumArmor_UnitDamage_DuraniumPreference() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        UnitKey warsunUnitKey = new UnitKey(Units.UnitType.Warsun, "red");
+        tile.addUnit(Constants.SPACE, warsunUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, warsunUnitKey, 1);
+
+        UnitKey flagshipUnitKey = new UnitKey(Units.UnitType.Flagship, "red");
+        tile.addUnit(Constants.SPACE, flagshipUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, flagshipUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, true, false);
+
+        assertTrue(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_NoUnitDamage() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 2, null, false, false);
+
+        assertFalse(actualMessage.contains("Would repair 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_NoUnitDamage_MultipleTypesOfDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        UnitKey warsunUnitKey = new UnitKey(Units.UnitType.Warsun, "red");
+        tile.addUnit(Constants.SPACE, warsunUnitKey, 1);
+
+        UnitKey flagshipUnitKey = new UnitKey(Units.UnitType.Flagship, "red");
+        tile.addUnit(Constants.SPACE, flagshipUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, false, false);
+
+        assertFalse(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_AutoAssignNoneToDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 1, null, false, false);
+
+        assertTrue(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_AutoAssignSomeToDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 2, null, false, false);
+
+        assertTrue(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+    
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_AutoAssignAllDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("fighter");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey fighterUnitKey = new UnitKey(Units.UnitType.Fighter, "red");
+        tile.addUnit(Constants.SPACE, fighterUnitKey, 1);
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 2);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, false, false);
+
+        assertFalse(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_MultipleTypesOfDamagedUnits() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        UnitKey warsunUnitKey = new UnitKey(Units.UnitType.Warsun, "red");
+        tile.addUnit(Constants.SPACE, warsunUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, warsunUnitKey, 1);
+
+        UnitKey flagshipUnitKey = new UnitKey(Units.UnitType.Flagship, "red");
+        tile.addUnit(Constants.SPACE, flagshipUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, flagshipUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, false, false);
+        assertTrue(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+    }
+        
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_DuraniumPreference() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        UnitKey warsunUnitKey = new UnitKey(Units.UnitType.Warsun, "red");
+        tile.addUnit(Constants.SPACE, warsunUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, warsunUnitKey, 1);
+
+        UnitKey flagshipUnitKey = new UnitKey(Units.UnitType.Flagship, "red");
+        tile.addUnit(Constants.SPACE, flagshipUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, flagshipUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, false, false);
+
+        assertTrue(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+        assertEquals(1, tile.getUnitHolders().get(Constants.SPACE).getDamagedUnitCount(warsunUnitKey));
+        assertEquals(2, tile.getUnitHolders().get(Constants.SPACE).getDamagedUnitCount(dreadnoughtUnitKey));
+        assertEquals(2, tile.getUnitHolders().get(Constants.SPACE).getDamagedUnitCount(flagshipUnitKey));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_SameShipTargeting() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 2, null, false, false);
+
+        assertTrue(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+        assertEquals(1, tile.getUnitHolders().get(Constants.SPACE).getUnitCount(dreadnoughtUnitKey));
+        assertEquals(0, tile.getUnitHolders().get(Constants.SPACE).getDamagedUnitCount(dreadnoughtUnitKey));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_DestroyedShips() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+        player.addOwnedUnitByID("flagship");
+        player.addOwnedUnitByID("warsun");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 2);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 3, null, false, false);
+
+        assertFalse(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+        assertEquals(0, tile.getUnitHolders().get(Constants.SPACE).getUnitCount(dreadnoughtUnitKey));
+        assertEquals(0, tile.getUnitHolders().get(Constants.SPACE).getDamagedUnitCount(dreadnoughtUnitKey));
+    }
+
+    @Test
+    void testAutoAssignSpaceCombatHits_DuraniumArmor_UnitDamage_ExtraSameShipTargeting() {
+        Player player = createPlayerWithDuraniumArmor(game, "red");
+        player.addOwnedUnitByID("dreadnought");
+
+        UnitKey dreadnoughtUnitKey = new UnitKey(Units.UnitType.Dreadnought, "red");
+        tile.addUnit(Constants.SPACE, dreadnoughtUnitKey, 4);
+        tile.addUnitDamage(Constants.SPACE, dreadnoughtUnitKey, 1);
+
+        String actualMessage = ButtonHelperModifyUnits.autoAssignSpaceCombatHits(player, game, tile, 4, null, false, false);
+
+        assertTrue(actualMessage.contains("Repaired 1 <normalEmoji> due to _Duranium Armor_"));
+        assertEquals(3, tile.getUnitHolders().get(Constants.SPACE).getUnitCount(dreadnoughtUnitKey));
+        assertEquals(2, tile.getUnitHolders().get(Constants.SPACE).getDamagedUnitCount(dreadnoughtUnitKey));
+    }
+
+    private static Player createPlayerWithDuraniumArmor(Game game, String color) {
+        Player player = new Player("101", "testUser", game);
+        player.setFactionEmoji("a");
+        player.setTechs(Arrays.asList("da"));
+        player.setColor(color);
+        return player;
+    }
+}


### PR DESCRIPTION
# Overview
Fix for #2699

Issue was in `#autoAssignSpaceCombatHits` when `justSummarizing == true` , destroyed units are not tracked before reaching final duranium check. 

- Added a map to track damaged units instead
- Added sort by preferred repair order (opposite hit order assignment).

I went pretty overboard on test cases, it was just faster for me to test personally. I am open to whatever feedback and best practices the devs prefer.  

# Example Combat with Changes
### DA on highest value ship
![Screenshot 2025-01-03 115045](https://github.com/user-attachments/assets/54e47a6a-e982-4f39-b248-41970479146f)
### DA on highest value ship with damage
![Screenshot 2025-01-03 115308](https://github.com/user-attachments/assets/92a94d4d-c5eb-4765-a1e4-4d3217c7778b)
### DA ship when hits can be assigned to lower value ship
![Screenshot 2025-01-03 115403](https://github.com/user-attachments/assets/6e5552c5-2c5a-426d-b38c-cbbb6e546343)
### DA not used as ship was undamaged
![Screenshot 2025-01-03 115446](https://github.com/user-attachments/assets/5a3a2a21-f3a9-407d-9f72-ddcb466b6325)
### DA not used as ship was blown up
![Screenshot 2025-01-03 115959](https://github.com/user-attachments/assets/a06dbc72-7776-43c3-b4c0-adaf6d64a12a)

