### PR TITLE
Add rate limit integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
             <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/ti4/spring/controller/RateLimitIntegrationTest.java
+++ b/src/test/java/ti4/spring/controller/RateLimitIntegrationTest.java
@@ -1,0 +1,30 @@
+package ti4.spring.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import ti4.testUtils.BaseTi4Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RateLimitIntegrationTest extends BaseTi4Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void hittingPingMoreThanThirtyTimesReturns429() throws Exception {
+        for (int i = 0; i < 30; i++) {
+            mockMvc.perform(get("/api/public/ping"))
+                .andExpect(status().isOk());
+        }
+
+        mockMvc.perform(get("/api/public/ping"))
+            .andExpect(status().isTooManyRequests());
+    }
+}


### PR DESCRIPTION
## Summary
- add integration test that ensures ping endpoint is rate limited
- pull in Spring Boot test dependency for MockMvc

## Testing
- `mvn -q -Dtest=RateLimitIntegrationTest test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68871d767d04832d9d96869a9631f715