### PR TITLE
Implement Franken draft auto-complete feature

### DIFF
--- a/src/main/java/ti4/buttons/handlers/FrankenButtonHandler.java
+++ b/src/main/java/ti4/buttons/handlers/FrankenButtonHandler.java
@@ -174,6 +174,12 @@ class FrankenButtonHandler {
                     }
                     return;
                 }
+                case "done" -> {
+                    player.setAutoFrankenDraft(true);
+                    MessageHelper.sendMessageToChannel(event.getMessageChannel(), "The bot will finish drafting for you.");
+                    FrankenDraftBagService.autoDraftCurrentBag(game, player);
+                    return;
+                }
                 case "show_bag" -> {
                     FrankenDraftBagService.showPlayerBag(game, player);
                     return;

--- a/src/main/java/ti4/draft/BagDraft.java
+++ b/src/main/java/ti4/draft/BagDraft.java
@@ -93,6 +93,10 @@ public abstract class BagDraft {
         MessageHelper.sendMessageToChannelWithButton(player.getCardsInfoThread(),
             player.getRepresentationUnfogged() + " you have been passed a new draft bag!",
             Buttons.gray(FrankenDraftBagService.ACTION_NAME + "show_bag", "Click here to show your current bag"));
+
+        if (player.isAutoFrankenDraft()) {
+            FrankenDraftBagService.autoDraftCurrentBag(player.getGame(), player);
+        }
     }
 
     public boolean allPlayersReadyToPass() {

--- a/src/main/java/ti4/map/pojo/PlayerProperties.java
+++ b/src/main/java/ti4/map/pojo/PlayerProperties.java
@@ -37,6 +37,7 @@ public class PlayerProperties {
     // State and settings
     private boolean passed;
     private boolean readyToPassBag;
+    private boolean autoFrankenDraft;
     private boolean searchWarrant;
     private boolean dummy;
     private boolean autoPassOnWhensAfters;


### PR DESCRIPTION
## Summary
- allow players to finish Franken drafts automatically
- add auto drafting logic to franken bag service
- add button to mark a player done drafting
- auto draft bags when a done player receives a bag
- store flag in player properties

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6884768c3174832da5564d0f3e0e4fd5