### PR TITLE
Fix promissory note info null owner

### DIFF
--- a/src/main/java/ti4/helpers/PromissoryNoteHelper.java
+++ b/src/main/java/ti4/helpers/PromissoryNoteHelper.java
@@ -88,6 +88,11 @@ public class PromissoryNoteHelper {
                             PromissoryNoteModel pnModel = Mapper.getPromissoryNotes().get(pn.getKey());
                             sb.append(index++).append("\\. ").append(CardEmojis.PN).append("  _").append(pnModel.getName()).append("_ ");
                             Player pnOwner = game.getPNOwner(pn.getKey());
+                            if (pnOwner == null) {
+                                MessageHelper.sendMessageToChannel(player.getCardsInfoThread(),
+                                    player.getRepresentation() + ", one of your promissory notes has no owner. The promissory note id is " + pn.getKey() + " and number is " + pn.getValue() + ".");
+                                continue;
+                            }
                             if (pnOwner == player) {
                                 sb.append("✋");
                             } else {


### PR DESCRIPTION
## Summary
- fix null pointer when listing promissory notes in play area

## Testing
- `mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e608c6f2c832dad046d1fda015cbd