### PR TITLE
fix null check for Cabal spacedock

### DIFF
--- a/src/main/java/ti4/map/Tile.java
+++ b/src/main/java/ti4/map/Tile.java
@@ -540,8 +540,11 @@ public class Tile {
             for (UnitKey unit : unitHolder.getUnitKeys()) {
                 if (unit.getUnitType() == UnitType.Spacedock && game != null) {
                     Player player = game.getPlayerFromColorOrFaction(unit.getColor());
-                    if (player != null && player.getUnitFromUnitKey(unit).getId().contains("cabal_spacedock")) {
-                        return true;
+                    if (player != null) {
+                        UnitModel model = player.getUnitFromUnitKey(unit);
+                        if (model != null && model.getId().contains("cabal_spacedock")) {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- ensure `hasCabalSpaceDockOrGravRiftToken` handles missing unit models safely

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8477c458832d8794635e661db840