### PR TITLE
Include action card lore when played

### DIFF
--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -410,7 +410,8 @@ public class ActionCardHelper {
                     + " Use buttons to decide whether to Sabo _" + actionCardTitle + "_.", xxchaButtons);
             }
         }
-        MessageEmbed acEmbed = actionCard.getRepresentationEmbed();
+        // Include flavor text when showing the action card that was played
+        MessageEmbed acEmbed = actionCard.getRepresentationEmbed(false, true);
         if (acID.contains("sabo")) {
             MessageHelper.sendMessageToChannelWithEmbed(mainGameChannel, message, acEmbed);
         } else {

--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -410,7 +410,6 @@ public class ActionCardHelper {
                     + " Use buttons to decide whether to Sabo _" + actionCardTitle + "_.", xxchaButtons);
             }
         }
-        // Include flavor text when showing the action card that was played
         MessageEmbed acEmbed = actionCard.getRepresentationEmbed(false, true);
         if (acID.contains("sabo")) {
             MessageHelper.sendMessageToChannelWithEmbed(mainGameChannel, message, acEmbed);


### PR DESCRIPTION
## Summary
- show action card flavor text in the embed when a card is played

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9b5a94cc832dae7faa671d04d025