### PR TITLE
Fix performance by using stream counts

### DIFF
--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -2625,7 +2625,9 @@ public class AgendaHelper {
 
             if (CollectionUtils.containsAny(player.getRelics(),
                 List.of("absol_shardofthethrone1", "absol_shardofthethrone2", "absol_shardofthethrone3"))) {
-                int count = player.getRelics().stream().filter(s -> s.contains("absol_shardofthethrone")).toList().size();
+                int count = (int) player.getRelics().stream()
+                    .filter(s -> s.contains("absol_shardofthethrone"))
+                    .count();
                 int shardVotes = 2 * count; // +2 votes per Absol shard
                 Button button = Buttons.gray("exhaustForVotes_absolShard_" + shardVotes,
                     "Use Shard of the Throne Votes (" + shardVotes + ")", SourceEmojis.Absol);
@@ -3125,7 +3127,9 @@ public class AgendaHelper {
         }
 
         // Absol Shard of the Throne
-        int shardCount = player.getRelics().stream().filter(s -> s.contains("absol_shardofthethrone")).toList().size();
+        int shardCount = (int) player.getRelics().stream()
+            .filter(s -> s.contains("absol_shardofthethrone"))
+            .count();
         if (shardCount > 0) { // +2 votes per Absol shard
             int shardVotes = 2 * shardCount;
             additionalVotesAndSources.put(

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -129,10 +129,12 @@ public class MapGenerator implements AutoCloseable {
             scoreTokenSpacing = 30;
 
         // Height of objectives section (=0 when there is 5 or less objectives in the column with most objectives)
-        int stage1PublicObjCount = game.getRevealedPublicObjectives().keySet().stream()
-            .filter(Mapper.getPublicObjectivesStage1()::containsKey).toList().size();
-        int stage2PublicObjCount = game.getRevealedPublicObjectives().keySet().stream()
-            .filter(Mapper.getPublicObjectivesStage2()::containsKey).toList().size();
+        int stage1PublicObjCount = (int) game.getRevealedPublicObjectives().keySet().stream()
+            .filter(Mapper.getPublicObjectivesStage1()::containsKey)
+            .count();
+        int stage2PublicObjCount = (int) game.getRevealedPublicObjectives().keySet().stream()
+            .filter(Mapper.getPublicObjectivesStage2()::containsKey)
+            .count();
         int otherObjCount = game.getRevealedPublicObjectives().size() - stage1PublicObjCount - stage2PublicObjCount;
         stage1PublicObjCount = game.getPublicObjectives1Peakable().size() + stage1PublicObjCount;
         stage2PublicObjCount = game.getPublicObjectives2Peakable().size() + stage2PublicObjCount;

--- a/src/main/java/ti4/listeners/UserLeaveServerListener.java
+++ b/src/main/java/ti4/listeners/UserLeaveServerListener.java
@@ -63,9 +63,9 @@ public class UserLeaveServerListener extends ListenerAdapter {
     }
 
     private static int userTotalGames(ManagedPlayer user) {
-        return user.getGames().stream()
+        return (int) user.getGames().stream()
             .filter(mg -> !mg.isHasEnded() && !mg.isHasWinner() && !mg.isVpGoalReached())
-            .toList().size();
+            .count();
     }
 
     private static Game gameWasReallyLeft(Guild guild, ManagedPlayer mPlayer, ManagedGame mGame) {

--- a/src/main/java/ti4/service/milty/GenerateSlicesService.java
+++ b/src/main/java/ti4/service/milty/GenerateSlicesService.java
@@ -39,7 +39,9 @@ public class GenerateSlicesService {
 
         List<MiltyDraftTile> allTiles = draftManager.getBlue();
         allTiles.addAll(draftManager.getRed());
-        int totalWHs = allTiles.stream().filter(tile -> tile.isHasAlphaWH() || tile.isHasBetaWH() || tile.isHasOtherWH()).toList().size();
+        int totalWHs = (int) allTiles.stream()
+            .filter(tile -> tile.isHasAlphaWH() || tile.isHasBetaWH() || tile.isHasOtherWH())
+            .count();
         int extraWHs = Math.min(totalWHs - 1, (int) (sliceCount * 1.5));
         if (specs.playerIDs.size() == 1) extraWHs = 0; //disable the behavior if there's only 1 player
         if (specs.playerIDs.size() == 2) extraWHs = 3; //lessen the behavior if there's 2 players


### PR DESCRIPTION
## Summary
- replace creation of temporary lists for counting elements with `count()` calls in stream operations

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8f5c2ff0832d82a9ceeffdba6cb1