### PR TITLE
Get replacement mid-milty draft working again

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -316,6 +316,7 @@ public class AsyncTI4DiscordBot {
         adminRoles.add(jda.getRoleById("1225597324206800996")); // ForlornGeas's Server
         adminRoles.add(jda.getRoleById("1226068025464197160")); // Rintsi's Server
         adminRoles.add(jda.getRoleById("1226805374007640095")); // Solax's Server
+        adminRoles.add(jda.getRoleById("1313965793532186725")); // ppups's Server
         adminRoles.add(jda.getRoleById("951230650680225863")); // Community Server
         adminRoles.removeIf(Objects::isNull);
 
@@ -332,6 +333,7 @@ public class AsyncTI4DiscordBot {
         developerRoles.add(jda.getRoleById("1225597362186223746")); // ForlornGeas's Server
         developerRoles.add(jda.getRoleById("1226068105071956058")); // Rintsi's Server
         developerRoles.add(jda.getRoleById("1226805601422676069")); // Solax's Server
+        developerRoles.add(jda.getRoleById("1313966002551128166")); // ppups's Server
         developerRoles.removeIf(Objects::isNull);
 
         //BOTHELPER ROLES
@@ -349,6 +351,7 @@ public class AsyncTI4DiscordBot {
         bothelperRoles.add(jda.getRoleById("1215450829096624129")); // Sigma's Server
         bothelperRoles.add(jda.getRoleById("1226068245010710558")); // Rintsi's Server
         bothelperRoles.add(jda.getRoleById("1226805674046914560")); // Solax's Server 
+        bothelperRoles.add(jda.getRoleById("1313965956338417784")); // ppups's Server
         bothelperRoles.add(jda.getRoleById("1248693989193023519")); // Community Server
         bothelperRoles.removeIf(Objects::isNull);
     }

--- a/src/main/java/ti4/commands/game/Replace.java
+++ b/src/main/java/ti4/commands/game/Replace.java
@@ -1,5 +1,6 @@
 package ti4.commands.game;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -131,6 +132,17 @@ class Replace extends GameStateSubcommand {
             // do not update stats for this action
             game.setActivePlayerID(replacementUser.getId());
         }
+        Map<String, Player> playersById = game.getPlayers();
+        Map<String, Player> updatedPlayersById = new HashMap<>();
+        for (String userId: game.getPlayers().keySet()) {
+            if(userId.equalsIgnoreCase(oldPlayerUserId)) {
+                updatedPlayersById.put(replacedPlayer.getUserID(), replacedPlayer);
+            }
+            else {
+                updatedPlayersById.put(userId, playersById.get(userId));
+            }
+        }
+        game.setPlayers(updatedPlayersById);
 
         //UPDATE FOW PERMISSIONS
         if (game.isFowMode()) {


### PR DESCRIPTION
MiltyDraftManager was throwing a null pointer when it tried to loop over the players using its updated copy of userIds because we never updated the Game objects Map of players by id to have the new userId in it.  