### PR TITLE
Fix NPE when player has no faction selected

### DIFF
--- a/src/main/java/ti4/map/Player.java
+++ b/src/main/java/ti4/map/Player.java
@@ -2457,9 +2457,14 @@ public class Player extends PlayerProperties {
         // TITLE
         StringBuilder title = new StringBuilder();
         title.append(getFactionEmoji()).append(" ");
-        if (!"null".equals(getDisplayName()))
+        if (!"null".equals(getDisplayName())) {
             title.append(getDisplayName()).append(" ");
-        title.append(faction.getFactionNameWithSourceEmoji());
+        }
+        if (faction != null) {
+            title.append(faction.getFactionNameWithSourceEmoji());
+        } else {
+            title.append("No Faction");
+        }
         eb.setTitle(title.toString());
 
         // // ICON


### PR DESCRIPTION
## Summary
- avoid NullPointerException in `getRepresentationEmbed` when the player
  has not yet chosen a faction

## Testing
- `mvn -q test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687d21414628832dbaf17198cbada2ae