### PR TITLE
Fix display of secret objective scoring ping

### DIFF
--- a/src/main/java/ti4/cron/AutoPingCron.java
+++ b/src/main/java/ti4/cron/AutoPingCron.java
@@ -241,7 +241,7 @@ public class AutoPingCron {
                 MessageHelper.sendMessageToChannel(game.getActionsChannel(), poMsg + "please indicate if you are scoring a public objective");
             }
             if (!game.isFowMode() && (soMsg.length() > 0)) {
-                MessageHelper.sendMessageToChannel(game.getActionsChannel(), poMsg + "please indicate if you are scoring a secret objective");
+                MessageHelper.sendMessageToChannel(game.getActionsChannel(), soMsg + "please indicate if you are scoring a secret objective");
             }
             AutoPingMetadataManager.addPing(game.getName());
         }


### PR DESCRIPTION
Status phase scoring reminder shows public objective message twice instead of players needing to score secrets. Fixed to use soMsg instead of poMsg for both cases.