### PR TITLE
Fix DateTimeHelper typo and expand tests

### DIFF
--- a/src/main/java/ti4/helpers/DateTimeHelper.java
+++ b/src/main/java/ti4/helpers/DateTimeHelper.java
@@ -51,7 +51,7 @@ public class DateTimeHelper {
 
         long nanoSeconds = totalNanoSeconds % 1000;
         long microSeconds = totalMicroSeconds % 1000;
-        long milleSeconds = totalMilliSeconds % 1000;
+        long milliSeconds = totalMilliSeconds % 1000;
         // long minutes = totalMinutes % 60;
         // long hours = totalHours % 24;
         // long days = totalDays;
@@ -61,7 +61,7 @@ public class DateTimeHelper {
         // sb.append(String.format("%02dm:", minutes));
 
         return String.format("%02ds:", totalSeconds) +
-            String.format("%03d:", milleSeconds) +
+            String.format("%03d:", milliSeconds) +
             String.format("%03d:", microSeconds) +
             String.format("%03d", nanoSeconds);
     }

--- a/src/test/java/ti4/helpers/DateTimeHelperTest.java
+++ b/src/test/java/ti4/helpers/DateTimeHelperTest.java
@@ -20,4 +20,20 @@ class DateTimeHelperTest {
         long actualDateTime = DateTimeHelper.getLongDateTimeFromDiscordSnowflake(snowflake);
         assertThat(actualDateTime).isEqualTo(expectedDateTime);
     }
+
+    @Test
+    void testGetTimeRepresentationNanoSeconds() {
+        assertThat(DateTimeHelper.getTimeRepresentationNanoSeconds(0L))
+            .isEqualTo("00s:000:000:000");
+        assertThat(DateTimeHelper.getTimeRepresentationNanoSeconds(1_000_000_000L))
+            .isEqualTo("01s:000:000:000");
+        assertThat(DateTimeHelper.getTimeRepresentationNanoSeconds(1_000_000L))
+            .isEqualTo("00s:001:000:000");
+    }
+
+    @Test
+    void testGetTimeRepresentationToMilliseconds() {
+        assertThat(DateTimeHelper.getTimeRepresentationToMilliseconds(12_345L))
+            .isEqualTo("00m:12s:345ms");
+    }
 }


### PR DESCRIPTION
## Summary
- fix milliSeconds variable typo in `DateTimeHelper`
- add tests covering nano and millisecond helper methods

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea830f154832d8f3d78d91610d1ad