### PR TITLE
Fix NPE when serializing technologies

### DIFF
--- a/src/main/java/ti4/map/PlayerStatsDashboardPayload.java
+++ b/src/main/java/ti4/map/PlayerStatsDashboardPayload.java
@@ -273,6 +273,7 @@ public class PlayerStatsDashboardPayload {
     public List<String> getTechnologies() {
         return player.getTechs().stream()
             .map(Mapper::getTech)
+            .filter(Objects::nonNull)
             .map(TechnologyModel::getName)
             .toList();
     }


### PR DESCRIPTION
## Summary
- safeguard PlayerStatsDashboardPayload#getTechnologies against unknown tech IDs

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e60676cc8832daa9252758a34aba5