### PR TITLE
Add TIGL nickname change command

### DIFF
--- a/src/main/java/ti4/commands/CommandManager.java
+++ b/src/main/java/ti4/commands/CommandManager.java
@@ -59,6 +59,7 @@ import ti4.commands.units.RemoveAllUnits;
 import ti4.commands.units.RemoveUnitDamage;
 import ti4.commands.units.RemoveUnits;
 import ti4.commands.user.UserCommand;
+import ti4.commands.tigl.TiglCommand;
 
 public class CommandManager {
 
@@ -119,6 +120,7 @@ public class CommandManager {
         new PlanetCommand(),
         new SelectionBoxDemoCommand(),
         new UserCommand(),
+        new TiglCommand(),
         new AsyncCommand(),
         new OmegaPhaseCommand()).collect(Collectors.toMap(ParentCommand::getName, command -> command));
 

--- a/src/main/java/ti4/commands/tigl/ChangeNickname.java
+++ b/src/main/java/ti4/commands/tigl/ChangeNickname.java
@@ -1,0 +1,22 @@
+package ti4.commands.tigl;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.commands.Subcommand;
+import ti4.helpers.Constants;
+import ti4.service.tigl.TiglUsernameChangeService;
+
+class ChangeNickname extends Subcommand {
+
+    public ChangeNickname() {
+        super(Constants.TIGL_CHANGE_NICKNAME, "Change your TIGL nickname");
+        addOptions(new OptionData(OptionType.STRING, Constants.TIGL_NICKNAME, "New TIGL nickname")
+            .setRequired(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        TiglUsernameChangeService.changeUsername(event);
+    }
+}

--- a/src/main/java/ti4/commands/tigl/TiglCommand.java
+++ b/src/main/java/ti4/commands/tigl/TiglCommand.java
@@ -1,0 +1,31 @@
+package ti4.commands.tigl;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import ti4.commands.ParentCommand;
+import ti4.commands.Subcommand;
+import ti4.helpers.Constants;
+
+public class TiglCommand implements ParentCommand {
+
+    private final Map<String, Subcommand> subcommands = Stream.of(
+        new ChangeNickname()
+    ).collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
+
+    @Override
+    public String getName() {
+        return Constants.TIGL;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Twilight Imperium Global League";
+    }
+
+    @Override
+    public Map<String, Subcommand> getSubcommands() {
+        return subcommands;
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1285,6 +1285,8 @@ public class Constants {
     public static final String SHOW_UNPLAYED_AC = "show_unplayed_ac";
     public static final String TIGL_RANK = "tigl_rank";
     public static final String TIGL = "tigl";
+    public static final String TIGL_CHANGE_NICKNAME = "change_nickname";
+    public static final String TIGL_NICKNAME = "nickname";
     public static final String SEARCH_NAMES = "search_names";
     public static final String SEARCH_TAGS = "search_tags";
     public static final String SEARCH_USERS = "search_users";

--- a/src/main/java/ti4/service/tigl/TiglUsernameChangeRequest.java
+++ b/src/main/java/ti4/service/tigl/TiglUsernameChangeRequest.java
@@ -1,0 +1,9 @@
+package ti4.service.tigl;
+
+import lombok.Data;
+
+@Data
+public class TiglUsernameChangeRequest {
+    private String discordId;
+    private String newTiglUserName;
+}

--- a/src/main/java/ti4/service/tigl/TiglUsernameChangeService.java
+++ b/src/main/java/ti4/service/tigl/TiglUsernameChangeService.java
@@ -1,0 +1,18 @@
+package ti4.service.tigl;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import ti4.helpers.Constants;
+import ti4.website.WebHelper;
+
+public class TiglUsernameChangeService {
+
+    public static void changeUsername(SlashCommandInteractionEvent event) {
+        var request = new TiglUsernameChangeRequest();
+        request.setDiscordId(event.getUser().getId());
+        String newName = event.getOption(Constants.TIGL_NICKNAME, null, OptionMapping::getAsString);
+        request.setNewTiglUserName(newName);
+
+        WebHelper.sendTiglUsernameChange(request, event.getMessageChannel());
+    }
+}

--- a/src/main/resources/web/web.properties
+++ b/src/main/resources/web/web.properties
@@ -6,3 +6,4 @@ website.bucket=asyncti4.com
 gamestate.api.urls=https://bbg9uiqewd.execute-api.us-east-1.amazonaws.com/Prod/map/{gameName},https://qw2j1lld43.execute-api.us-east-1.amazonaws.com/Production/map/{gameName}
 statistics.api.urls=https://api.ti4ultimate.com/api/Async/player-settings
 tigl.report-game.api.url=https://api.ti4ultimate.com/api/Tigl/report-game
+tigl.change-username.api.url=https://api.ti4ultimate.com/api/Tigl/change-username


### PR DESCRIPTION
## Summary
- support changing TIGL username via new slash command
- add `TiglCommand` parent and `change_nickname` subcommand
- send change nickname requests through `WebHelper`
- expose new TIGL constants
- add property for change-username API endpoint

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable import POM)*
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883ffaee978832db8627f5e92bb1f9d