### PR TITLE
Fix log severity for missing planet

### DIFF
--- a/src/main/java/ti4/image/PlayerAreaGenerator.java
+++ b/src/main/java/ti4/image/PlayerAreaGenerator.java
@@ -1773,7 +1773,7 @@ public class PlayerAreaGenerator {
             Planet planet = planetsInfo.get(planetName);
             if (planet == null) {
                 player.removePlanet(planetName);
-                BotLogger.error(new BotLogger.LogMessageOrigin(player), "Planet " + planetName + " not found in game " + game.getName() + ". Removing planet from player.");
+                BotLogger.warning(new BotLogger.LogMessageOrigin(player), "Planet " + planetName + " not found in game " + game.getName() + ". Removing planet from player.");
                 return deltaX;
             }
             PlanetModel planetModel = planet.getPlanetModel();


### PR DESCRIPTION
## Summary
- mark missing planet log in `PlayerAreaGenerator` as a warning instead of an error

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68877eed48f0832d8bb13a69df2af55d