### PR TITLE
Fix NPE on load when unit holder missing

### DIFF
--- a/src/main/java/ti4/map/persistence/GameLoadService.java
+++ b/src/main/java/ti4/map/persistence/GameLoadService.java
@@ -1129,8 +1129,10 @@ class GameLoadService {
         }
         for (int x = counts.size(); x < UnitState.values().length; x++)
             counts.add(0);
-        if (!tile.getUnitHolders().containsKey(spaceHolder))
+        if (!tile.getUnitHolders().containsKey(spaceHolder)) {
             BotLogger.error("Invalid unitHolder detected during load: " + tile.getTileID() + " / " + spaceHolder);
+            return;
+        }
         tile.getUnitHolders().get(spaceHolder).getUnitsByState().put(uk, counts);
     }
 


### PR DESCRIPTION
## Summary
- prevent `GameLoadService` from throwing an exception when a unit holder is unknown during game load

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a56be18e8832dafbbedae1bd9a10c