### PR TITLE
Make interaction logs single-line

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -61,7 +61,6 @@ import ti4.listeners.UserJoinServerListener;
 import ti4.listeners.UserLeaveServerListener;
 import ti4.map.manage.GameManager;
 import ti4.message.BotLogger;
-import ti4.message.MessageHelper;
 import ti4.migration.DataMigrationManager;
 import ti4.selections.SelectionManager;
 import ti4.service.emoji.ApplicationEmojiService;

--- a/src/main/java/ti4/listeners/SlashCommandListener.java
+++ b/src/main/java/ti4/listeners/SlashCommandListener.java
@@ -92,7 +92,7 @@ public class SlashCommandListener extends ListenerAdapter {
         if (member != null) {
             String commandText = "```fix\n" + member.getEffectiveName() + " used " + event.getCommandString() + "\n```";
             event.getChannel().sendMessage(commandText).queue(m -> {
-                BotLogger.logSlashCommand(event, m);
+                BotLogger.logSlashCommand(event);
                 SusSlashCommandService.checkIfShouldReportSusSlashCommand(event, m.getJumpUrl());
             }, BotLogger::catchRestError);
         }


### PR DESCRIPTION
Minor change to log message assembly and message storage in `BotLogger.AbstractEventLog`, technically not a breaking change since all external interfaces are left intact and the class is sealed.