### PR TITLE
Fix regex for assignDamage button

### DIFF
--- a/src/main/java/ti4/helpers/RegexHelper.java
+++ b/src/main/java/ti4/helpers/RegexHelper.java
@@ -105,7 +105,10 @@ public class RegexHelper {
     /** @return group "unittype" */
     public static String unitTypeRegex(String group) {
         Set<String> types = new HashSet<>();
-        Arrays.asList(UnitType.values()).forEach(x -> types.add(x.getValue()));
+        Arrays.asList(UnitType.values()).forEach(x -> {
+            types.add(x.getValue());
+            types.add(x.plainName());
+        });
         types.add("csd");
         return regexBuilder(group, types);
     }


### PR DESCRIPTION
## Summary
- broaden unitTypeRegex to match plain unit names as well as codes

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed5800a64832da64a7b946f62f3cf