### PR TITLE
Improve game save reliability with atomic file writes

### DIFF
--- a/src/main/java/ti4/helpers/Storage.java
+++ b/src/main/java/ti4/helpers/Storage.java
@@ -6,7 +6,6 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import lombok.SneakyThrows;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -294,8 +293,8 @@ public class Storage {
     @NotNull
     public static Path getGamePath(String gameName) {
         return Path.of(getStoragePath() + GAMES_PATH + gameName)
-            .toAbsolutePath()
-            .normalize();
+                .toAbsolutePath()
+                .normalize();
     }
 
     @NotNull

--- a/src/main/java/ti4/helpers/Storage.java
+++ b/src/main/java/ti4/helpers/Storage.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import lombok.SneakyThrows;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -292,7 +293,9 @@ public class Storage {
 
     @NotNull
     public static Path getGamePath(String gameName) {
-        return Path.of(getStoragePath() + GAMES_PATH + gameName);
+        return Path.of(getStoragePath() + GAMES_PATH + gameName)
+            .toAbsolutePath()
+            .normalize();
     }
 
     @NotNull

--- a/src/main/java/ti4/map/persistence/GameSaveService.java
+++ b/src/main/java/ti4/map/persistence/GameSaveService.java
@@ -1,5 +1,25 @@
 package ti4.map.persistence;
 
+import static ti4.map.persistence.GamePersistenceKeys.ENDGAMEINFO;
+import static ti4.map.persistence.GamePersistenceKeys.ENDMAPINFO;
+import static ti4.map.persistence.GamePersistenceKeys.ENDPLAYER;
+import static ti4.map.persistence.GamePersistenceKeys.ENDPLAYERINFO;
+import static ti4.map.persistence.GamePersistenceKeys.ENDTILE;
+import static ti4.map.persistence.GamePersistenceKeys.ENDTOKENS;
+import static ti4.map.persistence.GamePersistenceKeys.ENDUNITHOLDER;
+import static ti4.map.persistence.GamePersistenceKeys.ENDUNITS;
+import static ti4.map.persistence.GamePersistenceKeys.GAMEINFO;
+import static ti4.map.persistence.GamePersistenceKeys.MAPINFO;
+import static ti4.map.persistence.GamePersistenceKeys.PLANET_ENDTOKENS;
+import static ti4.map.persistence.GamePersistenceKeys.PLANET_TOKENS;
+import static ti4.map.persistence.GamePersistenceKeys.PLAYER;
+import static ti4.map.persistence.GamePersistenceKeys.PLAYERINFO;
+import static ti4.map.persistence.GamePersistenceKeys.TILE;
+import static ti4.map.persistence.GamePersistenceKeys.TOKENS;
+import static ti4.map.persistence.GamePersistenceKeys.UNITHOLDER;
+import static ti4.map.persistence.GamePersistenceKeys.UNITS;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -14,8 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
 import ti4.helpers.Constants;
@@ -36,25 +54,6 @@ import ti4.model.TemporaryCombatModifierModel;
 import ti4.service.map.CustomHyperlaneService;
 import ti4.service.milty.MiltyDraftManager;
 import ti4.service.option.FOWOptionService.FOWOption;
-
-import static ti4.map.persistence.GamePersistenceKeys.ENDGAMEINFO;
-import static ti4.map.persistence.GamePersistenceKeys.ENDMAPINFO;
-import static ti4.map.persistence.GamePersistenceKeys.ENDPLAYER;
-import static ti4.map.persistence.GamePersistenceKeys.ENDPLAYERINFO;
-import static ti4.map.persistence.GamePersistenceKeys.ENDTILE;
-import static ti4.map.persistence.GamePersistenceKeys.ENDTOKENS;
-import static ti4.map.persistence.GamePersistenceKeys.ENDUNITHOLDER;
-import static ti4.map.persistence.GamePersistenceKeys.ENDUNITS;
-import static ti4.map.persistence.GamePersistenceKeys.GAMEINFO;
-import static ti4.map.persistence.GamePersistenceKeys.MAPINFO;
-import static ti4.map.persistence.GamePersistenceKeys.PLANET_ENDTOKENS;
-import static ti4.map.persistence.GamePersistenceKeys.PLANET_TOKENS;
-import static ti4.map.persistence.GamePersistenceKeys.PLAYER;
-import static ti4.map.persistence.GamePersistenceKeys.PLAYERINFO;
-import static ti4.map.persistence.GamePersistenceKeys.TILE;
-import static ti4.map.persistence.GamePersistenceKeys.TOKENS;
-import static ti4.map.persistence.GamePersistenceKeys.UNITHOLDER;
-import static ti4.map.persistence.GamePersistenceKeys.UNITS;
 
 @UtilityClass
 class GameSaveService {
@@ -257,7 +256,6 @@ class GameSaveService {
         writeCards(game.getSentAgendas(), writer, Constants.SENT_AGENDAS);
         writeCards(game.getLaws(), writer, Constants.LAW);
         writeCards(game.getEventsInEffect(), writer, Constants.EVENTS_IN_EFFECT);
-
 
         List<String> events = game.getEvents();
         if (events == null) {

--- a/src/main/java/ti4/map/persistence/GameSaveService.java
+++ b/src/main/java/ti4/map/persistence/GameSaveService.java
@@ -50,6 +50,7 @@ import ti4.map.Player;
 import ti4.map.Tile;
 import ti4.map.UnitHolder;
 import ti4.message.BotLogger;
+import ti4.message.MessageHelper;
 import ti4.model.TemporaryCombatModifierModel;
 import ti4.service.map.CustomHyperlaneService;
 import ti4.service.milty.MiltyDraftManager;
@@ -81,6 +82,8 @@ class GameSaveService {
             Files.move(temporarySavePath, gameSavePath, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             BotLogger.error(new BotLogger.LogMessageOrigin(game), "Could not save map: " + game.getName(), e);
+            MessageHelper.sendMessageToChannel(
+                    game.getActionsChannel(), "Failed to save the game during the last command.");
             return false;
         } finally {
             deleteTemporaryFileIfNeeded(temporarySavePath);


### PR DESCRIPTION
Refactored GameSaveService to write game saves to a temporary file before atomically moving them to the final location, reducing the risk of data corruption. Updated Storage.getGamePath to return absolute, normalized paths. Extracted save logic into helper methods for better clarity and error handling.