### PR TITLE
Add faction performance statistic

### DIFF
--- a/src/main/java/ti4/service/statistics/game/FactionPerformanceStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/FactionPerformanceStatisticsService.java
@@ -1,0 +1,64 @@
+package ti4.service.statistics.game;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.apache.commons.lang3.StringUtils;
+import ti4.commands.statistics.GameStatisticsFilterer;
+import ti4.image.Mapper;
+import ti4.map.Game;
+import ti4.map.GamesPage;
+import ti4.map.Player;
+import ti4.message.MessageHelper;
+import ti4.model.FactionModel;
+
+@UtilityClass
+class FactionPerformanceStatisticsService {
+
+    public static void showFactionPerformance(SlashCommandInteractionEvent event) {
+        Map<String, Integer> factionWinCount = new HashMap<>();
+        Map<String, Integer> factionGameCount = new HashMap<>();
+        Map<String, Integer> factionPlayerTotals = new HashMap<>();
+
+        GamesPage.consumeAllGames(
+            GameStatisticsFilterer.getGamesFilter(event),
+            game -> calculate(game, factionWinCount, factionGameCount, factionPlayerTotals)
+        );
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Faction Performance (vs expected win rate):\n");
+        Mapper.getFactionsValues().stream()
+            .map(faction -> {
+                int wins = factionWinCount.getOrDefault(faction.getAlias(), 0);
+                int games = factionGameCount.getOrDefault(faction.getAlias(), 0);
+                int totalPlayers = factionPlayerTotals.getOrDefault(faction.getAlias(), 0);
+                double performance = games == 0 ? 0 : ((wins / (double) games) * (totalPlayers / (double) games) - 1) * 100;
+                return Map.entry(faction, performance);
+            })
+            .filter(entry -> factionGameCount.containsKey(entry.getKey().getAlias()))
+            .sorted(Map.Entry.<FactionModel, Double>comparingByValue().reversed())
+            .forEach(entry -> sb.append("`")
+                .append(StringUtils.leftPad(String.format("%.2f", entry.getValue()), 6))
+                .append("%` (")
+                .append(factionGameCount.getOrDefault(entry.getKey().getAlias(), 0))
+                .append(" games) ")
+                .append(entry.getKey().getFactionEmoji()).append(" ")
+                .append(entry.getKey().getFactionNameWithSourceEmoji())
+                .append("\n"));
+        MessageHelper.sendMessageToThread((MessageChannelUnion) event.getMessageChannel(), "Faction Performance", sb.toString());
+    }
+
+    private static void calculate(Game game, Map<String, Integer> winCount, Map<String, Integer> gameCount,
+                                   Map<String, Integer> playerTotals) {
+        int playerCount = game.getRealAndEliminatedPlayers().size();
+        game.getWinner().ifPresent(winner -> winCount.merge(winner.getFaction(), 1, Integer::sum));
+        for (Player player : game.getRealAndEliminatedAndDummyPlayers()) {
+            String faction = player.getFaction();
+            gameCount.merge(faction, 1, Integer::sum);
+            playerTotals.merge(faction, playerCount, Integer::sum);
+        }
+    }
+}

--- a/src/main/java/ti4/service/statistics/game/GameStatTypes.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatTypes.java
@@ -12,6 +12,7 @@ public enum GameStatTypes {
     FACTION_WINS("Wins per Faction", "Show the wins per faction"),
     SOS_SCORED("Times a secret objective has been scored", "Show the amount of times each secret objective was scored"),
     FACTION_WIN_PERCENT("Faction win percent", "Shows each faction's win percent rounded to the nearest integer"),
+    FACTION_PERFORMANCE("Faction performance", "Shows how much each faction over or under performs its expected win rate"),
     COLOUR_WINS("Wins per Colour", "Show the wins per colour"),
     WINNING_PATH("Winners Path to Victory", "Shows a count of each game's path to victory"),
     PHASE_TIMES("Phase Times", "Shows how long each phase lasted, in days"),

--- a/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
@@ -33,6 +33,7 @@ public class GameStatisticsService {
             case PHASE_TIMES -> RoundTimeStatisticsService.getRoundTimes(event);
             case SOS_SCORED -> VictoryPointsScoredStatisticsService.listScoredVictoryPoints(event);
             case FACTION_WIN_PERCENT -> FactionWinPercentStatisticsService.getFactionWinPercent(event);
+            case FACTION_PERFORMANCE -> FactionPerformanceStatisticsService.showFactionPerformance(event);
             case COLOUR_WINS -> MostWinningColorStatisticsService.showMostWinningColor(event);
             case GAME_COUNT -> GameCountStatisticsService.getGameCount(event);
             case WINNING_PATH -> WinningPathsStatisticsService.showWinningPaths(event);


### PR DESCRIPTION
## Summary
- add new `FactionPerformanceStatisticsService`
- track faction performance vs expected win rate
- expose the statistic via `GameStatTypes` and `GameStatisticsService`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9b9ba300832d879bdd5d2cdfb710