### PR TITLE
Refactor objective display and optimize planet sticker retrieval

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -1,7 +1,5 @@
 package ti4.helpers;
 
-import static org.apache.commons.lang3.StringUtils.*;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,11 +14,6 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.function.Consumers;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import lombok.Data;
 import net.dv8tion.jda.api.entities.Message;
@@ -42,6 +35,10 @@ import net.dv8tion.jda.api.requests.restaction.ThreadChannelAction;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.internal.utils.tuple.ImmutablePair;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.function.Consumers;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import ti4.ResourceHelper;
 import ti4.buttons.Buttons;
 import ti4.buttons.handlers.agenda.VoteButtonHandler;
@@ -111,6 +108,8 @@ import ti4.service.unit.AddUnitService;
 import ti4.service.unit.RemoveUnitService;
 import ti4.settings.users.UserSettingsManager;
 import ti4.website.AsyncTi4WebsiteHelper;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class ButtonHelper {
 
@@ -916,8 +915,7 @@ public class ButtonHelper {
 
         if (isPlayerElected(game, player, "minister_policy") && !player.hasAbility("scheming")) {
             String acAlias = null;
-            for (Map.Entry<String, Integer> ac : Helper.getLastEntryInHashMap(game.drawActionCard(player.getUserID()))
-                .entrySet()) {
+            for (Map.Entry<String, Integer> ac : Helper.getLastEntryInHashMap(game.drawActionCard(player.getUserID())).entrySet()) {
                 acAlias = ac.getKey();
             }
             message += " _Minister of Policy_ has been accounted for.";

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -1810,7 +1810,7 @@ public class MapGenerator implements AutoCloseable {
 
         for (Objective objective : objectives) {
             ObjectiveBox box = new ObjectiveBox(x, y, boxWidth, maxTextWidth, scoreTokenSpacing);
-            box.Display(game, graphics, this, objective);
+            box.display(game, graphics, this, objective);
             y += ObjectiveBox.getVerticalSpacing();
         }
 
@@ -1827,7 +1827,7 @@ public class MapGenerator implements AutoCloseable {
         boxWidth = ObjectiveBox.getBoxWidth(game, maxTextWidth, scoreTokenSpacing);
         for (Objective objective : objectives) {
             ObjectiveBox box = new ObjectiveBox(x, y, boxWidth, maxTextWidth, scoreTokenSpacing);
-            box.Display(game, graphics, this, objective);
+            box.display(game, graphics, this, objective);
             y += ObjectiveBox.getVerticalSpacing();
         }
 
@@ -1841,7 +1841,7 @@ public class MapGenerator implements AutoCloseable {
         boxWidth = ObjectiveBox.getBoxWidth(game, maxTextWidth, scoreTokenSpacing);
         for (Objective objective : objectives) {
             ObjectiveBox box = new ObjectiveBox(x, y, boxWidth, maxTextWidth, scoreTokenSpacing);
-            box.Display(game, graphics, this, objective);
+            box.display(game, graphics, this, objective);
             y += ObjectiveBox.getVerticalSpacing();
         }
 

--- a/src/main/java/ti4/image/Objective.java
+++ b/src/main/java/ti4/image/Objective.java
@@ -25,10 +25,8 @@ public record Objective(
     }
 
     public static List<Objective> retrieve(Game game) {
-        List<Objective> objectives = new ArrayList<>();
+        List<Objective> objectives = retrievePublic1(game);
 
-        appendRevealedObjectives(game, objectives, Type.Stage1);
-        appendUnrevealedObjectives(game, objectives, Type.Stage1);
         appendRevealedObjectives(game, objectives, Type.Stage2);
         appendUnrevealedObjectives(game, objectives, Type.Stage2);
         appendRevealedObjectives(game, objectives, Type.Custom);

--- a/src/main/java/ti4/image/ObjectiveBox.java
+++ b/src/main/java/ti4/image/ObjectiveBox.java
@@ -1,7 +1,6 @@
 package ti4.image;
 
-import java.awt.Color;
-import java.awt.Graphics;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.List;
 
@@ -38,7 +37,7 @@ public class ObjectiveBox {
         this.spaceForTokens = boxWidth - (maxTextWidth + bufferBetweenTextAndTokens * 2);
     }
 
-    public void Display(Game game, Graphics graphics, MapGenerator generator, Objective objective) {
+    public void display(Game game, Graphics graphics, MapGenerator generator, Objective objective) {
         setColor(graphics, objective);
 
         graphics.drawString(objective.getDisplayText(game), x, y + textVerticalOffset);

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -2491,11 +2491,9 @@ public class Game extends GameProperties {
                 ButtonHelperFactionSpecific.resolveDeceive(player, this);
                 return null;
             }
-            if (player != null) {
-                getActionCards().remove(id);
-                player.setActionCard(id);
-                return player.getActionCards();
-            }
+            getActionCards().remove(id);
+            player.setActionCard(id);
+            return player.getActionCards();
         } else if (!discardActionCards.isEmpty()) {
             reshuffleActionCardDiscard();
             return drawActionCard(userID);

--- a/src/main/java/ti4/model/PlanetModel.java
+++ b/src/main/java/ti4/model/PlanetModel.java
@@ -13,9 +13,9 @@ import net.dv8tion.jda.api.entities.emoji.CustomEmoji;
 import net.dv8tion.jda.api.entities.sticker.Sticker;
 import org.apache.commons.lang3.StringUtils;
 import ti4.AsyncTI4DiscordBot;
+import ti4.helpers.Stickers;
 import ti4.image.TileHelper;
 import ti4.image.UnitTokenPosition;
-import ti4.helpers.Stickers;
 import ti4.model.PlanetTypeModel.PlanetType;
 import ti4.model.Source.ComponentSource;
 import ti4.model.TechSpecialtyModel.TechSpecialty;
@@ -55,6 +55,8 @@ public class PlanetModel implements ModelInterface, EmbeddableModel {
     private List<String> searchTags = new ArrayList<>();
     private String contrastColor;
     private ComponentSource source;
+
+    private String cachedStickerUrl;
 
     @JsonIgnore
     public boolean isValid() {
@@ -169,12 +171,7 @@ public class PlanetModel implements ModelInterface, EmbeddableModel {
         eb.setColor(Color.black);
 
         eb.setDescription(getLegendaryAbilityText());
-        //if (getLegendaryAbilityFlavourText() != null) eb.addField("", getLegendaryAbilityFlavourText(), false);
         if (getStickerOrEmojiURL() != null) eb.setThumbnail(getStickerOrEmojiURL());
-
-        // footer can have some of the planet info
-        //eb.setFooter(getName());
-
         return eb.build();
     }
 
@@ -251,11 +248,18 @@ public class PlanetModel implements ModelInterface, EmbeddableModel {
 
     @JsonIgnore
     public String getStickerOrEmojiURL() {
+        if (cachedStickerUrl != null) {
+            return cachedStickerUrl;
+        }
+
         long ident = Stickers.getPlanetSticker(getId());
         if (ident == -1) {
-            return getEmojiURL();
+            cachedStickerUrl = getEmojiURL();
+        } else {
+            cachedStickerUrl = AsyncTI4DiscordBot.jda.retrieveSticker(Sticker.fromId(ident)).complete().getIconUrl();
         }
-        return AsyncTI4DiscordBot.jda.retrieveSticker(Sticker.fromId(ident)).complete().getIconUrl();
+
+        return cachedStickerUrl;
     }
 
     public boolean search(String searchString) {


### PR DESCRIPTION
Renamed ObjectiveBox.Display to display for consistency and updated all usages. Refactored Objective.retrieve to use retrievePublic1 for stage 1 objectives. Optimized PlanetModel.getStickerOrEmojiURL by caching the sticker URL to avoid repeated retrievals. Minor cleanup in Game.drawActionCard and imports.