### PR TITLE
Refactor rotation angle constants

### DIFF
--- a/src/main/java/ti4/image/BannerGenerator.java
+++ b/src/main/java/ti4/image/BannerGenerator.java
@@ -19,7 +19,7 @@ public class BannerGenerator {
     private static final BasicStroke stroke2 = new BasicStroke(2.0f);
     private static final BasicStroke stroke6 = new BasicStroke(6.0f);
     private static final BasicStroke stroke8 = new BasicStroke(8.0f);
-    private static final double NINETY_DEGREES_RADIANS = Math.toRadians(90);
+    private static final double NINETY_DEGREES_RADIANS = 1.5707963267948966;
     private static final double NEGATIVE_NINETY_DEGREES_RADIANS = -NINETY_DEGREES_RADIANS;
 
     public static void drawFactionBanner(Player player) {

--- a/src/main/java/ti4/image/BannerGenerator.java
+++ b/src/main/java/ti4/image/BannerGenerator.java
@@ -19,6 +19,8 @@ public class BannerGenerator {
     private static final BasicStroke stroke2 = new BasicStroke(2.0f);
     private static final BasicStroke stroke6 = new BasicStroke(6.0f);
     private static final BasicStroke stroke8 = new BasicStroke(8.0f);
+    private static final double NINETY_DEGREES_RADIANS = Math.toRadians(90);
+    private static final double NEGATIVE_NINETY_DEGREES_RADIANS = -NINETY_DEGREES_RADIANS;
 
     public static void drawFactionBanner(Player player) {
         BufferedImage bannerImage = new BufferedImage(325, 50, BufferedImage.TYPE_INT_ARGB);
@@ -35,9 +37,9 @@ public class BannerGenerator {
 
         bannerG.drawImage(backgroundImage, 0, 0, null);
         Graphics2D bannerG2d = (Graphics2D) bannerG;
-        bannerG2d.rotate(-1.5707963267948966);
+        bannerG2d.rotate(NEGATIVE_NINETY_DEGREES_RADIANS);
         bannerG2d.drawImage(colorImage, -60, 0, null);
-        bannerG2d.rotate(1.5707963267948966);
+        bannerG2d.rotate(NINETY_DEGREES_RADIANS);
         bannerG2d.drawImage(gradientImage, 0, 0, null);
         bannerG2d.drawImage(smallFactionImage, 2, 24, null);
         bannerG.drawImage(largeFactionImage, 180, -42, null);
@@ -95,9 +97,9 @@ public class BannerGenerator {
         bannerG.drawImage(backgroundImage, 0, 0, null);
 
         Graphics2D bannerG2d = (Graphics2D) bannerG;
-        bannerG2d.rotate(-1.5707963267948966);
+        bannerG2d.rotate(NEGATIVE_NINETY_DEGREES_RADIANS);
         bannerG2d.drawImage(colorImage, -60, 0, null);
-        bannerG2d.rotate(1.5707963267948966);
+        bannerG2d.rotate(NINETY_DEGREES_RADIANS);
         bannerG2d.drawImage(gradientImage, 0, 0, null);
         bannerG.drawImage(agendaImage, 0, 0, null);
         bannerG.setFont(Storage.getFont28());

--- a/src/main/java/ti4/image/DrawingUtil.java
+++ b/src/main/java/ti4/image/DrawingUtil.java
@@ -38,8 +38,7 @@ public class DrawingUtil {
     }
 
     private static final int DELTA_Y = 26;
-    private static final double NINETY_DEGREES_RADIANS = Math.toRadians(90);
-    private static final double NEGATIVE_NINETY_DEGREES_RADIANS = -NINETY_DEGREES_RADIANS;
+    private static final double NEGATIVE_NINETY_DEGREES_RADIANS = -1.5707963267948966;
 
     public static void superDrawString(
             Graphics g,

--- a/src/main/java/ti4/image/DrawingUtil.java
+++ b/src/main/java/ti4/image/DrawingUtil.java
@@ -38,6 +38,8 @@ public class DrawingUtil {
     }
 
     private static final int DELTA_Y = 26;
+    private static final double NINETY_DEGREES_RADIANS = Math.toRadians(90);
+    private static final double NEGATIVE_NINETY_DEGREES_RADIANS = -NINETY_DEGREES_RADIANS;
 
     public static void superDrawString(
             Graphics g,
@@ -617,7 +619,7 @@ public class DrawingUtil {
     public static void drawTextVertically(Graphics graphics, String text, int x, int y, Font font, boolean rightAlign) {
         Graphics2D graphics2D = (Graphics2D) graphics;
         AffineTransform originalTransform = graphics2D.getTransform();
-        graphics2D.rotate(-1.5707963267948966);
+        graphics2D.rotate(NEGATIVE_NINETY_DEGREES_RADIANS);
         graphics2D.setFont(font);
 
         if (rightAlign) {

--- a/src/main/java/ti4/image/TransactionGenerator.java
+++ b/src/main/java/ti4/image/TransactionGenerator.java
@@ -23,6 +23,8 @@ public class TransactionGenerator {
 
     private static final BasicStroke stroke2 = new BasicStroke(2.0f);
     private static final BasicStroke stroke5 = new BasicStroke(5.0f);
+    private static final double NINETY_DEGREES_RADIANS = Math.toRadians(90);
+    private static final double NEGATIVE_NINETY_DEGREES_RADIANS = -NINETY_DEGREES_RADIANS;
 
     public static BufferedImage drawTransactableStuffImage(Player p1, Player p2) {
         int width = 500, height = 160;
@@ -38,17 +40,17 @@ public class TransactionGenerator {
         String pn1 = "pa_pn_color_" + Mapper.getColorID(p1.getColor()) + ".png";
         BufferedImage color1 =
                 ImageHelper.readScaled(ResourceHelper.getInstance().getPAResource(pn1), pnHeight, pnWidth);
-        g2.rotate(-1.5707963267948966);
+        g2.rotate(NEGATIVE_NINETY_DEGREES_RADIANS);
         g2.drawImage(color1, -1 * pnHeight, 0, null);
-        g2.rotate(1.5707963267948966);
+        g2.rotate(NINETY_DEGREES_RADIANS);
 
         // Add player 2's color
         String pn2 = "pa_pn_color_" + Mapper.getColorID(p2.getColor()) + ".png";
         BufferedImage color2 =
                 ImageHelper.readScaled(ResourceHelper.getInstance().getPAResource(pn2), pnHeight, pnWidth);
-        g2.rotate(1.5707963267948966);
+        g2.rotate(NINETY_DEGREES_RADIANS);
         g2.drawImage(color2, height - pnHeight, -1 * width, null);
-        g2.rotate(-1.5707963267948966);
+        g2.rotate(NEGATIVE_NINETY_DEGREES_RADIANS);
 
         // Faction Icons
         int x = 5, y = 5;

--- a/src/main/java/ti4/image/TransactionGenerator.java
+++ b/src/main/java/ti4/image/TransactionGenerator.java
@@ -23,7 +23,7 @@ public class TransactionGenerator {
 
     private static final BasicStroke stroke2 = new BasicStroke(2.0f);
     private static final BasicStroke stroke5 = new BasicStroke(5.0f);
-    private static final double NINETY_DEGREES_RADIANS = Math.toRadians(90);
+    private static final double NINETY_DEGREES_RADIANS = 1.5707963267948966;
     private static final double NEGATIVE_NINETY_DEGREES_RADIANS = -NINETY_DEGREES_RADIANS;
 
     public static BufferedImage drawTransactableStuffImage(Player p1, Player p2) {


### PR DESCRIPTION
## Summary
- replace 1.5707963267948966 literal rotations with named constants
- centralize 90-degree radians constants for clarity and reuse
- use all-caps naming for rotation constants to match constant style

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a041891654832d96da59728588287c