### PR TITLE
Add error logging for async task failures

### DIFF
--- a/src/main/java/ti4/executors/ExecutionHistoryManager.java
+++ b/src/main/java/ti4/executors/ExecutionHistoryManager.java
@@ -47,6 +47,8 @@ public final class ExecutionHistoryManager {
             executionStartTimes.put(id, new Execution(timedRunnable.getName(), Instant.now()));
             try {
                 timedRunnable.run();
+            } catch (Throwable t) {
+                BotLogger.error("Unhandled exception in task: " + timedRunnable.getName(), t);
             } finally {
                 executionStartTimes.remove(id);
             }


### PR DESCRIPTION
## Summary
- log exceptions thrown by asynchronous tasks in the execution history manager

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68a69ca0dd2c832dba82068ebe943c36