### PR TITLE
Fix agenda mapping NPE

### DIFF
--- a/src/main/java/ti4/map/GameStatsDashboardPayload.java
+++ b/src/main/java/ti4/map/GameStatsDashboardPayload.java
@@ -88,10 +88,12 @@ public class GameStatsDashboardPayload {
     public List<String> getLaws() {
         var lawsInPlay = game.getLaws().keySet().stream()
             .map(Mapper::getAgenda)
+            .filter(Objects::nonNull)
             .map(AgendaModel::getName)
             .toList();
         var agendasInDiscard = game.getDiscardAgendas().keySet().stream()
             .map(Mapper::getAgenda)
+            .filter(Objects::nonNull)
             .map(AgendaModel::getName)
             .toList();
         return Stream.concat(lawsInPlay.stream(), agendasInDiscard.stream()).toList();

--- a/src/main/java/ti4/map/PlayerStatsDashboardPayload.java
+++ b/src/main/java/ti4/map/PlayerStatsDashboardPayload.java
@@ -113,6 +113,7 @@ public class PlayerStatsDashboardPayload {
         return game.getLaws().keySet().stream()
             .filter(lawId -> ButtonHelper.isPlayerElected(game, player, lawId))
             .map(Mapper::getAgenda)
+            .filter(Objects::nonNull)
             .map(AgendaModel::getName)
             .toList();
     }

--- a/src/test/java/ti4/map/GameStatisticsDashboardPayloadTest.java
+++ b/src/test/java/ti4/map/GameStatisticsDashboardPayloadTest.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class GameStatisticsDashboardPayloadTest {
+import java.util.Map;
+
+import ti4.testUtils.BaseTi4Test;
+
+class GameStatisticsDashboardPayloadTest extends BaseTi4Test {
 
     @Test
     void getSetupTime() {
@@ -24,6 +28,27 @@ class GameStatisticsDashboardPayloadTest {
         var setupTimestamp = new GameStatsDashboardPayload(game).getSetupTimestamp();
 
         assertThat(String.valueOf(setupTimestamp)).endsWith("70");
+    }
+
+    @Test
+    void getLawsIgnoresUnknownIds() {
+        var game = createGame();
+        game.setLaws(Map.of("unknown_law", 1));
+        game.setDiscardAgendas(Map.of("another_unknown", 2));
+
+        var laws = new GameStatsDashboardPayload(game).getLaws();
+
+        assertThat(laws).isEmpty();
+    }
+
+    @Test
+    void getLawsReturnsKnownNames() {
+        var game = createGame();
+        game.setLaws(Map.of("revolution", 1));
+
+        var laws = new GameStatsDashboardPayload(game).getLaws();
+
+        assertThat(laws).containsExactly("Anti-Intellectual Revolution");
     }
 
     private Game createGame() {


### PR DESCRIPTION
## Summary
- guard against invalid agendas in stats dashboards
- test GameStatsDashboardPayload laws handling

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e607d3ac4832d86f2471c40f01d44