### PR TITLE
Retry message send on Discord timeout

### DIFF
--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -17,6 +17,8 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.function.Consumers;
 import org.jetbrains.annotations.NotNull;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import java.net.SocketTimeoutException;
 
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -405,10 +407,9 @@ public class MessageHelper {
         while (iterator.hasNext()) {
             MessageCreateData messageCreateData = iterator.next();
             if (iterator.hasNext()) { // not last message
-                channel.sendMessage(messageCreateData).queue(null,
-                    error -> BotLogger.error(getRestActionFailureMessage(channel, "Failed to send intermediate message", messageCreateData, error), error));
+                sendMessageWithRetry(channel, messageCreateData, null, "Failed to send intermediate message", 1);
             } else { // last message, do action
-                channel.sendMessage(messageCreateData).queue(message -> {
+                sendMessageWithRetry(channel, messageCreateData, message -> {
                     ManagedGame managedGame = GameManager.getManagedGame(gameName);
                     if (finalMessageText != null && managedGame != null && !managedGame.isFowMode()) {
                         if (finalMessageText.contains("Use buttons to do your turn") || finalMessageText.contains("Use buttons to end turn")) {
@@ -420,9 +421,31 @@ public class MessageHelper {
                     if (restAction != null) {
                         restAction.run(message);
                     }
-                }, error -> BotLogger.error(getRestActionFailureMessage(channel, finalMessageText, messageCreateData, error), error));
+                }, finalMessageText, 1);
             }
         }
+    }
+
+    private static void sendMessageWithRetry(
+        MessageChannel channel,
+        MessageCreateData messageCreateData,
+        MessageFunction successAction,
+        String errorHeader,
+        int remainingAttempts
+    ) {
+        channel.sendMessage(messageCreateData).queue(message -> {
+            if (successAction != null) {
+                successAction.run(message);
+            }
+        }, error -> {
+            boolean shouldRetry = error instanceof ErrorResponseException && error.getCause() instanceof SocketTimeoutException && remainingAttempts > 0;
+            if (shouldRetry) {
+                BotLogger.warning(getRestActionFailureMessage(channel, errorHeader + " (retrying)", messageCreateData, error), error);
+                sendMessageWithRetry(channel, messageCreateData, successAction, errorHeader, remainingAttempts - 1);
+            } else {
+                BotLogger.error(getRestActionFailureMessage(channel, errorHeader, messageCreateData, error), error);
+            }
+        });
     }
 
     public static String getRestActionFailureMessage(MessageChannel channel, String errorHeader, MessageCreateData messageCreateData, Throwable error) {


### PR DESCRIPTION
## Summary
- handle intermittent Discord timeouts by retrying failed message sends

## Testing
- `mvn -q test` *(fails: `mvn` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687b342d74ec832d9e24577a787c0df0