### PR TITLE
Update pok.json

### DIFF
--- a/src/main/resources/data/franken_errata/pok.json
+++ b/src/main/resources/data/franken_errata/pok.json
@@ -73,8 +73,10 @@
         "ItemCategory": "ABILITY",
         "ItemId": "dark_whispers",
         "OptionalSwaps": [
-            "PN:dark_pact",
             "PN:blood_pact"
+        ],
+        "AdditionalComponents": [
+            "PN:dark_pact"
         ],
         "source": "pok"
     },


### PR DESCRIPTION
Fixed Dark Whispers, Empyrean Faction ability. So it properly adds Dark pact as the additional PN to the ability in franken