### PR TITLE
Fix TIGL faction names

### DIFF
--- a/src/main/java/ti4/service/game/EndGameService.java
+++ b/src/main/java/ti4/service/game/EndGameService.java
@@ -404,7 +404,11 @@ public class EndGameService {
             .map(player -> {
                 var tiglPlayerResult = new TiglPlayerResult();
                 tiglPlayerResult.setScore(player.getTotalVictoryPoints());
-                tiglPlayerResult.setFaction(player.getFaction());
+                if (player.getFactionModel() != null) {
+                    tiglPlayerResult.setFaction(player.getFactionModel().getFactionName());
+                } else {
+                    tiglPlayerResult.setFaction(player.getFaction());
+                }
                 tiglPlayerResult.setDiscordId(player.getUserID());
                 tiglPlayerResult.setDiscordTag(player.getUserName());
                 return tiglPlayerResult;


### PR DESCRIPTION
## Summary
- use full faction name when generating TIGL report

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6886660f0d54832dba78afca4153206f