### PR TITLE
Fix improper String comparisons

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
+++ b/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
@@ -3417,7 +3417,7 @@ public class ButtonHelperFactionSpecific {
             MessageHelper.sendMessageToChannel(
                     event.getMessageChannel(),
                     player.getRepresentation(true, false) + " does not have "
-                            + (count == "1" ? "a commodity" : count + " commodities")
+                            + ("1".equals(count) ? "a commodity" : count + " commodities")
                             + " to remove from _ATS Armaments_. Current count: " + player.getAtsCount() + ".");
             return;
         }

--- a/src/main/java/ti4/helpers/CryypterHelper.java
+++ b/src/main/java/ti4/helpers/CryypterHelper.java
@@ -312,10 +312,10 @@ public class CryypterHelper {
     private static void votcRiderButtons(Player player, List<Button> buttons, boolean play) {
         for (Leader leader : player.getLeaders()) {
             LeaderModel leaderModel = leader.getLeaderModel().orElse(null);
-            if (!leader.isLocked() && leaderModel.getAbilityWindow() == "After an agenda is revealed:") {
+            if (!leader.isLocked() && "After an agenda is revealed:".equals(leaderModel.getAbilityWindow())) {
                 FactionModel factionModel = Mapper.getFaction(leaderModel.getFaction());
                 String buttonID = "";
-                if (leaderModel.getType() == "hero") {
+                if ("hero".equals(leaderModel.getType())) {
                     buttonID = "Keleres Xxcha Hero";
                 } else {
                     buttonID = factionModel.getShortName() + " Envoy";


### PR DESCRIPTION
## Summary
- Use `.equals` for String comparisons when checking leader ability window and type
- Apply `.equals` in ATS commodity check

## Testing
- `mvn -q test` *(fails: Could not transfer parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f4cb7a140832dbc4963b441b4307c