### PR TITLE
Fix permission override chaining and SO scoring logic

### DIFF
--- a/src/main/java/ti4/service/game/CreateGameService.java
+++ b/src/main/java/ti4/service/game/CreateGameService.java
@@ -621,11 +621,11 @@ public class CreateGameService {
         Role everyoneRole = getRole("@everyone", guild);
         ChannelAction<Category> createCategoryAction = guild.createCategory(categoryName);
         if (bothelperRole != null)
-            createCategoryAction.addRolePermissionOverride(bothelperRole.getIdLong(), allow, null);
+            createCategoryAction = createCategoryAction.addRolePermissionOverride(bothelperRole.getIdLong(), allow, null);
         if (spectatorRole != null)
-            createCategoryAction.addRolePermissionOverride(spectatorRole.getIdLong(), allow, null);
+            createCategoryAction = createCategoryAction.addRolePermissionOverride(spectatorRole.getIdLong(), allow, null);
         if (everyoneRole != null)
-            createCategoryAction.addRolePermissionOverride(everyoneRole.getIdLong(), null, deny);
+            createCategoryAction = createCategoryAction.addRolePermissionOverride(everyoneRole.getIdLong(), null, deny);
         return createCategoryAction.complete();
     }
 

--- a/src/main/java/ti4/service/turn/PassService.java
+++ b/src/main/java/ti4/service/turn/PassService.java
@@ -11,10 +11,9 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ti4.buttons.Buttons;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.ButtonHelperCommanders;
-import ti4.helpers.Constants;
 import ti4.helpers.DiscordantStarsHelper;
-import ti4.helpers.omega_phase.PriorityTrackHelper;
 import ti4.helpers.SecretObjectiveHelper;
+import ti4.helpers.omega_phase.PriorityTrackHelper;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
@@ -94,12 +93,11 @@ public class PassService {
 
         DiscordantStarsHelper.checkKjalengardMechs(event, player, game);
         
-        if ("yes".equals(game.getStoredValue("autoProveEndurance_" + player.getFaction())))
-        {
+        if ("yes".equals(game.getStoredValue("autoProveEndurance_" + player.getFaction()))) {
             for (Map.Entry<String, Integer> so : player.getSecrets().entrySet()) {
-                if ("pe".equals(so.getKey()))
-                {
+                if ("pe".equals(so.getKey())) {
                     SecretObjectiveHelper.scoreSO(event, game, player, so.getValue(), (game.isFowMode() ? player.getPrivateChannel() : game.getMainGameChannel()));
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Corrects the chaining of addRolePermissionOverride calls in CreateGameService to ensure overrides are applied sequentially. In PassService, refactors autoProveEndurance logic to break after scoring the 'pe' secret objective, preventing multiple scores in a single pass.