### PR TITLE
Bot Colour Reacts

### DIFF
--- a/src/main/java/ti4/commands/custom/CustomizationOptions.java
+++ b/src/main/java/ti4/commands/custom/CustomizationOptions.java
@@ -29,6 +29,7 @@ class CustomizationOptions extends GameStateSubcommand {
         addOptions(new OptionData(OptionType.STRING, Constants.VERBOSITY, "Verbosity of bot output. Verbose/Average/Minimal  (Default = Verbose)").addChoices(verbChoices));
         addOptions(new OptionData(OptionType.STRING, Constants.CC_N_PLASTIC_LIMIT, "Turn ON or OFF pings for exceeding component limits").addChoices(onOff));
         addOptions(new OptionData(OptionType.STRING, Constants.BOT_FACTION_REACTS, "Turn ON or OFF the bot leaving your faction react on msgs").addChoices(onOff));
+        addOptions(new OptionData(OptionType.STRING, Constants.BOT_COLOR_REACTS, "Turn ON or OFF the bot leaving your color react on msgs").addChoices(onOff));
         addOptions(new OptionData(OptionType.STRING, Constants.BOT_STRAT_REACTS, "Turn ON or OFF the bot leaving your strategy card react on msgs").addChoices(onOff));
         addOptions(new OptionData(OptionType.STRING, Constants.SPIN_MODE, "Automatically spin rings at status cleanup. ON for Fin logic, insert custom logic, OFF to turn off"));
         addOptions(new OptionData(OptionType.BOOLEAN, Constants.SHOW_UNIT_TAGS, "Show faction unit tags on map images"));
@@ -77,6 +78,15 @@ class CustomizationOptions extends GameStateSubcommand {
                 game.setBotFactionReacts(true);
             } else if ("OFF".equalsIgnoreCase(ccNP)) {
                 game.setBotFactionReacts(false);
+            }
+        }
+        OptionMapping colorReacts = event.getOption(Constants.BOT_COLOR_REACTS);
+        if (colorReacts != null) {
+            String ccNP = colorReacts.getAsString();
+            if ("ON".equalsIgnoreCase(ccNP)) {
+                game.setBotColorReacts(true);
+            } else if ("OFF".equalsIgnoreCase(ccNP)) {
+                game.setBotColorReacts(false);
             }
         }
 

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1032,6 +1032,7 @@ public class Constants {
     public static final String CC_N_PLASTIC_LIMIT = "cc_n_plastic_limit";
     public static final String DRAFT_MODE = "draft_mode";
     public static final String BOT_FACTION_REACTS = "bot_faction_reacts";
+    public static final String BOT_COLOR_REACTS = "bot_color_reacts";
     public static final String BOT_STRAT_REACTS = "bot_strat_reacts";
     public static final String HAS_HAD_A_STATUS_PHASE = "has_had_a_status_phase";
     public static final String BOT_SHUSHING = "bot_shushing";

--- a/src/main/java/ti4/listeners/MessageListener.java
+++ b/src/main/java/ti4/listeners/MessageListener.java
@@ -27,6 +27,7 @@ import ti4.map.manage.ManagedGame;
 import ti4.message.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.service.emoji.CardEmojis;
+import ti4.service.emoji.ColorEmojis;
 import ti4.service.fow.FOWCombatThreadMirroring;
 import ti4.service.fow.WhisperService;
 import ti4.service.game.CreateGameService;
@@ -255,7 +256,7 @@ public class MessageListener extends ListenerAdapter {
                     });
             }
         }
-        if (managedGame == null || (!managedGame.isFactionReactMode() && !managedGame.isStratReactMode()) || managedGame.isFowMode()) {
+        if (managedGame == null || (!managedGame.isFactionReactMode() && !managedGame.isColorReactMode() && !managedGame.isStratReactMode()) || managedGame.isFowMode()) {
             return false;
         }
         Game game = managedGame.getGame();
@@ -268,8 +269,12 @@ public class MessageListener extends ListenerAdapter {
                 .retrievePast(2)
                 .queue(messages -> {
                     if (messages.size() == 2 && !event.getMessage().getAuthor().getId().equalsIgnoreCase(messages.get(1).getAuthor().getId())) {
-                        var emoji = Emoji.fromFormatted(player.getFactionEmoji());
                         if (managedGame.isFactionReactMode()) {
+                            var emoji = Emoji.fromFormatted(player.getFactionEmoji());
+                            messages.getFirst().addReaction(emoji).queue();
+                        }
+                        if (managedGame.isColorReactMode()) {
+                            var emoji = ColorEmojis.getColorEmoji(player.getColor()).asEmoji();
                             messages.getFirst().addReaction(emoji).queue();
                         }
                         if (managedGame.isStratReactMode()) {

--- a/src/main/java/ti4/map/GameProperties.java
+++ b/src/main/java/ti4/map/GameProperties.java
@@ -68,6 +68,7 @@ public class GameProperties {
 
     // Customization Flags/Settings
     private boolean botFactionReacts;
+    private boolean botColorReacts;
     private boolean botStratReacts;
     private boolean botShushing;
     private boolean ccNPlasticLimit = true;

--- a/src/main/java/ti4/map/manage/GameLoadService.java
+++ b/src/main/java/ti4/map/manage/GameLoadService.java
@@ -618,6 +618,7 @@ class GameLoadService {
                 case Constants.HACK_ELECTION_STATUS -> game.setHasHackElectionBeenPlayed(loadBooleanOrDefault(info, false));
                 case Constants.CC_N_PLASTIC_LIMIT -> game.setCcNPlasticLimit(loadBooleanOrDefault(info, false));
                 case Constants.BOT_FACTION_REACTS -> game.setBotFactionReacts(loadBooleanOrDefault(info, false));
+                case Constants.BOT_COLOR_REACTS -> game.setBotColorReacts(loadBooleanOrDefault(info, false));
                 case Constants.BOT_STRAT_REACTS -> game.setBotStratReacts(loadBooleanOrDefault(info, false));
                 case Constants.HAS_HAD_A_STATUS_PHASE -> game.setHasHadAStatusPhase(loadBooleanOrDefault(info, false));
                 case Constants.BOT_SHUSHING -> game.setBotShushing(loadBooleanOrDefault(info, false));

--- a/src/main/java/ti4/map/manage/GameSaveService.java
+++ b/src/main/java/ti4/map/manage/GameSaveService.java
@@ -433,6 +433,8 @@ class GameSaveService {
         writer.write(System.lineSeparator());
         writer.write(Constants.BOT_FACTION_REACTS + " " + game.isBotFactionReacts());
         writer.write(System.lineSeparator());
+        writer.write(Constants.BOT_COLOR_REACTS + " " + game.isBotColorReacts());
+        writer.write(System.lineSeparator());
         writer.write(Constants.BOT_STRAT_REACTS + " " + game.isBotStratReacts());
         writer.write(System.lineSeparator());
         writer.write(Constants.HAS_HAD_A_STATUS_PHASE + " " + game.isHasHadAStatusPhase());

--- a/src/main/java/ti4/map/manage/ManagedGame.java
+++ b/src/main/java/ti4/map/manage/ManagedGame.java
@@ -27,6 +27,7 @@ public class ManagedGame { // BE CAREFUL ADDING FIELDS TO THIS CLASS, AS IT CAN 
     private final boolean vpGoalReached;
     private final boolean fowMode;
     private final boolean factionReactMode;
+    private final boolean colorReactMode;
     private final boolean stratReactMode;
     private final boolean injectRules;
     private final String creationDate;
@@ -51,6 +52,7 @@ public class ManagedGame { // BE CAREFUL ADDING FIELDS TO THIS CLASS, AS IT CAN 
         vpGoalReached = game.getPlayers().values().stream().anyMatch(player -> player.getTotalVictoryPoints() >= game.getVp());
         fowMode = game.isFowMode();
         factionReactMode = game.isBotFactionReacts();
+        colorReactMode = game.isBotColorReacts();
         stratReactMode = game.isBotStratReacts();
         injectRules = game.isInjectRulesLinks();
         creationDate = game.getCreationDate();


### PR DESCRIPTION
Adds `/custom customization bot_color_reacts:`, which will have the bot react with the colour (destroyer) emoji, in the same vein as faction and strategy card reacts.
![image](https://github.com/user-attachments/assets/7f3b0407-085e-4d91-b76b-5e9f544f9d53)
