### PR TITLE
Refactor role checks and command permissions

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -74,12 +74,11 @@ import ti4.settings.GlobalSettings.ImplementedSettings;
 public class AsyncTI4DiscordBot {
 
     public static final long START_TIME_MILLISECONDS = System.currentTimeMillis();
-    public static final List<Role> adminRoles = new ArrayList<>();
-    public static final List<Role> developerRoles = new ArrayList<>();
-    public static final List<Role> bothelperRoles = new ArrayList<>();
+    public static final Set<Role> adminRoles = new HashSet<>();
+    public static final Set<Role> developerRoles = new HashSet<>();
+    public static final Set<Role> bothelperRoles = new HashSet<>();
 
     public static JDA jda;
-    private static String userID;
     public static String guildPrimaryID;
     public static boolean testingMode;
     public static Guild guildPrimary;
@@ -103,7 +102,6 @@ public class AsyncTI4DiscordBot {
         SpringApplication.run(AsyncTI4DiscordBot.class, args);
 
         // guildPrimaryID must be set before initializing listeners that use webhook logging
-        userID = args[1];
         guildPrimaryID = args[2];
 
         GlobalSettings.loadSettings();
@@ -404,7 +402,6 @@ public class AsyncTI4DiscordBot {
         adminRoles.add(jda.getRoleById("1126610851034583050")); // Fin's Server
         adminRoles.add(jda.getRoleById("824111008863092757")); // Fireseal's Server
         adminRoles.add(jda.getRoleById("336194595501244417")); // tedw4rd's Server
-        adminRoles.add(jda.getRoleById("1149705227625316352")); // who dis
         adminRoles.add(jda.getRoleById("1178659621225889875")); // Jepp2078's Server
         adminRoles.add(jda.getRoleById("1215451631622164610")); // Sigma's Server
         adminRoles.add(jda.getRoleById("1225597324206800996")); // ForlornGeas's Server
@@ -414,6 +411,7 @@ public class AsyncTI4DiscordBot {
         adminRoles.add(jda.getRoleById("1311111853912358922")); // TSI's Server
         adminRoles.add(jda.getRoleById("1368344911103000728")); // gozer's server (marshmallow manosphere)
         adminRoles.add(jda.getRoleById("1378475691531567185")); // Hadouken's Server
+        adminRoles.add(jda.getRoleById("1149705227625316352")); // Will's server
         adminRoles.removeIf(Objects::isNull);
 
         // DEVELOPER ROLES
@@ -437,10 +435,12 @@ public class AsyncTI4DiscordBot {
         developerRoles.add(jda.getRoleById("1311111944832553090")); // TSI's Server
         developerRoles.add(jda.getRoleById("1368344979579338762")); // gozer's server (marshmallow manosphere)
         developerRoles.add(jda.getRoleById("1378475796301217792")); // Hadouken's Server
+        developerRoles.add(jda.getRoleById("1406188584163213332")); // Will's server
         developerRoles.removeIf(Objects::isNull);
 
         // BOTHELPER ROLES
 
+        bothelperRoles.addAll(developerRoles); // developers may also execute bothelper commands
         bothelperRoles.addAll(adminRoles); // admins can also execute bothelper commands
         bothelperRoles.add(jda.getRoleById("1166011604488425482")); // Async Primary (Hub)
         bothelperRoles.add(jda.getRoleById("1090914992301281341")); // Async Secondary (Stroter's Paradise)
@@ -463,6 +463,7 @@ public class AsyncTI4DiscordBot {
         bothelperRoles.add(jda.getRoleById("1311112004089548860")); // TSI's Server
         bothelperRoles.add(jda.getRoleById("1368345023745097898")); // gozer's server (marshmallow manosphere)
         bothelperRoles.add(jda.getRoleById("1378475822528204901")); // Hadouken's Server
+        bothelperRoles.add(jda.getRoleById("1150031360610799676")); // Will's server
         bothelperRoles.removeIf(Objects::isNull);
     }
 

--- a/src/main/java/ti4/commands/CommandHelper.java
+++ b/src/main/java/ti4/commands/CommandHelper.java
@@ -13,8 +13,11 @@ import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.commands.Command.Choice;
+import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonInteraction;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import ti4.helpers.AliasHandler;
@@ -35,12 +38,11 @@ public class CommandHelper {
         return toChoices(Arrays.asList(values));
     }
 
-    public static List<Choice> toChoices(List<String> values) {
+    public static List<Choice> toChoices(Collection<String> values) {
         return values.stream().map(v -> new Choice(v, v)).toList();
     }
 
-    public static boolean acceptIfValidGame(
-            SlashCommandInteractionEvent event, boolean checkChannel, boolean checkPlayer) {
+    static boolean acceptIfValidGame(SlashCommandInteractionEvent event, boolean checkChannel, boolean checkPlayer) {
         var gameName = GameNameService.getGameName(event);
         var managedGame = GameManager.getManagedGame(gameName);
         if (managedGame == null) {
@@ -60,8 +62,7 @@ public class CommandHelper {
         }
         if (checkPlayer && getPlayerFromEvent(managedGame.getGame(), event) == null) {
             event.getHook()
-                    .editOriginal(
-                            "Command must be ran by a player in the game, please use `/game join gameName` or `/special2 setup_neutral_player`.")
+                    .editOriginal("Command must be ran by a player in the game, please use `/game join gameName`.")
                     .queue();
             return false;
         }
@@ -176,7 +177,7 @@ public class CommandHelper {
         return targetPlayers;
     }
 
-    public static boolean acceptIfHasRoles(SlashCommandInteractionEvent event, List<Role> acceptedRoles) {
+    public static boolean acceptIfHasRoles(SlashCommandInteractionEvent event, Collection<Role> acceptedRoles) {
         if (hasRole(event, acceptedRoles)) {
             return true;
         }
@@ -189,7 +190,7 @@ public class CommandHelper {
         return false;
     }
 
-    public static boolean hasRole(SlashCommandInteractionEvent event, List<Role> acceptedRoles) {
+    public static boolean hasRole(Interaction event, Collection<Role> acceptedRoles) {
         Member member = event.getMember();
         if (member == null) {
             return false;
@@ -205,10 +206,10 @@ public class CommandHelper {
 
     public static String getHeaderText(GenericInteractionCreateEvent event) {
         if (event instanceof SlashCommandInteractionEvent) {
-            return " used `" + ((SlashCommandInteractionEvent) event).getCommandString() + "`";
+            return " used `" + ((CommandInteractionPayload) event).getCommandString() + "`";
         }
         if (event instanceof ButtonInteractionEvent) {
-            return " pressed `" + ((ButtonInteractionEvent) event).getButton().getId() + "`";
+            return " pressed `" + ((ButtonInteraction) event).getButton().getId() + "`";
         }
         return " used the force";
     }

--- a/src/main/java/ti4/commands/admin/AdminCommand.java
+++ b/src/main/java/ti4/commands/admin/AdminCommand.java
@@ -16,18 +16,16 @@ public class AdminCommand implements ParentCommand {
                     new DeleteGame(),
                     new DisableBot(),
                     new ReloadMapperObjects(),
-                    new RestoreGame(),
                     new TourneyWinner(),
                     new DeletePersistenceManagerFile(),
                     new CardsInfoForPlayer(),
-                    new UpdateThreadArchiveTime() //
-                    )
+                    new UpdateThreadArchiveTime())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override
     public boolean accept(SlashCommandInteractionEvent event) {
         return ParentCommand.super.accept(event)
-                && CommandHelper.acceptIfHasRoles(event, AsyncTI4DiscordBot.developerRoles);
+                && CommandHelper.acceptIfHasRoles(event, AsyncTI4DiscordBot.adminRoles);
     }
 
     @Override

--- a/src/main/java/ti4/commands/async/AsyncCommand.java
+++ b/src/main/java/ti4/commands/async/AsyncCommand.java
@@ -8,9 +8,7 @@ import ti4.commands.Subcommand;
 
 public class AsyncCommand implements ParentCommand {
 
-    private final Map<String, Subcommand> subcommands = Stream.of(
-                    new ShowHeroes(), new ShowTourneyWinners() //
-                    )
+    private final Map<String, Subcommand> subcommands = Stream.of(new ShowHeroes(), new ShowTourneyWinners())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override

--- a/src/main/java/ti4/commands/bothelper/BothelperCommand.java
+++ b/src/main/java/ti4/commands/bothelper/BothelperCommand.java
@@ -24,13 +24,13 @@ public class BothelperCommand implements ParentCommand {
                     new ListButtons(),
                     new ReloadGame(),
                     new ServerGameStats(),
+                    new CorrectFaction(),
                     new ListDeadGames(),
                     new RemoveTitle(),
                     new EditTrackRecord(),
                     new CheckNextPingTime(),
                     new ListSlashCommandsUsed(),
-                    new ReserveGame() //
-                    )
+                    new ReserveGame())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override

--- a/src/main/java/ti4/commands/bothelper/CorrectFaction.java
+++ b/src/main/java/ti4/commands/bothelper/CorrectFaction.java
@@ -1,4 +1,4 @@
-package ti4.commands.player;
+package ti4.commands.bothelper;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -9,7 +9,6 @@ import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import ti4.AsyncTI4DiscordBot;
 import ti4.commands.CommandHelper;
 import ti4.commands.GameStateSubcommand;
 import ti4.helpers.AliasHandler;
@@ -22,30 +21,30 @@ import ti4.model.FactionModel;
 
 class CorrectFaction extends GameStateSubcommand {
 
-    public CorrectFaction() {
-        super(Constants.CORRECT_FACTION, "FOR BOTHELPER USE ONLY", true, true);
+    CorrectFaction() {
+        super(Constants.CORRECT_FACTION, "Change faction.", true, false);
         addOptions(new OptionData(OptionType.STRING, Constants.FACTION, "New faction")
                 .setRequired(true)
                 .setAutoComplete(true));
         addOptions(
                 new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Faction or Color for which you set stats")
+                        .setRequired(true)
                         .setAutoComplete(true));
     }
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        Game game = getGame();
-        if (CommandHelper.acceptIfHasRoles(event, AsyncTI4DiscordBot.bothelperRoles)) {
-            String newFaction = AliasHandler.resolveColor(
-                    event.getOption(Constants.FACTION).getAsString().toLowerCase());
-            newFaction = AliasHandler.resolveFaction(newFaction);
-            if (!Mapper.isValidFaction(newFaction)) {
-                MessageHelper.sendMessageToEventChannel(event, "Faction not valid");
-                return;
-            }
-
-            changeFactionSheetAndComponents(event, game, getPlayer(), newFaction);
+        String newFaction = AliasHandler.resolveColor(
+                event.getOption(Constants.FACTION).getAsString().toLowerCase());
+        newFaction = AliasHandler.resolveFaction(newFaction);
+        if (!Mapper.isValidFaction(newFaction)) {
+            MessageHelper.sendMessageToEventChannel(event, "Faction not valid");
+            return;
         }
+
+        Game game = getGame();
+        Player player = CommandHelper.getPlayerFromEvent(game, event);
+        changeFactionSheetAndComponents(event, game, player, newFaction);
     }
 
     private void changeFactionSheetAndComponents(

--- a/src/main/java/ti4/commands/developer/DeveloperCommand.java
+++ b/src/main/java/ti4/commands/developer/DeveloperCommand.java
@@ -17,7 +17,8 @@ public class DeveloperCommand implements ParentCommand {
                     new RunManualDataMigration(),
                     new GiveTheBotABreather(),
                     new ButtonProcessingStatistics(),
-                    new CacheStatistics())
+                    new CacheStatistics(),
+                    new RestoreGame())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override

--- a/src/main/java/ti4/commands/developer/RestoreGame.java
+++ b/src/main/java/ti4/commands/developer/RestoreGame.java
@@ -1,4 +1,4 @@
-package ti4.commands.admin;
+package ti4.commands.developer;
 
 import java.io.File;
 import net.dv8tion.jda.api.entities.Message.Attachment;
@@ -14,7 +14,7 @@ import ti4.message.MessageHelper;
 
 class RestoreGame extends Subcommand {
 
-    public RestoreGame() {
+    RestoreGame() {
         super(Constants.RESTORE_GAME, "Restore a game by uploading a save file");
         addOptions(
                 new OptionData(OptionType.ATTACHMENT, Constants.SAVE_FILE, "Save file to reload").setRequired(true),

--- a/src/main/java/ti4/commands/game/Replace.java
+++ b/src/main/java/ti4/commands/game/Replace.java
@@ -44,22 +44,11 @@ class Replace extends GameStateSubcommand {
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        Member member = event.getMember();
-        boolean isAdmin = false;
-        if (member != null) {
-            List<Role> roles = member.getRoles();
-            for (Role role : AsyncTI4DiscordBot.bothelperRoles) {
-                if (roles.contains(role)) {
-                    isAdmin = true;
-                    break;
-                }
-            }
-        }
-
+        boolean isBotHelper = CommandHelper.hasRole(event, AsyncTI4DiscordBot.bothelperRoles);
         Game game = getGame();
-        if (game.getPlayer(event.getUser().getId()) == null && !isAdmin) {
+        if (game.getPlayer(event.getUser().getId()) == null && !isBotHelper) {
             MessageHelper.sendMessageToChannel(
-                    event.getChannel(), "Only game players or Bothelpers can replace a player.");
+                    event.getChannel(), "Only game players or BotHelpers can replace a player.");
             return;
         }
 

--- a/src/main/java/ti4/commands/game/Swap.java
+++ b/src/main/java/ti4/commands/game/Swap.java
@@ -1,9 +1,6 @@
 package ti4.commands.game;
 
 import java.util.Collection;
-import java.util.List;
-import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -34,17 +31,7 @@ class Swap extends GameStateSubcommand {
         User callerUser = event.getUser();
         Game game = getGame();
         Collection<Player> players = game.getPlayers().values();
-        Member member = event.getMember();
-        boolean isAdmin = false;
-        if (member != null) {
-            List<Role> roles = member.getRoles();
-            for (Role role : AsyncTI4DiscordBot.adminRoles) {
-                if (roles.contains(role)) {
-                    isAdmin = true;
-                    break;
-                }
-            }
-        }
+        boolean isAdmin = CommandHelper.hasRole(event, AsyncTI4DiscordBot.adminRoles);
         if (players.stream().noneMatch(player -> player.getUserID().equals(callerUser.getId())) && !isAdmin) {
             MessageHelper.sendMessageToChannel(event.getChannel(), "Only game players can swap with a player.");
             return;

--- a/src/main/java/ti4/commands/player/PlayerCommand.java
+++ b/src/main/java/ti4/commands/player/PlayerCommand.java
@@ -26,7 +26,6 @@ public class PlayerCommand implements ParentCommand {
                     new SendDebt(),
                     new ClearDebt(),
                     new ChangeColor(),
-                    new CorrectFaction(),
                     new ChangeUnitDecal(),
                     new UnitInfo(),
                     new AddAllianceMember(),

--- a/src/main/java/ti4/map/pojo/SaveMapPojo.java
+++ b/src/main/java/ti4/map/pojo/SaveMapPojo.java
@@ -13,7 +13,7 @@ import ti4.map.Player;
 import ti4.message.BotLogger;
 
 @UtilityClass
-class SaveMapPojo { //
+class SaveMapPojo {
 
     private static final ObjectMapper objectMapper = ObjectMapperFactory.build();
 
@@ -74,7 +74,7 @@ class SaveMapPojo { //
         try {
             field.setAccessible(true);
             String name = field.getName();
-            Object val = field.get(props); // throws
+            Object val = field.get(props);
 
             String strVal = getOutputFromField(val, name);
             return name + " " + strVal;

--- a/src/main/java/ti4/service/game/CreateGameService.java
+++ b/src/main/java/ti4/service/game/CreateGameService.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.Nullable;
 import ti4.AsyncTI4DiscordBot;
 import ti4.ResourceHelper;
 import ti4.buttons.Buttons;
+import ti4.commands.CommandHelper;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.Constants;
 import ti4.helpers.Helper;
@@ -684,14 +685,8 @@ public class CreateGameService {
     }
 
     public static boolean isLockedFromCreatingGames(GenericInteractionCreateEvent event) {
-        Member member = event.getMember();
-        if (member != null) {
-            List<Role> roles = member.getRoles();
-            for (Role role : AsyncTI4DiscordBot.bothelperRoles) {
-                if (roles.contains(role)) {
-                    return false;
-                }
-            }
+        if (CommandHelper.hasRole(event, AsyncTI4DiscordBot.bothelperRoles)) {
+            return false;
         }
 
         var userSettings = UserSettingsManager.get(event.getUser().getId());


### PR DESCRIPTION
Replaces manual role checks with CommandHelper.hasRole for consistency and maintainability. Moves CorrectFaction command from player to bothelper, restricts admin commands to admin roles, and moves RestoreGame to developer commands. Updates role collections to use Set instead of List and adds missing roles for Will's server. Cleans up command registration and improves permission logic across commands.