### PR TITLE
Add winning path cache cron

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -38,6 +38,7 @@ import ti4.cron.ReuploadStaleEmojisCron;
 import ti4.cron.SabotageAutoReactCron;
 import ti4.cron.TechSummaryCron;
 import ti4.cron.UploadStatsCron;
+import ti4.cron.WinningPathCacheCron;
 import ti4.executors.ExecutorManager;
 import ti4.helpers.AliasHandler;
 import ti4.helpers.Constants;
@@ -264,6 +265,7 @@ public class AsyncTI4DiscordBot {
         AutoPingCron.register();
         ReuploadStaleEmojisCron.register();
         LogCacheStatsCron.register();
+        WinningPathCacheCron.register();
         UploadStatsCron.register();
         OldUndoFileCleanupCron.register();
         EndOldGamesCron.register();

--- a/src/main/java/ti4/commands/game/StartScenario.java
+++ b/src/main/java/ti4/commands/game/StartScenario.java
@@ -16,7 +16,6 @@ import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.map.Tile;
-import ti4.message.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.model.RelicModel;
 import ti4.service.emoji.FactionEmojis;
@@ -38,10 +37,10 @@ public class StartScenario extends GameStateSubcommand {
         Game game = getGame();
         String scenario = event.getOption(Constants.SCENARIO).getAsString();
 
-        if (scenario != null && scenario.contains("ordinian")) {
+        if (scenario.contains("ordinian")) {
             startOrdinianCodex1(game, event);
         }
-        if (scenario != null && scenario.contains("liberation")) {
+        if (scenario.contains("liberation")) {
             startLiberationCodex4(game, event);
         }
         MessageHelper.replyToMessage(event, "Successfully started the scenario.");
@@ -50,7 +49,7 @@ public class StartScenario extends GameStateSubcommand {
     public static void startOrdinianCodex1(Game game, GenericInteractionCreateEvent event) {
         game.setOrdinianC1Mode(true);
         var factions = List.of("arborec", "ghost", "muaat", "letnev", "nekro", "l1z1x");
-        if (game.getRealPlayers().size() == 0) {
+        if (game.getRealPlayers().isEmpty()) {
             AddTileListService.addTileListToMap(game, "{42} 32 43 25 47 33 36 19 37 28 21 48 29 27 24 38 30 40 22 10 50 26 4 49 45 17 35 31 5 44 39 8 41 34 6 20 23", event);
         }
         List<Player> players = new ArrayList<>();
@@ -99,7 +98,7 @@ public class StartScenario extends GameStateSubcommand {
     public static void startLiberationCodex4(Game game, GenericInteractionCreateEvent event) {
         game.setLiberationC4Mode(true);
         var factions = List.of("ghost", "xxcha", "sol", "naaz", "nekro", "nomad");
-        if (game.getRealPlayers().size() == 0) {
+        if (game.getRealPlayers().isEmpty()) {
             AddTileListService.addTileListToMap(game, "{c41} 21 35 77 63 48 70 68 60 47 76 25 66 30 72 27 26 22 75 1 74 67 8 62 79 14 31 29 53 41 34 17 65 45 57 64 49", event);
         }
         List<Player> players = new ArrayList<>();
@@ -109,8 +108,7 @@ public class StartScenario extends GameStateSubcommand {
             }
         }
         for (String faction : factions) {
-            if (players.size() == 0)
-            {
+            if (players.isEmpty()) {
                 MessageHelper.sendMessageToEventChannel(event, "You don't have six players, but I'll try my best anyway.");
                 break;
             }
@@ -120,10 +118,7 @@ public class StartScenario extends GameStateSubcommand {
                 if (faction.equalsIgnoreCase("ghost")) {
                     tile = game.getTileFromPositionOrAlias("creussgate");
                 }
-                boolean speaker = false;
-                if (faction.equalsIgnoreCase("nekro")) {
-                    speaker = true;
-                }
+                boolean speaker = faction.equalsIgnoreCase("nekro");
                 String color = players.get(face).getNextAvailableColour();
                 switch (faction.toLowerCase())
                 {

--- a/src/main/java/ti4/commands/relic/RelicAddCodexRelics.java
+++ b/src/main/java/ti4/commands/relic/RelicAddCodexRelics.java
@@ -22,7 +22,7 @@ class RelicAddCodexRelics extends GameStateSubcommand {
         List<String> allRelics = game.getAllRelics();
         if (!allRelics.contains("bookoflatvinia")) {
             game.shuffleRelicBack("bookoflatvinia");
-            newRelics += (relicCount > 0 ? " and " : "") +  "_Book of Latvinia_";
+            newRelics += "_Book of Latvinia_";
             relicCount++;
         }
         if (!allRelics.contains("circletofthevoid")) {
@@ -35,12 +35,9 @@ class RelicAddCodexRelics extends GameStateSubcommand {
             newRelics += (relicCount > 0 ? " and " : "") +  "_Neuraloop_";
             relicCount++;
         }
-        if (relicCount == 0)
-        {
-        MessageHelper.sendMessageToEventChannel(event, "No new relics have been added.");
-        }
-        else
-        {
+        if (relicCount == 0) {
+            MessageHelper.sendMessageToEventChannel(event, "No new relics have been added.");
+        } else {
             MessageHelper.sendMessageToEventChannel(event, (relicCount == 2 ? newRelics : newRelics.replaceFirst(" and ", ", ")) + (relicCount == 1 ? "has" : "have") + " been shuffled into the relic deck.");
         }
     }

--- a/src/main/java/ti4/cron/WinningPathCacheCron.java
+++ b/src/main/java/ti4/cron/WinningPathCacheCron.java
@@ -1,0 +1,23 @@
+package ti4.cron;
+
+import lombok.experimental.UtilityClass;
+import ti4.message.BotLogger;
+import ti4.service.statistics.game.WinningPathCacheService;
+
+import java.util.concurrent.TimeUnit;
+
+@UtilityClass
+public class WinningPathCacheCron {
+
+    public static void register() {
+        CronManager.schedulePeriodically(WinningPathCacheCron.class, WinningPathCacheCron::precompute, 5, 90, TimeUnit.MINUTES);
+    }
+
+    private static void precompute() {
+        try {
+            WinningPathCacheService.recomputeCache();
+        } catch (Exception e) {
+            BotLogger.error("**WinningPathCacheCron failed.**", e);
+        }
+    }
+}

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -4344,7 +4344,7 @@ public class Game extends GameProperties {
     }
 
     private boolean isCodex4() {
-        return getPlayers().values().stream().anyMatch(player -> player.getTechs().contains("x89c4"));
+        return getTechnologyDeck().contains("x89c4");
     }
 
     public boolean checkAllDecksAreOfficial() {

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -4301,9 +4301,50 @@ public class Game extends GameProperties {
                 .anyMatch(player -> player.getSecretVictoryPoints() > 3
                     && !player.getRelics().contains("obsidian"))
             || getPlayerCountForMap() < 3
-            || getRealAndEliminatedAndDummyPlayers().size() < 3
+            || getRealAndEliminatedPlayers().size() < 3
             || getPlayerCountForMap() > 8
-            || getRealAndEliminatedAndDummyPlayers().size() > 8;
+            || getRealAndEliminatedPlayers().size() > 8
+            || hasUnofficialNumberOfRevealedObjectives();
+    }
+
+    private boolean hasUnofficialNumberOfRevealedObjectives() {
+        int revealedStage1Count = publicObjectives1 == null ? 0 : publicObjectives1.size();
+        if (revealedStage1Count < 2) {
+            return true;
+        }
+
+        int revealedStage2Count = publicObjectives2 == null ? 0 : publicObjectives2.size();
+        int round = getRound();
+        String phaseOfGame = StringUtils.defaultString(getPhaseOfGame());
+        // if we're in action, we haven't revealed this round's public; can't filter on status because sometimes people reveal despite game end
+        int extraIfNotActionPhase = phaseOfGame.contains("action") ? 0 : 1;
+        // if neuraloop is in the deck, or we're not using Codex 4, we can make additional assumptions about number of publics
+        if (relics.contains("neuraloop") || !hasCodex4()) {
+            // 5 revealed by round 5 and Incentive Program
+            if (revealedStage1Count > 6) return true;
+            if (round < 5) {
+                // We can't have less stage 1s than this
+                if (revealedStage1Count < round + 1) return true;
+                // Round + 1 revealed by this point, plus Incentive Program; 1 extra if we're not in action phase
+                if (revealedStage1Count > round + 2 + extraIfNotActionPhase) return true;
+                // At most 1 Stage 2 can be revealed, by Incentive Program; 1 extra if we're not in action phase
+                if (revealedStage2Count > 1 + extraIfNotActionPhase) return true;
+            }
+            if (round >= 5) {
+                // We can't have less stage 1s than this
+                if (revealedStage1Count < 5) return true;
+                if (revealedStage2Count < round - 4) return true;
+                // 1 revealed per round past round 4 and Incentive Program; 1 extra if we're not in action phase
+                if (revealedStage2Count > round - 3 + extraIfNotActionPhase) return true;
+            }
+        }
+
+        // Extra stage 1 on round 1, Incentive Program during agenda phase; 1 extra if we're not in action phase
+        return revealedStage1Count + revealedStage2Count > round + 2 + extraIfNotActionPhase;
+    }
+
+    private boolean hasCodex4() {
+        return relics.contains("circletofthevoid") || players.values().stream().anyMatch(player -> player.getRelics().contains("circletofthevoid"));
     }
 
     public boolean checkAllDecksAreOfficial() {

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -4319,8 +4319,7 @@ public class Game extends GameProperties {
         // if we're in action, we haven't revealed this round's public; can't filter on status because sometimes people reveal despite game end
         int extraIfNotActionPhase = phaseOfGame.contains("action") ? 0 : 1;
         // if neuraloop is in the deck, or we're not using Codex 4, we can make additional assumptions about number of publics
-        // TODO: this should really say ... || !isCodex4()
-        if (relics.contains("neuraloop")) {
+        if (relics.contains("neuraloop") || !isCodex4()) {
             // 5 revealed by round 5 and Incentive Program
             if (revealedStage1Count > 6) return true;
             if (round < 5) {
@@ -4342,6 +4341,10 @@ public class Game extends GameProperties {
 
         // Extra stage 1 on round 1, Incentive Program during agenda phase; 1 extra if we're not in action phase
         return revealedStage1Count + revealedStage2Count > round + 2 + extraIfNotActionPhase;
+    }
+
+    private boolean isCodex4() {
+        return getPlayers().values().stream().anyMatch(player -> player.getTechs().contains("x89c4"));
     }
 
     public boolean checkAllDecksAreOfficial() {

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -4319,7 +4319,8 @@ public class Game extends GameProperties {
         // if we're in action, we haven't revealed this round's public; can't filter on status because sometimes people reveal despite game end
         int extraIfNotActionPhase = phaseOfGame.contains("action") ? 0 : 1;
         // if neuraloop is in the deck, or we're not using Codex 4, we can make additional assumptions about number of publics
-        if (relics.contains("neuraloop") || !hasCodex4()) {
+        // TODO: this should really say ... || !isCodex4()
+        if (relics.contains("neuraloop")) {
             // 5 revealed by round 5 and Incentive Program
             if (revealedStage1Count > 6) return true;
             if (round < 5) {
@@ -4341,10 +4342,6 @@ public class Game extends GameProperties {
 
         // Extra stage 1 on round 1, Incentive Program during agenda phase; 1 extra if we're not in action phase
         return revealedStage1Count + revealedStage2Count > round + 2 + extraIfNotActionPhase;
-    }
-
-    private boolean hasCodex4() {
-        return relics.contains("circletofthevoid") || players.values().stream().anyMatch(player -> player.getRelics().contains("circletofthevoid"));
     }
 
     public boolean checkAllDecksAreOfficial() {

--- a/src/main/java/ti4/service/game/EndGameService.java
+++ b/src/main/java/ti4/service/game/EndGameService.java
@@ -38,6 +38,7 @@ import ti4.service.emoji.ColorEmojis;
 import ti4.service.emoji.MiscEmojis;
 import ti4.service.statistics.game.GameStatisticsService;
 import ti4.service.statistics.game.WinningPathHelper;
+import ti4.service.statistics.game.WinningPathCacheService;
 import ti4.service.tigl.TiglGameReport;
 import ti4.service.tigl.TiglPlayerResult;
 import ti4.website.WebHelper;
@@ -187,6 +188,7 @@ public class EndGameService {
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), "**Game: `" + gameName + "` has ended!**");
 
         writeChronicle(game, event, publish);
+        WinningPathCacheService.addGame(game);
     }
 
     private static void writeChronicle(Game game, GenericInteractionCreateEvent event, boolean publish) {

--- a/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
@@ -42,7 +42,6 @@ public class GameStatisticsService {
         }
     }
 
-    // WARNING: This iterates over each game and is very slow.
     public String getWinningPathComparison(String winningPath, int playerCount, int totalVictoryPoints) {
         return WinningPathsStatisticsService.compareWinningPathToAllOthers(winningPath, playerCount, totalVictoryPoints);
     }

--- a/src/main/java/ti4/service/statistics/game/WinningPathCacheService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathCacheService.java
@@ -1,36 +1,29 @@
 package ti4.service.statistics.game;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.experimental.UtilityClass;
-import ti4.cache.CacheManager;
 import ti4.commands.statistics.GameStatisticsFilterer;
 import ti4.map.Game;
 import ti4.map.GamesPage;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @UtilityClass
 public class WinningPathCacheService {
 
-    private static final Cache<CacheKey, Map<String, Integer>> WINNING_PATH_CACHE = Caffeine.newBuilder()
-            .recordStats()
-            .build();
+    private static final Cache<CacheKey, Map<String, Integer>> WINNING_PATH_CACHE = Caffeine.newBuilder().build();
 
-    static {
-        CacheManager.registerCache("winningPathCache", WINNING_PATH_CACHE);
-    }
-
-    public static void recomputeCache() {
+    public static synchronized void recomputeCache() {
         WINNING_PATH_CACHE.invalidateAll();
         GamesPage.consumeAllGames(
-                GameStatisticsFilterer.getNormalFinishedGamesFilter(null, null),
-                game -> addGame(game)
+            GameStatisticsFilterer.getNormalFinishedGamesFilter(null, null),
+            WinningPathCacheService::addGame
         );
     }
 
-    public static void addGame(Game game) {
+    public static synchronized void addGame(Game game) {
         game.getWinner().ifPresent(winner -> {
             CacheKey key = new CacheKey(game.getRealAndEliminatedPlayers().size(), game.getVp());
             Map<String, Integer> map = WINNING_PATH_CACHE.get(key, k -> new HashMap<>());
@@ -39,11 +32,10 @@ public class WinningPathCacheService {
         });
     }
 
-    public static Map<String, Integer> getWinningPathCounts(int playerCount, int victoryPoints) {
+    public static synchronized Map<String, Integer> getWinningPathCounts(int playerCount, int victoryPoints) {
         Map<String, Integer> map = WINNING_PATH_CACHE.getIfPresent(new CacheKey(playerCount, victoryPoints));
         return map == null ? Map.of() : Map.copyOf(map);
     }
 
-    private record CacheKey(int playerCount, int victoryPoints) {
-    }
+    private record CacheKey(int playerCount, int victoryPoints) {}
 }

--- a/src/main/java/ti4/service/statistics/game/WinningPathCacheService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathCacheService.java
@@ -14,6 +14,7 @@ import ti4.map.GamesPage;
 public class WinningPathCacheService {
 
     private static final Cache<CacheKey, Map<String, Integer>> WINNING_PATH_CACHE = Caffeine.newBuilder().build();
+    private static boolean hasBeenComputed = false;
 
     public static synchronized void recomputeCache() {
         WINNING_PATH_CACHE.invalidateAll();
@@ -21,6 +22,7 @@ public class WinningPathCacheService {
             GameStatisticsFilterer.getNormalFinishedGamesFilter(null, null),
             WinningPathCacheService::addGame
         );
+        hasBeenComputed = true;
     }
 
     public static synchronized void addGame(Game game) {
@@ -33,6 +35,7 @@ public class WinningPathCacheService {
     }
 
     public static synchronized Map<String, Integer> getWinningPathCounts(int playerCount, int victoryPoints) {
+        if (!hasBeenComputed) recomputeCache();
         Map<String, Integer> map = WINNING_PATH_CACHE.getIfPresent(new CacheKey(playerCount, victoryPoints));
         return map == null ? Map.of() : Map.copyOf(map);
     }

--- a/src/main/java/ti4/service/statistics/game/WinningPathCacheService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathCacheService.java
@@ -1,0 +1,49 @@
+package ti4.service.statistics.game;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.experimental.UtilityClass;
+import ti4.cache.CacheManager;
+import ti4.commands.statistics.GameStatisticsFilterer;
+import ti4.map.Game;
+import ti4.map.GamesPage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@UtilityClass
+public class WinningPathCacheService {
+
+    private static final Cache<CacheKey, Map<String, Integer>> WINNING_PATH_CACHE = Caffeine.newBuilder()
+            .recordStats()
+            .build();
+
+    static {
+        CacheManager.registerCache("winningPathCache", WINNING_PATH_CACHE);
+    }
+
+    public static void recomputeCache() {
+        WINNING_PATH_CACHE.invalidateAll();
+        GamesPage.consumeAllGames(
+                GameStatisticsFilterer.getNormalFinishedGamesFilter(null, null),
+                game -> addGame(game)
+        );
+    }
+
+    public static void addGame(Game game) {
+        game.getWinner().ifPresent(winner -> {
+            CacheKey key = new CacheKey(game.getRealAndEliminatedPlayers().size(), game.getVp());
+            Map<String, Integer> map = WINNING_PATH_CACHE.get(key, k -> new HashMap<>());
+            String path = WinningPathHelper.buildWinningPath(game, winner);
+            map.put(path, map.getOrDefault(path, 0) + 1);
+        });
+    }
+
+    public static Map<String, Integer> getWinningPathCounts(int playerCount, int victoryPoints) {
+        Map<String, Integer> map = WINNING_PATH_CACHE.getIfPresent(new CacheKey(playerCount, victoryPoints));
+        return map == null ? Map.of() : Map.copyOf(map);
+    }
+
+    private record CacheKey(int playerCount, int victoryPoints) {
+    }
+}

--- a/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
@@ -72,6 +72,7 @@ public class WinningPathHelper {
         if (normalized.contains("imperial")) return "imperial rider";
         if (normalized.contains("censure")) return "censure";
         if (normalized.contains("crown") || normalized.contains("emph")) return "crown";
+        if (normalized.contains("latvinia")) return "latvinia";
         return "other (probably _Classified Document Leaks_)";
     }
 }

--- a/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
@@ -19,8 +19,7 @@ public class WinningPathHelper {
         int supportCount = winner.getSupportForTheThroneVictoryPoints();
         String otherPoints = summarizeOtherVictoryPoints(game, winner.getUserID());
 
-        if (supportCount >= 2)
-        {
+        if (supportCount >= 2) {
             return String.format(
                 "%d stage 1 objectives, %d stage 2 objectives, %d secret objectives, %d _Supports for the Thrones_%s",
                 stage1Count, stage2Count, secretCount, supportCount,

--- a/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
@@ -89,7 +89,6 @@ class WinningPathsStatisticsService {
         Map<String, Integer> winningPathCounts = WinningPathCacheService.getWinningPathCounts(playerCount, victoryPointTotal);
         int gamesWithWinnerCount = winningPathCounts.values().stream().reduce(0, Integer::sum);
         if (gamesWithWinnerCount >= 100) {
-            // TODO: Previously this was never null, but after loadless it is? Need investigation, but for now defaulting to 1.
             int winningPathCount = winningPathCounts.getOrDefault(winningPath, 1);
             double winningPathPercent = winningPathCount / (double) gamesWithWinnerCount;
             String winningPathCommonality = getWinningPathCommonality(winningPathCounts, winningPathCount);

--- a/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
@@ -86,7 +86,7 @@ class WinningPathsStatisticsService {
 
     static String compareWinningPathToAllOthers(String winningPath, int playerCount, int victoryPointTotal) {
         StringBuilder sb = new StringBuilder();
-        Map<String, Integer> winningPathCounts = getNormalGameWinningPaths(playerCount, victoryPointTotal);
+        Map<String, Integer> winningPathCounts = WinningPathCacheService.getWinningPathCounts(playerCount, victoryPointTotal);
         int gamesWithWinnerCount = winningPathCounts.values().stream().reduce(0, Integer::sum);
         if (gamesWithWinnerCount >= 100) {
             // TODO: Previously this was never null, but after loadless it is? Need investigation, but for now defaulting to 1.
@@ -109,17 +109,6 @@ class WinningPathsStatisticsService {
             }
         }
         return sb.toString();
-    }
-
-    private static Map<String, Integer> getNormalGameWinningPaths(int playerCount, int victoryPointTotal) {
-        Map<String, Integer> winningPathCount = new HashMap<>();
-
-        GamesPage.consumeAllGames(
-            GameStatisticsFilterer.getNormalFinishedGamesFilter(playerCount, victoryPointTotal),
-            game -> getWinningPath(game, winningPathCount)
-        );
-
-        return winningPathCount;
     }
 
     private static String getWinningPathCommonality(Map<String, Integer> winningPathCounts, int winningPathCount) {


### PR DESCRIPTION
## Summary
- add `WinningPathCacheService` to cache winning paths from completed games
- schedule `WinningPathCacheCron` for periodic pre-computation
- register the cron job in `AsyncTI4DiscordBot`
- update `WinningPathsStatisticsService` and `EndGameService` to use/update the cache

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68835921bbd8832dbedca914e83d06ae