### PR TITLE
Optimize settings persistence

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -305,6 +305,7 @@ public class AsyncTI4DiscordBot {
                     BotLogger.info("DID NOT FINISH PROCESSING STATISTICS");
                 }
                 CronManager.shutdown(); // will wait for up to an additional 20 seconds
+                GlobalSettings.shutdown();
                 BotLogger.info("SHUTDOWN PROCESS COMPLETE");
                 TimeUnit.SECONDS.sleep(1); // wait for BotLogger
                 jda.shutdown();


### PR DESCRIPTION
## Summary
- batch writes to `global_settings.json`
- ensure settings save at shutdown

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b8379e708832da6b002d3b56b2a06