### PR TITLE
Centralize regex patterns in PatternHelper

### DIFF
--- a/src/main/java/ti4/draft/FrankenDraft.java
+++ b/src/main/java/ti4/draft/FrankenDraft.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.items.AbilityDraftItem;
 import ti4.draft.items.AgentDraftItem;
 import ti4.draft.items.BlueTileDraftItem;
@@ -28,7 +28,6 @@ import ti4.service.milty.MiltyDraftHelper;
 import ti4.service.milty.MiltyDraftManager;
 
 public class FrankenDraft extends BagDraft {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public FrankenDraft(Game owner) {
         super(owner);
@@ -118,7 +117,7 @@ public class FrankenDraft extends BagDraft {
 
     private static List<FactionModel> getDraftableFactionsForGame(Game game) {
         List<FactionModel> factionSet = getAllFrankenLegalFactions();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedFactions"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedFactions"));
         if (!game.isDiscordantStarsMode()) {
             factionSet.removeIf(factionModel ->
                     factionModel.getSource().isDs() && !factionModel.getSource().isPok());

--- a/src/main/java/ti4/draft/FrankenDraft.java
+++ b/src/main/java/ti4/draft/FrankenDraft.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import ti4.helpers.PatternHelper;
 import ti4.draft.items.AbilityDraftItem;
 import ti4.draft.items.AgentDraftItem;
 import ti4.draft.items.BlueTileDraftItem;
@@ -20,6 +19,7 @@ import ti4.draft.items.SpeakerOrderDraftItem;
 import ti4.draft.items.StartingFleetDraftItem;
 import ti4.draft.items.StartingTechDraftItem;
 import ti4.draft.items.TechDraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.message.BotLogger;
@@ -117,7 +117,7 @@ public class FrankenDraft extends BagDraft {
 
     private static List<FactionModel> getDraftableFactionsForGame(Game game) {
         List<FactionModel> factionSet = getAllFrankenLegalFactions();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedFactions"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedFactions"));
         if (!game.isDiscordantStarsMode()) {
             factionSet.removeIf(factionModel ->
                     factionModel.getSource().isDs() && !factionModel.getSource().isPok());

--- a/src/main/java/ti4/draft/items/AbilityDraftItem.java
+++ b/src/main/java/ti4/draft/items/AbilityDraftItem.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.AbilityModel;
@@ -69,7 +69,7 @@ public class AbilityDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         for (FactionModel faction : factions) {
-            String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedAbilities"));
+            String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedAbilities"));
             for (String ability : faction.getAbilities()) {
                 if (Arrays.asList(results).contains(ability)) {
                     continue;

--- a/src/main/java/ti4/draft/items/AbilityDraftItem.java
+++ b/src/main/java/ti4/draft/items/AbilityDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -14,7 +14,6 @@ import ti4.model.FactionModel;
 import ti4.service.emoji.TI4Emoji;
 
 public class AbilityDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public AbilityDraftItem(String itemId) {
         super(Category.ABILITY, itemId);
@@ -70,7 +69,7 @@ public class AbilityDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         for (FactionModel faction : factions) {
-            String[] results = FIN_SEP.split(game.getStoredValue("bannedAbilities"));
+            String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedAbilities"));
             for (String ability : faction.getAbilities()) {
                 if (Arrays.asList(results).contains(ability)) {
                     continue;

--- a/src/main/java/ti4/draft/items/AgentDraftItem.java
+++ b/src/main/java/ti4/draft/items/AgentDraftItem.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -16,7 +16,6 @@ import ti4.service.emoji.LeaderEmojis;
 import ti4.service.emoji.TI4Emoji;
 
 public class AgentDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public AgentDraftItem(String itemId) {
         super(Category.AGENT, itemId);
@@ -86,7 +85,7 @@ public class AgentDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, LeaderModel> allLeaders = Mapper.getLeaders();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedLeaders"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
         for (FactionModel faction : factions) {
             List<String> agents = faction.getLeaders();
             agents.removeIf(

--- a/src/main/java/ti4/draft/items/AgentDraftItem.java
+++ b/src/main/java/ti4/draft/items/AgentDraftItem.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -85,7 +85,7 @@ public class AgentDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, LeaderModel> allLeaders = Mapper.getLeaders();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
         for (FactionModel faction : factions) {
             List<String> agents = faction.getLeaders();
             agents.removeIf(

--- a/src/main/java/ti4/draft/items/BlueTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/BlueTileDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.image.TileHelper;
@@ -21,7 +21,6 @@ import ti4.service.milty.MiltyDraftManager;
 import ti4.service.milty.MiltyDraftTile;
 
 public class BlueTileDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public BlueTileDraftItem(String itemId) {
         super(Category.BLUETILE, itemId);
@@ -90,7 +89,7 @@ public class BlueTileDraftItem extends DraftItem {
 
     public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedTiles"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
         for (MiltyDraftTile tile : draftManager.getBlue()) {
             if (Arrays.asList(results).contains(tile.getTile().getTileID())) {
                 continue;

--- a/src/main/java/ti4/draft/items/BlueTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/BlueTileDraftItem.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.image.TileHelper;
 import ti4.map.Game;
@@ -89,7 +89,7 @@ public class BlueTileDraftItem extends DraftItem {
 
     public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
         for (MiltyDraftTile tile : draftManager.getBlue()) {
             if (Arrays.asList(results).contains(tile.getTile().getTileID())) {
                 continue;

--- a/src/main/java/ti4/draft/items/CommanderDraftItem.java
+++ b/src/main/java/ti4/draft/items/CommanderDraftItem.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -15,7 +15,6 @@ import ti4.model.LeaderModel;
 import ti4.service.emoji.TI4Emoji;
 
 public class CommanderDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public CommanderDraftItem(String itemId) {
         super(Category.COMMANDER, itemId);
@@ -86,7 +85,7 @@ public class CommanderDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, LeaderModel> allLeaders = Mapper.getLeaders();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedLeaders"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
         for (FactionModel faction : factions) {
             List<String> leaders = faction.getLeaders();
             leaders.removeIf((String leader) ->

--- a/src/main/java/ti4/draft/items/CommanderDraftItem.java
+++ b/src/main/java/ti4/draft/items/CommanderDraftItem.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -85,7 +85,7 @@ public class CommanderDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, LeaderModel> allLeaders = Mapper.getLeaders();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
         for (FactionModel faction : factions) {
             List<String> leaders = faction.getLeaders();
             leaders.removeIf((String leader) ->

--- a/src/main/java/ti4/draft/items/CommoditiesDraftItem.java
+++ b/src/main/java/ti4/draft/items/CommoditiesDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -14,7 +14,6 @@ import ti4.service.emoji.MiscEmojis;
 import ti4.service.emoji.TI4Emoji;
 
 public class CommoditiesDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public CommoditiesDraftItem(String itemId) {
         super(Category.COMMODITIES, itemId);
@@ -73,7 +72,7 @@ public class CommoditiesDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedComms"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedComms"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/CommoditiesDraftItem.java
+++ b/src/main/java/ti4/draft/items/CommoditiesDraftItem.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -72,7 +72,7 @@ public class CommoditiesDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedComms"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedComms"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/FlagshipDraftItem.java
+++ b/src/main/java/ti4/draft/items/FlagshipDraftItem.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -16,7 +16,6 @@ import ti4.service.emoji.TI4Emoji;
 import ti4.service.emoji.UnitEmojis;
 
 public class FlagshipDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public FlagshipDraftItem(String itemId) {
         super(Category.FLAGSHIP, itemId);
@@ -105,7 +104,7 @@ public class FlagshipDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, UnitModel> allUnits = Mapper.getUnits();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedFSs"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedFSs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/FlagshipDraftItem.java
+++ b/src/main/java/ti4/draft/items/FlagshipDraftItem.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -104,7 +104,7 @@ public class FlagshipDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, UnitModel> allUnits = Mapper.getUnits();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedFSs"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedFSs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/HeroDraftItem.java
+++ b/src/main/java/ti4/draft/items/HeroDraftItem.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -15,7 +15,6 @@ import ti4.model.LeaderModel;
 import ti4.service.emoji.TI4Emoji;
 
 public class HeroDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public HeroDraftItem(String itemId) {
         super(Category.HERO, itemId);
@@ -86,7 +85,7 @@ public class HeroDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, LeaderModel> allLeaders = Mapper.getLeaders();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedLeaders"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
         for (FactionModel faction : factions) {
             List<String> leaders = faction.getLeaders();
             leaders.removeIf(

--- a/src/main/java/ti4/draft/items/HeroDraftItem.java
+++ b/src/main/java/ti4/draft/items/HeroDraftItem.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -85,7 +85,7 @@ public class HeroDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, LeaderModel> allLeaders = Mapper.getLeaders();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedLeaders"));
         for (FactionModel faction : factions) {
             List<String> leaders = faction.getLeaders();
             leaders.removeIf(

--- a/src/main/java/ti4/draft/items/HomeSystemDraftItem.java
+++ b/src/main/java/ti4/draft/items/HomeSystemDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.image.TileHelper;
@@ -17,7 +17,6 @@ import ti4.service.emoji.FactionEmojis;
 import ti4.service.emoji.TI4Emoji;
 
 public class HomeSystemDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public HomeSystemDraftItem(String itemId) {
         super(Category.HOMESYSTEM, itemId);
@@ -84,7 +83,7 @@ public class HomeSystemDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedHSs"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedHSs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/HomeSystemDraftItem.java
+++ b/src/main/java/ti4/draft/items/HomeSystemDraftItem.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.image.TileHelper;
 import ti4.map.Game;
@@ -83,7 +83,7 @@ public class HomeSystemDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedHSs"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedHSs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/MechDraftItem.java
+++ b/src/main/java/ti4/draft/items/MechDraftItem.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -96,7 +96,7 @@ public class MechDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, UnitModel> allUnits = Mapper.getUnits();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedMechs"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedMechs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/MechDraftItem.java
+++ b/src/main/java/ti4/draft/items/MechDraftItem.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -16,7 +16,6 @@ import ti4.service.emoji.TI4Emoji;
 import ti4.service.emoji.UnitEmojis;
 
 public class MechDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public MechDraftItem(String itemId) {
         super(Category.MECH, itemId);
@@ -97,7 +96,7 @@ public class MechDraftItem extends DraftItem {
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         Map<String, UnitModel> allUnits = Mapper.getUnits();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedMechs"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedMechs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/PNDraftItem.java
+++ b/src/main/java/ti4/draft/items/PNDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -15,7 +15,6 @@ import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.TI4Emoji;
 
 public class PNDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public PNDraftItem(String itemId) {
         super(Category.PN, itemId);
@@ -70,7 +69,7 @@ public class PNDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedPNs"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedPNs"));
         for (FactionModel faction : factions) {
             for (String pnID : faction.getPromissoryNotes()) {
                 if (Arrays.asList(results).contains(pnID)) {

--- a/src/main/java/ti4/draft/items/PNDraftItem.java
+++ b/src/main/java/ti4/draft/items/PNDraftItem.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -69,7 +69,7 @@ public class PNDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedPNs"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedPNs"));
         for (FactionModel faction : factions) {
             for (String pnID : faction.getPromissoryNotes()) {
                 if (Arrays.asList(results).contains(pnID)) {

--- a/src/main/java/ti4/draft/items/RedTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/RedTileDraftItem.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.image.TileHelper;
 import ti4.map.Game;
@@ -91,7 +91,7 @@ public class RedTileDraftItem extends DraftItem {
 
     public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
         for (MiltyDraftTile tile : draftManager.getRed()) {
             if (Arrays.asList(results).contains(tile.getTile().getTileID())) {
                 continue;

--- a/src/main/java/ti4/draft/items/RedTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/RedTileDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.image.TileHelper;
@@ -20,7 +20,6 @@ import ti4.service.milty.MiltyDraftManager;
 import ti4.service.milty.MiltyDraftTile;
 
 public class RedTileDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public RedTileDraftItem(String itemId) {
         super(Category.REDTILE, itemId);
@@ -92,7 +91,7 @@ public class RedTileDraftItem extends DraftItem {
 
     public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedTiles"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
         for (MiltyDraftTile tile : draftManager.getRed()) {
             if (Arrays.asList(results).contains(tile.getTile().getTileID())) {
                 continue;

--- a/src/main/java/ti4/draft/items/StartingFleetDraftItem.java
+++ b/src/main/java/ti4/draft/items/StartingFleetDraftItem.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.helpers.Helper;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -65,7 +65,7 @@ public class StartingFleetDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedFleets"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedFleets"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/StartingFleetDraftItem.java
+++ b/src/main/java/ti4/draft/items/StartingFleetDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.helpers.Helper;
 import ti4.image.Mapper;
@@ -15,7 +15,6 @@ import ti4.service.emoji.TI4Emoji;
 import ti4.service.emoji.TechEmojis;
 
 public class StartingFleetDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public StartingFleetDraftItem(String itemId) {
         super(Category.STARTINGFLEET, itemId);
@@ -66,7 +65,7 @@ public class StartingFleetDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedFleets"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedFleets"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/StartingTechDraftItem.java
+++ b/src/main/java/ti4/draft/items/StartingTechDraftItem.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -132,7 +132,7 @@ public class StartingTechDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedStartingTechs"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedStartingTechs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/StartingTechDraftItem.java
+++ b/src/main/java/ti4/draft/items/StartingTechDraftItem.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -16,7 +16,6 @@ import ti4.service.emoji.TI4Emoji;
 import ti4.service.emoji.TechEmojis;
 
 public class StartingTechDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public StartingTechDraftItem(String itemId) {
         super(Category.STARTINGTECH, itemId);
@@ -133,7 +132,7 @@ public class StartingTechDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedStartingTechs"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedStartingTechs"));
         for (FactionModel faction : factions) {
             if (Arrays.asList(results).contains(faction.getAlias())) {
                 continue;

--- a/src/main/java/ti4/draft/items/TechDraftItem.java
+++ b/src/main/java/ti4/draft/items/TechDraftItem.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.DraftErrataModel;
@@ -65,7 +65,7 @@ public class TechDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedTechs"));
+        String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedTechs"));
         for (FactionModel faction : factions) {
             for (var tech : faction.getFactionTech()) {
                 if (Arrays.asList(results).contains(tech)) {

--- a/src/main/java/ti4/draft/items/TechDraftItem.java
+++ b/src/main/java/ti4/draft/items/TechDraftItem.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import ti4.draft.DraftItem;
 import ti4.image.Mapper;
 import ti4.map.Game;
@@ -14,7 +14,6 @@ import ti4.model.TechnologyModel;
 import ti4.service.emoji.TI4Emoji;
 
 public class TechDraftItem extends DraftItem {
-    private static final Pattern FIN_SEP = Pattern.compile("finSep");
 
     public TechDraftItem(String itemId) {
         super(Category.TECH, itemId);
@@ -66,7 +65,7 @@ public class TechDraftItem extends DraftItem {
 
     private static List<DraftItem> buildAllItems(List<FactionModel> factions, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
-        String[] results = FIN_SEP.split(game.getStoredValue("bannedTechs"));
+        String[] results = PatternHelper.STORAGE_SEPARATOR_PATTERN.split(game.getStoredValue("bannedTechs"));
         for (FactionModel faction : factions) {
             for (var tech : faction.getFactionTech()) {
                 if (Arrays.asList(results).contains(tech)) {

--- a/src/main/java/ti4/helpers/PatternHelper.java
+++ b/src/main/java/ti4/helpers/PatternHelper.java
@@ -9,13 +9,12 @@ public class PatternHelper {
     public static final Pattern SPACE_PATTERN = Pattern.compile(" ");
     public static final Pattern UNDERSCORE_PATTERN = Pattern.compile("_");
     public static final Pattern DOUBLE_UNDERSCORE_PATTERN = Pattern.compile("__");
-    public static final Pattern STORAGE_SEPARATOR_PATTERN = Pattern.compile("finSep");
+    public static final Pattern FIN_SEPERATOR_PATTERN = Pattern.compile("finSep");
     public static final Pattern BLANK_WORD_PATTERN = Pattern.compile("blank");
     public static final Pattern NEWLINE_OPTIONAL_GT_PATTERN = Pattern.compile("\n(> )?");
-    public static final Pattern NON_RED_PATTERN = Pattern.compile("[^R]");
-    public static final Pattern NON_GREEN_PATTERN = Pattern.compile("[^G]");
-    public static final Pattern NON_YELLOW_PATTERN = Pattern.compile("[^Y]");
-    public static final Pattern NON_BLUE_PATTERN = Pattern.compile("[^B]");
-    public static final Pattern TILE_WITH_NAME_PATTERN = Pattern.compile("^\\s*\\d{3} \\(\\w+\\)\\s*$");
+    public static final Pattern NON_R_PATTERN = Pattern.compile("[^R]");
+    public static final Pattern NON_G_PATTERN = Pattern.compile("[^G]");
+    public static final Pattern NON_Y_PATTERN = Pattern.compile("[^Y]");
+    public static final Pattern NON_B_PATTERN = Pattern.compile("[^B]");
     public static final Pattern LOWERCASE_LETTER_PATTERN = Pattern.compile("[a-z]");
 }

--- a/src/main/java/ti4/helpers/PatternHelper.java
+++ b/src/main/java/ti4/helpers/PatternHelper.java
@@ -9,4 +9,13 @@ public class PatternHelper {
     public static final Pattern SPACE_PATTERN = Pattern.compile(" ");
     public static final Pattern UNDERSCORE_PATTERN = Pattern.compile("_");
     public static final Pattern DOUBLE_UNDERSCORE_PATTERN = Pattern.compile("__");
+    public static final Pattern STORAGE_SEPARATOR_PATTERN = Pattern.compile("finSep");
+    public static final Pattern BLANK_WORD_PATTERN = Pattern.compile("blank");
+    public static final Pattern NEWLINE_OPTIONAL_GT_PATTERN = Pattern.compile("\n(> )?");
+    public static final Pattern NON_RED_PATTERN = Pattern.compile("[^R]");
+    public static final Pattern NON_GREEN_PATTERN = Pattern.compile("[^G]");
+    public static final Pattern NON_YELLOW_PATTERN = Pattern.compile("[^Y]");
+    public static final Pattern NON_BLUE_PATTERN = Pattern.compile("[^B]");
+    public static final Pattern TILE_WITH_NAME_PATTERN = Pattern.compile("^\\s*\\d{3} \\(\\w+\\)\\s*$");
+    public static final Pattern LOWERCASE_LETTER_PATTERN = Pattern.compile("[a-z]");
 }

--- a/src/main/java/ti4/image/TileGenerator.java
+++ b/src/main/java/ti4/image/TileGenerator.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import ti4.helpers.PatternHelper;
 import java.util.stream.Collectors;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.utils.FileUpload;
@@ -30,6 +29,7 @@ import ti4.helpers.Constants;
 import ti4.helpers.DisplayType;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
+import ti4.helpers.PatternHelper;
 import ti4.helpers.PdsCoverage;
 import ti4.helpers.PdsCoverageHelper;
 import ti4.helpers.RandomHelper;
@@ -356,8 +356,11 @@ public class TileGenerator {
                 // Draft Stuff
                 if (TileHelper.isDraftTile(tile.getTileModel())) {
                     String tileID = tile.getTileID();
-                    String draftNum = PatternHelper.LOWERCASE_LETTER_PATTERN.matcher(tileID).replaceAll("");
-                    String draftColor = PatternHelper.BLANK_WORD_PATTERN.matcher(tileID.replaceAll("[0-9]", ""))
+                    String draftNum = PatternHelper.LOWERCASE_LETTER_PATTERN
+                            .matcher(tileID)
+                            .replaceAll("");
+                    String draftColor = PatternHelper.BLANK_WORD_PATTERN
+                            .matcher(tileID.replaceAll("[0-9]", ""))
                             .replaceAll("")
                             .toUpperCase();
                     Point draftNumPosition = new Point(85, 140);

--- a/src/main/java/ti4/image/TileGenerator.java
+++ b/src/main/java/ti4/image/TileGenerator.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import java.util.stream.Collectors;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.utils.FileUpload;
@@ -65,8 +65,6 @@ public class TileGenerator {
 
     public static final int TILE_WIDTH = 345;
     public static final int TILE_HEIGHT = 300;
-    private static final Pattern BLANK = Pattern.compile("blank");
-    private static final Pattern PATTERN = Pattern.compile("[a-z]");
 
     private final Game game;
     private final GenericInteractionCreateEvent event;
@@ -358,8 +356,8 @@ public class TileGenerator {
                 // Draft Stuff
                 if (TileHelper.isDraftTile(tile.getTileModel())) {
                     String tileID = tile.getTileID();
-                    String draftNum = PATTERN.matcher(tileID).replaceAll("");
-                    String draftColor = BLANK.matcher(tileID.replaceAll("[0-9]", ""))
+                    String draftNum = PatternHelper.LOWERCASE_LETTER_PATTERN.matcher(tileID).replaceAll("");
+                    String draftColor = PatternHelper.BLANK_WORD_PATTERN.matcher(tileID.replaceAll("[0-9]", ""))
                             .replaceAll("")
                             .toUpperCase();
                     Point draftNumPosition = new Point(85, 140);

--- a/src/main/java/ti4/image/TileHelper.java
+++ b/src/main/java/ti4/image/TileHelper.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import java.util.stream.Stream;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import org.apache.commons.collections4.CollectionUtils;
@@ -29,8 +29,6 @@ public class TileHelper {
     private static final Map<String, TileModel> tileIdsToTileModels = new HashMap<>();
     private static final Map<String, PlanetModel> planetIdsToPlanetModels = new HashMap<>();
     private static final Map<String, List<PlanetModel>> tileIdsToPlanetModels = new HashMap<>();
-    private static final Pattern PATTERN = Pattern.compile("^\\s*\\d{3} \\(\\w+\\)\\s*$");
-    private static final Pattern BLANK = Pattern.compile("blank");
 
     public static void init() {
         BotLogger.info("Initiating Planets");
@@ -136,7 +134,7 @@ public class TileHelper {
     }
 
     private static void duplicateDraftTiles(TileModel tile) {
-        String color = BLANK.matcher(tile.getAlias()).replaceAll("");
+        String color = PatternHelper.BLANK_WORD_PATTERN.matcher(tile.getAlias()).replaceAll("");
         String namePre =
                 Character.toUpperCase(color.charAt(0)) + color.substring(1).toLowerCase() + ", draft tile ";
 
@@ -198,7 +196,7 @@ public class TileHelper {
     }
 
     public static Tile getTile(GenericInteractionCreateEvent event, String tileNameOrPos, Game game) {
-        if (PATTERN.matcher(tileNameOrPos).matches()) {
+        if (PatternHelper.TILE_WITH_NAME_PATTERN.matcher(tileNameOrPos).matches()) {
             // If the tileNameOrPos is in the format "123 (XYZ)", we extract the position only
             tileNameOrPos = tileNameOrPos
                     .trim()

--- a/src/main/java/ti4/image/TileHelper.java
+++ b/src/main/java/ti4/image/TileHelper.java
@@ -11,11 +11,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import ti4.helpers.PatternHelper;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import org.apache.commons.collections4.CollectionUtils;
 import ti4.helpers.AliasHandler;
+import ti4.helpers.PatternHelper;
 import ti4.helpers.Storage;
 import ti4.map.Game;
 import ti4.map.Tile;
@@ -26,6 +27,7 @@ import ti4.model.TileModel;
 
 public class TileHelper {
 
+    public static final Pattern TILE_WITH_NAME_PATTERN = Pattern.compile("^\\s*\\d{3} \\(\\w+\\)\\s*$");
     private static final Map<String, TileModel> tileIdsToTileModels = new HashMap<>();
     private static final Map<String, PlanetModel> planetIdsToPlanetModels = new HashMap<>();
     private static final Map<String, List<PlanetModel>> tileIdsToPlanetModels = new HashMap<>();
@@ -196,7 +198,7 @@ public class TileHelper {
     }
 
     public static Tile getTile(GenericInteractionCreateEvent event, String tileNameOrPos, Game game) {
-        if (PatternHelper.TILE_WITH_NAME_PATTERN.matcher(tileNameOrPos).matches()) {
+        if (TILE_WITH_NAME_PATTERN.matcher(tileNameOrPos).matches()) {
             // If the tileNameOrPos is in the format "123 (XYZ)", we extract the position only
             tileNameOrPos = tileNameOrPos
                     .trim()

--- a/src/main/java/ti4/model/ExploreModel.java
+++ b/src/main/java/ti4/model/ExploreModel.java
@@ -4,7 +4,7 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import lombok.Data;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -13,7 +13,6 @@ import ti4.service.emoji.ExploreEmojis;
 
 @Data
 public class ExploreModel implements ModelInterface, EmbeddableModel {
-    private static final Pattern PATTERN = Pattern.compile("\n(> )?");
     private String id;
     private String name;
     private String type;
@@ -69,7 +68,7 @@ public class ExploreModel implements ModelInterface, EmbeddableModel {
         StringBuilder sb = new StringBuilder(getTypeEmoji()).append(" ");
         if (source != null) sb.append(source.emoji()).append(" ");
         sb.append("_").append(name).append("_\n> ");
-        sb.append(PATTERN.matcher(text).replaceAll("\n> "));
+        sb.append(PatternHelper.NEWLINE_OPTIONAL_GT_PATTERN.matcher(text).replaceAll("\n> "));
         return sb.toString();
     }
 

--- a/src/main/java/ti4/model/ExploreModel.java
+++ b/src/main/java/ti4/model/ExploreModel.java
@@ -4,10 +4,10 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import ti4.helpers.PatternHelper;
 import lombok.Data;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import ti4.helpers.PatternHelper;
 import ti4.model.Source.ComponentSource;
 import ti4.service.emoji.ExploreEmojis;
 

--- a/src/main/java/ti4/model/TechnologyModel.java
+++ b/src/main/java/ti4/model/TechnologyModel.java
@@ -9,10 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
-import ti4.helpers.PatternHelper;
 import lombok.Data;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import ti4.helpers.PatternHelper;
 import ti4.image.Mapper;
 import ti4.model.Source.ComponentSource;
 import ti4.service.emoji.FactionEmojis;
@@ -339,7 +339,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
         for (TechnologyType type : types) {
             switch (type) {
                 case PROPULSION -> {
-                    String blues = PatternHelper.NON_BLUE_PATTERN.matcher(reqs).replaceAll("");
+                    String blues = PatternHelper.NON_B_PATTERN.matcher(reqs).replaceAll("");
                     switch (blues) {
                         case "" -> output.append(TechEmojis.PropulsionDisabled);
                         case "B" -> output.append(TechEmojis.PropulsionTech);
@@ -348,7 +348,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
                     }
                 }
                 case CYBERNETIC -> {
-                    String yellows = PatternHelper.NON_YELLOW_PATTERN.matcher(reqs).replaceAll("");
+                    String yellows = PatternHelper.NON_Y_PATTERN.matcher(reqs).replaceAll("");
                     switch (yellows) {
                         case "" -> output.append(TechEmojis.CyberneticDisabled);
                         case "Y" -> output.append(TechEmojis.CyberneticTech);
@@ -357,7 +357,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
                     }
                 }
                 case BIOTIC -> {
-                    String greens = PatternHelper.NON_GREEN_PATTERN.matcher(reqs).replaceAll("");
+                    String greens = PatternHelper.NON_G_PATTERN.matcher(reqs).replaceAll("");
                     switch (greens) {
                         case "" -> output.append(TechEmojis.BioticDisabled);
                         case "G" -> output.append(TechEmojis.BioticTech);
@@ -366,7 +366,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
                     }
                 }
                 case WARFARE -> {
-                    String reds = PatternHelper.NON_RED_PATTERN.matcher(reqs).replaceAll("");
+                    String reds = PatternHelper.NON_R_PATTERN.matcher(reqs).replaceAll("");
                     switch (reds) {
                         case "" -> output.append(TechEmojis.WarfareDisabled);
                         case "R" -> output.append(TechEmojis.WarfareTech);

--- a/src/main/java/ti4/model/TechnologyModel.java
+++ b/src/main/java/ti4/model/TechnologyModel.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.regex.Pattern;
+import ti4.helpers.PatternHelper;
 import lombok.Data;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -23,10 +23,6 @@ import ti4.service.emoji.UnitEmojis;
 @Data
 public class TechnologyModel implements ModelInterface, EmbeddableModel {
 
-    private static final Pattern PATTERN = Pattern.compile("[^R]");
-    private static final Pattern REGEX = Pattern.compile("[^G]");
-    private static final Pattern REGEXP = Pattern.compile("[^Y]");
-    private static final Pattern PATTERN1 = Pattern.compile("[^B]");
     private String alias;
     private String name;
     private String shortName;
@@ -343,7 +339,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
         for (TechnologyType type : types) {
             switch (type) {
                 case PROPULSION -> {
-                    String blues = PATTERN1.matcher(reqs).replaceAll("");
+                    String blues = PatternHelper.NON_BLUE_PATTERN.matcher(reqs).replaceAll("");
                     switch (blues) {
                         case "" -> output.append(TechEmojis.PropulsionDisabled);
                         case "B" -> output.append(TechEmojis.PropulsionTech);
@@ -352,7 +348,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
                     }
                 }
                 case CYBERNETIC -> {
-                    String yellows = REGEXP.matcher(reqs).replaceAll("");
+                    String yellows = PatternHelper.NON_YELLOW_PATTERN.matcher(reqs).replaceAll("");
                     switch (yellows) {
                         case "" -> output.append(TechEmojis.CyberneticDisabled);
                         case "Y" -> output.append(TechEmojis.CyberneticTech);
@@ -361,7 +357,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
                     }
                 }
                 case BIOTIC -> {
-                    String greens = REGEX.matcher(reqs).replaceAll("");
+                    String greens = PatternHelper.NON_GREEN_PATTERN.matcher(reqs).replaceAll("");
                     switch (greens) {
                         case "" -> output.append(TechEmojis.BioticDisabled);
                         case "G" -> output.append(TechEmojis.BioticTech);
@@ -370,7 +366,7 @@ public class TechnologyModel implements ModelInterface, EmbeddableModel {
                     }
                 }
                 case WARFARE -> {
-                    String reds = PATTERN.matcher(reqs).replaceAll("");
+                    String reds = PatternHelper.NON_RED_PATTERN.matcher(reqs).replaceAll("");
                     switch (reds) {
                         case "" -> output.append(TechEmojis.WarfareDisabled);
                         case "R" -> output.append(TechEmojis.WarfareTech);


### PR DESCRIPTION
## Summary
- Move common regular expressions into `PatternHelper`
- Update models, tile utilities and draft items to reference shared patterns with descriptive names

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a028590c88832d981633a8fcc2f586