### PR TITLE
Show infantry count for Magen Defense Grid

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -2636,7 +2636,8 @@ public class ButtonHelper {
             int total = 0;
             UnitKey infKey = Units.getUnitKey(UnitType.Infantry, player.getColorID());
 
-            String msg = player.getFactionEmoji() + " resolved _Magen Defense Grid_ on " + tile.getPosition() + ":";
+            String msg = player.getFactionEmoji() + " resolved _Magen Defense Grid_ on " + tile.getPosition()
+                + ", placing %s infantry (%%s total so far):";
             for (UnitHolder uh : tile.getUnitHolders().values()) {
                 int count = uh.countPlayersUnitsWithModelCondition(player, UnitModel::getIsStructure);
                 if (player.hasAbility("byssus")) count += uh.getUnitCount(UnitType.Mech, player);
@@ -2653,8 +2654,10 @@ public class ButtonHelper {
                     }
                 }
             }
+            player.setMagenInfantryCounter(player.getMagenInfantryCounter() + total);
             ButtonHelper.deleteMessage(event);
-            MessageHelper.sendMessageToChannel(player.getCorrectChannel(), String.format(msg, Integer.toString(total)));
+            MessageHelper.sendMessageToChannel(player.getCorrectChannel(),
+                String.format(msg, total, player.getMagenInfantryCounter()));
         });
     }
 

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1100,6 +1100,7 @@ public class Constants {
     public static final String SET_PLANET_COMMS = "set_planet_comms";
     public static final String PILLAGE_COUNT = "pillage_count";
     public static final String SARWEEN_COUNT = "sarween_count";
+    public static final String MAGEN_INFANTRY_COUNT = "magen_infantry_count";
     public static final String PATH_TOKEN_COUNT = "path_token_count";
     public static final String HONOR_COUNT = "honor_count";
     public static final String DISHONOR_COUNT = "dishonor_count";

--- a/src/main/java/ti4/map/manage/GameLoadService.java
+++ b/src/main/java/ti4/map/manage/GameLoadService.java
@@ -1057,6 +1057,7 @@ class GameLoadService {
                 case Constants.BENTOR_HAS_FOUND_UFRAG -> player.setHasFoundUnkFrag(Boolean.parseBoolean(tokenizer.nextToken()));
                 case Constants.LANEFIR_ATS_COUNT -> player.setAtsCount(Integer.parseInt(tokenizer.nextToken()));
                 case Constants.SARWEEN_COUNT -> player.setSarweenCounter(Integer.parseInt(tokenizer.nextToken()));
+                case Constants.MAGEN_INFANTRY_COUNT -> player.setMagenInfantryCounter(Integer.parseInt(tokenizer.nextToken()));
                 case Constants.PILLAGE_COUNT -> player.setPillageCounter(Integer.parseInt(tokenizer.nextToken()));
                 case Constants.PATH_TOKEN_COUNT -> player.setPathTokenCounter(Integer.parseInt(tokenizer.nextToken()));
                 case Constants.HONOR_COUNT -> player.setHonorCounter(Integer.parseInt(tokenizer.nextToken()));

--- a/src/main/java/ti4/map/manage/GameSaveService.java
+++ b/src/main/java/ti4/map/manage/GameSaveService.java
@@ -626,6 +626,9 @@ class GameSaveService {
             writer.write(Constants.SARWEEN_COUNT + " " + player.getSarweenCounter());
             writer.write(System.lineSeparator());
 
+            writer.write(Constants.MAGEN_INFANTRY_COUNT + " " + player.getMagenInfantryCounter());
+            writer.write(System.lineSeparator());
+
             writer.write(Constants.PATH_TOKEN_COUNT + " " + player.getPathTokenCounter());
             writer.write(System.lineSeparator());
 

--- a/src/main/java/ti4/map/pojo/PlayerProperties.java
+++ b/src/main/java/ti4/map/pojo/PlayerProperties.java
@@ -78,6 +78,7 @@ public class PlayerProperties {
     //Stat tracking
     private int sarweenCounter;
     private int pillageCounter;
+    private int magenInfantryCounter;
 
     //Omega Phase
     private int priorityPosition;


### PR DESCRIPTION
## Summary
- add per-player Magen infantry counter
- persist counter in save/load
- report total infantry spawned via Magen each time it is used

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_688477117e9c832d8639c115f5d24ab2