### PR TITLE
Shorten agenda queue help message

### DIFF
--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -275,24 +275,14 @@ public class AgendaHelper {
     @ButtonHandler("explainQueue")
     public static void explainQueue(Game game, String buttonID, ButtonInteractionEvent event, Player player) {
         String msg = """
-            First, welcome to the idea of "whens" and "afters". "Whens" are any action card or ability that has a timing window of "When an agenda is revealed" and \
-            "Afters" are any action card or ability that has a timing window of "After an agenda is revealed". All whens need to be played (or declined to be played) \
-            before all afters, and all afters need to be played (or declined to be played) before voting can start. The bot attempts to facilitate this process \
-            via a queue system, so you can queue an after to play while the game is still waiting on everyone to decline on whens. Or you can queue a pre-vote \
-            or pre-abstain while the game is waiting on whens/afters to clear.
+            Here's how the agenda queue works:
 
-            According to game rules, whens and afters get played in a certain order (speaker order, also known as clockwise from the speaker). This order \
-            can often be relevant (if someone plays a rider before you, that may influence where you play your rider, or even if you play a rider at all.)
-
-            This queue system is basically asking you "If no-one who was in front of you in speaker order played anything, would you play anything?". \
-            If your answer is yes, then it will play your chosen ability/action card when everyone in front of you officially declines on playing anything. \
-            If they do decide to play something, then your answer will be tossed out and you will be asked to reconsider if you wish to play something, now that you have more information. \
-            If your answer was no then by default the system will assume that your answer will remain no, but after saying no you can tell the system to ask you again if someone else plays something.
-
-            It should be understood that there is little benefit in stalling your decision here. \
-            You have as much information as you need to answer the bot's queuestion, and if others provide more information (by playing any whens/afters) \
-            you will be asked to privately decide again at that later point. The one exception to this rule of thumb is if you can glean information from \
-            table chatter, which if you can, by all means wait to decide until you hear all the chatter.""";
+            • Abilities with "When an agenda is revealed" are resolved before those with "After an agenda is revealed".
+            • The bot asks players in speaker order if they'd act assuming no one earlier does.
+            • If you queue an effect, it triggers when it's your turn; if someone earlier acts, you'll be asked again.
+            • Saying no passes by default, but you can request another prompt if others act after you.
+            There's little benefit to stalling—new information will give you another chance to decide.
+            """;
 
         MessageHelper.sendEphemeralMessageToEventChannel(event, msg);
     }


### PR DESCRIPTION
## Summary
- Reduce "How Does This Work?" explanation to stay under Discord's 2000 character limit

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to missing spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68960e991b60832dbcff994c43230fb5