### PR TITLE
Update README with rate limiting details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ To get started with development, please read the following:
 
 1. [Code of Conduct](CODE_OF_CONDUCT.md)
 2. [Contribution Guide](CONTRIBUTING.md)
+
+## Rate Limiting
+
+The REST API uses a Bucket4j filter to control how frequently clients can make
+requests. Each authenticated user is allowed **30 requests per minute**. If a
+request is missing a Discord token or the user id cannot be determined, the
+filter falls back to rate limiting based on the caller's IP address so
+unauthenticated requests cannot bypass the limit.


### PR DESCRIPTION
## Summary
- document Bucket4j rate limiting in the README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68871d71fdc4832da890db67a2de2308