### PR TITLE
Fix Mutiny custom PO value based on agenda outcome

### DIFF
--- a/src/main/java/ti4/buttons/handlers/agenda/AgendaResolveButtonHandler.java
+++ b/src/main/java/ti4/buttons/handlers/agenda/AgendaResolveButtonHandler.java
@@ -6,7 +6,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
@@ -1078,7 +1077,6 @@ class AgendaResolveButtonHandler {
         }
 
         if (!"miscount".equalsIgnoreCase(agID) && !"absol_miscount".equalsIgnoreCase(agID)) {
-
             MessageHelper.sendMessageToChannel(event.getChannel(), resMes);
             if (!game.getPhaseOfGame().equalsIgnoreCase("action")) {
                 MessageHelper.sendMessageToChannelWithButtons(event.getChannel(), voteMessage, buttons);

--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -2421,10 +2421,10 @@ public class AgendaHelper {
 
         for (String outcome : outcomes.keySet()) {
             if (outcome.equalsIgnoreCase(winner)) {
-                StringTokenizer vote_info = new StringTokenizer(outcomes.get(outcome), ";");
+                StringTokenizer voteInfo = new StringTokenizer(outcomes.get(outcome), ";");
 
-                while (vote_info.hasMoreTokens()) {
-                    String specificVote = vote_info.nextToken();
+                while (voteInfo.hasMoreTokens()) {
+                    String specificVote = voteInfo.nextToken();
                     String faction = specificVote.substring(0, specificVote.indexOf('_'));
                     Player loser = game.getPlayerFromColorOrFaction(faction.toLowerCase());
                     if (loser != null


### PR DESCRIPTION
The value assigned to the custom public objective 'Mutiny' now depends on whether the agenda passed or failed, using 1 if it passed and -1 if it did not. This ensures correct scoring based on the agenda result.