### PR TITLE
Add bothelper permissions migration

### DIFF
--- a/src/main/java/ti4/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/migration/DataMigrationManager.java
@@ -48,6 +48,7 @@ public class DataMigrationManager {
         migrations.put("removeWekkersAbsolsPoliticalSecret_220125", MigrationHelper::removeWekkersAbsolsPoliticalSecrets);
         migrations.put("removeWekkersAbsolsPoliticalSecretAgain_220125", MigrationHelper::removeWekkersAbsolsPoliticalSecretsAgain);
         migrations.put("warnGamesWithOldDisplaceMap_270525", MigrationHelper::warnGamesWithOldDisplaceMap);
+        migrations.put("addBothelperPermissions_280725", MigrationHelper::addBothelperPermissions);
         //migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
     }
 


### PR DESCRIPTION
## Summary
- add migration helper to grant MANAGE_THREADS to non-game bothelpers
- register migration in the migration manager

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6887052e3ffc832db4cd12dcb9bd0162