### PR TITLE
Void tiles from dummy to null

### DIFF
--- a/src/main/java/ti4/commands/CommandHelper.java
+++ b/src/main/java/ti4/commands/CommandHelper.java
@@ -28,7 +28,6 @@ import ti4.map.Game;
 import ti4.map.Player;
 import ti4.map.Tile;
 import ti4.map.manage.GameManager;
-import ti4.service.fow.FOWPlusService;
 import ti4.service.game.GameNameService;
 
 @UtilityClass
@@ -231,13 +230,11 @@ public class CommandHelper {
 
     public Tile getTile(SlashCommandInteractionEvent event, Game game) {
         String tileName = StringUtils.substringBefore(event.getOption(Constants.TILE_NAME).getAsString().toLowerCase(), " ");
-        Tile tile = TileHelper.getTile(event, tileName, game);
-        return tile != null && !FOWPlusService.isVoid(tile) ? tile : null;
+        return TileHelper.getTile(event, tileName, game);
     }
 
     public Tile getTile(SlashCommandInteractionEvent event, Game game, String tileName) {
         tileName = StringUtils.substringBefore(tileName.toLowerCase(), " ");
-        Tile tile = TileHelper.getTile(event, tileName, game);
-        return tile != null && !FOWPlusService.isVoid(tile) ? tile : null;
+        return TileHelper.getTile(event, tileName, game);
     }
 }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -949,6 +949,8 @@ public class ButtonHelper {
         Game game, Tile activeSystem, Player player,
         boolean justChecking, ButtonInteractionEvent event
     ) {
+        if (activeSystem == null) return 0;
+
         int numberOfAbilities = 0;
         if (game.getStoredValue("allianceModeSimultaneousAction").isEmpty() && !player.getAllianceMembers().isEmpty()) {
             for (Player p2 : game.getRealPlayers()) {
@@ -2062,6 +2064,8 @@ public class ButtonHelper {
 
     public static List<String> getPlanetsWithSpecificUnit(Player player, Tile tile, String unit) {
         List<String> planetsWithUnit = new ArrayList<>();
+        if (tile == null) return planetsWithUnit;
+
         for (UnitHolder unitHolder : tile.getUnitHolders().values()) {
             if (unitHolder instanceof Planet planet) {
                 if (planet.getUnits()
@@ -3732,7 +3736,7 @@ public class ButtonHelper {
 
         }
         if (doesPlayerHaveFSHere("lanefir_flagship", player, tile)) {
-            List<Button> button2 = scanlinkResolution(player, game);
+            List<Button> button2 = scanlinkResolution(player, tile, game);
             if (!button2.isEmpty()) {
                 MessageHelper.sendMessageToChannel(player.getCorrectChannel(), player.getRepresentation()
                     + "Due to the Memory of Dusk (the Lanefir flagship), you may explore a planet you control in the system.");
@@ -4019,9 +4023,10 @@ public class ButtonHelper {
         deleteMessage(event);
     }
 
-    public static List<Button> getAbsolOrbitalButtons(Game game, Player player) {
-        Tile tile = game.getTileByPosition(game.getActiveSystem());
+    public static List<Button> getAbsolOrbitalButtons(Game game, Tile tile, Player player) {
         List<Button> buttons = new ArrayList<>();
+        if (tile == null) return buttons;
+
         for (UnitHolder planetUnit : tile.getUnitHolders().values()) {
             if ("space".equalsIgnoreCase(planetUnit.getName())) {
                 continue;
@@ -4050,9 +4055,10 @@ public class ButtonHelper {
         deleteMessage(event);
     }
 
-    public static List<Button> scanlinkResolution(Player player, Game game) {
-        Tile tile = game.getTileByPosition(game.getActiveSystem());
+    public static List<Button> scanlinkResolution(Player player, Tile tile, Game game) {
         List<Button> buttons = new ArrayList<>();
+        if (tile == null) return buttons;
+
         for (UnitHolder planetUnit : tile.getUnitHolders().values()) {
             if ("space".equalsIgnoreCase(planetUnit.getName())) {
                 continue;
@@ -4408,7 +4414,7 @@ public class ButtonHelper {
             buttons.add(Buttons.blue(finChecker + "purgeVaylerianHero", "Use Vaylerian Hero", FactionEmojis.vaylerian));
         }
         Tile active = game.getTileByPosition(game.getActiveSystem());
-        if (!active.isHomeSystem() && player.hasLeaderUnlocked("uydaihero")) {
+        if (active != null && !active.isHomeSystem() && player.hasLeaderUnlocked("uydaihero")) {
             buttons.add(Buttons.blue(finChecker + "purgeUydaiHero", "Use Uydai Hero", FactionEmojis.vaylerian));
         }
 
@@ -4444,6 +4450,9 @@ public class ButtonHelper {
         Map<String, Integer> displacedUnits = game.getMovedUnitsFromCurrentActivation();
         Map<String, String> planetRepresentations = Mapper.getPlanetRepresentations();
         Tile tile = game.getTileByPosition(game.getActiveSystem());
+        if (FOWPlusService.isVoid(game, game.getActiveSystem())) {
+            tile = FOWPlusService.voidTile(game.getActiveSystem());
+        }
         if (!game.getMovedUnitsFromCurrentActivation().isEmpty()) {
             tile = FlipTileService.flipTileIfNeeded(event, tile, game);
         }

--- a/src/main/java/ti4/helpers/ButtonHelperAgents.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAgents.java
@@ -1999,9 +1999,10 @@ public class ButtonHelperAgents {
         return buttons;
     }
 
-    public static List<Button> getL1Z1XAgentButtons(Game game, Player player) {
-        Tile tile = game.getTileByPosition(game.getActiveSystem());
+    public static List<Button> getL1Z1XAgentButtons(Game game, Tile tile, Player player) {
         List<Button> buttons = new ArrayList<>();
+        if (tile == null) return buttons;
+
         for (Planet planet : tile.getPlanetUnitHolders()) {
             String planetId = planet.getName();
             if (player.getPlanetsAllianceMode().contains(planetId) && FoWHelper.playerHasInfantryOnPlanet(player, tile, planetId)) {

--- a/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
+++ b/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
@@ -2547,6 +2547,9 @@ public class ButtonHelperFactionSpecific {
         }
 
         Tile tile = game.getTileByPosition(position);
+        if (FOWPlusService.isVoid(game, position)) {
+            tile = FOWPlusService.voidTile(position);
+        }
         List<Button> chooseTileButtons = new ArrayList<>();
         chooseTileButtons.add(Buttons.green("creussIFFResolve_" + type + "_" + tile.getPosition(), tile.getRepresentationForButtons(game, player)));
         chooseTileButtons.add(Buttons.red("blindIFFSelection_" + type + "~MDL", "Change Tile"));
@@ -2557,8 +2560,7 @@ public class ButtonHelperFactionSpecific {
     }
 
     public static boolean isTileCreussIFFSuitable(Game game, Player player, Tile tile) {
-        if (tile != null && tile.getTileModel() != null && tile.getTileModel().isHyperlane()
-            || FOWPlusService.isVoid(tile)) {
+        if (tile == null || tile.getTileModel() != null && tile.getTileModel().isHyperlane()) {
             return false;
         }
 
@@ -2736,9 +2738,12 @@ public class ButtonHelperFactionSpecific {
         event.getMessage().delete().queue();
     }
 
-    public static List<Button> getRohDhnaRecycleButtons(Game game, Player player) {
+    public static List<Button> getRohDhnaRecycleButtons(Game game, Tile tile, Player player) {
+        List<Button> buttons = new ArrayList<>();
+        if (tile == null) return buttons;
+
         List<UnitKey> availableUnits = new ArrayList<>();
-        Map<UnitKey, Integer> units = game.getTileByPosition(game.getActiveSystem()).getUnitHolders()
+        Map<UnitKey, Integer> units = tile.getUnitHolders()
             .get("space").getUnits();
         for (UnitKey unit : units.keySet()) {
             if (Objects.equals(unit.getColor(), player.getColor()) && (unit.getUnitType() == UnitType.Cruiser
@@ -2750,7 +2755,6 @@ public class ButtonHelperFactionSpecific {
             }
         }
 
-        List<Button> buttons = new ArrayList<>();
         for (UnitKey unit : availableUnits) {
             buttons.add(Buttons.green("FFCC_" + player.getFaction() + "_rohdhnaRecycle_" + unit.unitName(), unit.getUnitType().humanReadableName(), unit.unitEmoji()));
         }

--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -284,7 +284,7 @@ public class ButtonHelperTacticalAction {
 
     @ButtonHandler("doneWithTacticalAction")
     public static void concludeTacticalAction(Player player, Game game, ButtonInteractionEvent event) {
-        if (!game.isL1Hero()) {
+        if (!game.isL1Hero() && !FOWPlusService.isVoid(game, game.getActiveSystem())) {
             RiftSetModeService.concludeTacticalAction(player, game, event);
             ButtonHelper.exploreDET(player, game, event);
             ButtonHelperFactionSpecific.cleanCavUp(game, event);
@@ -375,8 +375,9 @@ public class ButtonHelperTacticalAction {
 
         String position = buttonID.contains("_") ? buttonID.split("_")[1] : game.getActiveSystem();
         Tile tile = game.getTileByPosition(position);
-        if (FOWPlusService.isVoid(tile)) {
+        if (FOWPlusService.isVoid(game, position)) {
             FOWPlusService.resolveVoidActivation(player, game);
+            tile = FOWPlusService.voidTile(position);
             message = "All units were lost.";
         }
 
@@ -396,7 +397,7 @@ public class ButtonHelperTacticalAction {
             && !game.playerHasLeaderUnlockedOrAlliance(player, "sardakkcommander")
             && tile.getUnitHolders().get("space").getUnitCount(UnitType.Infantry, player) < 1
             && tile.getUnitHolders().get("space").getUnitCount(UnitType.Mech, player) < 1
-            && !FOWPlusService.isVoid(tile)) {
+            && !FOWPlusService.isVoid(game, position)) {
             message = "Nothing moved. Use buttons to decide if you wish to build (if you can), or finish the activation.";
             systemButtons = ButtonHelper.moveAndGetLandingTroopsButtons(player, game, event);
             needPDSCheck = true;
@@ -632,19 +633,22 @@ public class ButtonHelperTacticalAction {
         game.setStoredValue("possiblyUsedRift", "");
         game.setStoredValue("lastActiveSystem", pos);
         List<Button> systemButtons = ButtonHelper.getTilesToMoveFrom(player, game, event);
-        Tile activeSystem = game.getTileByPosition(pos);
+        Tile tile = game.getTileByPosition(pos);
+        if (FOWPlusService.isVoid(game, pos)) {
+            tile = FOWPlusService.voidTile(pos);
+        }
         StringBuilder message = new StringBuilder(player.getRepresentationUnfogged() + " activated "
-            + activeSystem.getRepresentationForButtons(game, player) + ".");
+            + tile.getRepresentationForButtons(game, player) + ".");
 
         if (!game.isFowMode()) {
             for (Player player_ : game.getRealPlayers()) {
                 if (!game.isL1Hero() && !player.getFaction().equalsIgnoreCase(player_.getFaction())
                     && !player_.isPlayerMemberOfAlliance(player)
-                    && FoWHelper.playerHasUnitsInSystem(player_, activeSystem)) {
+                    && FoWHelper.playerHasUnitsInSystem(player_, tile)) {
                     message.append("\n").append(player_.getRepresentation()).append(" has units in the system.");
                 }
             }
-            for (UnitHolder planet : activeSystem.getPlanetUnitHolders()) {
+            for (UnitHolder planet : tile.getPlanetUnitHolders()) {
                 if (player.getPlanets().contains(planet.getName())) {
                     continue;
                 }
@@ -658,14 +662,14 @@ public class ButtonHelperTacticalAction {
         } else {
             List<Player> playersAdj = FoWHelper.getAdjacentPlayers(game, pos, true);
             for (Player player_ : playersAdj) {
-                String playerMessage = player_.getRepresentationUnfogged() + " - System " + activeSystem.getRepresentationForButtons(game, player_)
+                String playerMessage = player_.getRepresentationUnfogged() + " - System " + tile.getRepresentationForButtons(game, player_)
                     + " has been activated ";
                 MessageHelper.sendPrivateMessageToPlayer(player_, game, playerMessage);
             }
-            ButtonHelper.resolveOnActivationEnemyAbilities(game, activeSystem, player, false, event);
+            ButtonHelper.resolveOnActivationEnemyAbilities(game, tile, player, false, event);
         }
         if (game.playerHasLeaderUnlockedOrAlliance(player, "celdauricommander")
-            && ButtonHelper.getTilesOfPlayersSpecificUnits(game, player, UnitType.Spacedock).contains(activeSystem)) {
+            && ButtonHelper.getTilesOfPlayersSpecificUnits(game, player, UnitType.Spacedock).contains(tile)) {
             List<Button> buttons = new ArrayList<>();
             Button getCommButton = Buttons.blue("gain_1_comms", "Gain 1 Commodity", MiscEmojis.comm);
             buttons.add(getCommButton);
@@ -688,7 +692,6 @@ public class ButtonHelperTacticalAction {
             }
         }
 
-        Tile tile = game.getTileByPosition(pos);
         if (tile.getPlanetUnitHolders().isEmpty()
             && ButtonHelper.doesPlayerHaveFSHere("mortheus_flagship", player, tile)
             && !tile.getUnitHolders().get("space").getTokenList().contains(Mapper.getTokenID(Constants.FRONTIER))) {
@@ -700,7 +703,7 @@ public class ButtonHelperTacticalAction {
 
         MessageHelper.sendMessageToChannel(player.getCorrectChannel(), message.toString());
 
-        List<Button> button3 = ButtonHelperAgents.getL1Z1XAgentButtons(game, player);
+        List<Button> button3 = ButtonHelperAgents.getL1Z1XAgentButtons(game, tile, player);
         if (player.hasUnexhaustedLeader("l1z1xagent") && !button3.isEmpty() && !game.isL1Hero()) {
             String msg = player.getRepresentationUnfogged() + ", you can use buttons to resolve " + (player.hasUnexhaustedLeader("yssarilagent") ? "Clever Clever " : "")
                 + "I48S, the L1Z1Z" + (player.hasUnexhaustedLeader("yssarilagent") ? "/Yssaril" : "") + " agent, if you so wish.";
@@ -712,15 +715,15 @@ public class ButtonHelperTacticalAction {
                 player.getRepresentation() + ", you activated an anomaly, and so could now play _Harness Energy_.");
         }
 
-        List<Button> button2 = ButtonHelper.scanlinkResolution(player, game);
+        List<Button> button2 = ButtonHelper.scanlinkResolution(player, tile, game);
         if ((player.getTechs().contains("sdn") || player.getTechs().contains("absol_sdn")) && !button2.isEmpty() && !game.isL1Hero()) {
             MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), player.getRepresentation() + ", Please resolve _Scanlink Drone Network_.", button2);
             if (player.hasAbility("awaken") || player.hasUnit("titans_flagship") || player.hasUnit("sigma_ul_flagship_1") || player.hasUnit("sigma_ul_flagship_2")) {
-                ButtonHelper.resolveTitanShenanigansOnActivation(player, game, game.getTileByPosition(pos), event);
+                ButtonHelper.resolveTitanShenanigansOnActivation(player, game, tile, event);
             }
         } else {
             if (player.hasAbility("awaken")) {
-                ButtonHelper.resolveTitanShenanigansOnActivation(player, game, game.getTileByPosition(pos), event);
+                ButtonHelper.resolveTitanShenanigansOnActivation(player, game, tile, event);
             }
         }
         if (player.hasAbility("plague_reservoir") && player.hasTech("dxa")) {
@@ -742,14 +745,14 @@ public class ButtonHelperTacticalAction {
 
         // Resolve other abilities
         if (player.hasAbility("recycled_materials")) {
-            List<Button> buttons = ButtonHelperFactionSpecific.getRohDhnaRecycleButtons(game, player);
+            List<Button> buttons = ButtonHelperFactionSpecific.getRohDhnaRecycleButtons(game, tile, player);
             if (!buttons.isEmpty()) {
                 MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(),
                     "Use buttons to select which unit to recycle", buttons);
             }
         }
         if (player.hasRelic("absol_plenaryorbital") && !tile.isHomeSystem() && !tile.isMecatol() && !player.hasUnit("plenaryorbital")) {
-            List<Button> buttons4 = ButtonHelper.getAbsolOrbitalButtons(game, player);
+            List<Button> buttons4 = ButtonHelper.getAbsolOrbitalButtons(game, tile, player);
             if (!buttons4.isEmpty()) {
                 MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(),
                     "You can place down the _Plenary Orbital_.",
@@ -758,7 +761,7 @@ public class ButtonHelperTacticalAction {
         }
         if (!game.isFowMode()) {
             if (!game.isL1Hero()) {
-                ButtonHelper.resolveOnActivationEnemyAbilities(game, game.getTileByPosition(pos), player, false, event);
+                ButtonHelper.resolveOnActivationEnemyAbilities(game, tile, player, false, event);
             }
         }
         game.setStoredValue("crucibleBoost", "");

--- a/src/main/java/ti4/helpers/FoWHelper.java
+++ b/src/main/java/ti4/helpers/FoWHelper.java
@@ -636,6 +636,9 @@ public class FoWHelper {
      */
     public static List<Player> getAdjacentPlayers(Game game, String position, boolean includeSweep) {
         List<Player> players = new ArrayList<>();
+        if (FOWPlusService.isVoid(game, position))
+            return players;
+
         Set<String> tilesToCheck = getAdjacentTiles(game, position, null, false);
         Tile startingTile = game.getTileByPosition(position);
 
@@ -667,6 +670,8 @@ public class FoWHelper {
 
     /** Check if the specified player should have vision on the system */
     public static boolean playerIsInSystem(Game game, Tile tile, Player player, boolean forNeighbors) {
+        if (tile == null) return false;
+
         Set<String> unitHolderNames = tile.getUnitHolders().keySet();
         List<String> playerPlanets = player.getPlanetsAllianceMode();
         if (forNeighbors) {
@@ -699,13 +704,12 @@ public class FoWHelper {
 
     /** Check if the player has units in the system */
     public static boolean playerHasUnitsInSystem(Player player, Tile tile) {
-        return tile.containsPlayersUnits(player);
+        return tile != null && tile.containsPlayersUnits(player);
     }
 
     public static boolean playerHasPlanetsInSystem(Player player, Tile tile) {
-        if (tile == null || player == null) {
-            return false;
-        }
+        if (tile == null || player == null) return false;
+
         for (UnitHolder uH : tile.getPlanetUnitHolders()) {
             if (player.getPlanetsAllianceMode().contains(uH.getName())) {
                 return true;
@@ -717,8 +721,7 @@ public class FoWHelper {
 
     public static boolean playerHasShipsInSystem(Player player, Tile tile) {
         String colorID = Mapper.getColorID(player.getColor());
-        if (colorID == null)
-            return false; // player doesn't have a color
+        if (tile == null || colorID == null) return false;
 
         UnitHolder unitHolder = tile.getUnitHolders().get(Constants.SPACE);
         Map<UnitKey, Integer> units = new HashMap<>(unitHolder.getUnits());
@@ -733,8 +736,7 @@ public class FoWHelper {
 
     public static boolean playerHasActualShipsInSystem(Player player, Tile tile) {
         String colorID = Mapper.getColorID(player.getColor());
-        if (colorID == null)
-            return false; // player doesn't have a color
+        if (tile == null || colorID == null) return false;
 
         UnitHolder unitHolder = tile.getUnitHolders().get(Constants.SPACE);
         Map<UnitKey, Integer> units = new HashMap<>(unitHolder.getUnits());
@@ -773,8 +775,7 @@ public class FoWHelper {
 
     public static boolean playerHasFightersInSystem(Player player, Tile tile) {
         String colorID = Mapper.getColorID(player.getColor());
-        if (colorID == null)
-            return false; // player doesn't have a color
+        if (tile == null || colorID == null) return false; 
 
         UnitHolder unitHolder = tile.getUnitHolders().get(Constants.SPACE);
         Map<UnitKey, Integer> units = new HashMap<>(unitHolder.getUnits());
@@ -789,8 +790,8 @@ public class FoWHelper {
 
     public static boolean playerHasFightersInAdjacentSystems(Player player, Tile tile, Game game) {
         String colorID = Mapper.getColorID(player.getColor());
-        if (colorID == null)
-            return false; // player doesn't have a color
+        if (tile == null || colorID == null) return false;
+
         for (String pos : getAdjacentTilesAndNotThisTile(game, tile.getPosition(), player, false)) {
             Tile tile2 = game.getTileByPosition(pos);
             UnitHolder unitHolder = tile2.getUnitHolders().get(Constants.SPACE);
@@ -807,8 +808,7 @@ public class FoWHelper {
 
     public static boolean playerHasUnitsOnPlanet(Player player, UnitHolder unitHolder) {
         String colorID = Mapper.getColorID(player.getColor());
-        if (colorID == null)
-            return false; // player doesn't have a color
+        if (colorID == null) return false;
 
         Map<UnitKey, Integer> units = new HashMap<>(unitHolder.getUnits());
 
@@ -822,8 +822,7 @@ public class FoWHelper {
 
     public static boolean playerHasInfantryOnPlanet(Player player, Tile tile, String planet) {
         String colorID = Mapper.getColorID(player.getColor());
-        if (colorID == null)
-            return false; // player doesn't have a color
+        if (tile == null || colorID == null) return false;
 
         UnitHolder unitHolder = tile.getUnitHolders().get(planet);
         Map<UnitKey, Integer> units = new HashMap<>(unitHolder.getUnits());

--- a/src/main/java/ti4/helpers/SpinRingsHelper.java
+++ b/src/main/java/ti4/helpers/SpinRingsHelper.java
@@ -12,7 +12,6 @@ import ti4.map.Game;
 import ti4.map.Player;
 import ti4.map.Tile;
 import ti4.message.MessageHelper;
-import ti4.service.fow.FOWPlusService;
 import ti4.service.fow.FowCommunicationThreadService;
 
 @UtilityClass
@@ -109,7 +108,7 @@ public class SpinRingsHelper {
             if (steps > 0) {
                 for (int x = 1; x < (ring * 6 + 1); x++) {
                     Tile tile = game.getTileByPosition(ring + (x < 10 ? "0" : "") + x);
-                    if (tile == null || FOWPlusService.isVoid(tile)) {
+                    if (tile == null) {
                         continue;
                     }
 
@@ -181,7 +180,7 @@ public class SpinRingsHelper {
                 } else {
                     tile = game.getTileByPosition(y + "" + x);
                 }
-                if (tile == null || FOWPlusService.isVoid(tile)) {
+                if (tile == null) {
                     continue;
                 } 
 

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -90,7 +90,6 @@ import ti4.model.UnitModel;
 import ti4.model.metadata.AutoPingMetadataManager;
 import ti4.service.emoji.MiscEmojis;
 import ti4.service.emoji.SourceEmojis;
-import ti4.service.fow.FOWPlusService;
 import ti4.service.leader.CommanderUnlockCheckService;
 import ti4.service.milty.MiltyDraftManager;
 import ti4.service.option.FOWOptionService.FOWOption;
@@ -3284,8 +3283,7 @@ public class Game extends GameProperties {
 
     public Tile getTileByPosition(String position) {
         if (position == null) return null;
-        Tile tile = tileMap.get(position);
-        return tile == null && FOWPlusService.isActive(this) ? FOWPlusService.voidTile(position) : tile;
+        return tileMap.get(position);
     }
 
     public boolean isTileDuplicated(String tileID) {

--- a/src/main/java/ti4/service/fow/FOWPlusService.java
+++ b/src/main/java/ti4/service/fow/FOWPlusService.java
@@ -33,7 +33,7 @@ import ti4.service.emoji.MiscEmojis;
 import ti4.service.option.FOWOptionService.FOWOption;
 
 /*
-  To activate Extra Dark mode use /fow fow_options
+  To activate FoW+ mode use /fow fow_options
 
   * 0b tiles are hidden
   * Adjacent hyperlanes that don't connect to the viewing tile are hidden
@@ -53,7 +53,7 @@ public class FOWPlusService {
 
     //Only allow activating positions player can see
     public static boolean canActivatePosition(String position, Player player, Game game) {
-        return !isActive(game) || !isVoid(game, position) && FoWHelper.getTilePositionsToShow(game, player).contains(position);
+        return !isActive(game) || FoWHelper.getTilePositionsToShow(game, player).contains(position);
     }
 
     //Hide all 0b tiles from FoW map
@@ -62,16 +62,11 @@ public class FOWPlusService {
     }
 
     public static boolean isVoid(Game game, String position) {
-        return game.getTileByPosition(position).getTileID().equals(VOID_TILEID);
+        return isActive(game) && game.getTileByPosition(position) == null;
     }
 
-    public static boolean isVoid(Tile tile) {
-        return tile != null && VOID_TILEID.equals(tile.getTileID());
-    }
-
-    //Only return a void tile if looking for a valid position without a tile
     public static Tile voidTile(String position) {
-        return PositionMapper.isTilePositionValid(position) ? new Tile(VOID_TILEID, position) : null;
+        return new Tile(VOID_TILEID, position);
     }
 
     @ButtonHandler("blindTileSelection~MDL")
@@ -100,6 +95,9 @@ public class FOWPlusService {
 
         String targetPosition = position;
         Tile tile = game.getTileByPosition(targetPosition);
+        if (tile == null) {
+            tile = voidTile(targetPosition);
+        }
 
         List<Button> chooseTileButtons = new ArrayList<>();
         chooseTileButtons.add(Buttons.green(finChecker + "ringTile_" + targetPosition, tile.getRepresentationForButtons(game, player)));


### PR DESCRIPTION
Having game.getTileByPosition() return a dummy Void tile for positions witthout a tile in FoW Plus mode was a bit risky as that was used so much everywhere. Changed that there's no global "Void" tile, but just ability to activate null tiles.

So added a bunch of null checks too.