### PR TITLE
Prevent NPE in cards info button

### DIFF
--- a/src/main/java/ti4/buttons/handlers/info/CardsInfoButtonHandler.java
+++ b/src/main/java/ti4/buttons/handlers/info/CardsInfoButtonHandler.java
@@ -13,6 +13,9 @@ class CardsInfoButtonHandler {
 
     @ButtonHandler(value = "cardsInfo", save = false)
     public static void sendCardsInfo(Game game, Player player, GenericInteractionCreateEvent event) {
+        if (player == null) {
+            return;
+        }
         ThreadChannel channel = player.getCardsInfoThread();
         if (channel != null && !game.isFowMode()) {
             channel.getManager().setArchived(true).complete(); // archiving it to combat a common bug that is solved via archiving


### PR DESCRIPTION
## Summary
- ensure `CardsInfoButtonHandler` handles a missing player gracefully

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687db3242ec0832db2daff0644db9993