### PR TITLE
Use CircuitBreaker in developer pause command

### DIFF
--- a/src/main/java/ti4/commands/developer/GiveTheBotABreather.java
+++ b/src/main/java/ti4/commands/developer/GiveTheBotABreather.java
@@ -5,8 +5,8 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.commands.Subcommand;
-import ti4.helpers.Constants;
 import ti4.executors.CircuitBreaker;
+import ti4.helpers.Constants;
 import ti4.message.MessageHelper;
 
 class GiveTheBotABreather extends Subcommand {
@@ -21,7 +21,6 @@ class GiveTheBotABreather extends Subcommand {
     public void execute(SlashCommandInteractionEvent event) {
         int seconds = event.getOption(Constants.SECONDS, 10, OptionMapping::getAsInt);
         CircuitBreaker.openForSeconds(seconds);
-        MessageHelper.sendMessageToChannel(
-                event.getChannel(), "Circuit breaker opened for " + seconds + " seconds.");
+        MessageHelper.sendMessageToChannel(event.getChannel(), "Circuit breaker opened for " + seconds + " seconds.");
     }
 }

--- a/src/main/java/ti4/commands/developer/GiveTheBotABreather.java
+++ b/src/main/java/ti4/commands/developer/GiveTheBotABreather.java
@@ -6,9 +6,8 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.commands.Subcommand;
 import ti4.helpers.Constants;
-import ti4.message.BotLogger;
-import ti4.settings.GlobalSettings;
-import ti4.settings.GlobalSettings.ImplementedSettings;
+import ti4.executors.CircuitBreaker;
+import ti4.message.MessageHelper;
 
 class GiveTheBotABreather extends Subcommand {
 
@@ -20,13 +19,9 @@ class GiveTheBotABreather extends Subcommand {
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        GlobalSettings.setSetting(ImplementedSettings.READY_TO_RECEIVE_COMMANDS, false);
         int seconds = event.getOption(Constants.SECONDS, 10, OptionMapping::getAsInt);
-        try {
-            Thread.sleep(seconds * 1000L);
-        } catch (InterruptedException e) {
-            BotLogger.error(new BotLogger.LogMessageOrigin(event), "Forced Sleep interrupted", e);
-        }
-        GlobalSettings.setSetting(ImplementedSettings.READY_TO_RECEIVE_COMMANDS, true);
+        CircuitBreaker.openForSeconds(seconds);
+        MessageHelper.sendMessageToChannel(
+                event.getChannel(), "Circuit breaker opened for " + seconds + " seconds.");
     }
 }

--- a/src/main/java/ti4/executors/CircuitBreaker.java
+++ b/src/main/java/ti4/executors/CircuitBreaker.java
@@ -46,6 +46,14 @@ public class CircuitBreaker {
         return true;
     }
 
+    public static synchronized void openForSeconds(long seconds) {
+        open = true;
+        thresholdCount = 0;
+        closeDateTime = LocalDateTime.now().plusSeconds(seconds);
+        CronManager.scheduleOnce(CircuitBreaker.class, CircuitBreaker::reset, seconds, TimeUnit.SECONDS);
+        BotLogger.info("Circuit breaker manually opened for " + seconds + " seconds.");
+    }
+
     private static synchronized void reset() {
         thresholdCount = 0;
         open = false;


### PR DESCRIPTION
## Summary
- Allow manually opening the CircuitBreaker for a given duration
- Switch `give_the_bot_a_breather` developer command to use the CircuitBreaker

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a028a62eac832db4d2f3f7d9ef4d12