### PR TITLE
Add Bucket4j rate limiting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
             <version>3.1.8</version>
         </dependency>
         <dependency>
+            <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
+            <artifactId>bucket4j-spring-boot-starter</artifactId>
+            <version>0.11.1</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.5.17</version>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+bucket4j:
+  enabled: true
+  filter-order: 2
+  cache-to-use: caffeine
+  filters:
+    - url: /api/**
+      cache-name: buckets
+      rate-limits:
+        - expression: "request.getHeader('Authorization') != null ? request.getHeader('Authorization') : request.getRemoteAddr()"
+          bandwidths:
+            - capacity: 30
+              time: 1
+              unit: minutes


### PR DESCRIPTION
## Summary
- integrate bucket4j-spring-boot-starter for rate limiting
- configure Bucket4j using application.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68871ffc7648832d9bdbcda09907ccd2