### PR TITLE
Log response body for HTTP errors

### DIFF
--- a/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
+++ b/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
@@ -18,7 +18,7 @@ import ti4.message.BotLogger;
 public class ErrorLoggingFilter extends OncePerRequestFilter {
 
     private static final int START_OF_HTTP_ERROR_RANGE = 400;
-    
+
     @Override
     protected void doFilterInternal(
             @NotNull HttpServletRequest request,

--- a/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
+++ b/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
@@ -1,10 +1,11 @@
 package ti4.spring.service.auth;
 
+import java.io.IOException;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -16,13 +17,15 @@ import ti4.message.BotLogger;
 @Component
 public class ErrorLoggingFilter extends OncePerRequestFilter {
 
+    private static final int START_OF_HTTP_ERROR_RANGE = 400;
+    
     @Override
     protected void doFilterInternal(
             @NotNull HttpServletRequest request,
             @NotNull HttpServletResponse response,
             @NotNull FilterChain filterChain)
             throws ServletException, IOException {
-        ContentCachingResponseWrapper cachingResponse = new ContentCachingResponseWrapper(response);
+        var cachingResponse = new ContentCachingResponseWrapper(response);
         try {
             filterChain.doFilter(request, cachingResponse);
         } catch (Exception e) {
@@ -30,7 +33,7 @@ public class ErrorLoggingFilter extends OncePerRequestFilter {
             throw e;
         }
 
-        if (cachingResponse.getStatus() >= 400) {
+        if (cachingResponse.getStatus() >= START_OF_HTTP_ERROR_RANGE) {
             String body = new String(cachingResponse.getContentAsByteArray(), cachingResponse.getCharacterEncoding());
             String error = String.format(
                     "Request to %s returned status %s with body: %s",

--- a/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
+++ b/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
@@ -31,13 +31,10 @@ public class ErrorLoggingFilter extends OncePerRequestFilter {
         }
 
         if (cachingResponse.getStatus() >= 400) {
-            String body =
-                    new String(cachingResponse.getContentAsByteArray(), cachingResponse.getCharacterEncoding());
+            String body = new String(cachingResponse.getContentAsByteArray(), cachingResponse.getCharacterEncoding());
             String error = String.format(
                     "Request to %s returned status %s with body: %s",
-                    request.getRequestURI(),
-                    cachingResponse.getStatus(),
-                    body);
+                    request.getRequestURI(), cachingResponse.getStatus(), body);
             BotLogger.error(error);
         }
 

--- a/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
+++ b/src/main/java/ti4/spring/service/auth/ErrorLoggingFilter.java
@@ -1,11 +1,10 @@
 package ti4.spring.service.auth;
 
-import java.io.IOException;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
## Summary
- log response body when HTTP requests return error codes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fadd00b14832d8cab8cc96e0b5484