### PR TITLE
Handle missing send permission

### DIFF
--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.api.entities.channel.attribute.IThreadContainer;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel.AutoArchiveDuration;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.entities.emoji.CustomEmoji;
@@ -371,6 +372,18 @@ public class MessageHelper {
     private static void splitAndSentWithAction(String messageText, MessageChannel channel, MessageFunction restAction, List<MessageEmbed> embeds, List<Button> buttons) {
         if (channel == null) {
             return;
+        }
+
+        if (channel instanceof GuildMessageChannel guildChannel) {
+            try {
+                if (!guildChannel.canTalk()) {
+                    BotLogger.warning(guildChannel.getAsMention() + " Bot missing permission to send messages");
+                    return;
+                }
+            } catch (Exception e) {
+                BotLogger.error("Permission check failure for channel: " + guildChannel.getId(), e);
+                return;
+            }
         }
 
         List<MessageEmbed> sanitizedEmbeds;


### PR DESCRIPTION
## Summary
- check bot permissions before sending a message

## Testing
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b5b8f3848832d9c6167e66663c98d