### PR TITLE
Fix /game leave NPE

### DIFF
--- a/src/main/java/ti4/commands/game/Leave.java
+++ b/src/main/java/ti4/commands/game/Leave.java
@@ -20,7 +20,8 @@ public class Leave extends GameStateSubcommand {
     public void execute(SlashCommandInteractionEvent event) {
         Game game = getGame();
         User user = event.getUser();
-        if (game.getPlayer(user.getId()).isRealPlayer()) {
+        var player = game.getPlayer(user.getId());
+        if (player != null && player.isRealPlayer()) {
             MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "You are a real player, and thus should not do `/game leave`."
                 + " You should do `/game eliminate`, or `/game replace`, depending on what you are looking for.");
             return;
@@ -31,7 +32,8 @@ public class Leave extends GameStateSubcommand {
     }
 
     private String getResponseMessage(Game game, User user) {
-        if (game.getPlayer(user.getId()) != null && game.getPlayer(user.getId()).isRealPlayer()) {
+        var player = game.getPlayer(user.getId());
+        if (player != null && player.isRealPlayer()) {
             return "Did not leave game: " + game.getName() + ". Try a different method or set status to dummy. ";
         }
         return "Left map: " + game.getName() + " successful";


### PR DESCRIPTION
## Summary
- avoid NullPointerException when `/game leave` is called by a non‑player

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e60a9aaf0832da6e22ab0a2cad9e6