### PR TITLE
Fix null pointer in agenda refresh

### DIFF
--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -2706,6 +2706,11 @@ public class AgendaHelper {
             }
         }
         AgendaModel agendaModel = Mapper.getAgenda(agendaID);
+        if (agendaModel == null) {
+            MessageHelper.sendMessageToChannel(game.getMainGameChannel(),
+                "Unable to refresh agenda; no active agenda found.");
+            return;
+        }
         MessageEmbed agendaEmbed = agendaModel.getRepresentationEmbed();
 
         String revealMessage = "Refreshed Agenda";


### PR DESCRIPTION
## Summary
- handle `Mapper.getAgenda()` returning null in `refreshAgenda`

## Testing
- `mvn -q test` *(fails: unable to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68805b797070832db8b3253027f6ce7a