### PR TITLE
Add error handling to map rendering and website upload

### DIFF
--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.utils.FileUpload;
 import org.apache.commons.collections4.ListUtils;
@@ -390,16 +391,20 @@ public class MapGenerator implements AutoCloseable {
     }
 
     private void sendToWebsite() {
-        String testing = System.getenv("TESTING");
-        if (testing == null && displayTypeBasic == DisplayType.all && !isFoWPrivate) {
-            AsyncTi4WebsiteHelper.putMap(game.getName(), mainImageBytes, false, null);
-            AsyncTi4WebsiteHelper.putData(game.getName(), game);
-            AsyncTi4WebsiteHelper.putOverlays(game.getID(), websiteOverlays);
-            AsyncTi4WebsiteHelper.putPlayerData(game.getID(), game);
-        } else if (isFoWPrivate) {
-            Player player = CommandHelper.getPlayerFromGame(
+        try {
+            String testing = System.getenv("TESTING");
+            if (testing == null && displayTypeBasic == DisplayType.all && !isFoWPrivate) {
+                AsyncTi4WebsiteHelper.putMap(game.getName(), mainImageBytes, false, null);
+                AsyncTi4WebsiteHelper.putData(game.getName(), game);
+                AsyncTi4WebsiteHelper.putOverlays(game.getID(), websiteOverlays);
+                AsyncTi4WebsiteHelper.putPlayerData(game.getID(), game);
+            } else if (isFoWPrivate) {
+                Player player = CommandHelper.getPlayerFromGame(
                     game, event.getMember(), event.getUser().getId());
-            AsyncTi4WebsiteHelper.putMap(game.getName(), mainImageBytes, true, player);
+                AsyncTi4WebsiteHelper.putMap(game.getName(), mainImageBytes, true, player);
+            }
+        } catch (Exception e) {
+            BotLogger.error("Failed to send to game info to website", e);
         }
     }
 

--- a/src/main/java/ti4/image/MapRenderPipeline.java
+++ b/src/main/java/ti4/image/MapRenderPipeline.java
@@ -1,11 +1,13 @@
 package ti4.image;
 
+import javax.imageio.ImageIO;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import javax.imageio.ImageIO;
+
+import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.utils.FileUpload;
@@ -16,8 +18,10 @@ import ti4.helpers.DisplayType;
 import ti4.helpers.TimedRunnable;
 import ti4.map.Game;
 import ti4.message.logging.BotLogger;
+import ti4.message.logging.LogOrigin;
 import ti4.settings.GlobalSettings;
 
+@UtilityClass
 public class MapRenderPipeline {
 
     private static final int SHUTDOWN_TIMEOUT_SECONDS = 20;
@@ -44,6 +48,8 @@ public class MapRenderPipeline {
                         if (renderEvent.uploadToWebsite) {
                             mapGenerator.uploadToWebsite();
                         }
+                    } catch (Exception e) {
+                        BotLogger.error(new LogOrigin(renderEvent.event, renderEvent.game), "Failed to render event.", e);
                     }
                 });
 

--- a/src/main/java/ti4/image/PlayerAreaGenerator.java
+++ b/src/main/java/ti4/image/PlayerAreaGenerator.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
@@ -118,7 +119,7 @@ class PlayerAreaGenerator {
 
             Point tl = new Point(x, y);
             Rectangle rect = drawPlayerAreaOLD(player, tl);
-            if (rect != null && rect.height > 0) y += rect.height + 15;
+            if (rect.height > 0) y += rect.height + 15;
         }
     }
 


### PR DESCRIPTION
Wrapped website upload logic in MapGenerator with a try-catch block to log errors. Added error logging in MapRenderPipeline for render failures. Removed unnecessary null check in PlayerAreaGenerator for Rectangle height.