### PR TITLE
Fix /tech exhaust when no position provided

### DIFF
--- a/src/main/java/ti4/service/tech/PlayerTechService.java
+++ b/src/main/java/ti4/service/tech/PlayerTechService.java
@@ -85,7 +85,10 @@ public class PlayerTechService {
     public static void exhaustTechAndResolve(GenericInteractionCreateEvent event, Game game, Player player, String tech) {
         String pos = "";
         if (tech.contains("dskortg")) {
-            pos = tech.split("_")[1];
+            String[] splitTech = tech.split("_");
+            if (splitTech.length > 1) {
+                pos = splitTech[1];
+            }
             tech = "dskortg";
         }
         String inf = "";


### PR DESCRIPTION
## Summary
- avoid splitting dskortg tech strings without an underscore

## Testing
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687faad92f30832dafed7d8e63f66b88