### PR TITLE
Refactor button routing to use annotations

### DIFF
--- a/src/main/java/ti4/buttons/UnfiledButtonHandlers.java
+++ b/src/main/java/ti4/buttons/UnfiledButtonHandlers.java
@@ -899,7 +899,7 @@ public class UnfiledButtonHandlers {
         }
     }
 
-    // @ButtonHandler("strategicAction_")
+    @ButtonHandler("strategicAction_")
     public static void strategicAction(
         ButtonInteractionEvent event, Player player, String buttonID, Game game,
         MessageChannel mainGameChannel
@@ -1023,6 +1023,12 @@ public class UnfiledButtonHandlers {
                 Integer.parseInt(buttonID.split("_")[2]), event, false));
     }
 
+    @ButtonHandler("autoAssignGroundHits_")
+    public static void autoAssignGroundHits(ButtonInteractionEvent event, Player player, String buttonID, Game game) {
+        ButtonHelperModifyUnits.autoAssignGroundCombatHits(player, game, buttonID.split("_")[1],
+            Integer.parseInt(buttonID.split("_")[2]), event);
+    }
+
     @ButtonHandler("explore_look_All")
     public static void exploreLookAll(ButtonInteractionEvent event, Player player, Game game) {
         List<String> order = List.of("cultural", "industrial", "hazardous");
@@ -1063,6 +1069,7 @@ public class UnfiledButtonHandlers {
         ButtonHelper.deleteMessage(event);
     }
 
+    @ButtonHandler("movedNExplored_")
     public static void movedNExplored(
         ButtonInteractionEvent event, Player player, String buttonID, Game game
     ) {
@@ -1244,6 +1251,7 @@ public class UnfiledButtonHandlers {
         ButtonHelper.deleteMessage(event);
     }
 
+    @ButtonHandler(Constants.PO_SCORING)
     public static void poScoring(
         ButtonInteractionEvent event, Player player, String buttonID, Game game,
         MessageChannel privateChannel
@@ -1411,6 +1419,7 @@ public class UnfiledButtonHandlers {
     }
 
 
+    @ButtonHandler(Constants.SO_SCORE_FROM_HAND)
     public static void soScoreFromHand(
         ButtonInteractionEvent event,
         String buttonID,
@@ -2365,6 +2374,78 @@ public class UnfiledButtonHandlers {
         MessageHelper.sendMessageToChannelWithButtons(event.getChannel(), "", buttons);
     }
 
+    @ButtonHandler("checkWHView")
+    public static void checkWHView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.wormholes);
+    }
+
+    @ButtonHandler("checkAnomView")
+    public static void checkAnomView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.anomalies);
+    }
+
+    @ButtonHandler("checkLegendView")
+    public static void checkLegendView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.legendaries);
+    }
+
+    @ButtonHandler("checkEmptyView")
+    public static void checkEmptyView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.empties);
+    }
+
+    @ButtonHandler("checkAetherView")
+    public static void checkAetherView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.aetherstream);
+    }
+
+    @ButtonHandler("checkCannonView")
+    public static void checkCannonView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.spacecannon);
+    }
+
+    @ButtonHandler("checkTraitView")
+    public static void checkTraitView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.traits);
+    }
+
+    @ButtonHandler("checkTechSkipView")
+    public static void checkTechSkipView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.techskips);
+    }
+
+    @ButtonHandler("checkAttachmView")
+    public static void checkAttachmView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.attachments);
+    }
+
+    @ButtonHandler("checkShiplessView")
+    public static void checkShiplessView(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.shipless);
+    }
+
+    @ButtonHandler("checkUnlocked")
+    public static void checkUnlocked(ButtonInteractionEvent event, Game game) {
+        ButtonHelper.showFeatureType(event, game, DisplayType.unlocked);
+    }
+
+    @ButtonHandler("getSwapButtons_")
+    public static void getSwapButtons(ButtonInteractionEvent event, Player player, Game game) {
+        MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), "Swap",
+            ButtonHelper.getButtonsToSwitchWithAllianceMembers(player, game, true));
+    }
+
+    @ButtonHandler("refreshInfoButtons")
+    public static void refreshInfoButtons(ButtonInteractionEvent event) {
+        MessageHelper.sendMessageToChannelWithButtons(event.getChannel(), null, Buttons.REFRESH_INFO_BUTTONS);
+    }
+
+    @ButtonHandler("factionEmbedRefresh")
+    public static void factionEmbedRefresh(ButtonInteractionEvent event, Player player) {
+        MessageHelper.sendMessageToChannelWithEmbedsAndButtons(player.getCardsInfoThread(), null,
+            List.of(player.getRepresentationEmbed()), List.of(Buttons.FACTION_EMBED));
+    }
+
     @ButtonHandler("resetSpend_")
     public static void resetSpend_(ButtonInteractionEvent event, Player player, String buttonID, Game game) {
         Helper.refreshPlanetsOnTheRespend(player, game);
@@ -2448,6 +2529,7 @@ public class UnfiledButtonHandlers {
         MessageHelper.sendMessageToChannel(game.getMainGameChannel(), "Reversed strategy card picking order.");
     }
 
+    @ButtonHandler("lastMinuteDeliberation")
     public static void lastMinuteDeliberation(
         ButtonInteractionEvent event, Player player, Game game,
         MessageChannel actionsChannel
@@ -2486,6 +2568,7 @@ public class UnfiledButtonHandlers {
         ButtonHelper.deleteMessage(event);
     }
 
+    @ButtonHandler("decline_explore")
     public static void declineExplore(
         ButtonInteractionEvent event, Player player, Game game,
         MessageChannel mainGameChannel
@@ -2530,6 +2613,7 @@ public class UnfiledButtonHandlers {
     }
 
     @Deprecated
+    @ButtonHandler("gain1tgFromCommander")
     public static void gain1tgFromCommander(
         ButtonInteractionEvent event, Player player, Game game,
         MessageChannel mainGameChannel
@@ -2542,6 +2626,7 @@ public class UnfiledButtonHandlers {
         ButtonHelper.deleteMessage(event);
     }
 
+    @ButtonHandler("gain1tgFromMuaatCommander")
     public static void gain1tgFromMuaatCommander(
         ButtonInteractionEvent event, Player player, Game game,
         MessageChannel mainGameChannel
@@ -2554,6 +2639,7 @@ public class UnfiledButtonHandlers {
         ButtonHelper.deleteMessage(event);
     }
 
+    @ButtonHandler("gain1tgFromLetnevCommander")
     public static void gain1tgFromLetnevCommander(
         ButtonInteractionEvent event, Player player, Game game,
         MessageChannel mainGameChannel
@@ -2566,6 +2652,7 @@ public class UnfiledButtonHandlers {
         ButtonHelper.deleteMessage(event);
     }
 
+    @ButtonHandler("gain_1_tg")
     public static void gain1TG(ButtonInteractionEvent event, Player player, Game game, MessageChannel mainGameChannel) {
         String message = "";
         String labelP = event.getButton().getLabel();

--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -4089,6 +4089,7 @@ public class AgendaHelper {
         ReactionService.addReaction(event, game, player, message);
     }
 
+    @ButtonHandler("play_when")
     public static void playWhen(ButtonInteractionEvent event, Game game, Player player, MessageChannel mainGameChannel) {
         UnfiledButtonHandlers.clearAllReactions(event);
         ReactionService.addReaction(event, game, player, true, true, "is playing a \"when\".");

--- a/src/main/java/ti4/helpers/ButtonHelperStats.java
+++ b/src/main/java/ti4/helpers/ButtonHelperStats.java
@@ -26,6 +26,18 @@ public class ButtonHelperStats {
         });
     }
 
+    @ButtonHandler("convert_1_comms")
+    @ButtonHandler("convert_2_comms")
+    @ButtonHandler("convert_3_comms")
+    @ButtonHandler("convert_4_comms")
+    @ButtonHandler("convert_2_comms_stay")
+    public static void convertCommsLegacy(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        String[] parts = buttonID.split("_");
+        int amt = Integer.parseInt(parts[1]);
+        boolean deleteMsg = !buttonID.endsWith("_stay");
+        convertComms(event, game, player, amt, deleteMsg);
+    }
+
     static final Pattern gainCommsRegex = Pattern.compile("gainComms_" + RegexHelper.intRegex("amt") + "(_stay)?");
 
     @ButtonHandler("gainComms_") // gainComms_12(_stay)
@@ -35,6 +47,21 @@ public class ButtonHelperStats {
             int amt = Integer.parseInt(matcher.group("amt"));
             gainComms(event, game, player, amt, deleteMsg);
         });
+    }
+
+    @ButtonHandler("gain_1_comms")
+    @ButtonHandler("gain_2_comms")
+    @ButtonHandler("gain_3_comms")
+    @ButtonHandler("gain_4_comms")
+    @ButtonHandler("gain_1_comms_stay")
+    @ButtonHandler("gain_2_comms_stay")
+    @ButtonHandler("gain_3_comms_stay")
+    @ButtonHandler("gain_4_comms_stay")
+    public static void gainCommsLegacy(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        String[] parts = buttonID.split("_");
+        int amt = Integer.parseInt(parts[1]);
+        boolean deleteMsg = !buttonID.endsWith("_stay");
+        gainComms(event, game, player, amt, deleteMsg);
     }
 
     public static void convertComms(ButtonInteractionEvent event, Game game, Player player, int amt) {
@@ -106,6 +133,11 @@ public class ButtonHelperStats {
         afterGainCommsChecks(game, player, finalComm - initComm);
         ButtonHelper.resolveMinisterOfCommerceCheck(game, player, event);
         ButtonHelperAgents.cabalAgentInitiation(game, player);
+    }
+
+    @ButtonHandler("resolveHarness")
+    public static void resolveHarness(ButtonInteractionEvent event, Game game, Player player) {
+        replenishComms(event, game, player, false);
     }
 
     public static void gainTGs(GenericInteractionCreateEvent event, Game game, Player player, int amt, boolean skipOutput) {

--- a/src/main/java/ti4/helpers/SearchGameHelper.java
+++ b/src/main/java/ti4/helpers/SearchGameHelper.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.listeners.annotations.ButtonHandler;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.map.Player;
@@ -67,6 +68,11 @@ public class SearchGameHelper {
         }
         return filteredManagedGames.size();
 
+    }
+
+    @ButtonHandler("searchMyGames")
+    public static void searchMyGames(ButtonInteractionEvent event) {
+        searchGames(event.getUser(), event, false, false, false, true, false, true, false, false);
     }
 
     public static ArrayList<Integer> getGameDaysLength(User user, GenericInteractionCreateEvent event, boolean onlyMyTurn, boolean includeEndedGames, boolean showAverageTurnTime, boolean showSecondaries, boolean showGameModes, boolean ignoreSpectate, boolean ignoreAborted, boolean wantNum) {

--- a/src/main/java/ti4/service/button/ReactionService.java
+++ b/src/main/java/ti4/service/button/ReactionService.java
@@ -20,6 +20,8 @@ import ti4.message.GameMessageManager;
 import ti4.message.GameMessageType;
 import ti4.message.MessageHelper;
 import ti4.service.fow.GMService;
+import ti4.listeners.annotations.ButtonHandler;
+import ti4.helpers.Constants;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -191,5 +193,15 @@ public class ReactionService {
         return  GameMessageManager.getOne(game.getName(), messageId)
             .filter(message -> checkForSpecificPlayerReact(player, message))
             .isPresent();
+    }
+
+    @ButtonHandler(Constants.GENERIC_BUTTON_ID_PREFIX)
+    public static void genericButton(ButtonInteractionEvent event, Game game, Player player) {
+        addReaction(event, game, player);
+    }
+
+    @ButtonHandler("pass_on_abilities")
+    public static void passOnAbilities(ButtonInteractionEvent event, Game game, Player player) {
+        addReaction(event, game, player, " is " + event.getButton().getLabel().toLowerCase() + ".");
     }
 }


### PR DESCRIPTION
## Summary
- remove deprecated if/else handling in `ButtonProcessor`
- mark old button actions with `@ButtonHandler` annotations
- add button handlers for generic reactions and map feature buttons
- wire search games and commodity conversion buttons through annotations

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6884b76ecc20832d8d3f6bf434258cdb