### PR TITLE
Fix bounds check in Milty faction draft

### DIFF
--- a/src/main/java/ti4/service/milty/MiltyService.java
+++ b/src/main/java/ti4/service/milty/MiltyService.java
@@ -228,7 +228,7 @@ public class MiltyService {
         int i = 0;
         List<String> output = new ArrayList<>();
         while (output.size() < factionCount) {
-            if (i > randomOrder.size()) return output;
+            if (i >= randomOrder.size()) return output;
             String f = randomOrder.get(i);
             i++;
             if (output.contains(f)) continue;


### PR DESCRIPTION
## Summary
- prevent IndexOutOfBoundsException when building faction draft order

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894b0686330832d9a62ee3afebd6fa0