### PR TITLE
POK franken errata

### DIFF
--- a/src/main/resources/data/franken_errata/pok.json
+++ b/src/main/resources/data/franken_errata/pok.json
@@ -29,7 +29,8 @@
         "ItemCategory": "ABILITY",
         "ItemId": "dark_whispers",
         "OptionalSwaps": [
-            "PN:dark_pact"
+            "PN:dark_pact",
+            "PN:blood_pact"
         ],
         "source": "pok"
     },
@@ -51,6 +52,12 @@
         "OptionalSwaps": [
             "TECH:vay"
         ],
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "ABILITY",
+        "ItemId": "gashlai_physiology",
+        "Undraftable": true,
         "source": "pok"
     },
     {
@@ -100,6 +107,12 @@
     {
         "ItemCategory": "ABILITY",
         "ItemId": "propagation",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "ABILITY",
+        "ItemId": "quantum_entanglement",
         "Undraftable": true,
         "source": "pok"
     },
@@ -160,6 +173,9 @@
             "AGENT:nomadagentartuno",
             "AGENT:nomadagentthundarian"
         ],
+        "OptionalSwaps": [
+            "AGENT:nomadagentmercer"
+        ],
         "source": "pok"
     },
     {
@@ -182,7 +198,19 @@
     },
     {
         "ItemCategory": "AGENT",
+        "ItemId": "muaatagent",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "AGENT",
         "ItemId": "nomadagentartuno",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "AGENT",
+        "ItemId": "nomadagentmercer",
         "Undraftable": true,
         "source": "pok"
     },
@@ -200,7 +228,21 @@
     },
     {
         "ItemCategory": "COMMANDER",
+        "ItemId": "creusscommander",
+        "AdditionalComponents": [
+            "ABILITY:quantum_entanglement"
+        ],
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "COMMANDER",
         "ItemId": "mahactcommander",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "FLAGSHIP",
+        "ItemId": "creuss_flagship",
         "Undraftable": true,
         "source": "pok"
     },
@@ -258,6 +300,12 @@
     },
     {
         "ItemCategory": "MECH",
+        "ItemId": "nekro_mech",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "MECH",
         "ItemId": "sol_mech",
         "Undraftable": true,
         "source": "pok"
@@ -282,6 +330,12 @@
     },
     {
         "ItemCategory": "PN",
+        "ItemId": "blood_pact",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "PN",
         "ItemId": "dark_pact",
         "Undraftable": true,
         "source": "pok"
@@ -296,6 +350,14 @@
         "ItemCategory": "PN",
         "ItemId": "pop",
         "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "STARTINGTECH",
+        "ItemId": "muaat",
+        "OptionalSwaps": [
+            "AGENT:muaatagent"
+        ],
         "source": "pok"
     },
     {
@@ -315,8 +377,24 @@
     },
     {
         "ItemCategory": "TECH",
+        "ItemId": "lw2",
+        "AdditionalComponents": [
+            "ABILITY:mitosis"
+        ],
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "TECH",
         "ItemId": "m2",
         "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "TECH",
+        "ItemId": "mr",
+        "AdditionalComponents": [
+            "ABILITY:gashlai_physiology"
+        ],
         "source": "pok"
     },
     {

--- a/src/main/resources/data/franken_errata/pok.json
+++ b/src/main/resources/data/franken_errata/pok.json
@@ -61,6 +61,14 @@
     },
     {
         "ItemCategory": "ABILITY",
+        "ItemId": "imperia",
+        "OptionalSwaps": [
+            "COMMANDER:mahactcommander"
+        ],
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "ABILITY",
         "ItemId": "indoctrination",
         "OptionalSwaps": [
             "MECH:yin_mech"
@@ -146,18 +154,6 @@
         "source": "pok"
     },
     {
-        "ItemCategory": "AGENT",
-        "ItemId": "nomadagentartuno",
-        "Undraftable": true,
-        "source": "pok"
-    },
-    {
-        "ItemCategory": "AGENT",
-        "ItemId": "nomadagentthundarian",
-        "Undraftable": true,
-        "source": "pok"
-    },
-    {
         "ItemCategory": "ABILITY",
         "ItemId": "the_company",
         "AdditionalComponents": [
@@ -179,20 +175,32 @@
         "source": "pok"
     },
     {
-        "ItemCategory": "HOMESYSTEM",
-        "ItemId": "keleresa",
-        "Undraftable": true,
-        "source": "pok"
-    },
-    {
         "ItemCategory": "AGENT",
         "ItemId": "mentakagent",
         "Undraftable": true,
         "source": "pok"
     },
     {
+        "ItemCategory": "AGENT",
+        "ItemId": "nomadagentartuno",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "AGENT",
+        "ItemId": "nomadagentthundarian",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
         "ItemCategory": "COMMANDER",
         "ItemId": "cabalcommander",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "COMMANDER",
+        "ItemId": "mahactcommander",
         "Undraftable": true,
         "source": "pok"
     },
@@ -212,13 +220,13 @@
     },
     {
         "ItemCategory": "HERO",
-        "ItemId": "keleresheroodlynn",
+        "ItemId": "keleresheroharka",
         "AlwaysAddToPool": true,
         "source": "pok"
     },
     {
         "ItemCategory": "HERO",
-        "ItemId": "keleresheroharka",
+        "ItemId": "keleresheroodlynn",
         "AlwaysAddToPool": true,
         "source": "pok"
     },
@@ -228,6 +236,18 @@
         "AdditionalComponents": [
             "ABILITY:creuss_gate"
         ],
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "HOMESYSTEM",
+        "ItemId": "keleresa",
+        "Undraftable": true,
+        "source": "pok"
+    },
+    {
+        "ItemCategory": "MECH",
+        "ItemId": "jolnar_mech",
+        "Undraftable": true,
         "source": "pok"
     },
     {
@@ -256,13 +276,13 @@
     },
     {
         "ItemCategory": "PN",
-        "ItemId": "dark_pact",
+        "ItemId": "antivirus",
         "Undraftable": true,
         "source": "pok"
     },
     {
         "ItemCategory": "PN",
-        "ItemId": "pop",
+        "ItemId": "dark_pact",
         "Undraftable": true,
         "source": "pok"
     },
@@ -274,7 +294,7 @@
     },
     {
         "ItemCategory": "PN",
-        "ItemId": "antivirus",
+        "ItemId": "pop",
         "Undraftable": true,
         "source": "pok"
     },
@@ -309,26 +329,6 @@
         "ItemCategory": "TECH",
         "ItemId": "vay",
         "Undraftable": true,
-        "source": "pok"
-    },
-    {
-        "ItemCategory": "MECH",
-        "ItemId": "jolnar_mech",
-        "Undraftable": true,
-        "source": "pok"
-    },
-    {
-        "ItemCategory": "COMMANDER",
-        "ItemId": "mahactcommander",
-        "Undraftable": true,
-        "source": "pok"
-    },
-    {
-        "ItemCategory": "ABILITY",
-        "ItemId": "imperia",
-        "OptionalSwaps": [
-            "COMMANDER:mahactcommander"
-        ],
         "source": "pok"
     }
 ]

--- a/src/main/resources/data/franken_errata/pok.json
+++ b/src/main/resources/data/franken_errata/pok.json
@@ -242,7 +242,7 @@
     },
     {
         "ItemCategory": "FLAGSHIP",
-        "ItemId": "creuss_flagship",
+        "ItemId": "ghost_flagship",
         "Undraftable": true,
         "source": "pok"
     },

--- a/src/main/resources/data/franken_errata/pok.json
+++ b/src/main/resources/data/franken_errata/pok.json
@@ -228,7 +228,7 @@
     },
     {
         "ItemCategory": "COMMANDER",
-        "ItemId": "creusscommander",
+        "ItemId": "ghostcommander",
         "AdditionalComponents": [
             "ABILITY:quantum_entanglement"
         ],


### PR DESCRIPTION
  - Alphabetized `franken_errat/pok.json` for comparison with [the luminous spreadsheet](https://docs.google.com/spreadsheets/d/1zxe2Q5ICCiEOaABhjk6OohaoCDNGVxd9b522SS1-rUM/) by `ItemCategory` (primary) and `ItemId` (secondary)
 
  - Added these as undraftables:
    - `gashlai_physiology`
    - `quantum_entanglement`
    - `muaatagent`
    - `nomadagentmercer`
    - `creuss_flagship`
    - `nekro_mech`
    - `blood_pact`
  - Added these as optional swaps:
    - `ABILITY:dark_whispers`: `PN:blood_pact`
    - `ABILITY:the_company`: `AGENT:nomadagentmercer`
    - `STARTINGTECH:muaat`: `AGENT:muaatagent`
   
  - Added these as additional components:
    - `COMMANDER:creusscommander`: `ABILITY:quantum_entanglement`
    - `TECH:lw2`: `ABILITY:mitosis` (was already undraftable)
    - `TECH:mr2`: `ABILITY:gashlai_physiology`

  - Presumed reasons for extra undraftables:
    - `creuss_flagship`: Other delta wormholes might not be in the game
    - `nekro_mech`: `vax` and `vay` might not be in the game