### PR TITLE
Fix 'received' typo in message

### DIFF
--- a/src/main/java/ti4/service/fow/RiftSetModeService.java
+++ b/src/main/java/ti4/service/fow/RiftSetModeService.java
@@ -146,7 +146,7 @@ public class RiftSetModeService {
         PromissoryNoteHelper.sendPromissoryNoteInfo(game, winner, false);
 
         PromissoryNoteModel pnModel = Mapper.getPromissoryNotes().get(CRUCIBLE_PN);
-        MessageHelper.sendMessageToChannel(winner.getCorrectChannel(), winner.getRepresentation(true, true) + ", you recieved " + CardEmojis.PN + pnModel.getName());
+        MessageHelper.sendMessageToChannel(winner.getCorrectChannel(), winner.getRepresentation(true, true) + ", you received " + CardEmojis.PN + pnModel.getName());
     }
 
     public static void resolveExplore(String exploreCardId, Player player, Game game) {


### PR DESCRIPTION
## Summary
- correct `recieved` typo to `received` in `RiftSetModeService`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8f16a0b0832da5a22cde50a3072f