### PR TITLE
Address image retrieval throttling by using Statically CDN

### DIFF
--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -635,7 +635,7 @@ public class Helper {
             .getStrategyCardModelByInitiative(sc)
             .map(StrategyCardModel::getImageFileName)
             .orElse("sadFace.png");
-        return "https://raw.githubusercontent.com/AsyncTI4/TI4_map_generator_bot/refs/heads/master/src/main/resources/strat_cards/" + scImagePath + ".png";
+        return "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/strat_cards/" + scImagePath + ".png";
     }
 
     public static Emoji getPlayerReactionEmoji(Game game, Player player, Message message) {

--- a/src/main/resources/data/relics/absol.json
+++ b/src/main/resources/data/relics/absol.json
@@ -6,7 +6,7 @@
         "source": "absol",
         "flavourText": "*Goldos hoisted the ivory orb at the head of their army. At once, the weariness that filled the bodies and minds of each soldier vanished. They strode forth as if fresh from a week's rest.*",
         "homebrewReplacesID": "dominusorb",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/DominusOrb.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/DominusOrb.jpg?raw=true"
     },
     {
         "alias": "absol_dynamiscore",
@@ -15,7 +15,7 @@
         "source": "absol",
         "flavourText": "*Dart and Tai stood, mesmerized by the swirling mass. Neither had any idea what it was, but both were fairly sure they were about to retire.*",
         "homebrewReplacesID": "dynamiscore",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/DynamisCore.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/DynamisCore.jpg?raw=true"
     },
     {
         "alias": "absol_jr",
@@ -24,7 +24,7 @@
         "source": "absol",
         "flavourText": "*There was a long moment, stretching in silence until Dart blurted, “Can we help you somehow?”\nAll of the individuals seemed startled by the question, but the titan seemed the most perplexed.  “I do not know,” it said at last.  “I only remember that… I want to learn.  And… and to remember.”\n\n“I have no name. You,” it said, pointing to Dart. “Perhaps I shall be Dart II.”\n“H-how about Junior instead?” Dart offered. “I wouldn’t want anyone to get us confused, we already look so… uh… alike.”\nThe titan nodded solemnly.  “Yes. Yes, this is true.” It turned. “Junior. Yes. I like that name, and I would also like to come with you.”*",
         "homebrewReplacesID": "titanprototype",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/JR.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/JR.jpg?raw=true"
     },
     {
         "alias": "absol_luxarchtreatise",
@@ -32,7 +32,7 @@
         "text": "When performing a tactical action, you may exhaust this card to activate a system that contains 1 of your command tokens.[Note: still costs a command token]\n\nWhen you activate a system, you may place this card next to the game board.  If you do, you may ignore your fleet pool limit and add +2 to the results of your ships' combat rolls in the active system.  At the end of that action, purge this card.",
         "source": "absol",
         "flavourText": "*Written thousands of years before the fall of the Lazax, the Luxarch Treatsie contained detailed analyses of the Lazax's greatest victories.  With the return of the Mahact, it was imperative that the document be found.*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/LuxarchTreatise.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/LuxarchTreatise.jpg?raw=true"
     },
     {
         "alias": "absol_mawofworlds",
@@ -41,7 +41,7 @@
         "source": "absol",
         "flavourText": "*No larger than a carrier, the spherical lattice held a captive singularity at its heart. As they dumped the planet's entire energy grid into its core, the black hole began to spin, the complex logic-circuitry along the lattice slowly coming to life.*",
         "homebrewReplacesID": "mawofworlds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/MawOfWorlds.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/MawOfWorlds.jpg?raw=true"
     },
     {
         "alias": "absol_nanoforge",
@@ -50,7 +50,7 @@
         "source": "absol",
         "flavourText": "*Intended to bring prosperity, the forge was twisted into an instrument of war.\nThe planet heaved and shuddered as it merged with the Nano-forge, sputtering as its atmosphere became breathable for the first time.*",
         "homebrewReplacesID": "nanoforge",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/NanoForge.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/NanoForge.jpg?raw=true"
     },
     {
         "alias": "absol_plenaryorbital",
@@ -58,7 +58,7 @@
         "text": "PLENARY ORBITAL (Space Dock) DEPLOY:  After you activate a system, you may place this space dock on a non-home planet you control in that system other than Mecatol Rex and which does not contain a space dock.  This unit cannot be affected by opponent's action cards.  When this unit is destroyed or removed, purge this card. Up to 8 fighters in this system do not count against your ships' capacity. Up to 2 non-fighter ships in this system do not count against your fleet pool. PRODUCTION 10;PLANETARY SHIELD",
         "source": "absol",
         "flavourText": "*To many, the ring represented hope - a testament to the preseverance of the Gashlai.  To Magmus, it represented waste.  Extravagance.  Foolishness.  He sneered.*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/PlenaryOrbital.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/PlenaryOrbital.jpg?raw=true"
     },
     {
         "alias": "absol_quantumcore",
@@ -67,7 +67,7 @@
         "source": "absol",
         "flavourText": "*Trilossa slipped the core into the hololattice's main terminal.  The lattice was ancient - as old as the Flight itself - and tampering with it was tantamount to sin.  Hopefully the rest of the Flight would would see the necessity of the upgrade.*",
         "shortName": "Quantum\n-core",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/QuantumCore.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/QuantumCore.png?raw=true"
     },
     {
         "alias": "absol_emelpar",
@@ -76,7 +76,7 @@
         "source": "absol",
         "flavourText": "*As the hilt began to fuse with the flesh of her hand, she worried that she should set the scepter aside. But the whispered suggestions in her mind were too valuable and insightful to seriously consider such a rash and illogical act.*",
         "homebrewReplacesID": "emelpar",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/ScepterOfEmelpar.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/ScepterOfEmelpar.jpg?raw=true"
     },
     {
         "alias": "absol_shardofthethrone1",
@@ -85,7 +85,7 @@
         "source": "absol",
         "flavourText": "*\"What power does a broken piece of the Throne of Emperors hold? To me, none. But to everyone else...\"*",
         "homebrewReplacesID": "shard",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/ShardOfTheThrone1.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/ShardOfTheThrone1.jpg?raw=true"
     },
     {
         "alias": "absol_shardofthethrone2",
@@ -94,7 +94,7 @@
         "source": "absol",
         "flavourText": "*Qanoj watched the light reflect off of the shard and dance about his chambers.  It was such a pretty thing.  And yet, so many had died for it.*",
         "homebrewReplacesID": "shard",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/ShardOfTheThrone2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/ShardOfTheThrone2.jpg?raw=true"
     },
     {
         "alias": "absol_shardofthethrone3",
@@ -103,7 +103,7 @@
         "source": "absol",
         "flavourText": "*Legends claim that only the one who can bring together all the scattered pieces of the Throne of Emperors will truly be wothy to claim the seat.*",
         "homebrewReplacesID": "shard",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/ShardOfTheThrone3.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/ShardOfTheThrone3.jpg?raw=true"
     },
     {
         "alias": "absol_stellarconverter",
@@ -112,7 +112,7 @@
         "source": "absol",
         "flavourText": "*A power great enough to envelop a star, such that its energies might be concentrated… and scattered.*",
         "homebrewReplacesID": "stellarconverter",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/StellarConverter.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/StellarConverter.jpg?raw=true"
     },
     {
         "alias": "absol_codex",
@@ -121,7 +121,7 @@
         "source": "absol",
         "flavourText": "*No single tome could contain the collected knowledge of millennia of rulers. Thus, the last Emperor built a massive cruiser, its holds bulging with crystal info-matrices. It roams the outer reaches of the Gul system, awaiting a summons that will never come.*",
         "homebrewReplacesID": "codex",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/TheCodex.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/TheCodex.jpg?raw=true"
     },
     {
         "alias": "absol_emphidia",
@@ -130,7 +130,7 @@
         "source": "absol",
         "flavourText": "*The machines of the forgotten throne-world could only be controlled through the data-impulses of the black-barbed crown.*",
         "homebrewReplacesID": "emphidia",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/TheCrownOfEmphidia.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/TheCrownOfEmphidia.jpg?raw=true"
     },
     {
         "alias": "absol_thalnos",
@@ -139,7 +139,7 @@
         "source": "absol",
         "flavourText": "*A cloud of satellites spewed from the dreadnought's hull, drifting into a halo around the vessel. The battle seemed to pause for one long moment, before the drones' weapons flared, unleashing beams of energy in all directions.*",
         "homebrewReplacesID": "thalnos",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/TheCrownOfThalnos.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/TheCrownOfThalnos.jpg?raw=true"
     },
     {
         "alias": "absol_obsidian",
@@ -148,7 +148,7 @@
         "source": "absol",
         "flavourText": "*The inky blackness of the blade evoked feelings of discomfort and nausea in all who saw it. All but Sharsiss. It whispered to him promises of power. Promises of a reckoning that would see the Collective unmade. \"Good,\" he thought. \"Let them burn.\"*",
         "homebrewReplacesID": "obsidian",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/TheObsidian.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/TheObsidian.jpg?raw=true"
     },
     {
         "alias": "absol_prophetstears",
@@ -157,7 +157,7 @@
         "source": "absol",
         "flavourText": "*\"So you're going to drink a vial of murky liquid we found in a stasis vault on a dead world because you think it's the concentrated genetic essence of an entire species' most brilliant minds...and you think* I'm *being irrational?\"*",
         "homebrewReplacesID": "prophetstears",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/TheProphetsTears.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/TheProphetsTears.jpg?raw=true"
     },
     {
         "alias": "absol_syncretone",
@@ -166,7 +166,7 @@
         "source": "absol",
         "flavourText": "*One of many Guild secrets involves a tiny object known as the Syncretone.  Connor had heard the damn thing referred to by the Yssaril as 'innocuous' so many times now that he was absolutely positive it must be his by day's end.*",
         "shrinkName": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/absol/TheSyncretone.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/absol/TheSyncretone.jpg?raw=true"
     },
     {
         "alias": "absol_tyrantslament",
@@ -174,6 +174,6 @@
         "text": "TYRANT'S LAMENT (Note: is NOT a Flagship) DEPLOY: At the end of your turn, you may place this unit in any system that contains your ships. When this unit is removed or captured, purge this card.  This unit is not affected by action cards, anomalies, or your faction abilities or your technologies. SPACE CANNON 5(x3), ANTI-FIGHTER BARRAGE 5(x3), SUSTAIN DAMAGE, Move 2, Combat 5(x3)",
         "source": "absol",
         "flavourText": "*Instrument of Judgement\nThe Tyrant's Lament has never responded to a hail, and fights under no banner.  Wherever it appears, death rains.  And then it is gone.*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/TyrantsLament.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/TyrantsLament.jpg?raw=true"
     }
 ]

--- a/src/main/resources/data/relics/dane_leaks.json
+++ b/src/main/resources/data/relics/dane_leaks.json
@@ -5,6 +5,6 @@
         "text": "ACTION: Roll 1 die and purge this card; if the result is a 10, gain 1 victory point. Otherwise, remove all of your units from the galaxy and you are eliminated.\nThe Silver Flame may be exchanged as part of a transaction.",
         "source": "dane_leaks",
         "flavourText": "*Ank-Syl Siven flared, bright red briefly overtaking blue. \"Would I lie to you?\" The flame pulsed, suspended in the air before him. Was it real? Or just an illusion?*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/misc_homebrew/the_silver_flame.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/src/main/resources/hover_images/relics/misc_homebrew/the_silver_flame.png?raw=true"
     }
 ]

--- a/src/main/resources/data/relics/ds.json
+++ b/src/main/resources/data/relics/ds.json
@@ -4,48 +4,48 @@
         "name": "Accretion Engine",
         "text": "Apply +1 to the PRODUCTION value of each of your units with PRODUCTION. When you produce 1 or more units reduce the combined cost of the produced units by 1.",
         "source": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/ds/accretion_engine.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/ds/accretion_engine.png?raw=true"
     },
     {
         "alias": "decrypted_cartoglyph",
         "name": "Azdel's Key",
         "text": "ACTION: Purge this card to draw 3 system tiles with a blue-colored back at random. Place 1 of those tiles at the edge of the game board, adjacent to at least 2 other systems. Purge the rest.",
         "source": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/ds/azdels_key.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/ds/azdels_key.png?raw=true"
     },
     {
         "alias": "e6-g0_network",
         "name": "E6-G0 Network",
         "text": "You may have 2 additional action cards in your hand, game effects cannot prevent you from using this ability. At any time, you may exhaust this card to draw 1 action card.",
         "source": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/ds/e6go_network.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/ds/e6go_network.png?raw=true"
     },
     {
         "alias": "eye_of_vogul",
         "name": "Eye of Vogul",
         "text": "After you activate a system: Purge this card to treat 2 of your ships as adjacent to the active system until the end of this tactical action.",
         "source": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/ds/eye_of_vogul.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/ds/eye_of_vogul.png?raw=true"
     },
     {
         "alias": "starfall_array",
         "name": "Starfall Array",
         "text": "When 1 or more of your units roll dice for a unit ability, you may add +1 to the result of each of those dice, and 1 of those units may roll 1 additional die.",
         "source": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/ds/starfall_array.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/ds/starfall_array.png?raw=true"
     },
     {
         "alias": "throne_of_the_false_emperor",
         "name": "Forgotten Throne",
         "text": "ACTION: Purge this card to either gain 1 relic or immediately score 1 scored secret objective, or 1 of your unscored secret objectives, if you fulfill its requirements. [Note, this does not enable you to score the same secret twice, or to have more than 3 scored secrets]",
         "source": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/ds/forgotten_throne.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/ds/forgotten_throne.png?raw=true"
     },
     {
         "alias": "twilight_mirror",
         "name": "Twilight Mirror",
         "text": "At the start of the agenda phase, you may purge this card to resolve 1 non-strategic action.",
         "source": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/ds/twilight_mirror.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/ds/twilight_mirror.png?raw=true"
     }
 ]

--- a/src/main/resources/data/relics/pok.json
+++ b/src/main/resources/data/relics/pok.json
@@ -3,7 +3,7 @@
         "alias": "dominusorb",
         "name": "Dominus Orb",
         "text": "Before you move units during a tactical action, you may purge this card to move and transport units that are in systems that contain 1 of your command tokens.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/dominus_orb.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/dominus_orb.jpg?raw=true",
         "source": "pok",
         "flavourText": "*Goldos hoisted the ivory orb at the head of their army. At once, the weariness that filled the bodies and minds of each soldier vanished. They strode forth as if fresh from a week's rest.*"
     },
@@ -11,7 +11,7 @@
         "alias": "mawofworlds",
         "name": "Maw of Worlds",
         "text": "At the start of the agenda phase, you may purge this card and exhaust all of your planets to gain any 1 technology.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/maw_of_worlds.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/maw_of_worlds.jpg?raw=true",
         "source": "pok",
         "flavourText": "*No larger than a carrier, the spherical lattice held a captive singularity at its heart. As they dumped the planet's entire energy grid into its core, the black hole began to spin, the complex logic-circuitry along the lattice slowly coming to life.*"
     },
@@ -19,7 +19,7 @@
         "alias": "emelpar",
         "name": "Scepter of Emelpar",
         "text": "When you would spend a token from your strategy pool, you may exhaust this card to spend a token from your reinforcements instead.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/scepter_of_emelpar.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/scepter_of_emelpar.jpg?raw=true",
         "source": "pok",
         "flavourText": "*As the hilt began to fuse with the flesh of her hand, she worried that she should set the scepter aside. But the whispered suggestions in her mind were too valuable and insightful to seriously consider such a rash and illogical act.*"
     },
@@ -27,7 +27,7 @@
         "alias": "shard",
         "name": "Shard of the Throne",
         "text": "When you gain this card, gain 1 victory point, when you lose this card, lose 1 victory point. When a player gains control of a legendary planet you control or a planet you control in your home system, that player gains this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/shard_of_the_throne.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/shard_of_the_throne.jpg?raw=true",
         "source": "pok",
         "flavourText": "*\"What power does a broken piece of the Throne of Emperors hold? To me, none. But to everyone else...\"*"
     },
@@ -35,7 +35,7 @@
         "alias": "stellarconverter",
         "name": "Stellar Converter",
         "text": "ACTION: Choose 1 non-home, non-legendary planet other than Mecatol Rex in a system that is adjacent to 1 or more of your units that have BOMBARDMENT, destroy all units on that planet and purge its attachments and its planet card. Then, place the destroyed planet token on that planet and purge this card. [Note: You cannot choose a planet that you control]",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/stellar_converter.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/stellar_converter.jpg?raw=true",
         "source": "pok",
         "flavourText": "*A power great enough to envelop a star, such that its energies might be concentrated… and scattered.*"
     },
@@ -43,7 +43,7 @@
         "alias": "codex",
         "name": "The Codex",
         "text": "ACTION: Purge this card to take up to 3 action cards of your choice from the action card discard pile.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/the_codex.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/the_codex.jpg?raw=true",
         "source": "pok",
         "flavourText": "*No single tome could contain the collected knowledge of millennia of rulers. Thus, the last Emperor built a massive cruiser, its holds bulging with crystal info-matrices. It roams the outer reaches of the Mecatol system, awaiting a summons that will never come.*"
     },
@@ -51,7 +51,7 @@
         "alias": "emphidia",
         "name": "The Crown of Emphidia",
         "text": "After you perform a tactical action, you may exhaust this card to explore 1 planet you control. At the end of the status phase, if you control the \"Tomb of Emphidia,\" you may purge this card to gain 1 victory point.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/the_crown_of_emphidia.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/the_crown_of_emphidia.jpg?raw=true",
         "source": "pok",
         "flavourText": "*The machines of the forgotten throne-world could only be controlled through the data-impulses of the black-barbed crown.*",
         "shrinkName": true
@@ -60,7 +60,7 @@
         "alias": "thalnos",
         "name": "The Crown of Thalnos",
         "text": "During each combat round, this card's owner may reroll any number of their dice, applying +1 to the results, any units that reroll dice but do not produce at least 1 hit are destroyed.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/the_crown_of_thalnos.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/the_crown_of_thalnos.jpg?raw=true",
         "source": "pok",
         "flavourText": "*A cloud of satellites spewed from the dreadnought's hull, drifting into a halo around the vessel. The battle seemed to pause for one long moment, before the drones' weapons flared, unleashing beams of energy in all directions.*"
     },
@@ -68,7 +68,7 @@
         "alias": "obsidian",
         "name": "The Obsidian",
         "text": "When you gain this card, draw 1 secret objective. You can have 1 additional scored or unscored secret objective.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/the_obsidian.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/the_obsidian.jpg?raw=true",
         "source": "pok",
         "flavourText": "*The inky blackness of the blade evoked feelings of discomfort and nausea in all who saw it. All but Sharsiss. It whispered to him promises of power. Promises of a reckoning that would see the Collective unmade. \"Good,\" he thought. \"Let them burn.\"*"
     },
@@ -76,7 +76,7 @@
         "alias": "prophetstears",
         "name": "The Prophet's Tears",
         "text": "When you research a technology, you may exhaust this card to ignore 1 prerequisite or draw 1 action card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/pok/the_prophets_tears.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/pok/the_prophets_tears.jpg?raw=true",
         "source": "pok",
         "flavourText": "*\"So you're going to drink a vial of murky liquid we found in a stasis vault on a dead world because you think it's the concentrated genetic essence of an entire species' most brilliant minds...and you think* I'm *being irrational?\"*",
         "shortName": "Prophet's\nTears"

--- a/src/main/resources/data/relics/sigma.json
+++ b/src/main/resources/data/relics/sigma.json
@@ -5,7 +5,7 @@
         "text": "During the agenda phase, after an outcome that you voted for or predicted is resolved, gain 1 command token.\nAt the end of the agenda phase, you may purge this card to gain the speaker token.",
         "source": "sigma",
         "flavourText": "*The moontree was the symbol of the Galactic Council, and graced the Imperial Gardens on Mecatol Rex. The greatest ambassadors were granted a staff of moontree wood, as a symbol of their rank.*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/misc_homebrew/moontree_staff.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/misc_homebrew/moontree_staff.jpg?raw=true"
     },
     {
         "alias": "sigma_mirror_engine",
@@ -13,7 +13,7 @@
         "text": "When 1 or more of your units use PRODUCTION, apply +2 to their total PRODUCTION value. You may produce 1 additional fighter and infantry for their cost.",
         "source": "sigma",
         "flavourText": "*Word of advice: if you meet yourself, don't make eye contact. That'll wipe out time. Entirely. Forward and backward.*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/misc_homebrew/mirror_engine.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/misc_homebrew/mirror_engine.jpg?raw=true"
     },
     {
         "alias": "sigma_phoenix",
@@ -21,7 +21,7 @@
         "text": "After 1 of your units is destroyed: You may exhaust this card to produce a unit of the same type at any of your space docks; reduce the cost by 4 resources. If you have ships in the active system, you may place the unit in that system, even if another player has units there.",
         "source": "sigma",
         "flavourText": "*\"But you were dead!\"\n\"I got better.\"*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/misc_homebrew/phoenix.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/misc_homebrew/phoenix.png?raw=true"
     },
     {
         "alias": "sigma_forgotten",
@@ -29,6 +29,6 @@
         "text": "ACTION: Exhaust this card to produce up to 2 units in any system that that contains 1 of your space docks. Reduce the combined cost of the produced units by 8. Then, give this card to another player.",
         "source": "sigma",
         "flavourText": "*With the ability to access alternate realities, The Forgotten seemd to have a prefernce for thos in which it remained undiscovered, at least for a few extra years.*",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/relics/misc_homebrew/the_forgotten.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/misc_homebrew/the_forgotten.png?raw=true"
     }
 ]

--- a/src/main/resources/data/technologies/absol.json
+++ b/src/main/resources/data/technologies/absol.json
@@ -8,7 +8,7 @@
         "source": "absol",
         "text": "Your ships can move into and through asteroid fields and retain their printed Move value when moving out of nebulae.\nWhen other players' units use SPACE CANNON against your units, apply -1 to the result of each die roll.",
         "homebrewReplacesID": "amd",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/AntimassDeflectors.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/AntimassDeflectors.png?raw=true"
     },
     {
         "alias": "absol_det",
@@ -19,7 +19,7 @@
         "source": "absol",
         "text": "After you perform a tactical action in a system that contains a frontier token, if you have 1 or more ships in that system, you may explore that token.\nYour ships can retreat into adjacent systems that do not contain other players' units, even if you do not have units or control planets in that system.",
         "homebrewReplacesID": "det",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/DarkEnergyTap.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/DarkEnergyTap.png?raw=true"
     },
     {
         "alias": "absol_gd",
@@ -31,7 +31,7 @@
         "source": "absol",
         "text": "During your tactical actions, apply +1 to the move value of each of your ships that moves through 1 or more systems adjacent to a gravity rift or supernova, or that moves through 1 or more wormholes.\nAfter you roll dice for your ships moving through a gravity rift, you may reroll any number of those dice.",
         "homebrewReplacesID": "gd",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/GravityDrive.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/GravityDrive.png?raw=true"
     },
     {
         "alias": "absol_sr",
@@ -43,7 +43,7 @@
         "source": "absol",
         "text": "During your tactical actions, your non-blockaded space docks in adjacent systems may use the PRODUCTION 1 ability in the active system if it does not contain other players' ships. If you have a space dock unit upgrade technology, they instead may use PRODUCTION 2. All units produced are placed in the space area.",
         "homebrewReplacesID": "sr",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/SlingRelay.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/SlingRelay.png?raw=true"
     },
     {
         "alias": "absol_fl",
@@ -55,7 +55,7 @@
         "source": "absol",
         "text": "Once per turn, after you perform a tactical action, you may take an additional tactical action. You may activate the same system for this second tactical action; in that case, ensure that only 1 of your command tokens total is in the system by returning the second command token to your reinforcements instead of placing it in the active system.",
         "homebrewReplacesID": "fl",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/FleetLogistics.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/FleetLogistics.png?raw=true"
     },
     {
         "alias": "absol_lwd",
@@ -67,7 +67,7 @@
         "source": "absol",
         "text": "Your ships can move through systems that contain other players' ships.",
         "homebrewReplacesID": "lwd",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/lightwave_deflector.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/lightwave_deflector.jpg?raw=true"
     },
     {
         "alias": "absol_nm",
@@ -78,7 +78,7 @@
         "source": "absol",
         "text": "The maximum number of action cards you can have in your hand is increased by 3\nAt the end of your turn, you may exhaust this card to draw 2 action cards.",
         "homebrewReplacesID": "nm",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/NeuralMotivator.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/NeuralMotivator.png?raw=true"
     },
     {
         "alias": "absol_pa",
@@ -89,7 +89,7 @@
         "source": "absol",
         "text": "You can use technology specialties on planets you control without exhausting them, even if those planets are exhausted.\nAt the end of your turn, you may discard 2 action cards to explore a readied planet you control.",
         "homebrewReplacesID": "pa",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/Psychoarchaeology.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/Psychoarchaeology.png?raw=true"
     },
     {
         "alias": "absol_dxa",
@@ -101,7 +101,7 @@
         "source": "absol",
         "text": "After you gain control of a planet, you may place 1 infantry from your reinforcements on that planet.\nIf you have an infantry unit upgrade technology, you may reroll any dice rolled as part of your infantry units' abilities.",
         "homebrewReplacesID": "dxa",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/DacxiveAnimators.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/DacxiveAnimators.png?raw=true"
     },
     {
         "alias": "absol_bs",
@@ -113,7 +113,7 @@
         "source": "absol",
         "text": "You may exhaust this card at the end of your turn to ready 1 of your other technologies.",
         "homebrewReplacesID": "bs",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/Biostims.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/Biostims.png?raw=true"
     },
     {
         "alias": "absol_hm",
@@ -125,7 +125,7 @@
         "source": "absol",
         "text": "Once per turn, after you perform an action, you may take a component action. \nYou may exhaust this card at the end of your turn to gain 1 command token.",
         "homebrewReplacesID": "hm",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/HyperMetabolism.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/HyperMetabolism.png?raw=true"
     },
     {
         "alias": "absol_x89",
@@ -137,7 +137,7 @@
         "source": "absol",
         "text": "When your units use BOMBARDMENT, the first hit may be used to produce and assign 1 hit against each ground force on the planet.\nAt the start of a round of ground combat on a planet you control, you may exhaust this card to destroy all ground forces on the planet.",
         "homebrewReplacesID": "x89",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/X89BacterialWeapons.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/X89BacterialWeapons.png?raw=true"
     },
     {
         "alias": "absol_st",
@@ -148,7 +148,7 @@
         "source": "absol",
         "text": "'When you produce units, reduce the combined cost of the produced units by 1, plus an additional 1 for every 10 of the combined cost.\nDuring the production step of your tactical actions, you may spend 1 resource to repair 1 of your damaged units in the active system, or all of your damaged units in the active system if that system contains 1 or more of your space docks.",
         "homebrewReplacesID": "st",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/SarweenTools.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/SarweenTools.png?raw=true"
     },
     {
         "alias": "absol_techquantumcore",
@@ -159,7 +159,7 @@
         ],
         "source": "absol",
         "text": "During the movement step of your tactical actions, you may move 1 of your structures from a system that does not contain 1 of your command tokens to a planet you control in the active system.\nWhen an opponent commits ground forces to a planet that contains 1 or more of your structures, you may destroy 1 structure on that planet to return the committed units to the space area.  If you do, purge this card",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/QuantumCore.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/QuantumCore.png?raw=true"
     },
     {
         "alias": "absol_sdn",
@@ -170,7 +170,7 @@
         "source": "absol",
         "text": "When you activate a system as part of a tactical action, you may explore 1 planet in that system that contains 1 or more of your units.\nWhenever you would resolve an exploration card, you may instead discard that card and gain 1 trade good.",
         "homebrewReplacesID": "sdn",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/ScanlinkDroneNetwork.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/ScanlinkDroneNetwork.png?raw=true"
     },
     {
         "alias": "absol_gls",
@@ -182,7 +182,7 @@
         "source": "absol",
         "text": "When a player would resolve a retreat, your units may first use SPACE CANNON against the retreating player’s ships in the active system.\nYou may exhaust this card before 1 or more of your units use SPACE CANNON; hits produced by those units must be assigned to non-fighter ships if able.",
         "homebrewReplacesID": "gls",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/GravitonLaserSystems.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/GravitonLaserSystems.png?raw=true"
     },
     {
         "alias": "absol_pi",
@@ -194,7 +194,7 @@
         "source": "absol",
         "text": "At the start of your turn, you may exhaust this card to redistribute your command tokens.\nWhen you cast votes during the agenda phase, you may cast 3 additional votes",
         "homebrewReplacesID": "pi",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/PredictiveIntelligence.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/PredictiveIntelligence.png?raw=true"
     },
     {
         "alias": "absol_td",
@@ -206,7 +206,7 @@
         "source": "absol",
         "text": "You may exhaust this card at the start of your turn during the action phase; remove up to 4 of your ground forces from the game board and place them on 1 or more planets you control.\nYou may exhaust this card at the start of a round of ground combat on a planet you control. If you do, at the end of that combat round, you may remove all of your ground forces from that planet and place them on another planet you control.",
         "homebrewReplacesID": "td",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/TransitDiodes.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/TransitDiodes.png?raw=true"
     },
     {
         "alias": "absol_ie",
@@ -218,7 +218,7 @@
         "source": "absol",
         "text": "You may treat each planet with a planet trait that contains 1 or more of your structures as having any planet trait.\nEach planet you control gains the PRODUCTION 1 ability as if it were a unit.",
         "homebrewReplacesID": "ie",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/IntegratedEconomy.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/IntegratedEconomy.png?raw=true"
     },
     {
         "alias": "absol_ps",
@@ -229,7 +229,7 @@
         "source": "absol",
         "text": "When 1 or more of your units use unit abilities, 1 of those units may roll 1 additional die.\nWhen the result of your non-fighter ships' combat roll exceeds that ship's combat value by 3 or more, your opponent cannot assign that hit to a fighter unless they first destroy 1 of their fighters in the active system.",
         "homebrewReplacesID": "ps",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/PlasmaScoring.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/PlasmaScoring.png?raw=true"
     },
     {
         "alias": "absol_aida",
@@ -240,7 +240,7 @@
         "source": "absol",
         "text": "When you research a unit upgrade technology, you may exhaust this card to ignore any 1 prerequisite.\nWhen you pass, you may spend 6 influence to research a unit upgrade technology.",
         "homebrewReplacesID": "aida",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/AIDevelopmentAlgorithm.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/AIDevelopmentAlgorithm.png?raw=true"
     },
     {
         "alias": "absol_md",
@@ -252,7 +252,7 @@
         "source": "absol",
         "text": "At the start of ground combat on a planet you control that contains 1 or more of your structures, you may produce 1 hit per structure and assign them to your opponent's ground forces.\nAfter you perform a tactical action, you may exhaust this card and spend 4 resources to place a structure on a planet you control in the active system.",
         "homebrewReplacesID": "md",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/MagenDefenseGrid.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/MagenDefenseGrid.png?raw=true"
     },
     {
         "alias": "absol_sar",
@@ -264,7 +264,7 @@
         "source": "absol",
         "text": "You may produce 1 additional mech for their cost. [Note: think of mechs as now similar to fighters and infantry, buy 2 for the price of 1]\nACTION: Exhaust this card to produce 1 ship in any system that contains 1 of your space docks.",
         "homebrewReplacesID": "sar",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/SelfAssemblyRoutines.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/SelfAssemblyRoutines.png?raw=true"
     },
     {
         "alias": "absol_da",
@@ -276,7 +276,7 @@
         "source": "absol",
         "text": "Your ships can move into and through asteroid fields.\nDuring each combat round, after you assign hits to your units, repair 1 of your damaged units that did not use SUSTAIN DAMAGE during this combat round.",
         "homebrewReplacesID": "da",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/DuraniumArmor.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/DuraniumArmor.png?raw=true"
     },
     {
         "alias": "absol_asc",
@@ -288,7 +288,7 @@
         "source": "absol",
         "text": "At the start of space combat, your opponent must destroy 1 of their non-fighter ships for every 3 of your non-fighter, non-Infantry ships in the active system.",
         "homebrewReplacesID": "asc",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/AssaultCannon.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/AssaultCannon.png?raw=true"
     },
     {
         "alias": "absol_sd2",
@@ -300,7 +300,7 @@
         "source": "absol",
         "text": "PRODUCTION X\nThis unit's PRODUCTION value is equal to 4 more than the resource value of this planet.\nUp to 5 fighters in this system do not count against your ships' capacity. 1 non-fighter ship in this system does not count against your fleet pool.",
         "homebrewReplacesID": "sd2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/SpaceDockII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/SpaceDockII.png?raw=true"
     },
     {
         "alias": "absol_inf2",
@@ -312,7 +312,7 @@
         "source": "absol",
         "text": "Cost: 1(x2), Combat 7\nAfter this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
         "homebrewReplacesID": "inf2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
     },
     {
         "alias": "absol_pds2",
@@ -324,7 +324,7 @@
         "source": "absol",
         "text": "PLANETARY SHIELD, SPACE CANNON 5\nYou may use this unit's SPACE CANNON against ships that are adjacent to this unit's system.",
         "homebrewReplacesID": "pds2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
     },
     {
         "alias": "absol_ff2",
@@ -336,7 +336,7 @@
         "source": "absol",
         "text": "Cost: 1(x2), Combat 8, Move 2\nThis unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool.",
         "homebrewReplacesID": "ff2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
     },
     {
         "alias": "absol_dd2",
@@ -348,7 +348,7 @@
         "source": "absol",
         "text": "Cost 1, Combat 8, Move 2\nANTI-FIGHTER BARRAGE 6(x3)\nWhen this unit generates a hit on a combat roll, your opponent must destroy 1 fighter in the active system, if able.",
         "homebrewReplacesID": "dd2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/DestroyerII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/DestroyerII.png?raw=true"
     },
     {
         "alias": "absol_cr2",
@@ -360,7 +360,7 @@
         "source": "absol",
         "text": "Cost 2, Combat 6, Move 3, Capacity 1",
         "homebrewReplacesID": "cr2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
     },
     {
         "alias": "absol_cv2",
@@ -372,7 +372,7 @@
         "source": "absol",
         "text": "Cost 3, Combat 9, Move 2, Capacity 6",
         "homebrewReplacesID": "cv2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
     },
     {
         "alias": "absol_dn2",
@@ -384,7 +384,7 @@
         "source": "absol",
         "text": "Cost 4, Combat 5, Move 2, Capacity 1\nSUSTAIN DAMAGE, BOMBARDMENT 5\nThis unit cannot be destroyed by \"Direct Hit\" action cards.",
         "homebrewReplacesID": "dn2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
     },
     {
         "alias": "absol_ws",
@@ -396,7 +396,7 @@
         "source": "absol",
         "text": "Cost 10, Combat 3(x3), Move 2, Capacity 6\nSUSTAIN DAMAGE, BOMBARDMENT 3(x3)\nOther player's units in this system lose PLANETARY SHIELD.",
         "homebrewReplacesID": "ws",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/generic/WarSun.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/generic/WarSun.png?raw=true"
     },
     {
         "alias": "absol_pm",
@@ -409,7 +409,7 @@
         "source": "absol",
         "text": "When you give another player 1 or more commodities, they gain an equal number of trade goods.",
         "homebrewReplacesID": "pm",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/ProductionBiomes.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/ProductionBiomes.png?raw=true"
     },
     {
         "alias": "absol_qdn",
@@ -422,7 +422,7 @@
         "source": "absol",
         "text": "When another player would choose a strategy card during the strategy phase, if you do not have a strategy card, you may exhaust this card, spend a token from your strategy pool, and give that player 1 trade good for each player that does not have a strategy card to choose your strategy card before them.",
         "homebrewReplacesID": "qdn",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/QuantumDatahubNode.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/QuantumDatahubNode.png?raw=true"
     },
     {
         "alias": "absol_ac2",
@@ -436,7 +436,7 @@
         "source": "absol",
         "text": "Cost 3, Combat 9, Move 2, Capacity 8\nSUSTAIN DAMAGE",
         "homebrewReplacesID": "ac2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
     },
     {
         "alias": "absol_so2",
@@ -450,7 +450,7 @@
         "source": "absol",
         "text": "Cost: 1(x2), Combat 6\nAfter this unit is destroyed, roll 1 die. If the result is 5 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet that contains 1 of your space docks.",
         "homebrewReplacesID": "so2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/SpecOpsII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/SpecOpsII.png?raw=true"
     },
     {
         "alias": "absol_l4",
@@ -463,7 +463,7 @@
         "source": "absol",
         "text": "During an invasion, units cannot use SPACE CANNON against your units.\nYou may exhaust this card at the start of a ground combat; your opponent cannot make combat rolls during the first combat round.",
         "homebrewReplacesID": "l4",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/L4Disruptors.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/L4Disruptors.png?raw=true"
     },
     {
         "alias": "absol_nes",
@@ -476,7 +476,7 @@
         "source": "absol",
         "text": "When 1 of your units uses SUSTAIN DAMAGE, cancel 2 hits instead of 1.",
         "homebrewReplacesID": "nes",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/noneuclidean_shielding.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/noneuclidean_shielding.jpg?raw=true"
     },
     {
         "alias": "absol_it",
@@ -489,7 +489,7 @@
         "source": "absol",
         "text": "You may spend 1 token from your strategy pool when one of your neighbors plays an action card; cancel that action card.",
         "homebrewReplacesID": "it",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/InstinctTraining.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/InstinctTraining.png?raw=true"
     },
     {
         "alias": "absol_nf",
@@ -502,7 +502,7 @@
         "source": "absol",
         "text": "After another player activates a system that contains 1 or more of your ships, you may exhaust this card and spend 1 token from your strategy pool; immediately end that player's turn.",
         "homebrewReplacesID": "nf",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/nullification_field.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/nullification_field.jpg?raw=true"
     },
     {
         "alias": "absol_scc",
@@ -515,7 +515,7 @@
         "source": "absol",
         "text": "During your tactical actions, you may treat systems that contain 1 or more of your space docks as adjacent.",
         "homebrewReplacesID": "scc",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/SpatialConduitCylinder.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/SpatialConduitCylinder.png?raw=true"
     },
     {
         "alias": "absol_ers",
@@ -528,7 +528,7 @@
         "source": "absol",
         "text": "When another player moves ships into a system that contains 1 or more of your structures, gain trade goods equal to the number of non-fighter ships that moved into that system.",
         "homebrewReplacesID": "ers",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/EResSiphons.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/EResSiphons.png?raw=true"
     },
     {
         "alias": "absol_vpw",
@@ -541,7 +541,7 @@
         "source": "absol",
         "text": "When you commit ground forces to a planet from 1 or more other planets, you may commit 2 ground forces from each planet.\nAfter making combat rolls during a round of ground combat, if your opponent produced 1 or more hits, you produce 1 additional hit.",
         "homebrewReplacesID": "vpw",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/ValkyrieParticleWeave.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/ValkyrieParticleWeave.png?raw=true"
     },
     {
         "alias": "absol_exo2",
@@ -555,7 +555,7 @@
         "source": "absol",
         "text": "Cost 4, Combat 5, Move 2, Capacity 1\nSUSTAIN DAMAGE, BOMBARDMENT 4(x2)\nThis unit cannot be destroyed by \"Direct Hit\" action cards. After a round of space combat, you may destroy this unit to destroy up to 2 ships in this system.",
         "homebrewReplacesID": "exo2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
     },
     {
         "alias": "absol_is",
@@ -568,7 +568,7 @@
         "source": "absol",
         "text": "When you research a technology, you may exhaust this card to ignore all prerequisites on that technology.\nACTION: You may exhaust this card and spend 1 command token from your strategy pool and 4 resources to research a technology.",
         "homebrewReplacesID": "is",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/Inheritancesystems.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/Inheritancesystems.png?raw=true"
     },
     {
         "alias": "absol_sdn2",
@@ -582,7 +582,7 @@
         "source": "absol",
         "text": "Cost 4, Combat 4, Move 2, Capacity 2\nSUSTAIN DAMAGE, BOMBARDMENT 4\nThis unit cannot be destroyed by \"Direct Hit\" action cards.",
         "homebrewReplacesID": "sdn2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
     },
     {
         "alias": "absol_ng",
@@ -595,7 +595,7 @@
         "source": "absol",
         "text": "After another player activates a system that contains 1 or more of your ships, you may force that player to remove 1 token from their fleet pool and return it to their reinforcements.\nDuring combat, when your opponent plays an action card, produce 1 hit; your opponent must assign it to 1 of their units.",
         "homebrewReplacesID": "ng",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/Neuroglaive.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/Neuroglaive.png?raw=true"
     },
     {
         "alias": "absol_hcf2",
@@ -609,7 +609,7 @@
         "source": "absol",
         "text": "Cost: 1(x2), Combat 7, Move 2\nThis unit may move without being transported. Fighters in excess of your ships' capacity count as 1/2 of a ship against your fleet pool.",
         "homebrewReplacesID": "hcf2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
     },
     {
         "alias": "absol_so",
@@ -622,7 +622,7 @@
         "source": "absol",
         "text": "At the end of each space combat in systems that contain or are adjacent to your ships, gain 1 commodity.\nIf you win a space combat, you may produce 1 ship of any type that was destroyed during that combat, and may spend commodities as resources.",
         "homebrewReplacesID": "so",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/SalvageOperations.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/SalvageOperations.png?raw=true"
     },
     {
         "alias": "absol_mc",
@@ -635,7 +635,7 @@
         "source": "absol",
         "text": "When you spend trade goods, every 2 trade goods spent are worth 3 resources or influence instead of 2.",
         "homebrewReplacesID": "mc",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/MirrorComputing.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/MirrorComputing.png?raw=true"
     },
     {
         "alias": "absol_tp",
@@ -648,7 +648,7 @@
         "source": "absol",
         "text": "During your turn of the action phase, players that have passed cannot play action cards.\nAt the start of a round of ground combat, you may discard 1 action card to apply -1 to the results of your opponent's die rolls during that combat round.",
         "homebrewReplacesID": "tp",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/TransparasteelPlating.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/TransparasteelPlating.png?raw=true"
     },
     {
         "alias": "absol_mi",
@@ -661,7 +661,7 @@
         "source": "absol",
         "text": "After 1 of your command tokens is placed in a system that contains another player's units, you may exhaust this card to look at that player's hand of action cards. Choose 1 of those cards and add it to your hand.",
         "homebrewReplacesID": "mi",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/MageonImplants.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/MageonImplants.png?raw=true"
     },
     {
         "alias": "absol_lgf",
@@ -674,7 +674,7 @@
         "source": "absol",
         "text": "During your tactical actions, you treat your home system and the Mecatol Rex system as if they each contained a gamma wormhole.",
         "homebrewReplacesID": "lgf",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/LazaxGateFolding.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/LazaxGateFolding.png?raw=true"
     },
     {
         "alias": "absol_htp",
@@ -687,7 +687,7 @@
         "source": "absol",
         "text": "During the Production step of your tactical actions, you may treat the resource value of any number of planets you control as if it were equal to that planet's influence value instead.",
         "homebrewReplacesID": "htp",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/HegemonicTradePolicy?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/HegemonicTradePolicy?raw=true"
     },
     {
         "alias": "absol_mr",
@@ -700,7 +700,7 @@
         "source": "absol",
         "text": "Your ships can move into supernovas.\nEach supernova that contains 1 or more of your units gains the PRODUCTION 5 ability as if it were 1 of your units.",
         "homebrewReplacesID": "mr",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/magmus_reactor_omega.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/magmus_reactor_omega.jpg?raw=true"
     },
     {
         "alias": "absol_pws2",
@@ -713,7 +713,7 @@
         "source": "absol",
         "text": "Cost 8, Combat 3(x3), Move 3, Capacity 6\nSUSTAIN DAMAGE, BOMBARDMENT 3(x3)\nOther player's units in this system lose PLANETARY SHIELD. This unit cannot be destroyed by \"Direct Hit\" action cards.",
         "homebrewReplacesID": "pws2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/PrototypeWarSunII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/PrototypeWarSunII.png?raw=true"
     },
     {
         "alias": "absol_yso",
@@ -726,7 +726,7 @@
         "source": "absol",
         "text": "After you produce units, place up to 2 infantry from your reinforcements on any planet you control or in any space area that contains 1 or more of your ships.",
         "homebrewReplacesID": "yso",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/yin_spinner_omega.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/yin_spinner_omega.jpg?raw=true"
     },
     {
         "alias": "absol_ic",
@@ -739,7 +739,7 @@
         "source": "absol",
         "text": "ACTION: Exhaust this card, choose a system and destroy any number of your cruisers or destroyers in adjacent systems. Generate 1 hit for each ship you destroyed; you opponent must assign those hits to their ships in the chosen system, and must assign them to non-fighter ships, if able.",
         "homebrewReplacesID": "ic",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/ImpulseCore.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/ImpulseCore.png?raw=true"
     },
     {
         "alias": "absol_cm",
@@ -752,7 +752,7 @@
         "source": "absol",
         "text": "At the start of your turn, you may exhaust this card to produce 1 unit at each of your space docks.\nApply +2 to your ship's combat rolls in asteroid fields.",
         "homebrewReplacesID": "cm",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/ChaosMapping.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/ChaosMapping.png?raw=true"
     },
     {
         "alias": "absol_ffac2",
@@ -766,7 +766,7 @@
         "source": "absol",
         "text": "Move 2, Capacity 6\nPRODUCTION 7\nThis unit is placed in the space area instead of on a planet. This unit can move and retreat as if it were a ship. If this unit is blockaded, it is destroyed. 1 non-fighter ship in this system does not count against your fleet pool.",
         "homebrewReplacesID": "ffac2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/FloatingFactoryII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/FloatingFactoryII.png?raw=true"
     },
     {
         "alias": "absol_wg",
@@ -779,7 +779,7 @@
         "source": "absol",
         "text": "ACTION: Exhaust this card to place or move up to 2 Creuss wormhole tokens into systems that contain a planet you control and/or non-home systems that do not contain another player's ships.",
         "homebrewReplacesID": "wg",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/WormholeGenerator.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/WormholeGenerator.png?raw=true"
     },
     {
         "alias": "absol_ds",
@@ -792,7 +792,7 @@
         "source": "absol",
         "text": "During each round of space combat in a system that contains 1 or more wormholes, you produce 1 additional hit.  Your opponent must assign this hit to 1 of their non-fighter ships, if able.",
         "homebrewReplacesID": "ds",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/DimensionalSplicer.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/DimensionalSplicer.png?raw=true"
     },
     {
         "alias": "absol_bio",
@@ -805,7 +805,7 @@
         "source": "absol",
         "text": "When you produce units in a system, you may exhaust this card and reduce the combined PRODUCTION value of your units in that system by up to half (rounded down) to reduce the combined cost of the produced units by the same amount.",
         "homebrewReplacesID": "bio",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/Bioplasmosis.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/Bioplasmosis.png?raw=true"
     },
     {
         "alias": "absol_lw2",
@@ -819,7 +819,7 @@
         "source": "absol",
         "text": "Cost: 1(x2), Combat 7\nPRODUCTION 2\nAfter this unit is destroyed, place the unit on this card.\nAt the start of your next turn, for every 2 units that are on this card, place 1 on a planet you control.",
         "homebrewReplacesID": "lw2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/LetaniWarriorII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/LetaniWarriorII.png?raw=true"
     },
     {
         "alias": "absol_ht2",
@@ -833,7 +833,7 @@
         "source": "absol",
         "text": "Combat 6.\nPLANETARY SHIELD, SPACE CANNON 5, SUSTAIN DAMAGE, PRODUCTION 1\nThis unit is treated as both a structure and a ground force. It cannot be transported. You may use this unit's SPACE CANNON against ships that are adjacent to this unit's systems.",
         "homebrewReplacesID": "ht2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
     },
     {
         "alias": "absol_se2",
@@ -847,7 +847,7 @@
         "source": "absol",
         "text": "Cost 2, Combat 6, Move 3, Capacity 2\nSUSTAIN DAMAGE",
         "homebrewReplacesID": "se2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
     },
     {
         "alias": "absol_as",
@@ -860,7 +860,7 @@
         "source": "absol",
         "text": "After you or one of your neighbors activates a system that is adjacent to an anomaly, you may apply +1 to the move value of all of that player's ships during this tactical action.",
         "homebrewReplacesID": "as",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/aetherstream.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/aetherstream.jpg?raw=true"
     },
     {
         "alias": "absol_vw",
@@ -873,7 +873,7 @@
         "source": "absol",
         "text": "At any time, you may look at the top card of the frontier exploration deck. After you do, you may exhaust this card to shuffle the frontier exploration deck.\nAfter a player moves ships into a system that contains 1 or more of your units, they must give you 1 promissory note from their hand, if able.",
         "homebrewReplacesID": "vw",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/Voidwatch.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/Voidwatch.png?raw=true"
     },
     {
         "alias": "absol_pfa",
@@ -886,7 +886,7 @@
         "source": "absol",
         "text": "After you explore a planet, ready that planet.",
         "homebrewReplacesID": "pfa",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/prefab_arcologies.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/prefab_arcologies.jpg?raw=true"
     },
     {
         "alias": "absol_sc",
@@ -899,7 +899,7 @@
         "source": "absol",
         "text": "At the start of a combat round, you may exhaust a relic fragment in your play area to apply +1 to the results of each of your units’ combat rolls during this combat round.",
         "homebrewReplacesID": "sc",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/Supercharge.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/Supercharge.png?raw=true"
     },
     {
         "alias": "absol_ah",
@@ -925,7 +925,7 @@
         "source": "absol",
         "text": "Cost 1, Combat 7, Move 2, Capacity 1\nANTI-FIGHTER BARRAGE 6(x3)\nWhen this unit generates a hit on a combat roll, your opponent must destroy 1 fighter in the active system, if able. When this unit uses ANTI-FIGHTER BARRAGE, each result of 9 or 10 also destroys 1 of your opponents infantry in the space area of the active system.",
         "homebrewReplacesID": "swa2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/StrikeWingAlphaII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/StrikeWingAlphaII.png?raw=true"
     },
     {
         "alias": "absol_vtx",
@@ -938,7 +938,7 @@
         "source": "absol",
         "text": "ACTION: Exhaust this card to choose another player's non-structure unit in a system that is adjacent to 1 or more of your space docks. Capture 1 unit of that type from that player's reinforcements.",
         "homebrewReplacesID": "vtx",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/vortex.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/vortex.jpg?raw=true"
     },
     {
         "alias": "absol_dt2",
@@ -952,7 +952,7 @@
         "source": "absol",
         "text": "PRODUCTION 7\nThis system is a gravity rift; your ships do not roll for this gravity rift. Place a dimensional tear token beneath this unit as a reminder.\nUp to 10 fighters in this system do not count against your ships' capacity. 1 non-fighter ship in this system does not count against your fleet pool.",
         "homebrewReplacesID": "dt2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/DimensionalTearII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/DimensionalTearII.png?raw=true"
     },
     {
         "alias": "absol_tcs",
@@ -965,7 +965,7 @@
         "source": "absol",
         "text": "At any time during the action phase, you may exhaust this card to perform a transaction with another player. As part of that transaction, you may ready that player's agent.",
         "homebrewReplacesID": "tcs",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/TemporalCommandSuite.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/TemporalCommandSuite.png?raw=true"
     },
     {
         "alias": "absol_m2",
@@ -978,7 +978,7 @@
         "source": "absol",
         "text": "Cost 8, Combat 5(x3), Move 3, Capacity 6\nSUSTAIN DAMAGE, ANTI-FIGHTER BARRAGE 5(x3)\nYou may treat this unit as if it were adjacent to systems that contain 1 or more of your mechs.",
         "homebrewReplacesID": "m2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/MemoriaII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/MemoriaII.png?raw=true"
     },
     {
         "alias": "absol_gr",
@@ -991,7 +991,7 @@
         "source": "absol",
         "text": "When you would cast votes during the agenda phase, you may exhaust 1 planet controlled by each other player whose command tokens are on the Mahact player’s command sheet. You may cast votes from these planets as if you controlled them, even if you would otherwise be prevented from voting.",
         "homebrewReplacesID": "gr",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/GeneticRecombination.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/GeneticRecombination.png?raw=true"
     },
     {
         "alias": "absol_cl2",
@@ -1005,7 +1005,7 @@
         "source": "absol",
         "text": "Cost: 1(x2), Combat 7\nAfter this unit is destroyed, gain 2 commodities or convert 1 of your commodities to a trade good. Then, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet that contains 1 of your structures.",
         "homebrewReplacesID": "cl2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/CrimsonLegionnaireII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/CrimsonLegionnaireII.png?raw=true"
     },
     {
         "alias": "absol_iihq",
@@ -1018,7 +1018,7 @@
         "source": "absol",
         "text": "You are neighbors with all players that have units or control planets in or adjacent to the Mecatol Rex system.\nGain the Custodia Vigilia planet card and its legendary planet ability card. You cannot lose these cards, and this card cannot have an X or Y assimilator token placed on it.\n\n[Custodia Vigilia is a 2/3 legendary planet with the ability:\nWhile you control Mecatol Rex, it gains SPACE CANNON 5 and PRODUCTION 3.\nGain 2 command tokens when another player scores Custodians VP using Imperial Primary.]",
         "homebrewReplacesID": "iihq",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/iihq_modernization.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/iihq_modernization.jpg?raw=true"
     },
     {
         "alias": "absol_asn",
@@ -1031,6 +1031,6 @@
         "source": "absol",
         "text": "After you resolve the PRODUCTION abilities of 1 or more of your units, you may resolve the PRODUCTION ability of 1 of your other units in any system; the additional use does not trigger this ability.",
         "homebrewReplacesID": "asn",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/AgencySupplyNetwork.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/AgencySupplyNetwork.png?raw=true"
     }
 ]

--- a/src/main/resources/data/technologies/flagshipping.json
+++ b/src/main/resources/data/technologies/flagshipping.json
@@ -8,6 +8,6 @@
         "source": "flagshipping",
         "text": "At the start of any space combat, you may choose 1 participating unit with the SUSTAIN DAMAGE ability; repair or damage that unit.",
         "shortName": "Changer of Ways",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/misc_homebrew/changer_of_ways.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/misc_homebrew/changer_of_ways.png?raw=true"
     }
 ]

--- a/src/main/resources/data/technologies/pok.json
+++ b/src/main/resources/data/technologies/pok.json
@@ -7,7 +7,7 @@
         ],
         "source": "base",
         "text": "Your ships can move into and through asteroid fields.\nWhen other players' units use SPACE CANNON against your units, apply -1 to the result of each die roll.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/antimass_deflectors.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/antimass_deflectors.png?raw=true",
         "initials": "AMD",
         "shortName": "Antimass Deflect'rs"
     },
@@ -20,7 +20,7 @@
         "requirements": "B",
         "source": "base",
         "text": "After you activate a system, apply +1 to the move value of 1 of your ships during this tactical action.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/gravity_drive.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/gravity_drive.png?raw=true",
         "initials": "GD"
     },
     {
@@ -32,7 +32,7 @@
         "requirements": "BB",
         "source": "base",
         "text": "During each of your turns of the action phase, you may perform 2 actions instead of 1.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/fleet_logistics.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/fleet_logistics.png?raw=true",
         "initials": "FL"
     },
     {
@@ -44,7 +44,7 @@
         "requirements": "BBB",
         "source": "base",
         "text": "Your ships can move through systems that contain other players' ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/lightwave_deflector.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/lightwave_deflector.png?raw=true",
         "initials": "L/W"
     },
     {
@@ -55,7 +55,7 @@
         ],
         "source": "pok",
         "text": "After you perform a tactical action in a system that contains a frontier token, if you have 1 or more ships in that system, explore that token.\nYour ships can retreat into adjacent systems that do not contain other players' units, even if you do not have units or control planets in that system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/dark_energy_tap.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/dark_energy_tap.png?raw=true",
         "initials": "DET",
         "shortName": "Dark N.R.G. Tap"
     },
@@ -68,7 +68,7 @@
         "requirements": "B",
         "source": "pok",
         "text": "ACTION: Exhaust this card to produce 1 ship in any system that contains one of your space docks.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/sling_relay.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/sling_relay.png?raw=true",
         "initials": "SR"
     },
     {
@@ -79,7 +79,7 @@
         ],
         "source": "base",
         "text": "During the status phase, draw 2 action cards instead of 1.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/neural_motivator.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/neural_motivator.png?raw=true",
         "initials": "NM"
     },
     {
@@ -91,7 +91,7 @@
         "requirements": "G",
         "source": "base",
         "text": "After you win a ground combat, you may place 1 infantry from your reinforcements on that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/dacxive_animators.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/dacxive_animators.png?raw=true",
         "initials": "DA"
     },
     {
@@ -103,7 +103,7 @@
         "requirements": "GG",
         "source": "base",
         "text": "During the status phase, gain 3 command tokens instead of 2.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/hyper_metabolism.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/hyper_metabolism.png?raw=true",
         "shrinkName": true,
         "shortName": "Hyper\nMetabolism",
         "initials": "HM"
@@ -117,7 +117,7 @@
         "requirements": "GGG",
         "source": "base",
         "text": "ACTION: Exhaust this card and choose 1 planet in a system that contains 1 or more of your ships that have BOMBARDMENT; destroy all infantry on that planet",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/x89_bacterial_weapon.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/x89_bacterial_weapon.png?raw=true",
         "initials": "X89",
         "shortName": "X-89 Bact. Weapon"
     },
@@ -130,7 +130,7 @@
         "requirements": "GGG",
         "source": "codex1",
         "text": "After 1 or more of your units use BOMBARDMENT against a planet, if at least 1 of your opponent's infantry was destroyed, you may destroy all of your opponent's infantry on that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/x89_bacterial_weapon_omega.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/x89_bacterial_weapon_omega.png?raw=true",
         "initials": "X89",
         "shortName": "X-89 Bact. Weapon"
     },
@@ -142,7 +142,7 @@
         ],
         "source": "pok",
         "text": "You can use technology specialties on planets you control without exhausting them, even if those planets are exhausted.\nDuring the action phase, you can exhaust planets you control that have technology specialties to gain 1 trade good.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/psychoarchaeology.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/psychoarchaeology.png?raw=true",
         "initials": "PSY",
         "shortName": "Psychoarch\n-aeology",
         "shrinkName": true
@@ -156,7 +156,7 @@
         "requirements": "G",
         "source": "pok",
         "text": "You may exhaust this card at the end of your turn to ready 1 of your planets that has a technology specialty or 1 of your other technologies.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/biostims.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/biostims.png?raw=true",
         "initials": "BS"
     },
     {
@@ -167,7 +167,7 @@
         ],
         "source": "base",
         "text": "When 1 or more of your units use BOMBARDMENT or SPACE CANNON, 1 of those units may roll 1 additional die.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/plasma_scoring.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/plasma_scoring.png?raw=true",
         "initials": "PS"
     },
     {
@@ -179,7 +179,7 @@
         "requirements": "R",
         "source": "base",
         "text": "You may exhaust this card at the start of a round of ground combat on a planet that contains 1 or more of your units that have PLANETARY SHIELD; your opponent cannot make combat rolls this combat round.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/magen_defense_grid.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/magen_defense_grid.png?raw=true",
         "initials": "MDG",
         "shortName": "Magen Def. Grid"
     },
@@ -192,7 +192,7 @@
         "requirements": "R",
         "source": "codex1",
         "text": "At the start of ground combat on a planet that contains 1 or more of your structures, you may produce 1 hit and assign it to 1 of your opponent's ground forces.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/magen_defense_grid_omega.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/magen_defense_grid_omega.png?raw=true",
         "initials": "MDG",
         "shortName": "Magen Def. Grid"
     },
@@ -205,7 +205,7 @@
         "requirements": "RR",
         "source": "base",
         "text": "During each combat round, after you assign hits to your units, repair 1 of your damaged units that did not use SUSTAIN DAMAGE during this combat round.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/duranium_armor.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/duranium_armor.png?raw=true",
         "initials": "DA"
     },
     {
@@ -217,7 +217,7 @@
         "requirements": "RRR",
         "source": "base",
         "text": "At the start of a space combat in a system that contains 3 or more of your non-fighter ships, your opponent must destroy 1 of their non-fighter ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/assault_cannon.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/assault_cannon.png?raw=true",
         "initials": "AC"
     },
     {
@@ -228,7 +228,7 @@
         ],
         "source": "pok",
         "text": "When you research a unit upgrade technology, you may exhaust this card to ignore any 1 prerequisite.\nWhen 1 or more of your units use PRODUCTION, you may exhaust this card to reduce the combined cost of the produced units by the number of unit upgrade technologies that you own.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/ai_development_algorithm.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/ai_development_algorithm.png?raw=true",
         "initials": "AI",
         "shortName": "AI Develop. Algorithm"
     },
@@ -241,7 +241,7 @@
         "requirements": "R",
         "source": "pok",
         "text": "After 1 or more of your units use PRODUCTION, you may exhaust this card to place 1 mech from your reinforcements on a planet you control in that system.\nAfter 1 of your mechs is destroyed, gain 1 trade good.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/self_assembly_routines.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/self_assembly_routines.png?raw=true",
         "initials": "SAR",
         "shortName": "Self-Ass. Routines"
     },
@@ -253,7 +253,7 @@
         ],
         "source": "base",
         "text": "When 1 or more of your units use PRODUCTION, reduce the combined cost of the produced units by 1.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/sarween_tools.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/sarween_tools.png?raw=true",
         "initials": "ST"
     },
     {
@@ -265,7 +265,7 @@
         "requirements": "Y",
         "source": "base",
         "text": "You may exhaust this card before 1 or more of your units uses SPACE CANNON; hits produced by those units must be assigned to non-fighter ships if able.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/graviton_laser_system.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/graviton_laser_system.png?raw=true",
         "initials": "GLS",
         "shortName": "Graviton Laser Sys."
     },
@@ -278,7 +278,7 @@
         "requirements": "YY",
         "source": "base",
         "text": "You may exhaust this card at the start of your turn during the action phase; remove up to 4 of your ground forces from the game board and place them on 1 or more planets you control.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/transit_diodes.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/transit_diodes.png?raw=true",
         "initials": "TD"
     },
     {
@@ -290,7 +290,7 @@
         "requirements": "YYY",
         "source": "base",
         "text": "After you gain control of a planet, you may produce any number of units on that planet that have a combined cost equal to or less than that planet's resource value.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/integrated_economy.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/integrated_economy.png?raw=true",
         "initials": "IE",
         "shortName": "Integr't'd Economy"
     },
@@ -302,7 +302,7 @@
         ],
         "source": "pok",
         "text": "When you activate a system, you may explore 1 planet in that system which contains 1 or more of your units.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/scanlink_drone_network.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/scanlink_drone_network.png?raw=true",
         "initials": "SDN",
         "shortName": "Scanlink Drone Net."
     },
@@ -315,7 +315,7 @@
         "requirements": "Y",
         "source": "pok",
         "text": "At the end of your turn, you may exhaust this card to redistribute your command tokens.\nWhen you cast votes during the agenda phase, you may cast 3 additional votes; if you do, and the outcome you voted for is not resolved, exhaust this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/predictive_intelligence.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/predictive_intelligence.png?raw=true",
         "initials": "PI",
         "shortName": "Predictive Intell'ce"
     },
@@ -328,7 +328,7 @@
         "requirements": "RRRY",
         "source": "base",
         "text": "Cost 12, Combat 3(x3), Move 2, Capacity 6\nSUSTAIN DAMAGE, BOMBARDMENT 3(x3)\n Other players' units in this system lose PLANETARY SHIELD.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/warsun.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/warsun.jpg?raw=true"
     },
     {
         "alias": "sd2",
@@ -339,7 +339,7 @@
         "requirements": "YY",
         "source": "base",
         "text": "PRODUCTION X\nThis unit's PRODUCTION value is equal to 4 more than the resource value of this planet.\nUp to 3 fighters in this system do not count against your ships' capacity.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/spacedock_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/spacedock_2.jpg?raw=true"
     },
     {
         "alias": "cr2",
@@ -350,7 +350,7 @@
         "requirements": "GYR",
         "source": "base",
         "text": "Cost 2, Combat 6, Move 3, Capacity 1",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
     },
     {
         "alias": "dn2",
@@ -361,7 +361,7 @@
         "requirements": "BBY",
         "source": "base",
         "text": "Cost 4, Combat 5, Move 2, Capacity 1\nSUSTAIN DAMAGE, BOMBARDMENT 5\nThis unit cannot be destroyed by \"Direct Hit\" action cards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
     },
     {
         "alias": "dd2",
@@ -372,7 +372,7 @@
         "requirements": "RR",
         "source": "base",
         "text": "Cost 1, Combat 8, Move 2\nANTI-FIGHTER BARRAGE 6(x3)",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/destroyer_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/destroyer_2.jpg?raw=true"
     },
     {
         "alias": "pds2",
@@ -383,7 +383,7 @@
         "requirements": "RY",
         "source": "base",
         "text": "PLANETARY SHIELD, SPACE CANNON 5\nYou may use this unit's SPACE CANNON against ships that are adjacent to this unit's system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
     },
     {
         "alias": "cv2",
@@ -394,7 +394,7 @@
         "requirements": "BB",
         "source": "base",
         "text": "Cost 3, Combat 9, Move 2, Capacity 6",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
     },
     {
         "alias": "ff2",
@@ -405,7 +405,7 @@
         "requirements": "GB",
         "source": "base",
         "text": "Cost 1(x2), Combat 8, Move 2\nThis unit may move without being transported.\nFighters in excess of your ships' capacity count against your fleet pool.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
     },
     {
         "alias": "inf2",
@@ -416,7 +416,7 @@
         "requirements": "GG",
         "source": "base",
         "text": "Cost 1(x2), Combat 7\nAfter this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
     },
     {
         "alias": "lw2",
@@ -429,7 +429,7 @@
         "baseUpgrade": "inf2",
         "source": "base",
         "text": "Cost 1(x2), Combat 7\nPRODUCTION 2\nAfter this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/letani_warrior_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/letani_warrior_2.jpg?raw=true"
     },
     {
         "alias": "swa2",
@@ -442,7 +442,7 @@
         "baseUpgrade": "dd2",
         "source": "pok",
         "text": "Cost 1, Combat 7, Move 2, Capacity 1\nANTI-FIGHTER BARRAGE 6(x3)\nWhen this unit uses ANTI-FIGHTER BARRAGE, each result of 9 or 10 also destroys 1 of your opponents infantry in the space area of the active system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/strike_wing_alpha_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/strike_wing_alpha_2.jpg?raw=true"
     },
     {
         "alias": "l4",
@@ -455,7 +455,7 @@
         "source": "base",
         "text": "During an invasion, units cannot use SPACE CANNON against your units.",
         "shortName": "L4 Dis-\nruptors",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/l4_disruptors.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/l4_disruptors.jpg?raw=true"
     },
     {
         "alias": "cm",
@@ -467,7 +467,7 @@
         "faction": "saar",
         "source": "base",
         "text": "Other players cannot activate asteroid fields that contain 1 or more of your ships.\nAt the start of your turn during the action phase, you may produce 1 unit in a system that contains at least 1 of your units that has PRODUCTION.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/chaos_mapping.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/chaos_mapping.jpg?raw=true"
     },
     {
         "alias": "pws2",
@@ -480,7 +480,7 @@
         "baseUpgrade": "ws",
         "source": "base",
         "text": "Cost 10, Combat 3(x3), Move 3, Capacity 6\nSUSTAIN DAMAGE, BOMBARDMENT 3(x3)\nOther players' units in this system lose PLANETARY SHIELD.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/prototype_war_sun_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/prototype_war_sun_2.jpg?raw=true"
     },
     {
         "alias": "qdn",
@@ -494,7 +494,7 @@
         "text": "At the end of the strategy phase, you may spend 1 token from your strategy pool and give another player 3 of your trade goods. If you do, give 1 of your strategy cards to that player and take 1 of their strategy cards.",
         "shrinkName": true,
         "shortName": "Quantum\nDatahub Nd",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/quantum_datahub_node.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/quantum_datahub_node.jpg?raw=true"
     },
     {
         "alias": "as",
@@ -507,7 +507,7 @@
         "source": "pok",
         "text": "After you or one of your neighbors activates a system that is adjacent to an anomaly, you may apply +1 to the move value of all of that player's ships during this tactical action.",
         "shortName": "Aether-\nstream",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/aetherstream.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/aetherstream.jpg?raw=true"
     },
     {
         "alias": "ac2",
@@ -520,7 +520,7 @@
         "baseUpgrade": "cv2",
         "source": "base",
         "text": "Cost 3, Combat 9, Move 2, Capacity 8\nSUSTAIN DAMAGE",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
     },
     {
         "alias": "sdn2",
@@ -533,7 +533,7 @@
         "baseUpgrade": "dn2",
         "source": "base",
         "text": "Cost 4, Combat 4, Move 2, Capacity 2\nSUSTAIN DAMAGE, BOMBARDMENT 4\nThis unit cannot be destroyed by \"Direct Hit\" action cards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
     },
     {
         "alias": "cl2",
@@ -546,7 +546,7 @@
         "baseUpgrade": "inf2",
         "source": "pok",
         "text": "Cost 1(x2), Combat 7\nAfter this unit is destroyed, gain 1 commodity or convert 1 of your commodities to a trade good. Then, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/crimson_legionnaire_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/crimson_legionnaire_2.jpg?raw=true"
     },
     {
         "alias": "mc",
@@ -558,7 +558,7 @@
         "faction": "mentak",
         "source": "base",
         "text": "When you spend trade goods, each trade good is worth 2 resources or influence instead of 1.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/mirror_computing.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/mirror_computing.jpg?raw=true"
     },
     {
         "alias": "hcf2",
@@ -571,7 +571,7 @@
         "baseUpgrade": "ff2",
         "source": "base",
         "text": "Cost 1(x2), Combat 7, Move 2\nThis unit may move without being transported.\nFighters in excess of your ships' capacity count as 1/2 of a ship against your fleet pool.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
     },
     {
         "alias": "pfa",
@@ -583,7 +583,7 @@
         "faction": "naaz",
         "source": "pok",
         "text": "After you explore a planet, ready that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/prefab_arcologies.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/prefab_arcologies.jpg?raw=true"
     },
     {
         "alias": "vax",
@@ -594,7 +594,7 @@
         "faction": "nekro",
         "source": "base",
         "text": "When you would gain another player's technology using 1 of your faction abilities, you may place the \"X\" assimilator token on a faction technology owned by that player instead.\nWhile that token is on a technology, this card gains that technology's text.\nYou cannot place an assimilator token on technology that already has an assimilator token.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/valefar_assimilator_x.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/valefar_assimilator_x.jpg?raw=true"
     },
     {
         "alias": "m2",
@@ -606,7 +606,7 @@
         "faction": "nomad",
         "source": "pok",
         "text": "Cost 8, Combat 5(x2), Move 2, Capacity 6\nSUSTAIN DAMAGE, ANTI-FIGHTER BARRAGE 5(x3)\nYou may treat this unit as if it were adjacent to systems that contain one or more of your mechs.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/memoria_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/memoria_2.jpg?raw=true"
     },
     {
         "alias": "exo2",
@@ -619,7 +619,7 @@
         "baseUpgrade": "dn2",
         "source": "base",
         "text": "Cost 4, Combat 5, Move 2, Capacity 1\nSUSTAIN DAMAGE, BOMBARDMENT 4(x2)\nThis unit cannot be destroyed by \"Direct Hit\" action cards.\nAfter a round of space combat, you may destroy this unit to destroy up to 2 ships in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
     },
     {
         "alias": "se2",
@@ -632,7 +632,7 @@
         "baseUpgrade": "cr2",
         "source": "pok",
         "text": "Cost 2, Combat 6, Move 3, Capacity 2\nSUSTAIN DAMAGE",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
     },
     {
         "alias": "scc",
@@ -646,7 +646,7 @@
         "text": "You may exhaust this card after you activate a system that contains 1 or more of your units; that system is adjacent to all other systems that contain 1 or more of your units during this activation.",
         "shrinkName": false,
         "shortName": "Spatial\nCond't Cyl.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/spacial_conduit_cylinder.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/spacial_conduit_cylinder.jpg?raw=true"
     },
     {
         "alias": "dt2",
@@ -659,7 +659,7 @@
         "baseUpgrade": "sd2",
         "source": "pok",
         "text": "PRODUCTION 7\nThis system is a gravity rift; your ships do not roll for this gravity rift. Place a dimensional tear token beneath this unit as a reminder.\nUp to 12 fighters in this system do not count against your ships' capacity.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/dimensional_tear_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/dimensional_tear_2.jpg?raw=true"
     },
     {
         "alias": "lgf",
@@ -671,7 +671,7 @@
         "faction": "winnu",
         "source": "base",
         "text": "During your tactical actions, if you do not control Mecatol Rex, treat its system as if it has both an α and β wormhole.\nACTION: If you control Mecatol Rex, exhaust this card to place 1 infantry from your reinforcements on Mecatol Rex.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/lazax_gate_folding.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/lazax_gate_folding.jpg?raw=true"
     },
     {
         "alias": "it",
@@ -683,7 +683,7 @@
         "faction": "xxcha",
         "source": "base",
         "text": "You may exhaust this card and spend 1 token from your strategy pool when another player plays an action card; cancel that action card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/instinct_training.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/instinct_training.jpg?raw=true"
     },
     {
         "alias": "mi",
@@ -695,7 +695,7 @@
         "faction": "yssaril",
         "source": "base",
         "text": "ACTION: Exhaust this card to look at another player's hand of action cards.  Choose 1 of those cards and add it to your hand.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/mageon_implants.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/mageon_implants.jpg?raw=true"
     },
     {
         "alias": "bio",
@@ -708,7 +708,7 @@
         "source": "base",
         "text": "At the end of the status phase, you may remove any number of infantry from planets you control and place them on 1 or more planets you control in the same or adjacent systems.",
         "shortName": "Bio-\nplasmosis",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/bioplasmosis.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/bioplasmosis.jpg?raw=true"
     },
     {
         "alias": "ah",
@@ -721,7 +721,7 @@
         "source": "pok",
         "text": "Other players cannot move ships through systems that contain your structures.\nEach planet that contains 1 or more of your structures gains the PRODUCTION 1 ability as if it were a unit.",
         "shortName": "Aerie Holo\n-lattice",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/aerie_hololattice.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/aerie_hololattice.jpg?raw=true"
     },
     {
         "alias": "nes",
@@ -735,7 +735,7 @@
         "text": "When 1 of your units uses SUSTAIN DAMAGE, cancel 2 hits instead of 1.",
         "shortName": "Non-Euclid.\nShielding",
         "shrinkName": false,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/noneuclidean_shielding.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/noneuclidean_shielding.jpg?raw=true"
     },
     {
         "alias": "ffac2",
@@ -748,7 +748,7 @@
         "baseUpgrade": "sd2",
         "source": "base",
         "text": "Move 2, Capacity 5\nPRODUCTION 7.\nThis unit is placed in the space area instead of on a planet.\nThis unit can move and retreat as if it were a ship.\nIf this unit is blockaded, it is destroyed.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/floating_factory_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/floating_factory_2.jpg?raw=true"
     },
     {
         "alias": "mr",
@@ -760,7 +760,7 @@
         "faction": "muaat",
         "source": "base",
         "text": "Your ships can move into supernovas.\nEach supernova that contains 1 or more of your units gains the PRODUCTION 5 ability as if it were 1 of your units.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/magmus_reactor_omega.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/magmus_reactor_omega.jpg?raw=true"
     },
     {
         "alias": "pm",
@@ -773,7 +773,7 @@
         "source": "base",
         "text": "ACTION: Exhaust this card and spend 1 token from your strategy pool to gain 4 trade goods and choose 1 other player; that player gains 2 trade goods.",
         "shrinkName": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/production_biomes.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/production_biomes.jpg?raw=true"
     },
     {
         "alias": "vw",
@@ -785,7 +785,7 @@
         "faction": "empyrean",
         "source": "pok",
         "text": "After a player moves ships into a system that contains 1 or more of your units, they must give you 1 promissory note from their hand, if able.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/voidwatch.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/voidwatch.jpg?raw=true"
     },
     {
         "alias": "so2",
@@ -798,7 +798,7 @@
         "baseUpgrade": "inf2",
         "source": "base",
         "text": "Cost 1(x2), Combat 6\nAfter this unit is destroyed, roll 1 die. If the result is 5 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/spec_ops_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/spec_ops_2.jpg?raw=true"
     },
     {
         "alias": "wg",
@@ -810,7 +810,7 @@
         "faction": "ghost",
         "source": "base",
         "text": "ACTION: Exhaust this card to place or move a Creuss wormhole token into either a system that contains a planet you control or a non-home system that does not contain another player's ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/wormhole_generator_omega.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/wormhole_generator_omega.jpg?raw=true"
     },
     {
         "alias": "ds",
@@ -823,7 +823,7 @@
         "source": "base",
         "text": "At the start of space combat in a system that contains a wormhole and 1 or more of your ships, you may produce 1 hit and assign it to 1 of your opponent's ships.",
         "shrinkName": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/dimensional_splicer.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/dimensional_splicer.jpg?raw=true"
     },
     {
         "alias": "is",
@@ -836,7 +836,7 @@
         "source": "base",
         "text": "You may exhaust this card and spend 2 resources when you research a technology; ignore all of that technology's prerequisites.",
         "shrinkName": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/inheritance_systems.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/inheritance_systems.jpg?raw=true"
     },
     {
         "alias": "gr",
@@ -850,7 +850,7 @@
         "text": "You may exhaust this card before a player casts votes; that player must cast at least 1 vote for an outcome of your choice or remove 1 token from their fleet pool and return it to their reinforcements.",
         "shrinkName": true,
         "shortName": "Genetic Re-\ncombination",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/genetic_recombination.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/genetic_recombination.jpg?raw=true"
     },
     {
         "alias": "so",
@@ -863,7 +863,7 @@
         "source": "base",
         "text": "After you win or lose a space combat, gain 1 trade good; if you won the combat, you may also produce 1 ship in that system of any ship type that was destroyed during the combat.",
         "shortName": "Salvage Operat'ns",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/salvage_operations.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/salvage_operations.jpg?raw=true"
     },
     {
         "alias": "ng",
@@ -876,7 +876,7 @@
         "source": "base",
         "text": "After another player activates a system that contains 1 or more of your ships, that player removes 1 token from their fleet pool and returns it to their reinforcements.",
         "shortName": "Neuro-\nglaive",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/neuroglaive.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/neuroglaive.jpg?raw=true"
     },
     {
         "alias": "sc",
@@ -889,7 +889,7 @@
         "source": "pok",
         "text": "At the start of a combat round, you may exhaust this card to apply +1 to the result of each of your unit's combat rolls during this combat round.",
         "shortName": "Super-\ncharge",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/supercharge.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/supercharge.jpg?raw=true"
     },
     {
         "alias": "vay",
@@ -900,7 +900,7 @@
         "faction": "nekro",
         "source": "base",
         "text": "When you would gain another players technology using 1 of your faction abilities, you may place the \"Y\" assimilator token on a faction technology owned by that player instead.\nWhile that token is on a technology, this card gains that technology's text.\nYou cannot place an assimilator token on technology that already has an assimilator token.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/valefar_assimilator_y.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/valefar_assimilator_y.jpg?raw=true"
     },
     {
         "alias": "tcs",
@@ -914,7 +914,7 @@
         "text": "After any player's agent becomes exhausted, you may exhaust this card to ready that agent; if you ready another player's agent, you may perform a transaction with that player.",
         "shrinkName": true,
         "shortName": "Temporal\nC'mm'nd St.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/temporal_command_suite.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/temporal_command_suite.jpg?raw=true"
     },
     {
         "alias": "vpw",
@@ -928,7 +928,7 @@
         "text": "After making combat rolls during a round of ground combat, if your opponent produced 1 or more hits, you produce 1 additional hit.",
         "shortName": "Valkyrie\nPtcl. Weave",
         "shrinkName": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/valkyrie_particle_weave.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/valkyrie_particle_weave.jpg?raw=true"
     },
     {
         "alias": "ht2",
@@ -941,7 +941,7 @@
         "baseUpgrade": "pds2",
         "source": "pok",
         "text": "Combat 6\nPLANETARY SHIELD, SPACE CANNON 5, SUSTAIN DAMAGE, PRODUCTION 1\nThis unit is treated as both a structure and a ground force. It cannot be transported.\nYou may use this unit's SPACE CANNON against ships that are adjacent to this unit's systems.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
     },
     {
         "alias": "ers",
@@ -953,7 +953,7 @@
         "faction": "jolnar",
         "source": "base",
         "text": "After another player activates a system that contains 1 or more of your ships, gain 4 trade goods.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/eres_siphons.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/eres_siphons.jpg?raw=true"
     },
     {
         "alias": "vtx",
@@ -965,7 +965,7 @@
         "faction": "cabal",
         "source": "pok",
         "text": "ACTION: Exhaust this card to choose another player's non-structure unit in a system that is adjacent to 1 or more of your space docks. Capture 1 unit of that type from that player's reinforcements.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/vortex.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/vortex.jpg?raw=true"
     },
     {
         "alias": "htp",
@@ -979,7 +979,7 @@
         "text": "Exhaust this card when 1 or more of your units use PRODUCTION; swap the resource and influence values of 1 planet you control until the end of your turn.",
         "shrinkName": true,
         "shortName": "Hegemonic Trade Plcy",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/hegemonic_trade_policy.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/hegemonic_trade_policy.jpg?raw=true"
     },
     {
         "alias": "nf",
@@ -993,7 +993,7 @@
         "text": "After another player activates a system that contains 1 or more of your ships, you may exhaust this card and spend 1 token from your strategy pool; immediately end that player's turn.",
         "shrinkName": true,
         "shortName": "Nullificat'n\nField",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/nullification_field.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/nullification_field.jpg?raw=true"
     },
     {
         "alias": "yso",
@@ -1006,7 +1006,7 @@
         "source": "base",
         "text": "After you produce units, place up to 2 infantry from your reinforcements on any planet you control or in any space area that contains 1 or more of your ships.",
         "shortName": "Yin Spinner",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/yin_spinner_omega.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/yin_spinner_omega.jpg?raw=true"
     },
     {
         "alias": "ic",
@@ -1018,7 +1018,7 @@
         "faction": "yin",
         "source": "base",
         "text": "At the start of a space combat, you may destroy 1 of your cruisers or destroyers in the active system to produce 1 hit against your opponent's ships; that hit must be assigned by your opponent to 1 of their non-fighters ships if able.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/impulse_core.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/impulse_core.jpg?raw=true"
     },
     {
         "alias": "tp",
@@ -1032,7 +1032,7 @@
         "text": "During your turn of the action phase, players that have passed cannot play action cards.",
         "shrinkName": true,
         "shortName": "Transpara.\nPlating",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/transparasteel_plating.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/transparasteel_plating.jpg?raw=true"
     },
     {
         "alias": "iihq",
@@ -1046,7 +1046,7 @@
         "text": "You are neighbors with all players that have units or control planets in or adjacent to the Mecatol Rex system.\nGain the Custodia Vigilia planet card and its legendary planet ability card. You cannot lose these cards, and this card cannot have an X or Y assimilator token placed on it.\n\n[Custodia Vigilia is a 2/3 legendary planet with the ability:\nWhile you control Mecatol Rex, it gains SPACE CANNON 5 and PRODUCTION 3.\nGain 2 command tokens when another player scores Custodians VP using Imperial Primary.]",
         "shortName": "I.I.H.Q. Mod-\nernization",
         "shrinkName": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/iihq_modernization.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/iihq_modernization.jpg?raw=true"
     },
     {
         "alias": "asn",
@@ -1060,6 +1060,6 @@
         "text": "Whenever you resolve one of your PRODUCTION abilities, you may resolve an additional one of your PRODUCTION abilities in any system; the additional use does not trigger this ability.",
         "shortName": "Agency\nSupply Net.",
         "shrinkName": false,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/agency_supply_network.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/agency_supply_network.jpg?raw=true"
     }
 ]

--- a/src/main/resources/data/units/absol.json
+++ b/src/main/resources/data/units/absol.json
@@ -11,7 +11,7 @@
         "planetaryShield": true,
         "isStructure": true,
         "ability": "DEPLOY: After you activate a system, attach this card to a non-home planet other than Mecatol Rex you control in that system that does not contain a space dock. The planet this card is attached to contains this unit.\nUp to 8 fighters in this system do not count against your ships' capacity. Up to 2 non-fighter ships in the system do not count against your fleet pool.\nThis unit cannot be affected by opponent's action cards.\nWhen this unit is destroyed or removed, purge this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/PlenaryOrbital.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/PlenaryOrbital.jpg?raw=true"
     },
     {
         "id": "tyrantslament",
@@ -30,7 +30,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "DEPLOY: At the end of your turn, you may place this unit in any system that contains your ships.\nWhen this unit is removed or captured, purge this card.\nThis unit is not affected by action cards, anomalies, or your faction abilities or technologies.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/TyrantsLament.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/TyrantsLament.jpg?raw=true"
     },
     {
         "id": "absol_xxcha_mech",
@@ -49,7 +49,7 @@
         "isGroundForce": true,
         "ability": "When this unit uses SUSTAIN DAMAGE, cancel 2 hits instead of 1.",
         "homebrewReplacesID": "xxcha_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/Indomitus.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/Indomitus.png?raw=true"
     },
     {
         "id": "absol_yssaril_mech",
@@ -66,7 +66,7 @@
         "isGroundForce": true,
         "ability": "This unit can be committed from planets in the active system and from planets and space areas in adjacent systems that do not contain 1 of your command tokens.",
         "homebrewReplacesID": "yssaril_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/BlackshadeInfiltrator.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/BlackshadeInfiltrator.png?raw=true"
     },
     {
         "id": "absol_muaat_mech",
@@ -83,7 +83,7 @@
         "isGroundForce": true,
         "ability": "When you use your STAR FORGE faction ability or your flagship component action in this system or an adjacent system, you may place 1 infantry from your reinforcements with this unit.",
         "homebrewReplacesID": "muaat_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/BlackshadeInfiltrator.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/BlackshadeInfiltrator.png?raw=true"
     },
     {
         "id": "absol_yin_mech",
@@ -100,7 +100,7 @@
         "isGroundForce": true,
         "ability": "You may use the Indoctrination ability on this planet without spending influence.",
         "homebrewReplacesID": "yin_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/MoyinsAshes.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/MoyinsAshes.png?raw=true"
     },
     {
         "id": "absol_saar_mech",
@@ -117,7 +117,7 @@
         "isGroundForce": true,
         "ability": "DEPLOY:  After you gain control of a planet, you may spend 1 trade good to replace 1 infantry on that planet with 1 mech.",
         "homebrewReplacesID": "saar_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/ScavengerZeta.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/ScavengerZeta.png?raw=true"
     },
     {
         "id": "absol_arborec_mech",
@@ -136,7 +136,7 @@
         "isGroundForce": true,
         "ability": "This unit may count as a structure when it is on a planet.\nDEPLOY: When you would place a structure on a planet, you may place 1 mech on that planet instead.",
         "homebrewReplacesID": "arborec_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/LetaniBehemoth.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/LetaniBehemoth.png?raw=true"
     },
     {
         "id": "absol_keleres_mech",
@@ -153,7 +153,7 @@
         "isGroundForce": true,
         "ability": "Once per invasion, other players must spend 1 influence per mech to commit ground forces to this planet.",
         "homebrewReplacesID": "keleres_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/Omniopiares.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/Omniopiares.png?raw=true"
     },
     {
         "id": "absol_naaz_mech_space",
@@ -169,7 +169,7 @@
         "isShip": true,
         "ability": "If this unit is in the space area of the active system, it is also a ship.\nAt the end of a space battle in the active system, flip this card.",
         "homebrewReplacesID": "naaz_mech_space",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/ZGravEidolon.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/ZGravEidolon.png?raw=true"
     },
     {
         "id": "absol_spacedock2",
@@ -186,7 +186,7 @@
         "isStructure": true,
         "ability": "This unit's PRODUCTION value is equal to 4 more than the resource value of this planet.\nUp to 5 fighters in this system do not count against your ships' capacity.1 non-fighter ship in this system does not count against your fleet pool",
         "homebrewReplacesID": "spacedock2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/SpaceDockII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/SpaceDockII.png?raw=true"
     },
     {
         "id": "absol_infantry2",
@@ -203,7 +203,7 @@
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home.",
         "homebrewReplacesID": "infantry2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
     },
     {
         "id": "absol_pds2",
@@ -220,7 +220,7 @@
         "planetaryShield": true,
         "isStructure": true,
         "homebrewReplacesID": "pds2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
     },
     {
         "id": "absol_fighter2",
@@ -238,7 +238,7 @@
         "isShip": true,
         "ability": "This unit may move without being transported.\nFighters in excess of your ships' capacity count against your fleet pool.",
         "homebrewReplacesID": "fighter2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
     },
     {
         "id": "absol_destroyer2",
@@ -258,7 +258,7 @@
         "isShip": true,
         "ability": "When this unit generates a hit on a combat roll, your opponent must destroy 1 fighter in the active system, if able.",
         "homebrewReplacesID": "destroyer2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/DestroyerII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/DestroyerII.png?raw=true"
     },
     {
         "id": "absol_cruiser2",
@@ -276,7 +276,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "homebrewReplacesID": "cruiser2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
     },
     {
         "id": "absol_carrier2",
@@ -294,7 +294,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "homebrewReplacesID": "carrier2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
     },
     {
         "id": "absol_dreadnought2",
@@ -317,7 +317,7 @@
         "isShip": true,
         "homebrewReplacesID": "dreadnought2",
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
     },
     {
         "id": "absol_warsun",
@@ -339,7 +339,7 @@
         "isShip": true,
         "ability": "Other players' units in this system lose PLANETARY SHIELD.",
         "homebrewReplacesID": "warsun",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/absol/WarSun.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/absol/WarSun.png?raw=true"
     },
     {
         "id": "absol_sol_carrier2",
@@ -360,7 +360,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "homebrewReplacesID": "sol_carrier2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
     },
     {
         "id": "absol_sol_infantry2",
@@ -378,7 +378,7 @@
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll 1 die. If the result is 5 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
         "homebrewReplacesID": "sol_infantry2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/SpecOpsII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/SpecOpsII.png?raw=true"
     },
     {
         "id": "absol_sardakk_dreadnought2",
@@ -401,7 +401,7 @@
         "isShip": true,
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.\nAfter a round of space combat, you may destroy this unit to destroy up to 2 ships in the system.",
         "homebrewReplacesID": "sardakk_dreadnought2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
     },
     {
         "id": "absol_l1z1x_dreadnought2",
@@ -424,7 +424,7 @@
         "isShip": true,
         "homebrewReplacesID": "l1z1x_dreadnought2",
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
     },
     {
         "id": "absol_naalu_fighter2",
@@ -443,7 +443,7 @@
         "combatDieCount": 1,
         "homebrewReplacesID": "naalu_fighter2",
         "ability": "This unit may move without being transported.\nEach fighter in excess of your ships' capacity counts as 1/2 of a ship against your fleet pool.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
     },
     {
         "id": "absol_muaat_warsun2",
@@ -468,7 +468,7 @@
         "isShip": true,
         "ability": "Other players' units in this system lose the PLANETARY SHIELD ability.\nThis unit cannot be destroyed by \"Direct Hit\" action cards.",
         "homebrewReplacesID": "muaat_warsun2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/PrototypeWarSunII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/PrototypeWarSunII.png?raw=true"
     },
     {
         "id": "absol_saar_spacedock2",
@@ -486,7 +486,7 @@
         "isStructure": true,
         "ability": "This unit is placed in the space area instead of on a planet.\nThis unit can move and retreat as if it were a ship.\nIf this unit is blockaded, it is destroyed.\n1 non-fighter ship in this system does not count against your fleet pool.",
         "homebrewReplacesID": "saar_spacedock2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/FloatingFactoryII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/FloatingFactoryII.png?raw=true"
     },
     {
         "id": "absol_arborec_infantry2",
@@ -505,7 +505,7 @@
         "isGroundForce": true,
         "ability": "After this unit is destroyed, place the unit on this card. At the start of your next turn, for every 2 units that are on this card, place 1 on a planet you control.",
         "homebrewReplacesID": "arborec_infantry2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/LetaniWarriorII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/LetaniWarriorII.png?raw=true"
     },
     {
         "id": "absol_titans_pds2",
@@ -528,7 +528,7 @@
         "isGroundForce": true,
         "ability": "This unit is treated as both a structure and a ground force. It cannot be transported.\nYou may use this unit's SPACE CANNON against ships that are adjacent to this unit's systems.",
         "homebrewReplacesID": "titans_pds2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
     },
     {
         "id": "absol_titans_cruiser2",
@@ -548,7 +548,7 @@
         "sustainDamage": true,
         "isShip": true,
         "homebrewReplacesID": "titans_cruiser2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
     },
     {
         "id": "absol_argent_destroyer2",
@@ -570,7 +570,7 @@
         "isShip": true,
         "ability": "When this unit generates a hit on a combat roll, your opponent must destroy 1 fighter in the active system, if able.\nWhen this unit uses ANTI-FIGHTER BARRAGE, each result of 9 or 10 also destroys 1 of your opponent's infantry in the space area of the active system.",
         "homebrewReplacesID": "argent_destroyer2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/StrikeWingAlphaII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/StrikeWingAlphaII.png?raw=true"
     },
     {
         "id": "absol_cabal_spacedock2",
@@ -586,7 +586,7 @@
         "isStructure": true,
         "ability": "PRODUCTION 7. This system is a gravity rift; your ships do not roll for this gravity rift. Place a dimensional tear token beneath this unit as a reminder.\nUp to 10 fighters in this system do not count against your ships' capacity. 1 non-fighter ship in this system does not count against your fleet pool.",
         "homebrewReplacesID": "cabal_spacedock2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/DimensionalTearII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/DimensionalTearII.png?raw=true"
     },
     {
         "id": "absol_cabal_spacedock2Alt",
@@ -624,7 +624,7 @@
         "isShip": true,
         "ability": "You may treat this unit as if it were adjacent to systems that contain 1 or more of your mechs.",
         "homebrewReplacesID": "nomad_flagship2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/MemoriaII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/MemoriaII.png?raw=true"
     },
     {
         "id": "absol_mahact_infantry2",
@@ -642,6 +642,6 @@
         "isGroundForce": true,
         "ability": "After this unit is destroyed, gain 2 commodities or convert 1 of your commodities to a trade good. Then, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet that contains 1 of your structures.",
         "homebrewReplacesID": "mahact_infantry2",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/absol/faction/CrimsonLegionnaireII.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/absol/faction/CrimsonLegionnaireII.png?raw=true"
     }
 ]

--- a/src/main/resources/data/units/baseUnits.json
+++ b/src/main/resources/data/units/baseUnits.json
@@ -12,7 +12,7 @@
         "combatHitsOn": 7,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/cruiser.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/cruiser.png?raw=true"
     },
     {
         "id": "cruiser2",
@@ -30,7 +30,7 @@
         "combatHitsOn": 6,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/cruiser_2.jpg?raw=true"
     },
     {
         "id": "carrier",
@@ -46,7 +46,7 @@
         "combatHitsOn": 9,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/carrier.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/carrier.png?raw=true"
     },
     {
         "id": "carrier2",
@@ -64,7 +64,7 @@
         "combatHitsOn": 9,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/carrier_2.jpg?raw=true"
     },
     {
         "id": "destroyer",
@@ -81,7 +81,7 @@
         "afbHitsOn": 9,
         "afbDieCount": 2,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/destroyer.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/destroyer.png?raw=true"
     },
     {
         "id": "destroyer2",
@@ -100,7 +100,7 @@
         "afbHitsOn": 6,
         "afbDieCount": 3,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/destroyer_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/destroyer_2.jpg?raw=true"
     },
     {
         "id": "dreadnought",
@@ -120,7 +120,7 @@
         "sustainDamage": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/dreadnought.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/dreadnought.png?raw=true"
     },
     {
         "id": "dreadnought2",
@@ -143,7 +143,7 @@
         "canBeDirectHit": false,
         "isShip": true,
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/dreadnought_2.jpg?raw=true"
     },
     {
         "id": "fighter",
@@ -157,7 +157,7 @@
         "combatHitsOn": 9,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/fighter.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/fighter.png?raw=true"
     },
     {
         "id": "fighter2",
@@ -175,7 +175,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "ability": "This unit may move without being transported.\nFighters in excess of your ships' capacity count against your fleet pool.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/fighter_2.jpg?raw=true"
     },
     {
         "id": "flagship",
@@ -206,7 +206,7 @@
         "combatHitsOn": 8,
         "combatDieCount": 1,
         "isGroundForce": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/infantry.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/infantry.png?raw=true"
     },
     {
         "id": "infantry2",
@@ -223,7 +223,7 @@
         "combatDieCount": 1,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/infantry_2.jpg?raw=true"
     },
     {
         "id": "pds",
@@ -236,7 +236,7 @@
         "spaceCannonDieCount": 1,
         "planetaryShield": true,
         "isStructure": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/pds.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/pds.png?raw=true"
     },
     {
         "id": "pds2",
@@ -253,7 +253,7 @@
         "ability": "You may use this unit's SPACE CANNON against ships that are in adjacent systems.",
         "planetaryShield": true,
         "isStructure": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/pds_2.jpg?raw=true"
     },
     {
         "id": "spacedock",
@@ -266,7 +266,7 @@
         "basicProduction": "res",
         "capacityValue": 3,
         "isStructure": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/spacedock.png?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/spacedock.png?raw=true",
         "ability": "This unit's PRODUCTION value is equal to 2 more than the resource value of this planet.\nUp to 3 fighters in this system do not count against your ships' capacity."
     },
     {
@@ -282,7 +282,7 @@
         "basicProduction": "res",
         "capacityValue": 3,
         "isStructure": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/spacedock_2.jpg?raw=true",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/spacedock_2.jpg?raw=true",
         "ability": "This unit's PRODUCTION value is equal to 4 more than the resource value of this planet.\nUp to 3 fighters in this system do not count against your ships' capacity."
     },
     {
@@ -291,7 +291,7 @@
         "asyncId": "ws",
         "name": "Not a War Sun Yet",
         "source": "base",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/generic/warsun_0.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/generic/warsun_0.png?raw=true"
     },
     {
         "id": "warsun",
@@ -313,7 +313,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other player's units in this system lose PLANETARY SHIELD.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/generic/warsun.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/generic/warsun.jpg?raw=true"
     },
     {
         "id": "mech",

--- a/src/main/resources/data/units/ds.json
+++ b/src/main/resources/data/units/ds.json
@@ -16,7 +16,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit makes a combat roll, it rolls 1 additional die for each secret objective you have scored.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/nemsys.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/nemsys.jpg?raw=true"
     },
     {
         "id": "augers_mech",
@@ -32,7 +32,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After researching a technology, you may place 1 mech on a legendary planet, or a planet that has a technology specialty, that you control.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/iledrith.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/iledrith.jpg?raw=true"
     },
     {
         "id": "axis_flagship",
@@ -51,7 +51,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After this ship produces 1 or more hits during a round of space combat, you may repair 1 ship you control in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/bearer_of_heavens.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/bearer_of_heavens.jpg?raw=true"
     },
     {
         "id": "axis_mech",
@@ -67,7 +67,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "You may treat a spacedock on this planet as if it has PRODUCTION 5.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/forgetender.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/forgetender.jpg?raw=true"
     },
     {
         "id": "bentor_flagship",
@@ -92,7 +92,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Apply +1 to the results of this ship's combat and ability rolls for each Fragment token on your faction sheet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/wayfinder.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/wayfinder.png?raw=true"
     },
     {
         "id": "bentor_mech",
@@ -108,7 +108,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: When you place a Fragment token on your faction sheet, you may place 1 mech on a planet you control.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/auctioneer.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/auctioneer.png?raw=true"
     },
     {
         "id": "celdauri_flagship",
@@ -129,7 +129,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "You may use the PRODUCTION ability of other player's space docks in this system to produce ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/supremacy.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/supremacy.jpg?raw=true"
     },
     {
         "id": "celdauri_mech",
@@ -145,7 +145,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After another player activates a system, you may spend 1 trade good or 1 commodity to place 1 mech on a planet in that system that contains 1 of your space docks.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/minuteman.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/minuteman.jpg?raw=true"
     },
     {
         "id": "celdauri_spacedock",
@@ -162,7 +162,7 @@
         "afbDieCount": 2,
         "isStructure": true,
         "ability": "This unit's PRODUCTION value is equal to 2 more than the resource or influence value of this planet.\nUp to 3 fighters in this system do not count against your ships' capacity.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/trade_port.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/trade_port.jpg?raw=true"
     },
     {
         "id": "celdauri_spacedock2",
@@ -180,7 +180,7 @@
         "afbDieCount": 2,
         "isStructure": true,
         "ability": "This unit's PRODUCTION value is equal to 4 more than the resource or influence value of this planet.\nUp to 3 fighters in this system do not count against your ships' capacity.\nThis unit may use its ANTI-FIGHTER BARRAGE during each round of space combat.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/trade_port_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/trade_port_2.jpg?raw=true"
     },
     {
         "id": "cheiran_dreadnought",
@@ -202,7 +202,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit is destroyed, you may place 1 fighter from your reinforcements in this system's space area.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/chitin_hulk.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/chitin_hulk.png?raw=true"
     },
     {
         "id": "cheiran_dreadnought2",
@@ -224,7 +224,7 @@
         "sustainDamage": true,
         "isShip": true,
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.\nWhen this unit is destroyed, you may place 1 fighter or 1 destroyer from your reinforcements in this system's space area.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/chitin_hulk_2.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/chitin_hulk_2.png?raw=true"
     },
     {
         "id": "cheiran_flagship",
@@ -245,7 +245,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit makes a combat or ability roll, it rolls 1 additional die if this system is adjacent to or contains 1 of your structures.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/lithodax.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/lithodax.png?raw=true"
     },
     {
         "id": "cheiran_mech",
@@ -261,7 +261,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "When this unit is destroyed, you may place 1 infantry from your reinforcements on this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/nauplius.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/nauplius.png?raw=true"
     },
     {
         "id": "cymiae_flagship",
@@ -280,7 +280,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After you win a combat in this system, you may take 1 of your opponent's action cards, at random.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/reprocessor_alpha.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/reprocessor_alpha.jpg?raw=true"
     },
     {
         "id": "cymiae_infantry",
@@ -295,7 +295,7 @@
         "combatHitsOn": 5,
         "combatDieCount": 1,
         "isGroundForce": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/unholy_abomination.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/unholy_abomination.jpg?raw=true"
     },
     {
         "id": "cymiae_infantry2",
@@ -312,7 +312,7 @@
         "combatDieCount": 1,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your turn, place each unit that is on this card on a planet you control, if able.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/unholy_abomination_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/unholy_abomination_2.jpg?raw=true"
     },
     {
         "id": "cymiae_mech",
@@ -328,7 +328,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "At the start of each ground combat round, if this planet contains no more than 1 of your mechs, repair this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/revenant.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/revenant.jpg?raw=true"
     },
     {
         "id": "dihmohn_dreadnought",
@@ -350,7 +350,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When another ship in this system would be destroyed during combat, you may have this ship become damaged instead.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/aegis.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/aegis.jpg?raw=true"
     },
     {
         "id": "dihmohn_dreadnought2",
@@ -372,7 +372,7 @@
         "sustainDamage": true,
         "isShip": true,
         "ability": "When another ship in this system would be destroyed by a game effect, you may have this ship become damaged instead.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/aegis_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/aegis_2.jpg?raw=true"
     },
     {
         "id": "dihmohn_flagship",
@@ -391,7 +391,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After this unit moves into the active system, you may produce up to 2 units that have a combined cost of 4 or less in that system. [Note: this cannot produce ships if enemy ships are present]",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/maximus.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/maximus.jpg?raw=true"
     },
     {
         "id": "dihmohn_mech",
@@ -407,7 +407,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "At the start of a combat in this system you may repair 1 unit you control that is participating in that combat.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/repairitor.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/repairitor.jpg?raw=true"
     },
     {
         "id": "edyn_flagship",
@@ -426,7 +426,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Apply +1 to the results of this unit's combat rolls for each law in play.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/kaliburn.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/kaliburn.png?raw=true"
     },
     {
         "id": "edyn_mech",
@@ -442,7 +442,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "This system is a Sigil. Place an Edyn Sigil token beneath this unit as a reminder. Game effects cannot prevent you from using this ability.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/rune_bearer.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/rune_bearer.png?raw=true"
     },
     {
         "id": "florzen_fighter",
@@ -461,7 +461,7 @@
         "afbDieCount": 1,
         "ability": "This unit may move without being transported.\nFighters in excess of your ships' capacity count against your fleet pool.",
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/corsair.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/corsair.jpg?raw=true"
     },
     {
         "id": "florzen_fighter2",
@@ -481,7 +481,7 @@
         "afbDieCount": 1,
         "ability": "This unit may move without being transported. Fighters in excess of your ships' capacity count against your fleet pool.",
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/corsair_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/corsair_2.jpg?raw=true"
     },
     {
         "id": "florzen_flagship",
@@ -500,7 +500,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other players cannot play action cards during a space combat in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/man_o_war.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/man_o_war.jpg?raw=true"
     },
     {
         "id": "florzen_mech",
@@ -516,7 +516,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "You may spend influence as resources to produce this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/privateer.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/privateer.jpg?raw=true"
     },
     {
         "id": "freesystems_flagship",
@@ -535,7 +535,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit makes a combat roll, it rolls 1 additional die for each planet in this system of any single trait.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/vox.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/vox.jpg?raw=true"
     },
     {
         "id": "freesystems_mech",
@@ -551,7 +551,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After you use your RALLY TO THE CAUSE faction ability in a system, you may spend 1 trade good to place 1 mech on a planet you control adjacent to that system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/liberator.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/liberator.jpg?raw=true"
     },
     {
         "id": "ghemina_flagship_lady",
@@ -572,7 +572,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When another player's structure in this system is destroyed, gain 2 trade goods.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/the_lady.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/the_lady.png?raw=true"
     },
     {
         "id": "ghemina_flagship_lord",
@@ -591,7 +591,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After a player explores a planet in this system, place 1 infantry from their reinforcements on that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/the_lord.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/the_lord.png?raw=true"
     },
     {
         "id": "ghemina_mech",
@@ -607,7 +607,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After you win a ground combat on this planet, if this planet contains exactly 1 other mech, explore this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/jotun.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/jotun.jpg?raw=true"
     },
     {
         "id": "ghemina_carrier",
@@ -624,7 +624,7 @@
         "combatHitsOn": 9,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/combat_transport.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/combat_transport.jpg?raw=true"
     },
     {
         "id": "ghemina_carrier2",
@@ -643,7 +643,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "ability": "You may reroll 1 of your unit's combat dice during each round of ground combat on a planet in this system that contains 2 or fewer of your infantry.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/combat_transport_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/combat_transport_2.jpg?raw=true"
     },
     {
         "id": "ghoti_flagship",
@@ -662,7 +662,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "While in play, this unit is also treated as a space dock with a PRODUCTION value equal to the number of tokens in your fleet pool.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/all_mother.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/all_mother.png?raw=true"
     },
     {
         "id": "ghoti_mech",
@@ -678,7 +678,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "This unit can be blockaded.\nWhen producing ships in your home system, place up to 1 of those units in this system's space area if it is not blockaded.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/tioleombp.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/tioleombp.png?raw=true"
     },
     {
         "id": "gledge_flagship",
@@ -699,7 +699,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit makes a combat or ability roll, it rolls 1 additional die for each mech in or adjacent to this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/beg_bersha.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/beg_bersha.png?raw=true"
     },
     {
         "id": "gledge_mech",
@@ -715,7 +715,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "When you exhaust this planet to spend resources, you may also spend 1 of its influence as a resource.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/exodriller.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/exodriller.png?raw=true"
     },
     {
         "id": "gledge_pds",
@@ -730,7 +730,7 @@
         "planetaryShield": true,
         "isStructure": true,
         "ability": "When this unit makes a SPACE CANNON roll against another player's units, if it rolls at least 1 result of 9 or 10, explore this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/orion_platform.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/orion_platform.png?raw=true"
     },
     {
         "id": "gledge_pds2",
@@ -747,7 +747,7 @@
         "isStructure": true,
         "deepSpaceCannon": true,
         "ability": "When this unit produces 1 or more hits against another player's units, explore this planet.\nYou may use this unit's SPACE CANNON against ships that are adjacent to this unit's system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/orion_platform_2.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/orion_platform_2.png?raw=true"
     },
     {
         "id": "khrask_cruiser",
@@ -766,7 +766,7 @@
         "bombardHitsOn": 8,
         "bombardDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/shattered_sky.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/shattered_sky.jpg?raw=true"
     },
     {
         "id": "khrask_cruiser2",
@@ -786,7 +786,7 @@
         "bombardHitsOn": 6,
         "bombardDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/shattered_sky_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/shattered_sky_2.jpg?raw=true"
     },
     {
         "id": "khrask_flagship",
@@ -805,7 +805,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "At the start of a space combat in this system, choose up to 2 non-fighter ships to gain SUSTAIN DAMAGE until the end of combat.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/splintering_gale.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/splintering_gale.jpg?raw=true"
     },
     {
         "id": "khrask_mech",
@@ -821,7 +821,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "Units other than your mechs do not make combat rolls during the first round of ground combat on this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/megalith.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/megalith.jpg?raw=true"
     },
     {
         "id": "kjalengard_carrier",
@@ -839,7 +839,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "ability": "This unit may ignore the movement effects of non-supernova anomalies. [Note: This does not ignore Gravity Rifts Rolls/non-movement-effects!]",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/star_dragon.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/star_dragon.png?raw=true"
     },
     {
         "id": "kjalengard_carrier2",
@@ -858,7 +858,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "ability": "This unit may ignore the movement effects of anomalies. [Note: This does not ignore Gravity Rifts Rolls/non-movement-effects]",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/star_dragon_2.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/star_dragon_2.png?raw=true"
     },
     {
         "id": "kjalengard_flagship",
@@ -877,7 +877,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After the first round of combat in this system, place up to 2 of your captured units in this system or on that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/hulgades_hammer.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/hulgades_hammer.png?raw=true"
     },
     {
         "id": "kjalengard_mech",
@@ -893,7 +893,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "When you pass, place 1 infantry from your reinforcements on this planet if there is a Glory token in or adjacent to this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/skald.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/skald.png?raw=true"
     },
     {
         "id": "kollecc_flagship",
@@ -912,7 +912,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit retreats, you may capture each of your units that retreat.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/nightingale_v.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/nightingale_v.jpg?raw=true"
     },
     {
         "id": "kollecc_mech",
@@ -928,7 +928,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "At the end of a tactical action in this system, you may place up to 2 ground forces from this planet onto your faction sheet, those units are captured.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/nightshade_vanguard.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/nightshade_vanguard.jpg?raw=true"
     },
     {
         "id": "kolume_flagship",
@@ -949,7 +949,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Hits produced by the SPACE CANNON abilities of your units in this system cannot be canceled.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/halberd.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/halberd.png?raw=true"
     },
     {
         "id": "kolume_mech",
@@ -967,7 +967,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "Hits produced by this unit cannot be assigned to non-fighter ships. After you spend a command token from your strategy pool, repair this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/rook.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/rook.png?raw=true"
     },
     {
         "id": "kortali_flagship",
@@ -988,7 +988,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After you win a space combat in this system, you may have this ship become damaged to gain 1 command token.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/magistrate.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/magistrate.png?raw=true"
     },
     {
         "id": "kortali_mech",
@@ -1005,7 +1005,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "This unit cannot lose its PLANETARY SHIELD.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/justicar.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/justicar.jpg?raw=true"
     },
     {
         "id": "kyro_flagship",
@@ -1024,7 +1024,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When you commit units to a planet in this system, commit 1 infantry from your reinforcements to that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/auriga.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/auriga.png?raw=true"
     },
     {
         "id": "kyro_mech",
@@ -1040,7 +1040,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "When this unit would be destroyed, if it is damaged, you may discard 1 action card to repair it instead.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/pustule.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/pustule.png?raw=true"
     },
     {
         "id": "lanefir_flagship",
@@ -1059,7 +1059,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "At the end of a tactical action in this system, you may explore 1 planet you control in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/memory_of_dusk.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/memory_of_dusk.png?raw=true"
     },
     {
         "id": "lanefir_mech",
@@ -1075,7 +1075,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: At the start of your turn, purge 1 of your relic fragments to place 1 mech on a planet you control, if you do, you may end your turn. [Note: Treated as a component action in the bot, despite not entirely being one]",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/troubadour.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/troubadour.png?raw=true"
     },
     {
         "id": "lizho_fighter",
@@ -1092,7 +1092,7 @@
         "bombardHitsOn": 9,
         "bombardDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/heavy_bomber.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/heavy_bomber.jpg?raw=true"
     },
     {
         "id": "lizho_fighter2",
@@ -1112,7 +1112,7 @@
         "bombardDieCount": 1,
         "ability": "This unit may move without being transported.\nFighters in excess of your ships' capacity count against your fleet pool.",
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/heavy_bomber_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/heavy_bomber_2.jpg?raw=true"
     },
     {
         "id": "lizho_flagship",
@@ -1131,7 +1131,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "This unit can only be destroyed by an uncanceled hit being assigned to it.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/silence_of_stars.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/silence_of_stars.jpg?raw=true"
     },
     {
         "id": "lizho_mech",
@@ -1147,7 +1147,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "At the start of your turn, you may remove 1 trap attachment from the game board and attach it to this planet, or swap any trap attachment with 1 on this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/orozhin_elite.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/orozhin_elite.jpg?raw=true"
     },
     {
         "id": "mirveda_flagship",
@@ -1166,7 +1166,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After each round of space combat in this system, place 1 fighter from your reinforcements in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/nexus.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/nexus.jpg?raw=true"
     },
     {
         "id": "mirveda_mech",
@@ -1182,7 +1182,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "For every 2 unit upgrade technologies you own, apply +1 to the result of this unit's combat rolls.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/javelin.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/javelin.jpg?raw=true"
     },
     {
         "id": "mirveda_pds",
@@ -1202,7 +1202,7 @@
         "isPlanetOnly": false,
         "isSpaceOnly": true,
         "ability": "This unit is placed in a space area instead of on a planet.\nThis unit can move and retreat as if it were a ship.\nThis unit can be blockaded, if it is blockaded, it is destroyed.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/gauss_cannon.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/gauss_cannon.jpg?raw=true"
     },
     {
         "id": "mirveda_pds2",
@@ -1224,7 +1224,7 @@
         "isPlanetOnly": false,
         "isSpaceOnly": true,
         "ability": "This unit is placed in a space area instead of on a planet.\nThis unit can move and retreat as if it were a ship.\nThis unit can be blockaded, if it is blockaded, it is destroyed.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/gauss_cannon_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/gauss_cannon_2.jpg?raw=true"
     },
     {
         "id": "mortheus_flagship",
@@ -1243,7 +1243,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After you activate this system, if it does not contain any planets, you may place 1 frontier token in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/particle_sieve.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/particle_sieve.jpg?raw=true"
     },
     {
         "id": "mortheus_mech",
@@ -1259,7 +1259,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "When a player commits 1 or more units to a planet you control adjacent to this system, you may swap this unit with 1 of your infantry on that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/duuban.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/duuban.jpg?raw=true"
     },
     {
         "id": "mykomentori_flagship",
@@ -1278,7 +1278,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Once per round of space combat, when a non-fighter ship in this system is destroyed, you may gain 1 commodity.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/psyclobea_qarnyx.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/psyclobea_qarnyx.jpg?raw=true"
     },
     {
         "id": "mykomentori_mech",
@@ -1294,7 +1294,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll a die. If the result is 6 or greater, place the unit on this card. At the start of your turn, you may replace 1 infantry you control with a unit that is on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/amandia_pholdis.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/amandia_pholdis.jpg?raw=true"
     },
     {
         "id": "mykomentori_spacedock",
@@ -1310,7 +1310,7 @@
         "isStructure": true,
         "planetaryShield": true,
         "ability": "This unit’s PRODUCTION value is equal to 2 more than the resource value of this planet.\nDEPLOY: When you gain control of a planet, you may replace 4 infantry on that planet with 1 space dock.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/mycelium_ring.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/mycelium_ring.jpg?raw=true"
     },
     {
         "id": "mykomentori_spacedock2",
@@ -1326,7 +1326,7 @@
         "isStructure": true,
         "planetaryShield": true,
         "ability": "This unit’s PRODUCTION value is equal to 5 more than the resource value of this planet.\nDEPLOY: When you gain control of a planet, you may replace 3 infantry on that planet with 1 space dock.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/mycelium_ring_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/mycelium_ring_2.jpg?raw=true"
     },
     {
         "id": "nivyn_flagship",
@@ -1345,7 +1345,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "If a unit in this system would be destroyed, you may remove it from the game board instead.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/eradica.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/eradica.jpg?raw=true"
     },
     {
         "id": "nivyn_mech",
@@ -1362,7 +1362,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After this system is activated, you may have this unit become damaged to place or move the Wound token into this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/voidflare_warden_i.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/voidflare_warden_i.jpg?raw=true"
     },
     {
         "id": "nivyn_mech2",
@@ -1380,7 +1380,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After a system is activated, you may have this unit become damaged to place or move the Wound token into this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/voidflare_warden_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/voidflare_warden_2.jpg?raw=true"
     },
     {
         "id": "nokar_destroyer",
@@ -1399,7 +1399,7 @@
         "afbDieCount": 2,
         "isShip": true,
         "ability": "After this unit is destroyed during combat, roll a die, on a result of 9 or 10, produce up to 1 hit against ships against your opponent's ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/sabre.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/sabre.png?raw=true"
     },
     {
         "id": "nokar_destroyer2",
@@ -1419,7 +1419,7 @@
         "afbDieCount": 3,
         "isShip": true,
         "ability": "After this unit is destroyed during combat, roll a die, on a result equal to or greater than 7, produce up to 1 hit against your opponent's ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/sabre_2.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/sabre_2.png?raw=true"
     },
     {
         "id": "nokar_flagship",
@@ -1438,7 +1438,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Apply +1 to the results of this unit's combat rolls for every 2 destroyers you control.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/annah_regia.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/annah_regia.png?raw=true"
     },
     {
         "id": "nokar_mech",
@@ -1454,7 +1454,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "You may treat this system as adjacent to the active system for the purposes of declaring and resolving retreats.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/freelance_outfit.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/freelance_outfit.png?raw=true"
     },
     {
         "id": "olradin_flagship",
@@ -1473,7 +1473,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When you move this ship, apply +1 to the move value of each of your other ships during this tactical action.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/rallypoint.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/rallypoint.jpg?raw=true"
     },
     {
         "id": "olradin_mech",
@@ -1489,7 +1489,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "You have not selected your policies yet. This mech's ability depends on your Policies.\nIf you have at least 2 ➕ Policies, and if this planet contains no more than 1 of your mechs, apply +1 to its influence value.\nIf you have at least 2 ➖ Policies, and if this planet contains no more than 1 of your mechs, apply +1 to its resource value.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/exemplar_glitch.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/exemplar_glitch.png?raw=true"
     },
     {
         "id": "olradin_mech_negative",
@@ -1505,7 +1505,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "If this planet contains no more than 1 of your mechs, apply +1 to its resource value.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/exemplar_malus.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/exemplar_malus.png?raw=true"
     },
     {
         "id": "olradin_mech_positive",
@@ -1521,7 +1521,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "If this planet contains no more than 1 of your mechs, apply +1 to its influence value.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/exemplar_bonum.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/exemplar_bonum.png?raw=true"
     },
     {
         "id": "rohdhna_warsun",
@@ -1538,7 +1538,7 @@
         "combatDieCount": 2,
         "isShip": true,
         "ability": "This unit produces only 1 fighter or infantry for their cost instead of 2.\nThis unit cannot move or be produced.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/terrafactory.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/terrafactory.jpg?raw=true"
     },
     {
         "id": "rohdhna_warsun2",
@@ -1563,7 +1563,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other player's units in this system lose PLANETARY SHIELD.\nThis unit produces only 1 fighter or infantry for their cost instead of 2.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/terrafactory_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/terrafactory_2.jpg?raw=true"
     },
     {
         "id": "rohdhna_flagship",
@@ -1582,7 +1582,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "DEPLOY: After you activate a system, you may spend 4 resources to replace 1 of your non-fighter ships in that system with your flagship.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/kyvir.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/kyvir.jpg?raw=true"
     },
     {
         "id": "rohdhna_mech",
@@ -1598,7 +1598,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After you use your Recycled Materials faction ability in a system, you may place 1 mech in that system's space area or on a planet you control in that system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/autofabricator.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/autofabricator.jpg?raw=true"
     },
     {
         "id": "tnelis_destroyer",
@@ -1616,7 +1616,7 @@
         "afbHitsOn": 9,
         "afbDieCount": 3,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/blockade_runner.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/blockade_runner.jpg?raw=true"
     },
     {
         "id": "tnelis_destroyer2",
@@ -1636,7 +1636,7 @@
         "afbDieCount": 4,
         "isShip": true,
         "ability": "This ship can move through systems that contain other players' ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/blockade_runner_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/blockade_runner_2.jpg?raw=true"
     },
     {
         "id": "tnelis_flagship",
@@ -1655,7 +1655,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "At the start of a round of combat, choose 1 ship in this system, during this combat round, that ship rolls 1 less combat die.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/principia_aneris.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/principia_aneris.jpg?raw=true"
     },
     {
         "id": "tnelis_mech",
@@ -1671,7 +1671,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After you move a destroyer into a non-home system other than Mecatol Rex, you may spend 3 resources to place 1 mech on a planet in that system. [Note: can DEPLOY 1 mech for each destroyer that moves]",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/daedalon.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/daedalon.jpg?raw=true"
     },
     {
         "id": "vaden_flagship",
@@ -1692,7 +1692,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After this unit produces 1 or more hits during a BOMBARDMENT roll, gain 1 trade good.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/aurum_vadra.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/aurum_vadra.jpg?raw=true"
     },
     {
         "id": "vaden_mech",
@@ -1708,7 +1708,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "At the end of a round of ground combat, you may remove 1 of your opponent's control tokens from your faction sheet to place 1 infantry unit from your reinforcements on this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/collector.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/collector.jpg?raw=true"
     },
     {
         "id": "vaylerian_cruiser",
@@ -1726,7 +1726,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "ability": "During a round of space combat, if your opponent cannot declare a retreat, hits produced by this ship must be assigned to non-fighter ships, if able.\nThis unit may only transport ground forces.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/raider.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/raider.jpg?raw=true"
     },
     {
         "id": "vaylerian_cruiser2",
@@ -1745,7 +1745,7 @@
         "combatDieCount": 1,
         "isShip": true,
         "ability": "During a round of space combat, if your opponent cannot declare a retreat, hits produced by this ship cannot be canceled and must be assigned to non-fighter ships, if able.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/raider_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/raider_2.jpg?raw=true"
     },
     {
         "id": "vaylerian_flagship",
@@ -1764,7 +1764,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "At the start of a space combat in this system, you may choose 1 adjacent system.\nYour opponent cannot retreat to that system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/lost_cause.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/lost_cause.jpg?raw=true"
     },
     {
         "id": "vaylerian_mech",
@@ -1780,7 +1780,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "During your tactical actions, hits produced by SPACE CANNON cannot be assigned to 1 of your ships in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/eclipse.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/eclipse.jpg?raw=true"
     },
     {
         "id": "veldyr_dreadnought",
@@ -1803,7 +1803,7 @@
         "sustainDamage": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/lancer_dreadnought.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/lancer_dreadnought.jpg?raw=true"
     },
     {
         "id": "veldyr_dreadnought2",
@@ -1827,7 +1827,7 @@
         "sustainDamage": true,
         "isShip": true,
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/lancer_dreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/lancer_dreadnought_2.jpg?raw=true"
     },
     {
         "id": "veldyr_flagship",
@@ -1846,7 +1846,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this ship makes a combat roll, it rolls 1 additional die for each round of combat that has been resolved this combat.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/richtyrian.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/richtyrian.jpg?raw=true"
     },
     {
         "id": "veldyr_mech",
@@ -1862,7 +1862,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After a player activates this system, you may remove this unit from the game board to place 1 PDS from your reinforcements on this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/aurora_stormcaller.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/aurora_stormcaller.png?raw=true"
     },
     {
         "id": "zealots_flagship",
@@ -1881,7 +1881,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "For each unit upgrade technology your opponent owns, apply +1 to the results of this unit's combat rolls.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/reckoning.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/reckoning.jpg?raw=true"
     },
     {
         "id": "zealots_mech",
@@ -1897,7 +1897,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "Apply +1 to this unit's combat rolls for each faction technology your opponent owns.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/templar.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/templar.jpg?raw=true"
     },
     {
         "id": "zelian_flagship",
@@ -1920,7 +1920,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit makes a combat or unit ability roll, it rolls 1 additional die for each asteroid field adjacent to this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/flagships/worldcracker.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/flagships/worldcracker.jpg?raw=true"
     },
     {
         "id": "zelian_infantry",
@@ -1938,7 +1938,7 @@
         "bombardDieCount": 1,
         "isGroundForce": true,
         "ability": "During invasion, this unit must commit to a planet it bombards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/faction/impactor.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/faction/impactor.jpg?raw=true"
     },
     {
         "id": "zelian_infantry2",
@@ -1957,7 +1957,7 @@
         "bombardDieCount": 1,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/ds/impactor_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/ds/impactor_2.jpg?raw=true"
     },
     {
         "id": "zelian_mech",
@@ -1973,7 +1973,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "At the start of invasion, if this unit is in the space area of the active system, you may remove this unit from the game board to destroy 1 unit on a planet in that system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/ds/mechs/collider.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/ds/mechs/collider.jpg?raw=true"
     },
     {
         "id": "uydai_mech",

--- a/src/main/resources/data/units/flagshipping.json
+++ b/src/main/resources/data/units/flagshipping.json
@@ -17,7 +17,7 @@
         "ability": "At the start of a space combat in this system, you may place 1 fighter in this system.\nAt the start of a ground combat in this system, you may place 1 infantry on that planet if you have not placed a unit with this ship's ability this action.",
         "unlock": "UNLOCK: Win a ground combat.",
         "homebrewReplacesID": "sol_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/sol_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/sol_1a.png?raw=true"
     },
     {
         "id": "sigma_sol_flagship_2",
@@ -36,7 +36,7 @@
         "isShip": true,
         "ability": "At the start of a space combat in this system, place 1 fighter in this system.\nAt the start of a ground combat in this system, place 1 infantry on that planet.",
         "unlock": "UNLOCK: Win a ground combat on a legendary planet, Mecatol Rex, or in a home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/sol_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/sol_2a.png?raw=true"
     },
     
     {
@@ -57,7 +57,7 @@
         "ability": "Other players cannot cancel more than 1 hit with SUSTAIN DAMAGE during each space combat round in this system.",
         "unlock": "When you resolve your Pillage faction ability, place 1 control token on this card.\nUNLOCK: have 6 control tokens on this card.",
         "homebrewReplacesID": "mentak_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/mentak_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/mentak_1a.png?raw=true"
     },
     {
         "id": "sigma_mentak_flagship_2",
@@ -76,7 +76,7 @@
         "isShip": true,
         "ability": "Other players' ships in or adjacent to this system cannot use SUSTAIN DAMAGE.",
         "unlock": "When you resolve your Pillage faction ability, place 1 control token on this card.\nUNLOCK: have 12 control tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/mentak_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/mentak_2a.png?raw=true"
     },
     
     {
@@ -97,7 +97,7 @@
         "ability": "When this ship is destroyed during a space combat, produce 3 hits against your opponent's ships in the active system.",
         "unlock": "After 1 of your units is destroyed, place 1 control token on this card.\nUNLOCK: Have 4 control tokens on this card.",
         "homebrewReplacesID": "yin_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/yin_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/yin_1a.png?raw=true"
     },
     {
         "id": "sigma_yin_flagship_2",
@@ -116,7 +116,7 @@
         "isShip": true,
         "ability": "When a hit is produced against your units in this system, you may assign that hit to any of your units in this system, regardless of type.\nWhen this ship is destroyed, destroy all ships in this system.",
         "unlock": "After 1 of your units is destroyed, place 1 control token on this card.\nUNLOCK: Have 12 control tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/yin_a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/yin_a.png?raw=true"
     },
     
     {
@@ -137,7 +137,7 @@
         "ability": "ACTION: Spend 1 token from your strategy pool to place ships with a combined cost of 2 or less in this system.",
         "unlock": "UNLOCK: Have a war sun in or adjacent to a system that contains a supernova.",
         "homebrewReplacesID": "muaat_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/muaat_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/muaat_1a.png?raw=true"
     },
     {
         "id": "sigma_muaat_flagship_2",
@@ -156,7 +156,7 @@
         "isShip": true,
         "ability": "When 1 of your war suns in this system would be destroyed, you may damage or destroy this ship instead.\nACTION: Spend 1 token from your strategy pool to place ships with a combined cost of 2 or less in this or adjacent systems.",
         "unlock": "UNLOCK: Have 2 of your war suns in or adjacent to the system that contains The Inferno I",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/muaat_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/muaat_2a.png?raw=true"
     },
     {
         "id": "sigma_muaat_mech",
@@ -173,7 +173,7 @@
         "isGroundForce": true,
         "ability": "When you use your Star Forge faction ability in this or an adjacent system, or use the component action of your flagship when it is in this or an adjacent system, you may place 1 infantry from your reinforcements with this unit.",
         "homebrewReplacesID": "muaat_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/muaat_mech.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/muaat_mech.png?raw=true"
     },
     
     {
@@ -195,7 +195,7 @@
         "productionValue": 4,
         "unlock": "UNLOCK: During the production step of a tactical action, produce 8 units.",
         "homebrewReplacesID": "arborec_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/arborec_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/arborec_1a.png?raw=true"
     },
     {
         "id": "sigma_arborec_flagship_2",
@@ -215,7 +215,7 @@
         "ability": "When you produce fighters or infantry in this system, you may produce 1 additional unit for their cost.",
         "productionValue": 12,
         "unlock": "UNLOCK: During the production step of a tactical action, produce 12 units.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/arborec_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/arborec_2a.png?raw=true"
     },
     
     {
@@ -238,7 +238,7 @@
         "bombardDieCount": 2,
         "unlock": "UNLOCK: produce 3 BOMBARDMENT hits during 1 invasion.",
         "homebrewReplacesID": "l1z1x_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/lizix_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/lizix_1a.png?raw=true"
     },
     {
         "id": "sigma_l1z1x_flagship_2",
@@ -259,7 +259,7 @@
         "bombardHitsOn": 6,
         "bombardDieCount": 4,
         "unlock": "UNLOCK: produce 6 BOMBARDMENT hits during 1 invasion.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/lizix_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/lizix_2a.png?raw=true"
     },
     
     {
@@ -280,7 +280,7 @@
         "ability": "When this ship makes a combat roll, it rolls a number of dice equal to the number of your opponent's non-fighter ships in this system.",
         "unlock": "UNLOCK: Win a combat in the Mecatol Rex system.",
         "homebrewReplacesID": "winnu_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/winnu_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/winnu_1a.png?raw=true"
     },
     {
         "id": "sigma_winnu_flagship_2",
@@ -299,7 +299,7 @@
         "isShip": true,
         "ability": "When this ship makes a combat roll, it rolls a number of dice equal to the number of ships your opponent had in the active system at the start of the space combat.",
         "unlock": "UNLOCK: Control Mecatol Rex and 2 legendary planets.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/winnu_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/winnu_2a.png?raw=true"
     },
     
     {
@@ -320,7 +320,7 @@
         "ability": "At the start of a space combat, choose any number of your ground forces in the space area of this system to participate in that combat as though they were fighters.",
         "unlock": "UNLOCK: When you would gain a technology from a player with their Flagship I unlocked using 1 of your faction abilities, you may instead unlock this unit.",
         "homebrewReplacesID": "nekro_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/nekro_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/nekro_1a.png?raw=true"
     },
     {
         "id": "sigma_nekro_flagship_2",
@@ -339,7 +339,7 @@
         "isShip": true,
         "ability": "If you own each non-faction technology owned by your opponent, apply +2 to the result of this unit's combat rolls.\nAt the start of a space combat, choose any number of your ground forces in this system to participate in that combat as though they were ships.",
         "unlock": "UNLOCK: When you would gain a technology from a player with their Flagship II unlocked using 1 of your faction abilities, you may instead unlock this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/nekro_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/nekro_2a.png?raw=true"
     },
     
     {
@@ -360,7 +360,7 @@
         "ability": "Other players cannot use ANTI-FIGHTER BARRAGE against your units in this system.",
         "unlock": "UNLOCK: Have 8 fighters on the game board.",
         "homebrewReplacesID": "naalu_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/naalu_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/naalu_1a.png?raw=true"
     },
     {
         "id": "sigma_naalu_flagship_2",
@@ -379,7 +379,7 @@
         "isShip": true,
         "ability": "Other players cannot use ANTI-FIGHTER BARRAGE against your units in this system.\nDuring an invasion in this system, you may commit fighters to planets as though they were ground forces. When combat ends, return those units to the space area.",
         "unlock": "UNLOCK: Have 20 fighters on the game board.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/naalu_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/naalu_2a.png?raw=true"
     },
     {
         "id": "sigma_naalu_mech",
@@ -396,7 +396,7 @@
         "isGroundForce": true,
         "ability": "Only this unit rolls combat dice during the first round of ground combat on this planet.\nWhen another player activates this system, place 1 infantry on this planet.",
         "homebrewReplacesID": "naalu_mech",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/naalu_mech.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/naalu_mech.png?raw=true"
     },
     
     {
@@ -417,7 +417,7 @@
         "ability": "At the start of each space combat round in this system, repair this ship.",
         "unlock": "When 1 of your opponent's non-fighter ships is destroyed during space combat, place a number of control tokens on this card equal to that ship's cost.\nUNLOCK: Have 8 control tokens on this card.",
         "homebrewReplacesID": "letnev_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/letnev_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/letnev_1a.png?raw=true"
     },
     {
         "id": "sigma_letnev_flagship_2",
@@ -436,7 +436,7 @@
         "isShip": true,
         "ability": "At the start of each space combat round in this system, repair this ship, then place 1 fighter for every 8 resources in the combined cost of your non-fighter ships in this system.\nThis unit cannot be destroyed by \"Direct Hit\" action cards.",
         "unlock": "When 1 of your opponent's non-fighter ships is destroyed during space combat, place a number of control tokens on this card equal to that ship's cost.\nUNLOCK: Have 20 control tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/letnev_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/letnev_2a.png?raw=true"
     },
     
     {
@@ -457,7 +457,7 @@
         "ability": "During your actions, this ship may transport structures as though they were ground forces; they lose all abilities and attributes until the end of the action. If any of your PDS are in the space area of a system at the end of the action, they are destroyed.",
         "unlock": "UNLOCK: Participate in a space combat in a system containing 1 or more of your space docks.",
         "homebrewReplacesID": "saar_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/saar_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/saar_1a.png?raw=true"
     },
     {
         "id": "sigma_saar_flagship_2",
@@ -476,7 +476,7 @@
         "isShip": true,
         "ability": "During your actions, this ship may transport structures as though they were ground forces; they lose all abilities and attributes until the end of the action. If any of your PDS are in the space area of a system at the end of the action, they are destroyed.",
         "unlock": "UNLOCK: 1 of your structures is destroyed.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/saar_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/saar_2a.png?raw=true"
     },
     
     {
@@ -497,7 +497,7 @@
         "ability": "When this ship produces a hit with a combat roll, it gains 1 additional combat dice for this round of combat; roll that dice immediately.",
         "unlock": "UNLOCK: Control a planet with a technology speciality.",
         "homebrewReplacesID": "jolnar_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/jolnar_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/jolnar_1a.png?raw=true"
     },
     {
         "id": "sigma_jolnar_flagship_2",
@@ -516,7 +516,7 @@
         "isShip": true,
         "ability": "When this ship produces a hit with a combat roll, it gains 1 additional combat dice for this round of combat; roll that dice immediately.",
         "unlock": "If you control a planet with a technology speciality, or own 4 technologies of 1 color, place the technology token of the corresponding color on this card.\nUNLOCK: Have 4 tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/jolnar_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/jolnar_2a.png?raw=true"
     },
     
     {
@@ -537,7 +537,7 @@
         "ability": "Apply +1 to the result of each of your other ship's combat rolls in this system.",
         "unlock": "UNLOCK: Produce 4 hits during 1 round of combat.",
         "homebrewReplacesID": "sardakk_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/norr_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/norr_1a.png?raw=true"
     },
     {
         "id": "sigma_norr_flagship_2",
@@ -556,7 +556,7 @@
         "isShip": true,
         "ability": "Apply +1 to the result of each of your unit's combat and ability rolls in this system.",
         "unlock": "UNLOCK: Produce 8 hits during 1 round of combat.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/norr_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/norr_2a.png?raw=true"
     },
     
     {
@@ -579,7 +579,7 @@
         "spaceCannonDieCount": 2,
         "unlock": "When you perform the primary or secondary ability of a strategy card, place the corresponding token on this card.\nUNLOCK: Have 4 tokens on this card.",
         "homebrewReplacesID": "xxcha_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/xxcha_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/xxcha_1a.png?raw=true"
     },
     {
         "id": "sigma_xxcha_flagship_2",
@@ -601,7 +601,7 @@
         "spaceCannonDieCount": 4,
         "deepSpaceCannon": true,
         "unlock": "When you perform the primary or secondary ability of a strategy card, place the corresponding token on this card.\nUNLOCK: Have 8 tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/xxcha_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/xxcha_2a.png?raw=true"
     },
     
     {
@@ -622,7 +622,7 @@
         "ability": "This ship can move through systems that contain other player's ships.",
         "unlock": "UNLOCK: See an unscored secret objective belonging to another player.",
         "homebrewReplacesID": "yssaril_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/yssaril_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/yssaril_1a.png?raw=true"
     },
     {
         "id": "sigma_yssaril_flagship_2",
@@ -641,7 +641,7 @@
         "isShip": true,
         "ability": "This ship can move through systems that contain other player's units, and ignores the movement effects of anomalies.",
         "unlock": "UNLOCK: Gain control of a planet in a system that is not adjacent to another planet you control or any of your units.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/yssaril_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/yssaril_2a.png?raw=true"
     },
     
     {
@@ -662,7 +662,7 @@
         "ability": "You may spend any number of trade goods to cancel 1 hit each, produced against your units in this system; the player that produced the hit gains the trade good.",
         "unlock": "When you resolve a transaction with another player, place 1 of their control tokens on this card.\nUNLOCK: Have a control token from each other player on this card.",
         "homebrewReplacesID": "hacan_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/hacan_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/hacan_1a.png?raw=true"
     },
     {
         "id": "sigma_hacan_flagship_2",
@@ -681,7 +681,7 @@
         "isShip": true,
         "ability": "You may spend any number of trade goods to cancel up to 3 hits each, all produced by the same player against your units in this system; that player gains the trade good.",
         "unlock": "When you resolve a transaction with another player, place 1 of their control tokens on this card.\nUNLOCK: Have 6 control tokens for each other player in the game on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/hacan_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/hacan_2a.png?raw=true"
     },
     
     {
@@ -702,7 +702,7 @@
         "ability": "You treat this system as if it contained a delta wormhole.\nDuring movement, this ship may move before or after your other ships.\nThis ship does not roll for gravity rifts.",
         "unlock": "UNLOCK: Have ships in systems that collectively contain a total of 4 or more wormholes.",
         "homebrewReplacesID": "ghost_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/creuss_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/creuss_1a.png?raw=true"
     },
     {
         "id": "sigma_creuss_flagship_2",
@@ -721,7 +721,7 @@
         "isShip": true,
         "ability": "You treat this system as if it contained a delta wormhole.\nDuring movement, this ship may move before or after your other ships.\nThis ship does not roll for gravity rifts.\nYou may move this ship to an adjacent system at the start of a space combat there.",
         "unlock": "UNLOCK: Have ships in systems that collectively contain a total of 6 or more wormholes.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/creuss_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/creuss_2a.png?raw=true"
     },
     
     {
@@ -742,7 +742,7 @@
         "ability": "During a combat against a player without a command token in your fleet pool, apply +1 to the result of this unit's combat rolls.",
         "unlock": "UNLOCK: Have 1 Support For The Throne in your play area.",
         "homebrewReplacesID": "mahact_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/mahact_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/mahact_1a.png?raw=true"
     },
     {
         "id": "sigma_mahact_flagship_2",
@@ -761,7 +761,7 @@
         "isShip": true,
         "ability": "During a combat against a player without a command token in your fleet pool, apply +2 to the result of this unit's combat rolls.\nWhen you win a combat in this system, place 1 command token from your opponent's reinforcements in this system.",
         "unlock": "UNLOCK: Have 2 Supports Fors Thes Thrones in your play area.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/mahact_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/mahact_2a.png?raw=true"
     },
     
     {
@@ -784,7 +784,7 @@
         "afbDieCount": 2,
         "unlock": "This unit is unlocked at the start of the game.",
         "homebrewReplacesID": "nomad_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/nomad_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/nomad_1a.png?raw=true"
     },
     {
         "id": "sigma_nomad_flagship_2",
@@ -805,7 +805,7 @@
         "afbHitsOn": 6,
         "afbDieCount": 3,
         "unlock": "UNLOCK: When you would score a public objective or draw a secret objective, you may instead unlock the Memoria II.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/nomad_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/nomad_2a.png?raw=true"
     },
     {
         "id": "sigma_nomad_flagship_3",
@@ -827,7 +827,7 @@
         "afbDieCount": 4,
         "productionValue": 1,
         "unlock": "UNLOCK: With the Memoria II unlocked, when you would score a public objective or draw a secret objective, you may instead unlock the Memoria III.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/nomad_3a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/nomad_3a.png?raw=true"
     },
     {
         "id": "sigma_cavalry_1",
@@ -900,7 +900,7 @@
         "ability": "When you capture a unit in this system, also capture a fighter or infantry token from the supply.\nWhen you produce this ship, you may return 24 fighters and/or infantry tokens instead of spending resources.",
         "unlock": "When you capture another player's unit, place 1 of that player's control tokens on this card.\nUNLOCK: Have 4 of 1 player's control tokens on this card.",
         "homebrewReplacesID": "cabal_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/vuilraith_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/vuilraith_1a.png?raw=true"
     },
     {
         "id": "sigma_vuilraith_flagship_2",
@@ -919,7 +919,7 @@
         "isShip": true,
         "ability": "When another unit is destroyed in this system, including your own, capture it, then capture a fighter or infantry token from the supply.\nWhen you produce this ship, you may return 16 fighters and/or infantry tokens instead of spending resources.",
         "unlock": "When you capture another player's unit, place 1 of that player's control tokens on this card.\nUNLOCK: Have 12 of 1 player's control tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/vuilraith_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/vuilraith_2a.png?raw=true"
     },
     
     {
@@ -940,7 +940,7 @@
         "ability": "DEPLOY: After you activate a system that contains 1 of your PDS, you may replace that PDS with this ship.",
         "unlock": "UNLOCK: Control 2 attachments amongst planets you control.",
         "homebrewReplacesID": "titans_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/ul_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/ul_1a.png?raw=true"
     },
     {
         "id": "sigma_ul_flagship_2",
@@ -959,7 +959,7 @@
         "isShip": true,
         "ability": "When this ship is destroyed, place a ship with a cost of 4 or less from your reinforcements in this system.\nDEPLOY: After you activate a system that contains 1 of your PDS, you may replace that PDS with this ship.",
         "unlock": "UNLOCK: Control 5 attachments amongst planets you control.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/ul_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/ul_2a.png?raw=true"
     },
     
     {
@@ -980,7 +980,7 @@
         "ability": "When any player's unit in this system with the SUSTAIN DAMAGE ability becomes damaged, you may spend 3 influence to repair that unit; it cannot be destroyed by a \"Direct Hit\" action card triggered by that use of SUSTAIN DAMAGE.",
         "unlock": "UNLOCK: Explore a frontier token adjacent to another player's home system.",
         "homebrewReplacesID": "empyrean_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/empyrean_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/empyrean_1a.png?raw=true"
     },
     {
         "id": "sigma_empyrean_flagship_2",
@@ -999,7 +999,7 @@
         "isShip": true,
         "ability": "When any player's unit in this system or an adjacent system with the SUSTAIN DAMAGE ability becomes damaged, you may spend 1 influence to repair that unit; it cannot be destroyed by a \"Direct Hit\" action card triggered by that use of SUSTAIN DAMAGE.",
         "unlock": "UNLOCK: Purge a frontier exploration card.\nACTION: Purge an unknown relic fragment.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/empyrean_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/empyrean_2a.png?raw=true"
     },
     
     {
@@ -1020,7 +1020,7 @@
         "ability": "Apply +1 to the result of each of your mech's combat rolls in this system.",
         "unlock": "UNLOCK: You purge a relic fragment or an exploration deck is depleted.",
         "homebrewReplacesID": "naaz_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/naazrokha_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/naazrokha_1a.png?raw=true"
     },
     {
         "id": "sigma_naazrokha_flagship_2",
@@ -1039,7 +1039,7 @@
         "isShip": true,
         "ability": "Your mechs in this system roll 1 additional die during combat.\nWhen you win a combat in this system, you may repair 1 participating unit.",
         "unlock": "When you purge a relic fragment, or when an exploration deck is depleted, place the corresponding trait token on this card.\nUNLOCK: have 3 tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/naazrokha_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/naazrokha_2a.png?raw=true"
     },
     
     {
@@ -1060,7 +1060,7 @@
         "ability": "Other players apply -2 to the result of each dice roll when they use SPACE CANNON against your ships in this system.",
         "unlock": "When you destroy a unit using a unit ability, place a control token on this card.\nUNLOCK: Have 4 control tokens on this card.",
         "homebrewReplacesID": "argent_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/argent_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/argent_1a.png?raw=true"
     },
     {
         "id": "sigma_argent_flagship_2",
@@ -1079,7 +1079,7 @@
         "isShip": true,
         "ability": "When using SPACE CANNON, other players apply -2 and you apply +2 to the result of each die roll against units in adjacent systems, and other players apply -3 and you apply +3 to the result of each die roll against units in this system.",
         "unlock": "When you destroy a unit using a unit ability, place a control token on this card.\nUNLOCK: Have 12 control tokens on this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/argent_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/argent_2a.png?raw=true"
     },
     
     {
@@ -1100,7 +1100,7 @@
         "ability": "Other players must spend 2 influence to activate this system.",
         "unlock": "UNLOCK: Give another player 3 commodities and/or trade goods when resolving a transaction.",
         "homebrewReplacesID": "keleres_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/keleres_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/keleres_1a.png?raw=true"
     },
     {
         "id": "sigma_keleresa_flagship_2",
@@ -1119,7 +1119,7 @@
         "isShip": true,
         "ability": "Other players must spend 4 influence to activate this system. When they do, gain 1 command token from this system or your reinforcements.",
         "unlock": "UNLOCK: With the Artemiris I unlocked, give another player 6 commodities and/or trade goods when resolving a transaction.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/keleres_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/keleres_2a.png?raw=true"
     },
     {
         "id": "sigma_keleresm_flagship_1",
@@ -1139,7 +1139,7 @@
         "ability": "Other players must spend 2 influence to activate the system that contains this ship.",
         "unlock": "UNLOCK: Give another player 4 commodities or trade goods when resolving a transaction.",
         "homebrewReplacesID": "keleres_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/keleres_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/keleres_1a.png?raw=true"
     },
     {
         "id": "sigma_keleresm_flagship_2",
@@ -1158,7 +1158,7 @@
         "isShip": true,
         "ability": "Other players must spend 4 influence to activate the system that contains this ship. When they do, gain 1 command token from this system or your reinforcements.",
         "unlock": "UNLOCK: With the Artemiris I unlocked, give another player 8 commodities or trade goods when resolving a transaction.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/keleres_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/keleres_2a.png?raw=true"
     },
     {
         "id": "sigma_keleresx_flagship_1",
@@ -1178,7 +1178,7 @@
         "ability": "Other players must spend 2 influence to activate the system that contains this ship.",
         "unlock": "UNLOCK: Give another player 4 commodities or trade goods when resolving a transaction.",
         "homebrewReplacesID": "keleres_flagship",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/keleres_1a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/keleres_1a.png?raw=true"
     },
     {
         "id": "sigma_keleresx_flagship_1_flagship_2",
@@ -1197,7 +1197,7 @@
         "isShip": true,
         "ability": "Other players must spend 4 influence to activate the system that contains this ship. When they do, gain 1 command token from this system or your reinforcements.",
         "unlock": "UNLOCK: With the Artemiris I unlocked, give another player 8 commodities or trade goods when resolving a transaction.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/flagshipping/keleres_2a.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/flagshipping/keleres_2a.png?raw=true"
     }
 
 ]

--- a/src/main/resources/data/units/keleres.json
+++ b/src/main/resources/data/units/keleres.json
@@ -16,7 +16,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other players must spend 2 influence to activate the system that contains this ship.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/artemiris.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/artemiris.png?raw=true"
     },
     {
         "id": "keleres_mech",
@@ -32,6 +32,6 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "Other players must spend 1 influence to commit ground forces to the planet that contains this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/omniopiares.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/omniopiares.jpg?raw=true"
     }
 ]

--- a/src/main/resources/data/units/pok.json
+++ b/src/main/resources/data/units/pok.json
@@ -16,7 +16,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After you activate this system, you may produce up to 5 units in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/duha_menaimon.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/duha_menaimon.png?raw=true"
     },
     {
         "id": "arborec_infantry",
@@ -32,7 +32,7 @@
         "combatHitsOn": 8,
         "combatDieCount": 1,
         "isGroundForce": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/letani_warrior.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/letani_warrior.jpg?raw=true"
     },
     {
         "id": "arborec_infantry2",
@@ -50,7 +50,7 @@
         "combatDieCount": 1,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll 1 die. If the result is 6 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/letani_warrior_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/letani_warrior_2.jpg?raw=true"
     },
     {
         "id": "arborec_mech",
@@ -68,7 +68,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: When you would use your Mitosis faction ability you may replace 1 of your infantry with 1 mech from your reinforcements instead.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/letani_behemoth.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/letani_behemoth.jpg?raw=true"
     },
     {
         "id": "argent_destroyer",
@@ -87,7 +87,7 @@
         "afbHitsOn": 9,
         "afbDieCount": 2,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/strike_wing_alpha.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/strike_wing_alpha.jpg?raw=true"
     },
     {
         "id": "argent_destroyer2",
@@ -108,7 +108,7 @@
         "afbDieCount": 3,
         "isShip": true,
         "ability": "When this unit uses ANTI-FIGHTER BARRAGE, each result of 9 or 10 also destroys 1 of your opponent's infantry in the space area of the active system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/strike_wing_alpha_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/strike_wing_alpha_2.jpg?raw=true"
     },
     {
         "id": "argent_flagship",
@@ -127,7 +127,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other players cannot use space cannon against your ships in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/quetzecoatl.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/quetzecoatl.png?raw=true"
     },
     {
         "id": "argent_mech",
@@ -143,7 +143,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "This unit does not count against capacity if it is being transported or if it is in a space area with 1 or more of your ships that have capacity values.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/aerie_sentinel.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/aerie_sentinel.jpg?raw=true"
     },
     {
         "id": "cabal_flagship",
@@ -164,7 +164,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Capture all other non-structure units that are destroyed in this system, including your own.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/the_terror_between.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/the_terror_between.png?raw=true"
     },
     {
         "id": "cabal_mech",
@@ -180,7 +180,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "When your infantry on this planet are destroyed, place them on your faction sheet; those units are captured.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/reanimator.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/reanimator.jpg?raw=true"
     },
     {
         "id": "cabal_spacedock",
@@ -193,7 +193,7 @@
         "productionValue": 5,
         "isStructure": true,
         "ability": "This system is a gravity rift; your ships do not roll for this gravity rift. Place a dimensional tear token beneath this unit as a reminder.\nUp to 6 fighters in this system do not count against your ships' capacity.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/dimensional_tear.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/dimensional_tear.jpg?raw=true"
     },
     {
         "id": "cabal_spacedock2",
@@ -207,7 +207,7 @@
         "productionValue": 7,
         "isStructure": true,
         "ability": "This system is a gravity rift; your ships do not roll for this gravity rift. Place a dimensional tear token beneath this unit as a reminder.\nUp to 12 fighters in this system do not count against your ships' capacity.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/dimensional_tear_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/dimensional_tear_2.jpg?raw=true"
     },
     {
         "id": "empyrean_flagship",
@@ -226,7 +226,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After any player's unit in this system or an adjacent system uses SUSTAIN DAMAGE, you may spend 2 influence to repair that unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/dynamo.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/dynamo.png?raw=true"
     },
     {
         "id": "empyrean_mech",
@@ -242,7 +242,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "You may remove this unit from a system that contains or is adjacent to another player's units to cancel an action card played by that player.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/watcher.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/watcher.jpg?raw=true"
     },
     {
         "id": "ghost_flagship",
@@ -261,7 +261,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "This ship's system contains a delta wormhole.\nDuring movement, this ship may move before or after your other ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/hil_colish.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/hil_colish.png?raw=true"
     },
     {
         "id": "ghost_mech",
@@ -277,7 +277,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After any player activates a system, you may remove this unit from the game board to place or move a Creuss wormhole token into this system. [Note: this system refers to the system the mech is in. It does not refer to the active system]",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/icarus_drive.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/icarus_drive.jpg?raw=true"
     },
     {
         "id": "hacan_flagship",
@@ -296,7 +296,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "After you roll a die during a space combat in this system, you may spend 1 trade good to apply +1 to the result.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/wrath_of_kenara.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/wrath_of_kenara.png?raw=true"
     },
     {
         "id": "hacan_mech",
@@ -312,7 +312,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "This planet's card may be traded as part of a transaction; if you do, move all of your units from this planet to another planet you control.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/pride_of_kenara.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/pride_of_kenara.jpg?raw=true"
     },
     {
         "id": "jolnar_flagship",
@@ -331,7 +331,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When making a combat roll for this ship, each result of 9 or 10, before applying modifiers, produces 2 additional hits.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/jns_hylarim.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/jns_hylarim.png?raw=true"
     },
     {
         "id": "jolnar_mech",
@@ -347,7 +347,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "Your infantry on this planet are not affected by your Fragile faction ability.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/shield_paling.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/shield_paling.jpg?raw=true"
     },
     {
         "id": "l1z1x_dreadnought",
@@ -368,7 +368,7 @@
         "sustainDamage": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/superdreadnought.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/superdreadnought.jpg?raw=true"
     },
     {
         "id": "l1z1x_dreadnought2",
@@ -390,7 +390,7 @@
         "sustainDamage": true,
         "isShip": true,
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/superdreadnought_2.jpg?raw=true"
     },
     {
         "id": "l1z1x_flagship",
@@ -409,7 +409,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "During a space combat, hits produced by this ship and by your dreadnoughts in this system must be assigned to non-fighter ships if able.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/001.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/001.png?raw=true"
     },
     {
         "id": "l1z1x_mech",
@@ -427,7 +427,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "While not participating in ground combat, this unit can use it's BOMBARDMENT ability on planets in its system as if it were a ship.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/annihilator.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/annihilator.jpg?raw=true"
     },
     {
         "id": "letnev_flagship",
@@ -448,7 +448,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other player's units in this system lose PLANETARY SHIELD.\nAt the start of each space combat round, repair this ship.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/arc_secundus.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/arc_secundus.png?raw=true"
     },
     {
         "id": "letnev_mech",
@@ -464,7 +464,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: At the start of a round of ground combat, you may spend 2 resources to replace 1 of your infantry in that combat with 1 mech.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/dunlain_reaper.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/dunlain_reaper.jpg?raw=true"
     },
     {
         "id": "mahact_flagship",
@@ -483,7 +483,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "During combat against an opponent whose command token is not in your fleet pool, apply +2 to the results of this unit's combat rolls.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/arvicon_rex.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/arvicon_rex.png?raw=true"
     },
     {
         "id": "mahact_infantry",
@@ -499,7 +499,7 @@
         "combatDieCount": 1,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, gain 1 commodity or convert 1 of your commodities to a trade good.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/crimson_legionnaire.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/crimson_legionnaire.jpg?raw=true"
     },
     {
         "id": "mahact_infantry2",
@@ -516,7 +516,7 @@
         "combatDieCount": 1,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, gain 1 commodity or convert 1 of your commodities to a trade good. Then, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/crimson_legionnaire_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/crimson_legionnaire_2.jpg?raw=true"
     },
     {
         "id": "mahact_mech",
@@ -532,7 +532,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After a player whose command token is in your fleet pool activates this system, you may spend their token from your fleet pool to end their turn; they gain that token.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/starlancer.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/starlancer.jpg?raw=true"
     },
     {
         "id": "mentak_flagship",
@@ -551,7 +551,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other player's ships in this system cannot use SUSTAIN DAMAGE.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/fourth_moon.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/fourth_moon.png?raw=true"
     },
     {
         "id": "mentak_mech",
@@ -567,7 +567,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "Other player's ground forces on this planet cannot use SUSTAIN DAMAGE.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/moll_terminus.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/moll_terminus.jpg?raw=true"
     },
     {
         "id": "muaat_flagship",
@@ -586,7 +586,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "ACTION: Spend 1 token from your strategy pool to place 1 cruiser in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/the_inferno.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/the_inferno.png?raw=true"
     },
     {
         "id": "muaat_warsun",
@@ -609,7 +609,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other players' units in this system lose the PLANETARY SHIELD ability.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/prototype_war_sun.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/prototype_war_sun.jpg?raw=true"
     },
     {
         "id": "muaat_warsun2",
@@ -633,7 +633,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Other players' units in this system lose the PLANETARY SHIELD ability.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/prototype_war_sun_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/prototype_war_sun_2.jpg?raw=true"
     },
     {
         "id": "muaat_mech",
@@ -649,7 +649,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "When you use your Star Forge faction ability in this system or an adjacent system, you may place 1 infantry from your reinforcements with this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/ember_colossus.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/ember_colossus.jpg?raw=true"
     },
     {
         "id": "naalu_fighter",
@@ -665,7 +665,7 @@
         "isSpaceOnly": false,
         "combatHitsOn": 8,
         "combatDieCount": 1,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/hybrid_crystal_fighter.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/hybrid_crystal_fighter.jpg?raw=true"
     },
     {
         "id": "naalu_fighter2",
@@ -684,7 +684,7 @@
         "combatHitsOn": 7,
         "combatDieCount": 1,
         "ability": "This unit may move without being transported.\nEach fighter in excess of your ships' capacity counts as 1/2 of a ship against your fleet pool.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/hybrid_crystal_fighter_2.jpg?raw=true"
     },
     {
         "id": "naalu_flagship",
@@ -703,7 +703,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "During an invasion in this system, you may commit fighters to planets as if they were ground forces. After combat, return those units to the space area.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/matriarch.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/matriarch.png?raw=true"
     },
     {
         "id": "naalu_mech",
@@ -719,7 +719,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "During combat against an opponent who has at least 1 relic fragment, apply +2 to the results of this unit's combat rolls.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/iconoclast.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/iconoclast.jpg?raw=true"
     },
     {
         "id": "naalu_mech_omega",
@@ -735,7 +735,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "Other players cannot use ANTI-FIGHTER BARRAGE against your units in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/iconoclast_omega.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/iconoclast_omega.jpg?raw=true"
     },
     {
         "id": "naaz_flagship",
@@ -754,7 +754,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Your mechs in this system roll 1 additional die during combat.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/visz_el_vir.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/visz_el_vir.png?raw=true"
     },
     {
         "id": "naaz_mech",
@@ -770,7 +770,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "If this unit is in the space area of the active system at the start of a space combat, flip this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/eidolon.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/eidolon.jpg?raw=true"
     },
     {
         "id": "naaz_mech_space",
@@ -785,7 +785,7 @@
         "combatDieCount": 2,
         "isShip": true,
         "ability": "If this unit is in the space area of the active system, it is also a ship.\nAt the end of a space battle in the active system, flip this card.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/eidolon_zgrav.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/eidolon_zgrav.jpg?raw=true"
     },
     {
         "id": "nekro_flagship",
@@ -804,7 +804,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "At the start of a space combat, choose any number of your ground forces in this system to participate in that combat as if they were ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/the_alastor.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/the_alastor.png?raw=true"
     },
     {
         "id": "nekro_mech",
@@ -820,7 +820,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "During combat against an opponent who has an \"X\" or \"Y\" token on 1 or more of their technologies, apply +2 to the result of each of this unit's combat rolls.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/mordred.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/mordred.jpg?raw=true"
     },
     {
         "id": "nomad_flagship",
@@ -842,7 +842,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "You may treat this unit as if it were adjacent to systems that contain 1 or more of your mechs.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/memoria.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/memoria.png?raw=true"
     },
     {
         "id": "nomad_flagship2",
@@ -865,7 +865,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "You may treat this unit as if it were adjacent to systems that contain 1 or more of your mechs.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/memoria_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/memoria_2.jpg?raw=true"
     },
     {
         "id": "cavalry1",
@@ -917,7 +917,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "While this unit is in a space area during combat, you may use its SUSTAIN DAMAGE ability to cancel a hit that is produced against your ships in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/quantum_manipulator.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/quantum_manipulator.jpg?raw=true"
     },
     {
         "id": "saar_flagship",
@@ -937,7 +937,7 @@
         "sustainDamage": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/son_of_ragh.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/son_of_ragh.png?raw=true"
     },
     {
         "id": "saar_spacedock",
@@ -954,7 +954,7 @@
         "isPlanetOnly": false,
         "isSpaceOnly": true,
         "ability": "This unit is placed in the space area instead of on a planet.\nThis unit can move and retreat as if it were a ship.\nIf this unit is blockaded, it is destroyed.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/floating_factory.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/floating_factory.jpg?raw=true"
     },
     {
         "id": "saar_spacedock2",
@@ -972,7 +972,7 @@
         "isPlanetOnly": false,
         "isSpaceOnly": true,
         "ability": "This unit is placed in the space area instead of on a planet.\nThis unit can move and retreat as if it were a ship.\nIf this unit is blockaded, it is destroyed.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/floating_factory_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/floating_factory_2.jpg?raw=true"
     },
     {
         "id": "saar_mech",
@@ -988,7 +988,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After you gain control of a planet, you may spend 1 trade good to place 1 mech on that planet",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/scavenger_zeta.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/scavenger_zeta.jpg?raw=true"
     },
     {
         "id": "sardakk_dreadnought",
@@ -1009,7 +1009,7 @@
         "sustainDamage": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/exotrireme.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/exotrireme.jpg?raw=true"
     },
     {
         "id": "sardakk_dreadnought2",
@@ -1031,7 +1031,7 @@
         "sustainDamage": true,
         "isShip": true,
         "ability": "This unit cannot be destroyed by \"Direct Hit\" action cards.\nAfter a round of space combat, you may destroy this unit to destroy up to 2 ships in the system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/exotrireme_2.jpg?raw=true"
     },
     {
         "id": "sardakk_flagship",
@@ -1050,7 +1050,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "Apply +1 to the result of each of your other ship's combat rolls in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/cmorran_norr.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/cmorran_norr.png?raw=true"
     },
     {
         "id": "sardakk_mech",
@@ -1066,7 +1066,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After this unit uses it's SUSTAIN DAMAGE ability during ground combat, it produces 1 hit against your opponent's ground forces on this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/valkyrie_exoskeleton.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/valkyrie_exoskeleton.jpg?raw=true"
     },
     {
         "id": "sol_carrier",
@@ -1083,7 +1083,7 @@
         "combatHitsOn": 9,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/advanced_carrier.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/advanced_carrier.jpg?raw=true"
     },
     {
         "id": "sol_carrier2",
@@ -1103,7 +1103,7 @@
         "sustainDamage": true,
         "canBeDirectHit": true,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/advanced_carrier_2.jpg?raw=true"
     },
     {
         "id": "sol_flagship",
@@ -1122,7 +1122,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "At the end of the status phase, place 1 infantry from your reinforcements in this system's space area.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/genesis.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/genesis.png?raw=true"
     },
     {
         "id": "sol_infantry",
@@ -1137,7 +1137,7 @@
         "combatHitsOn": 7,
         "combatDieCount": 1,
         "isGroundForce": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/spec_ops.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/spec_ops.jpg?raw=true"
     },
     {
         "id": "sol_infantry2",
@@ -1154,7 +1154,7 @@
         "combatDieCount": 1,
         "isGroundForce": true,
         "ability": "After this unit is destroyed, roll 1 die. If the result is 5 or greater, place the unit on this card. At the start of your next turn, place each unit that is on this card on a planet you control in your home system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/spec_ops_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/spec_ops_2.jpg?raw=true"
     },
     {
         "id": "sol_mech",
@@ -1170,7 +1170,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After you use your Orbital Drop faction ability, you may spend 3 resources to place 1 mech on that planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/zs_thunderbolt_m2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/zs_thunderbolt_m2.jpg?raw=true"
     },
     {
         "id": "titans_cruiser",
@@ -1187,7 +1187,7 @@
         "combatHitsOn": 7,
         "combatDieCount": 1,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/saturn_engine.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/saturn_engine.jpg?raw=true"
     },
     {
         "id": "titans_cruiser2",
@@ -1206,7 +1206,7 @@
         "combatDieCount": 1,
         "sustainDamage": true,
         "isShip": true,
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/saturn_engine_2.jpg?raw=true"
     },
     {
         "id": "titans_flagship",
@@ -1225,7 +1225,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "DEPLOY: After you activate a system that contains 1 or more of your PDS, you may replace 1 of those PDS with this unit.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/ouranos.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/ouranos.png?raw=true"
     },
     {
         "id": "titans_mech",
@@ -1241,7 +1241,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: When you would place a PDS on a planet, you may place 1 mech and 1 infantry on that planet instead.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/hecatoncheires.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/hecatoncheires.jpg?raw=true"
     },
     {
         "id": "titans_pds",
@@ -1261,7 +1261,7 @@
         "isStructure": true,
         "isGroundForce": true,
         "ability": "This unit is treated as both a structure and a ground force. It cannot be transported.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/faction/heltitan.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/faction/heltitan.jpg?raw=true"
     },
     {
         "id": "titans_pds2",
@@ -1283,7 +1283,7 @@
         "isStructure": true,
         "isGroundForce": true,
         "ability": "This unit is treated as both a structure and a ground force. It cannot be transported.\nYou may use this unit's SPACE CANNON against ships that are adjacent to this unit's systems.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/techs/faction/heltitan_2.jpg?raw=true"
     },
     {
         "id": "winnu_flagship",
@@ -1302,7 +1302,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this unit makes a combat roll, it rolls a number of dice (hit on a 7) equal to the number of your opponent's non-fighter ships in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/salai_sai_corian.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/salai_sai_corian.png?raw=true"
     },
     {
         "id": "winnu_mech",
@@ -1318,7 +1318,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "After you resolve a tactical action where you gained control of this planet, you may place 1 PDS or 1 Space Dock from your reinforcements on this planet.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/reclaimer.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/reclaimer.jpg?raw=true"
     },
     {
         "id": "xxcha_flagship",
@@ -1340,7 +1340,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "You may use this unit's SPACE CANNON against ships that are in adjacent systems.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/loncara_ssodu.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/loncara_ssodu.png?raw=true"
     },
     {
         "id": "xxcha_mech",
@@ -1359,7 +1359,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "You may use this unit's SPACE CANNON against ships that are in adjacent systems.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/indomitus.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/indomitus.jpg?raw=true"
     },
     {
         "id": "yin_flagship",
@@ -1378,7 +1378,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "When this ship is destroyed, destroy all ships in this system.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/van_hauge.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/van_hauge.png?raw=true"
     },
     {
         "id": "yin_mech",
@@ -1394,7 +1394,7 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: When you use your Indoctrination faction ability, you may spend 1 additional influence to replace your opponent's unit with 1 mech instead of 1 infantry.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/moyins_ashes.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/moyins_ashes.jpg?raw=true"
     },
     {
         "id": "yssaril_flagship",
@@ -1413,7 +1413,7 @@
         "canBeDirectHit": true,
         "isShip": true,
         "ability": "This ship can move through systems that contain other player's ships.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/flagships/ysia_yssrila.png?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/flagships/ysia_yssrila.png?raw=true"
     },
     {
         "id": "yssaril_mech",
@@ -1429,6 +1429,6 @@
         "sustainDamage": true,
         "isGroundForce": true,
         "ability": "DEPLOY: After you use your Stall Tactics faction ability, you may place 1 mech on a planet you control.",
-        "imageURL": "https://github.com/AsyncTI4/TI4_map_generator_bot/blob/master/src/main/resources/hover_images/units/pok/mechs/blackshade_infiltrator.jpg?raw=true"
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/pok/mechs/blackshade_infiltrator.jpg?raw=true"
     }
 ]


### PR DESCRIPTION
Mouse-overs in the webpage version of the game state is failing due to throttling against github, I'm not sure if this is a result of browsers making dozens of requests at the same time or github stopping anonymous retrievals of "hot spot" resources, but moving to a CDN should do the trick in either case.

Statically is a free CDN which handles cache population from github with a pretty minor change in the image retrieval path via the "staticzap" feature (https://statically.io/docs/using-staticzap/) -- Using staticzap you can set the repo owner/name/tag via URL and the images will autopopulate upon first retrieval.  The maps should should be pretty speedy from that point forward.  

Statically/Staticzap uses a 1day TTL on files retrieved from master branches -- so if there's some image you need to update down the road it will take a day for folks to actually retrieve that update.  If you need updates quicker than that, you can publish to a feature branch and update the references to pull from that, which would force retrieval of the new version.