### PR TITLE
Add Bucket4j rate limiting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
+            <artifactId>bucket4j-spring-boot-starter</artifactId>
+            <version>0.13.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
@@ -88,11 +93,6 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>3.1.8</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.vladimir-bukhtoyarov</groupId>
-            <artifactId>bucket4j-core</artifactId>
-            <version>8.10.1</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
             <version>3.1.8</version>
         </dependency>
         <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.10.1</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.5.17</version>

--- a/src/main/java/ti4/spring/exception/TooManyRequestsException.java
+++ b/src/main/java/ti4/spring/exception/TooManyRequestsException.java
@@ -1,0 +1,12 @@
+package ti4.spring.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+public class TooManyRequestsException extends RuntimeException {
+
+    public TooManyRequestsException() {
+        super("Too many requests");
+    }
+}

--- a/src/main/java/ti4/spring/service/auth/RateLimitFilter.java
+++ b/src/main/java/ti4/spring/service/auth/RateLimitFilter.java
@@ -1,0 +1,69 @@
+package ti4.spring.service.auth;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import ti4.cache.CacheManager;
+import ti4.spring.exception.TooManyRequestsException;
+
+@Component
+@Order(2)
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private static final int CAPACITY = 20;
+    private static final Duration REFILL_DURATION = Duration.ofMinutes(1);
+
+    private final Cache<String, Bucket> buckets = Caffeine.newBuilder()
+        .maximumSize(10000)
+        .expireAfterAccess(10, TimeUnit.MINUTES)
+        .build();
+
+    public RateLimitFilter() {
+        CacheManager.registerCache("rateLimitBuckets", buckets);
+    }
+
+    private Bucket resolveBucket(String userId) {
+        Bucket bucket = buckets.getIfPresent(userId);
+        if (bucket == null) {
+            Bandwidth limit = Bandwidth.classic(CAPACITY, Refill.greedy(CAPACITY, REFILL_DURATION));
+            bucket = Bucket.builder().addLimit(limit).build();
+            buckets.put(userId, bucket);
+        }
+        return bucket;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NotNull HttpServletRequest request,
+            @NotNull HttpServletResponse response,
+            @NotNull FilterChain filterChain) throws ServletException, IOException {
+        String userId = null;
+        try {
+            userId = RequestContext.getUserId();
+        } catch (Exception ignored) {
+        }
+
+        if (userId != null) {
+            Bucket bucket = resolveBucket(userId);
+            if (!bucket.tryConsume(1)) {
+                throw new TooManyRequestsException();
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## Summary
- include Bucket4j dependency
- register a new RateLimitFilter
- create TooManyRequestsException for 429 responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68864622ed88832d9e57b86fb5d79956