### PR TITLE
Fix timestamp exception handling

### DIFF
--- a/src/main/java/ti4/map/GameStatsDashboardPayload.java
+++ b/src/main/java/ti4/map/GameStatsDashboardPayload.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.DateTimeException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -236,7 +237,7 @@ public class GameStatsDashboardPayload {
     public long getTimestamp() {
         try {
             return Instant.ofEpochMilli(game.getLastModifiedDate()).getEpochSecond();
-        } catch (DateTimeParseException e) {
+        } catch (DateTimeException e) {
             return Instant.now().getEpochSecond();
         }
     }


### PR DESCRIPTION
## Summary
- fix fallback exception type for timestamp generation

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d8ef3adb4832d8dd83356e140f1bd