### PR TITLE
Remove unused parameter

### DIFF
--- a/src/main/java/ti4/commands/event/DrawEvent.java
+++ b/src/main/java/ti4/commands/event/DrawEvent.java
@@ -24,6 +24,6 @@ class DrawEvent extends GameStateSubcommand {
         for (int i = 0; i < count; i++) {
             game.drawEvent(player.getUserID());
         }
-        EventInfo.sendEventInfo(game, player, event);
+        EventInfo.sendEventInfo(player, event);
     }
 }

--- a/src/main/java/ti4/commands/event/EventInfo.java
+++ b/src/main/java/ti4/commands/event/EventInfo.java
@@ -9,7 +9,6 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import ti4.commands.GameStateSubcommand;
 import ti4.helpers.Constants;
 import ti4.image.Mapper;
-import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
 import ti4.model.EventModel;
@@ -22,17 +21,17 @@ class EventInfo extends GameStateSubcommand {
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        sendEventInfo(getGame(), getPlayer(), event);
+        sendEventInfo(getPlayer(), event);
         MessageHelper.sendMessageToEventChannel(event, "Event Info Sent");
     }
 
-    public static void sendEventInfo(Game game, Player player, SlashCommandInteractionEvent event) {
+    public static void sendEventInfo(Player player, SlashCommandInteractionEvent event) {
         String headerText = player.getRepresentationUnfogged() + " used `" + event.getCommandString() + "`";
         MessageHelper.sendMessageToPlayerCardsInfoThread(player, headerText);
-        sendEventInfo(game, player);
+        sendEventInfo(player);
     }
 
-    public static void sendEventInfo(Game game, Player player) {
+    public static void sendEventInfo(Player player) {
         MessageHelper.sendMessageEmbedsToCardsInfoThread(player, "__Events in Hand:__", getEventMessageEmbeds(player));
     }
 


### PR DESCRIPTION
## Summary
- drop `game` parameter from `sendEventInfo` methods
- adjust usages accordingly

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6e1f4ab0832da9d2f036be7c6bec