### PR TITLE
Create Game: Handle 0 "last game" instances

### DIFF
--- a/src/main/java/ti4/buttons/handlers/game/CreateGameButtonHandler.java
+++ b/src/main/java/ti4/buttons/handlers/game/CreateGameButtonHandler.java
@@ -51,16 +51,19 @@ class CreateGameButtonHandler {
         String gameSillyName = StringUtils.substringBetween(buttonMsg, "Game Fun Name: ", "\n");
         String gameName = CreateGameService.getNextGameName();
         String lastGame = CreateGameService.getLastGameName();
-        if (!GameManager.isValid(lastGame)) {
-            BotLogger.log("**Unable to create new games because the last game cannot be found. Was it deleted but the roles still exist?**");
-            return;
-        }
-        Game game = GameManager.getManagedGame(lastGame).getGame();
-        if (game != null && game.getCustomName().equalsIgnoreCase(gameSillyName)) {
-            MessageHelper.sendMessageToChannel(event.getMessageChannel(),
-                "The custom name of the last game is the same as the one for this game, so the bot suspects a double press " +
-                    "occurred and is cancelling the creation of another game.");
-            return;
+        Game game;
+        if(!lastGame.equalsIgnoreCase("pbd1")) {
+            if (!GameManager.isValid(lastGame)) {
+                BotLogger.log("**Unable to create new games because the last game cannot be found. Was it deleted but the roles still exist?**");
+                return;
+            }
+            game = GameManager.getManagedGame(lastGame).getGame();
+            if (game != null && game.getCustomName().equalsIgnoreCase(gameSillyName)) {
+                MessageHelper.sendMessageToChannel(event.getMessageChannel(),
+                    "The custom name of the last game is the same as the one for this game, so the bot suspects a double press " +
+                        "occurred and is cancelling the creation of another game.");
+                return;
+            }
         }
         List<Member> members = new ArrayList<>();
         Member gameOwner = null;


### PR DESCRIPTION
getLastGameName defaults to "pdb1" when there hasn't been any games yet. And of course there are no roles in that case. This leads to the early termination.

This PR updates the check so that "lastGame" has to be a reasonable value before checking for orphaned roles.