### PR TITLE
Filter out early round games from statistics

### DIFF
--- a/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
+++ b/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
@@ -26,6 +26,8 @@ public class GameStatisticsFilterer {
     public static final String WINNING_FACTION_FILTER = "winning_faction";
     public static final String EXCLUDED_GAME_TYPES_FILTER = "exclude_game_types";
 
+    private static final int MINIMUM_ROUND = 3;
+
     public static List<OptionData> gameStatsFilters() {
         List<OptionData> filters = new ArrayList<>();
         filters.add(new OptionData(OptionType.INTEGER, GameStatisticsFilterer.PLAYER_COUNT_FILTER, "Filter games by player count, e.g. 3-8"));
@@ -60,7 +62,8 @@ public class GameStatisticsFilterer {
             .and(game -> filterOnHomebrew(homebrewFilter, game))
             .and(game -> filterOnHasWinner(hasWinnerFilter, game))
             .and(game -> filterOnWinningFaction(winningFactionFilter, game))
-            .and(GameStatisticsFilterer::filterAbortedGames);
+            .and(GameStatisticsFilterer::filterAbortedGames)
+            .and(GameStatisticsFilterer::filterEarlyRounds);
     }
 
     private static boolean filterOnWinningFaction(String winningFactionFilter, Game game) {
@@ -76,7 +79,8 @@ public class GameStatisticsFilterer {
             .and(game -> filterOnVictoryPointGoal(victoryPointGoalFilter, game))
             .and(game -> filterOnHomebrew(Boolean.FALSE, game))
             .and(game -> filterOnHasWinner(Boolean.TRUE, game))
-            .and(GameStatisticsFilterer::filterAbortedGames);
+            .and(GameStatisticsFilterer::filterAbortedGames)
+            .and(GameStatisticsFilterer::filterEarlyRounds);
     }
 
     private static boolean filterOnFogType(Boolean fogFilter, Game game) {
@@ -125,6 +129,10 @@ public class GameStatisticsFilterer {
 
     private static boolean filterAbortedGames(Game game) {
         return !game.isHasEnded() || game.getWinner().isPresent();
+    }
+
+    private static boolean filterEarlyRounds(Game game) {
+        return game.getRound() >= MINIMUM_ROUND;
     }
 
     private static boolean filterOnHomebrew(Boolean homebrewFilter, Game game) {

--- a/src/test/java/ti4/commands/statistics/GameStatisticsFiltererTest.java
+++ b/src/test/java/ti4/commands/statistics/GameStatisticsFiltererTest.java
@@ -1,0 +1,37 @@
+package ti4.commands.statistics;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.testUtils.BaseTi4Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameStatisticsFiltererTest extends BaseTi4Test {
+    @Test
+    void filterRemovesGamesWithTwoRoundsOrLess() {
+        Game round1 = createGame(1);
+        Game round2 = createGame(2);
+        Game round3 = createGame(3);
+
+        Predicate<Game> filter = GameStatisticsFilterer.getNormalFinishedGamesFilter(null, null);
+
+        assertThat(filter.test(round1)).isFalse();
+        assertThat(filter.test(round2)).isFalse();
+        assertThat(filter.test(round3)).isTrue();
+    }
+
+    private Game createGame(int round) {
+        Game game = new Game();
+        game.setRound(round);
+        game.setVp(0);
+        game.setHasEnded(true);
+        Player player = new Player("p1", "p1", game);
+        game.setPlayers(Map.of("p1", player));
+        return game;
+    }
+}


### PR DESCRIPTION
## Summary
- exclude games that are only two rounds or shorter from stats calculations
- add a unit test to verify the filter

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b70a25730832d8dfc40172ff492fa