### PR TITLE
Add prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ ENV USER=$DISCORD_USER
 ENV SERVER=$DISCORD_SERVER
 ENV SERVER2=$DISCORD_SERVER2
 # ENTRYPOINT java -Xmx1400m -jar tibot.jar $DISCORD_BOT_KEY $DISCORD_USER $DISCORD_SERVER
+# ENTRYPOINT ["java", "-XX:MaxRAMPercentage=90.0", "-XX:InitialRAMPercentage=30.0", "-jar", "tibot.jar", "$BOT_KEY", "$USER", "$SERVER"]
 ENTRYPOINT ["java", "-XX:MaxRAMPercentage=90.0", "-XX:InitialRAMPercentage=30.0", "-jar", "tibot.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -238,13 +238,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <release>21</release>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>org.projectlombok</groupId>
-              <artifactId>lombok</artifactId>
-              <version>1.18.38</version>
-            </path>
-          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,18 @@
     <maven.compiler.target>21</maven.compiler.target>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>1.15.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -109,6 +121,16 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>prometheus-metrics-core</artifactId>
+      <version>1.4.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+      <version>1.4.1</version>
     </dependency>
     <!-- TEST -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,18 +16,6 @@
     <maven.compiler.target>21</maven.compiler.target>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>1.15.3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -44,10 +32,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
@@ -101,6 +105,10 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>5.0.0-alpha.14</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
     <!-- TEST -->
     <dependency>
@@ -230,6 +238,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <release>21</release>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.38</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -52,6 +52,7 @@ import ti4.image.Mapper;
 import ti4.image.PositionMapper;
 import ti4.image.TileHelper;
 import ti4.listeners.AutoCompleteListener;
+import ti4.listeners.BotRuntimeStatsListener;
 import ti4.listeners.ButtonListener;
 import ti4.listeners.ChannelCreationListener;
 import ti4.listeners.DeletionListener;
@@ -128,6 +129,7 @@ public class AsyncTI4DiscordBot {
                 .build();
 
         jda.addEventListener(
+                new BotRuntimeStatsListener(),
                 new MessageListener(),
                 new DeletionListener(),
                 new ChannelCreationListener(),

--- a/src/main/java/ti4/listeners/BotRuntimeStatsListener.java
+++ b/src/main/java/ti4/listeners/BotRuntimeStatsListener.java
@@ -1,0 +1,20 @@
+// File: BotRuntimeStatsListener.java
+// What: Listener that increments bot runtime request statistics on each Discord interaction.
+// How: Extends ListenerAdapter and handles GenericInteractionCreateEvent to call
+// BotRuntimeStats.incrementRequestCount().
+
+package ti4.listeners;
+
+import javax.annotation.Nonnull;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import ti4.service.statistics.SREStats;
+
+public class BotRuntimeStatsListener extends ListenerAdapter {
+
+    @Override
+    public void onGenericInteractionCreate(@Nonnull GenericInteractionCreateEvent event) {
+        // Count any interaction request (slash, button, modal, selection, etc.)
+        SREStats.incrementRequestCount();
+    }
+}

--- a/src/main/java/ti4/message/logging/BotLogger.java
+++ b/src/main/java/ti4/message/logging/BotLogger.java
@@ -20,6 +20,7 @@ import ti4.helpers.DateTimeHelper;
 import ti4.helpers.DiscordWebhook;
 import ti4.helpers.ThreadArchiveHelper;
 import ti4.message.MessageHelper;
+import ti4.service.statistics.SREStats;
 import ti4.settings.GlobalSettings;
 
 @UtilityClass
@@ -160,6 +161,11 @@ public class BotLogger {
             @Nonnull String message,
             @Nullable Throwable err,
             @Nonnull LogSeverity severity) {
+        // Count Error-severity logs once per entry
+        if (severity == LogSeverity.Error) {
+            SREStats.incrementErrorCount();
+        }
+
         TextChannel channel;
         StringBuilder msg = new StringBuilder();
 

--- a/src/main/java/ti4/service/statistics/SREStats.java
+++ b/src/main/java/ti4/service/statistics/SREStats.java
@@ -1,0 +1,113 @@
+package ti4.service.statistics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+
+/*
+ * SREStats: Micrometer-backed counters for bot requests and errors.
+ *
+ * What this file does:
+ * - Exposes counters and helpers to increment and read total counts.
+ *
+ * How it does it:
+ * - Lazily builds Micrometer Counters on a shared MeterRegistry (set via init()).
+ * - If init() wasn't called yet, falls back to an in-memory SimpleMeterRegistry.
+ */
+@UtilityClass
+public class SREStats {
+
+    private static class RegistryHolder {
+        private static volatile MeterRegistry registry;
+    }
+
+    private static final String REQUESTS_TOTAL_NAME = "ti4.bot.requests.total";
+    private static final String ERRORS_TOTAL_NAME = "ti4.bot.errors.total";
+
+    private static final List<Tag> COMMON_TAGS = List.of(Tag.of("component", "bot"));
+
+    private static volatile Counter REQUESTS_TOTAL;
+    private static volatile Counter ERRORS_TOTAL;
+
+    /**
+     * Initialize the metrics registry used by this class. Call once during application startup.
+     * If not called, a SimpleMeterRegistry is used as a fallback (metrics won't be exported).
+     */
+    public static void init(MeterRegistry meterRegistry) {
+        RegistryHolder.registry = meterRegistry;
+        REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
+                .tags(COMMON_TAGS)
+                .description("Total incoming bot interaction requests")
+                .register(meterRegistry);
+        ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
+                .tags(COMMON_TAGS)
+                .description("Total error-severity events observed by the bot")
+                .register(meterRegistry);
+    }
+
+    private static MeterRegistry registry() {
+        MeterRegistry reg = RegistryHolder.registry;
+        if (reg == null) {
+            synchronized (SREStats.class) {
+                if (RegistryHolder.registry == null) {
+                    RegistryHolder.registry = new SimpleMeterRegistry();
+                }
+                reg = RegistryHolder.registry;
+            }
+        }
+        return reg;
+    }
+
+   private static Counter requestsCounter() {
+       Counter c = REQUESTS_TOTAL;
+       if (c == null) {
+           synchronized (SREStats.class) {
+               if (REQUESTS_TOTAL == null) {
+                   REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
+                           .tags(COMMON_TAGS)
+                           .description("Total incoming bot interaction requests")
+                           .register(registry());
+               }
+               c = REQUESTS_TOTAL;
+           }
+       }
+       return c;
+   }
+
+   private static Counter errorsCounter() {
+       Counter c = ERRORS_TOTAL;
+       if (c == null) {
+           synchronized (SREStats.class) {
+               if (ERRORS_TOTAL == null) {
+                   ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
+                           .tags(COMMON_TAGS)
+                           .description("Total error-severity events observed by the bot")
+                           .register(registry());
+               }
+               c = ERRORS_TOTAL;
+           }
+       }
+       return c;
+   }
+
+   // Request counters
+   public static void incrementRequestCount() {
+       requestsCounter().increment();
+   }
+
+   public static long getRequestCount() {
+       return (long) requestsCounter().count();
+   }
+
+   // Error counters
+   public static void incrementErrorCount() {
+       errorsCounter().increment();
+   }
+
+   public static long getErrorCount() {
+       return (long) errorsCounter().count();
+   }
+}

--- a/src/main/java/ti4/service/statistics/SREStats.java
+++ b/src/main/java/ti4/service/statistics/SREStats.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.experimental.UtilityClass;
 
 /*
@@ -31,6 +32,8 @@ public class SREStats {
 
     private static final List<Tag> BOT_TAGS = List.of(Tag.of("component", "bot"));
     private static final List<Tag> HTTP_TAGS = List.of(Tag.of("component", "http"));
+    private static final List<Tag> REQUEST_TAGS = List.of(Tag.of("status", "request"));
+    private static final List<Tag> ERROR_TAGS = List.of(Tag.of("status", "error"));
 
     private static volatile Counter REQUESTS_TOTAL;
     private static volatile Counter ERRORS_TOTAL;
@@ -44,20 +47,20 @@ public class SREStats {
     public static void init(MeterRegistry meterRegistry) {
         RegistryHolder.registry = meterRegistry;
         REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
-                .tags(BOT_TAGS)
+                .tags(Stream.concat(BOT_TAGS.stream(), REQUEST_TAGS.stream()).toList())
                 .description("Total incoming bot interaction requests")
                 .register(meterRegistry);
         ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
-                .tags(BOT_TAGS)
+                .tags(Stream.concat(BOT_TAGS.stream(), ERROR_TAGS.stream()).toList())
                 .description("Total error-severity events observed by the bot")
                 .register(meterRegistry);
-        WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
-                .tags(HTTP_TAGS)
-                .description("Total webserver HTTP request errors")
-                .register(meterRegistry);
         WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
-                .tags(HTTP_TAGS)
+                .tags(Stream.concat(HTTP_TAGS.stream(), REQUEST_TAGS.stream()).toList())
                 .description("Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
+                .register(meterRegistry);
+        WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
+                .tags(Stream.concat(HTTP_TAGS.stream(), ERROR_TAGS.stream()).toList())
+                .description("Total webserver HTTP request errors")
                 .register(meterRegistry);
     }
 
@@ -82,7 +85,8 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (REQUESTS_TOTAL == null) {
                 REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
-                        .tags(BOT_TAGS)
+                        .tags(Stream.concat(BOT_TAGS.stream(), REQUEST_TAGS.stream())
+                                .toList())
                         .description("Total incoming bot interaction requests")
                         .register(registry());
             }
@@ -98,7 +102,8 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (ERRORS_TOTAL == null) {
                 ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
-                        .tags(BOT_TAGS)
+                        .tags(Stream.concat(BOT_TAGS.stream(), ERROR_TAGS.stream())
+                                .toList())
                         .description("Total error-severity events observed by the bot")
                         .register(registry());
             }
@@ -114,7 +119,8 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (WEBSERVER_REQUEST_ERROR_TOTAL == null) {
                 WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
-                        .tags(HTTP_TAGS)
+                        .tags(Stream.concat(HTTP_TAGS.stream(), ERROR_TAGS.stream())
+                                .toList())
                         .description("Total webserver HTTP request errors")
                         .register(registry());
             }
@@ -130,7 +136,8 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (WEBSERVER_REQUESTS_TOTAL == null) {
                 WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
-                        .tags(HTTP_TAGS)
+                        .tags(Stream.concat(HTTP_TAGS.stream(), REQUEST_TAGS.stream())
+                                .toList())
                         .description(
                                 "Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
                         .register(registry());

--- a/src/main/java/ti4/service/statistics/SREStats.java
+++ b/src/main/java/ti4/service/statistics/SREStats.java
@@ -26,11 +26,11 @@ public class SREStats {
 
     private static final String REQUESTS_TOTAL_NAME = "ti4.bot.requests.total";
     private static final String ERRORS_TOTAL_NAME = "ti4.bot.errors.total";
-    // Renamed from "upstream" to "webserver" to reflect actual meaning
     private static final String WEBSERVER_REQUEST_ERROR_TOTAL_NAME = "ti4.bot.webserver.http.errors.total";
     private static final String WEBSERVER_REQUESTS_TOTAL_NAME = "ti4.bot.webserver.http.requests.total";
 
-    private static final List<Tag> COMMON_TAGS = List.of(Tag.of("component", "bot"));
+    private static final List<Tag> BOT_TAGS = List.of(Tag.of("component", "bot"));
+    private static final List<Tag> HTTP_TAGS = List.of(Tag.of("component", "http"));
 
     private static volatile Counter REQUESTS_TOTAL;
     private static volatile Counter ERRORS_TOTAL;
@@ -44,21 +44,21 @@ public class SREStats {
     public static void init(MeterRegistry meterRegistry) {
         RegistryHolder.registry = meterRegistry;
         REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
-                .tags(COMMON_TAGS)
-                .description("Total incoming bot interaction requests")
-                .register(meterRegistry);
+            .tags(BOT_TAGS)
+            .description("Total incoming bot interaction requests")
+            .register(meterRegistry);
         ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
-                .tags(COMMON_TAGS)
-                .description("Total error-severity events observed by the bot")
-                .register(meterRegistry);
+            .tags(BOT_TAGS)
+            .description("Total error-severity events observed by the bot")
+            .register(meterRegistry);
         WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
-                .tags(COMMON_TAGS)
-                .description("Total webserver HTTP request errors")
-                .register(meterRegistry);
+            .tags(HTTP_TAGS)
+            .description("Total webserver HTTP request errors")
+            .register(meterRegistry);
         WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
-                .tags(COMMON_TAGS)
-                .description("Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
-                .register(meterRegistry);
+            .tags(HTTP_TAGS)
+            .description("Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
+            .register(meterRegistry);
     }
 
     private static MeterRegistry registry() {
@@ -82,9 +82,9 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (REQUESTS_TOTAL == null) {
                 REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
-                        .tags(COMMON_TAGS)
-                        .description("Total incoming bot interaction requests")
-                        .register(registry());
+                    .tags(BOT_TAGS)
+                    .description("Total incoming bot interaction requests")
+                    .register(registry());
             }
             return REQUESTS_TOTAL;
         }
@@ -98,9 +98,9 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (ERRORS_TOTAL == null) {
                 ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
-                        .tags(COMMON_TAGS)
-                        .description("Total error-severity events observed by the bot")
-                        .register(registry());
+                    .tags(BOT_TAGS)
+                    .description("Total error-severity events observed by the bot")
+                    .register(registry());
             }
             return ERRORS_TOTAL;
         }
@@ -114,9 +114,9 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (WEBSERVER_REQUEST_ERROR_TOTAL == null) {
                 WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
-                        .tags(COMMON_TAGS)
-                        .description("Total webserver HTTP request errors")
-                        .register(registry());
+                    .tags(HTTP_TAGS)
+                    .description("Total webserver HTTP request errors")
+                    .register(registry());
             }
             return WEBSERVER_REQUEST_ERROR_TOTAL;
         }
@@ -130,10 +130,10 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (WEBSERVER_REQUESTS_TOTAL == null) {
                 WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
-                        .tags(COMMON_TAGS)
-                        .description(
-                                "Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
-                        .register(registry());
+                    .tags(HTTP_TAGS)
+                    .description(
+                        "Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
+                    .register(registry());
             }
             return WEBSERVER_REQUESTS_TOTAL;
         }

--- a/src/main/java/ti4/service/statistics/SREStats.java
+++ b/src/main/java/ti4/service/statistics/SREStats.java
@@ -44,21 +44,21 @@ public class SREStats {
     public static void init(MeterRegistry meterRegistry) {
         RegistryHolder.registry = meterRegistry;
         REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
-            .tags(BOT_TAGS)
-            .description("Total incoming bot interaction requests")
-            .register(meterRegistry);
+                .tags(BOT_TAGS)
+                .description("Total incoming bot interaction requests")
+                .register(meterRegistry);
         ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
-            .tags(BOT_TAGS)
-            .description("Total error-severity events observed by the bot")
-            .register(meterRegistry);
+                .tags(BOT_TAGS)
+                .description("Total error-severity events observed by the bot")
+                .register(meterRegistry);
         WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
-            .tags(HTTP_TAGS)
-            .description("Total webserver HTTP request errors")
-            .register(meterRegistry);
+                .tags(HTTP_TAGS)
+                .description("Total webserver HTTP request errors")
+                .register(meterRegistry);
         WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
-            .tags(HTTP_TAGS)
-            .description("Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
-            .register(meterRegistry);
+                .tags(HTTP_TAGS)
+                .description("Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
+                .register(meterRegistry);
     }
 
     private static MeterRegistry registry() {
@@ -82,9 +82,9 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (REQUESTS_TOTAL == null) {
                 REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
-                    .tags(BOT_TAGS)
-                    .description("Total incoming bot interaction requests")
-                    .register(registry());
+                        .tags(BOT_TAGS)
+                        .description("Total incoming bot interaction requests")
+                        .register(registry());
             }
             return REQUESTS_TOTAL;
         }
@@ -98,9 +98,9 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (ERRORS_TOTAL == null) {
                 ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
-                    .tags(BOT_TAGS)
-                    .description("Total error-severity events observed by the bot")
-                    .register(registry());
+                        .tags(BOT_TAGS)
+                        .description("Total error-severity events observed by the bot")
+                        .register(registry());
             }
             return ERRORS_TOTAL;
         }
@@ -114,9 +114,9 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (WEBSERVER_REQUEST_ERROR_TOTAL == null) {
                 WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
-                    .tags(HTTP_TAGS)
-                    .description("Total webserver HTTP request errors")
-                    .register(registry());
+                        .tags(HTTP_TAGS)
+                        .description("Total webserver HTTP request errors")
+                        .register(registry());
             }
             return WEBSERVER_REQUEST_ERROR_TOTAL;
         }
@@ -130,10 +130,10 @@ public class SREStats {
         synchronized (SREStats.class) {
             if (WEBSERVER_REQUESTS_TOTAL == null) {
                 WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
-                    .tags(HTTP_TAGS)
-                    .description(
-                        "Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
-                    .register(registry());
+                        .tags(HTTP_TAGS)
+                        .description(
+                                "Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
+                        .register(registry());
             }
             return WEBSERVER_REQUESTS_TOTAL;
         }

--- a/src/main/java/ti4/service/statistics/SREStats.java
+++ b/src/main/java/ti4/service/statistics/SREStats.java
@@ -26,11 +26,16 @@ public class SREStats {
 
     private static final String REQUESTS_TOTAL_NAME = "ti4.bot.requests.total";
     private static final String ERRORS_TOTAL_NAME = "ti4.bot.errors.total";
+    // Renamed from "upstream" to "webserver" to reflect actual meaning
+    private static final String WEBSERVER_REQUEST_ERROR_TOTAL_NAME = "ti4.bot.webserver.http.errors.total";
+    private static final String WEBSERVER_REQUESTS_TOTAL_NAME = "ti4.bot.webserver.http.requests.total";
 
     private static final List<Tag> COMMON_TAGS = List.of(Tag.of("component", "bot"));
 
     private static volatile Counter REQUESTS_TOTAL;
     private static volatile Counter ERRORS_TOTAL;
+    private static volatile Counter WEBSERVER_REQUEST_ERROR_TOTAL;
+    private static volatile Counter WEBSERVER_REQUESTS_TOTAL;
 
     /**
      * Initialize the metrics registry used by this class. Call once during application startup.
@@ -46,68 +51,127 @@ public class SREStats {
                 .tags(COMMON_TAGS)
                 .description("Total error-severity events observed by the bot")
                 .register(meterRegistry);
+        WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
+                .tags(COMMON_TAGS)
+                .description("Total webserver HTTP request errors")
+                .register(meterRegistry);
+        WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
+                .tags(COMMON_TAGS)
+                .description("Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
+                .register(meterRegistry);
     }
 
     private static MeterRegistry registry() {
         MeterRegistry reg = RegistryHolder.registry;
-        if (reg == null) {
-            synchronized (SREStats.class) {
-                if (RegistryHolder.registry == null) {
-                    RegistryHolder.registry = new SimpleMeterRegistry();
-                }
-                reg = RegistryHolder.registry;
-            }
+        if (reg != null) {
+            return reg;
         }
-        return reg;
+        synchronized (SREStats.class) {
+            if (RegistryHolder.registry == null) {
+                RegistryHolder.registry = new SimpleMeterRegistry();
+            }
+            return RegistryHolder.registry;
+        }
     }
 
-   private static Counter requestsCounter() {
-       Counter c = REQUESTS_TOTAL;
-       if (c == null) {
-           synchronized (SREStats.class) {
-               if (REQUESTS_TOTAL == null) {
-                   REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
-                           .tags(COMMON_TAGS)
-                           .description("Total incoming bot interaction requests")
-                           .register(registry());
-               }
-               c = REQUESTS_TOTAL;
-           }
-       }
-       return c;
-   }
+    private static Counter requestsCounter() {
+        Counter c = REQUESTS_TOTAL;
+        if (c != null) {
+            return c;
+        }
+        synchronized (SREStats.class) {
+            if (REQUESTS_TOTAL == null) {
+                REQUESTS_TOTAL = Counter.builder(REQUESTS_TOTAL_NAME)
+                        .tags(COMMON_TAGS)
+                        .description("Total incoming bot interaction requests")
+                        .register(registry());
+            }
+            return REQUESTS_TOTAL;
+        }
+    }
 
-   private static Counter errorsCounter() {
-       Counter c = ERRORS_TOTAL;
-       if (c == null) {
-           synchronized (SREStats.class) {
-               if (ERRORS_TOTAL == null) {
-                   ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
-                           .tags(COMMON_TAGS)
-                           .description("Total error-severity events observed by the bot")
-                           .register(registry());
-               }
-               c = ERRORS_TOTAL;
-           }
-       }
-       return c;
-   }
+    private static Counter errorsCounter() {
+        Counter c = ERRORS_TOTAL;
+        if (c != null) {
+            return c;
+        }
+        synchronized (SREStats.class) {
+            if (ERRORS_TOTAL == null) {
+                ERRORS_TOTAL = Counter.builder(ERRORS_TOTAL_NAME)
+                        .tags(COMMON_TAGS)
+                        .description("Total error-severity events observed by the bot")
+                        .register(registry());
+            }
+            return ERRORS_TOTAL;
+        }
+    }
 
-   // Request counters
-   public static void incrementRequestCount() {
-       requestsCounter().increment();
-   }
+    private static Counter webserverRequestsErrorCounter() {
+        Counter c = WEBSERVER_REQUEST_ERROR_TOTAL;
+        if (c != null) {
+            return c;
+        }
+        synchronized (SREStats.class) {
+            if (WEBSERVER_REQUEST_ERROR_TOTAL == null) {
+                WEBSERVER_REQUEST_ERROR_TOTAL = Counter.builder(WEBSERVER_REQUEST_ERROR_TOTAL_NAME)
+                        .tags(COMMON_TAGS)
+                        .description("Total webserver HTTP request errors")
+                        .register(registry());
+            }
+            return WEBSERVER_REQUEST_ERROR_TOTAL;
+        }
+    }
 
-   public static long getRequestCount() {
-       return (long) requestsCounter().count();
-   }
+    private static Counter webserverRequestsTotalCounter() {
+        Counter c = WEBSERVER_REQUESTS_TOTAL;
+        if (c != null) {
+            return c;
+        }
+        synchronized (SREStats.class) {
+            if (WEBSERVER_REQUESTS_TOTAL == null) {
+                WEBSERVER_REQUESTS_TOTAL = Counter.builder(WEBSERVER_REQUESTS_TOTAL_NAME)
+                        .tags(COMMON_TAGS)
+                        .description(
+                                "Total webserver HTTP requests handled/initiated by the bot's internal Spring server")
+                        .register(registry());
+            }
+            return WEBSERVER_REQUESTS_TOTAL;
+        }
+    }
 
-   // Error counters
-   public static void incrementErrorCount() {
-       errorsCounter().increment();
-   }
+    // Request counters
+    public static void incrementRequestCount() {
+        requestsCounter().increment();
+    }
 
-   public static long getErrorCount() {
-       return (long) errorsCounter().count();
-   }
+    public static long getRequestCount() {
+        return (long) requestsCounter().count();
+    }
+
+    // Error counters
+    public static void incrementErrorCount() {
+        errorsCounter().increment();
+    }
+
+    public static long getErrorCount() {
+        return (long) errorsCounter().count();
+    }
+
+    // Webserver HTTP request counters (totals)
+    public static void incrementWebserverRequestCount() {
+        webserverRequestsTotalCounter().increment();
+    }
+
+    public static long getWebserverRequestCount() {
+        return (long) webserverRequestsTotalCounter().count();
+    }
+
+    // Webserver HTTP request counters (errors)
+    public static void incrementWebserverRequestErrorCount() {
+        webserverRequestsErrorCounter().increment();
+    }
+
+    public static long getWebserverRequestErrorCount() {
+        return (long) webserverRequestsErrorCounter().count();
+    }
 }

--- a/src/main/java/ti4/spring/auth/ErrorLoggingFilter.java
+++ b/src/main/java/ti4/spring/auth/ErrorLoggingFilter.java
@@ -27,6 +27,7 @@ public class ErrorLoggingFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         var cachingResponse = new ContentCachingResponseWrapper(response);
         SREStats.incrementWebserverRequestCount();
+        SREStats.incrementRequestCount();
 
         try {
             filterChain.doFilter(request, cachingResponse);

--- a/src/main/java/ti4/spring/auth/ErrorLoggingFilter.java
+++ b/src/main/java/ti4/spring/auth/ErrorLoggingFilter.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 import ti4.message.logging.BotLogger;
+import ti4.service.statistics.SREStats;
 
 @Order(3)
 @Component
@@ -25,10 +26,13 @@ public class ErrorLoggingFilter extends OncePerRequestFilter {
             @NotNull FilterChain filterChain)
             throws ServletException, IOException {
         var cachingResponse = new ContentCachingResponseWrapper(response);
+        SREStats.incrementWebserverRequestCount();
+
         try {
             filterChain.doFilter(request, cachingResponse);
         } catch (Exception e) {
             BotLogger.error("Exception during request to " + request.getRequestURI(), e);
+            SREStats.incrementWebserverRequestErrorCount();
             throw e;
         }
 
@@ -38,6 +42,7 @@ public class ErrorLoggingFilter extends OncePerRequestFilter {
                     "Request to %s returned status %s with body: %s",
                     request.getRequestURI(), cachingResponse.getStatus(), body);
             BotLogger.error(error);
+            SREStats.incrementWebserverRequestErrorCount();
         }
 
         cachingResponse.copyBodyToResponse();

--- a/src/main/java/ti4/spring/configuration/ActuatorApiKeyFilter.java
+++ b/src/main/java/ti4/spring/configuration/ActuatorApiKeyFilter.java
@@ -1,0 +1,75 @@
+package ti4.spring.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * What: A servlet filter that, for /actuator/**, grants ROLE_ACTUATOR when X-API-KEY matches the configured key.
+ * How:
+ *  - Activates only for request paths that start with /actuator/.
+ *  - If the configured key is blank/null, the filter is effectively disabled (no auth is set).
+ *  - If the request is already authenticated (by any other mechanism), do nothing (do not re-check X-API-KEY).
+ *  - Otherwise, if header "X-API-KEY" matches the configured key, sets an authenticated principal with ROLE_ACTUATOR.
+ *  - If missing or mismatched, does not short-circuit; downstream authorization will return 401/403 as appropriate.
+ */
+public class ActuatorApiKeyFilter extends OncePerRequestFilter {
+
+    private static final String ACTUATOR_PATH = "/actuator/";
+    private static final String API_KEY_HEADER = "X-API-KEY";
+
+    private final String expectedKey;
+
+    public ActuatorApiKeyFilter(String expectedKey) {
+        this.expectedKey = expectedKey;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // Only run for /actuator/**, and only if a key is configured (non-blank)
+        String path = request.getRequestURI();
+        boolean isActuator = path != null && (path.equals("/actuator") || path.startsWith(ACTUATOR_PATH));
+        boolean keyConfigured = StringUtils.hasText(expectedKey);
+        return !(isActuator && keyConfigured);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String apiKey = request.getHeader(API_KEY_HEADER);
+        if (apiKey == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        boolean apiKeyMatches = apiKey.equals(expectedKey);
+        if (apiKeyMatches) {
+            var current = SecurityContextHolder.getContext().getAuthentication();
+            Object principal = current != null ? current.getPrincipal() : "actuator";
+            Object credentials = current != null ? current.getCredentials() : "N/A";
+            List<GrantedAuthority> merged = new ArrayList<>();
+            if (current != null && current.getAuthorities() != null) {
+                merged.addAll(current.getAuthorities());
+            }
+            merged.add(new SimpleGrantedAuthority("ROLE_ACTUATOR"));
+
+            UsernamePasswordAuthenticationToken elevated =
+                    new UsernamePasswordAuthenticationToken(principal, credentials, merged);
+            if (current != null) {
+                elevated.setDetails(current.getDetails());
+            }
+            SecurityContextHolder.getContext().setAuthentication(elevated);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/ti4/spring/configuration/ManualPrometheusRegistryConfiguration.java
+++ b/src/main/java/ti4/spring/configuration/ManualPrometheusRegistryConfiguration.java
@@ -1,0 +1,92 @@
+package ti4.spring.configuration;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/*
+
+can you explain @/src/main/java/ti4/spring/configuration/MetricsConfiguration.java?
+It doesn't seem to be wired correctly. We can't find "MeterRegistry". Maybe we should
+declare a concrete type instead? It works locally, but not in docker.
+
+> Root cause
+> Your code in MetricsConfiguration.java is correct. The failure to inject MeterRegistry
+> is almost certainly due to packaging: your build uses maven-jar-plugin + maven-assembly-plugin
+> to create a fat JAR. These tools do not merge Spring Boot’s auto-configuration resource
+> files (META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports)
+> by default. As a result, Spring Boot’s Micrometer auto-configuration classes are not discovered
+> at runtime, and no MeterRegistry bean is created, causing the UnsatisfiedDependencyException.
+>
+> Why this happens
+>
+> Spring Boot 3 uses resource-based autoconfiguration discovery via AutoConfiguration.imports.
+> When you build an uber JAR with the assembly plugin, duplicate resource files are typically
+> overwritten rather than merged. That drops many auto-config entries (including Micrometer’s),
+> so @EnableAutoConfiguration does not import them.
+>
+> Locally in IDE (classpath run), it would work because individual JARs contribute their own
+> resource entries. The error surfaces in the packaged/assembled JAR.
+>
+> Preferred fix (use Spring Boot packaging)
+>
+> Replace assembly-based fat jar with Spring Boot’s packaging. This correctly merges metadata
+> and produces an executable boot-jar.
+> In pom.xml, add the Spring Boot repackage plugin and remove the assembly fat-jar execution
+> for runtime distribution.
+> Keep your existing plain jar if you need it, but deploy/run the boot-jar.
+>
+> Example plugin block (replace the assembly usage for runtime with this):
+>
+> - Add spring-boot-maven-plugin:
+>     - groupId: org.springframework.boot
+>     - artifactId: spring-boot-maven-plugin
+>     - execution: repackage
+>
+>     Alternative fix (if you must keep an uber JAR)
+>
+> Switch to maven-shade-plugin and add resource transformers that merge Boot 3’s metadata:
+> Merge META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+> Merge META-INF/spring/org.springframework.boot.actuate.autoconfigure/… if present
+> For any libs still using Spring Boot 2-style, also merge META-INF/spring.factories This
+> ensures all auto-configurations remain discoverable in the shaded jar.
+>
+> --------------------------------------
+>
+> Interim workaround (not recommended long-term)
+>
+> Manually provide a registry bean so injection succeeds, e.g., define a PrometheusMeterRegistry
+> bean in a configuration class and keep the parameter type as MeterRegistry. This unblocks
+> startup but bypasses Boot’s CompositeMeterRegistry and can lead to double registration once
+> packaging is fixed. Use only while migrating packaging.
+
+Temporary manual Prometheus MeterRegistry wiring.
+Provides Prometheus-backed MeterRegistry if Boot autoconfiguration doesn't produce one
+(e.g., when packaging drops auto-config metadata).
+Uses @ConditionalOnMissingBean so it will not conflict once proper Boot autoconfiguration
+is restored; then Boot will supply its managed (Composite) registry. */
+@Configuration
+public class ManualPrometheusRegistryConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    public PrometheusConfig prometheusConfig() {
+        return PrometheusConfig.DEFAULT;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Clock micrometerClock() {
+        return Clock.SYSTEM;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MeterRegistry.class)
+    public MeterRegistry meterRegistry(PrometheusConfig config, Clock clock) {
+        // Use the default Prometheus CollectorRegistry to ensure Actuator (if present) sees the same registry.
+        return new PrometheusMeterRegistry(config);
+    }
+}

--- a/src/main/java/ti4/spring/configuration/MetricsConfiguration.java
+++ b/src/main/java/ti4/spring/configuration/MetricsConfiguration.java
@@ -1,0 +1,30 @@
+package ti4.spring.configuration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/*
+ * MetricsConfiguration: wires the Spring Boot MeterRegistry into SREStats so custom Micrometer counters
+ * are registered on the application's Prometheus-enabled registry and appear at /actuator/prometheus.
+ *
+ * What this file does:
+ * - Provides a Spring @Configuration that runs at startup and initializes SREStats with the managed MeterRegistry.
+ *
+ * How it does it:
+ * - Declares a CommandLineRunner bean that receives the auto-configured MeterRegistry and calls SREStats.init(...).
+ * - This ensures SREStats does NOT fall back to SimpleMeterRegistry (which is not exported) and instead uses the
+ *   same registry Spring Actuator Prometheus endpoint exports.
+ */
+@Configuration
+public class MetricsConfiguration {
+
+    @Bean
+    CommandLineRunner initSREStats(MeterRegistry meterRegistry) {
+        return args -> {
+            // Initialize the static metrics utility with the Actuator-managed registry.
+            ti4.service.statistics.SREStats.init(meterRegistry);
+        };
+    }
+}

--- a/src/main/java/ti4/spring/configuration/SecurityConfiguration.java
+++ b/src/main/java/ti4/spring/configuration/SecurityConfiguration.java
@@ -1,12 +1,14 @@
 package ti4.spring.configuration;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import ti4.spring.auth.DiscordOpaqueTokenIntrospector;
 
 @RequiredArgsConstructor
@@ -16,13 +18,22 @@ public class SecurityConfiguration {
 
     private final DiscordOpaqueTokenIntrospector discordOpaqueTokenIntrospector;
 
+    @Value("${management.endpoints.actuator.api.key:${MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY:}}")
+    private String actuatorApiKey;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.requestMatchers("/api/public/**")
+                .authorizeHttpRequests(auth -> auth.requestMatchers("/actuator/**")
+                        .hasRole("ACTUATOR")
+                        // Public API paths
+                        .requestMatchers("/api/public/**")
                         .permitAll()
+                        // Everything else requires auth
                         .anyRequest()
                         .authenticated())
+                // Add API key filter for /actuator/** when key is configured.
+                .addFilterBefore(new ActuatorApiKeyFilter(actuatorApiKey), AuthorizationFilter.class)
                 .oauth2ResourceServer(
                         oauth2 -> oauth2.opaqueToken(token -> token.introspector(discordOpaqueTokenIntrospector)));
 

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -14,6 +14,7 @@ management:
     prometheus:
       enabled: true
   metrics:
+    enabled: true
     export:
       prometheus:
         enabled: true

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -1,2 +1,19 @@
+# Application configuration:
+# - What: Configures server port and Spring Boot Actuator Prometheus exposure.
+# - How: 'server.port' sets the HTTP port; 'management.*' configures actuator endpoints and metrics export.
+
 server:
   port: 8081
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true


### PR DESCRIPTION
@wholton I have added a fix, but I'm not versed enough with Java to understand the implications. Feedback would be appreciated

The issue was not being able to find a MeterRegistry implementation to inject, which works locally because there's implementations on the classpath, but not in docker (inside a JAR) where the resource files are not merged automatically. The solution should be a migration to a "Spring boot packaging" instead of a regular packaging system, but this seemed like a painful migration. The secondary solution given was to use maven-shade-plugin, which I don't know what to do.

The workaround was to hardwire the class to a prometheus-specific implementation, instead of the implementation-agnostic micrometer is abandoned. This fixes the runtime, but is hardcoded to prometheus and also might throw exceptions if we ever try to migrate to springboot packaging.


See this comment by Roo Code to see what went wrong.

> Root cause
> Your code in MetricsConfiguration.java is correct. The failure to inject MeterRegistry
> is almost certainly due to packaging: your build uses maven-jar-plugin + maven-assembly-plugin
> to create a fat JAR. These tools do not merge Spring Boot’s auto-configuration resource
> files (META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports)
> by default. As a result, Spring Boot’s Micrometer auto-configuration classes are not discovered
> at runtime, and no MeterRegistry bean is created, causing the UnsatisfiedDependencyException.
>
> Why this happens
>
> Spring Boot 3 uses resource-based autoconfiguration discovery via AutoConfiguration.imports.
> When you build an uber JAR with the assembly plugin, duplicate resource files are typically
> overwritten rather than merged. That drops many auto-config entries (including Micrometer’s),
> so @EnableAutoConfiguration does not import them.
>
> Locally in IDE (classpath run), it would work because individual JARs contribute their own
> resource entries. The error surfaces in the packaged/assembled JAR.
>
> Preferred fix (use Spring Boot packaging)
>
> Replace assembly-based fat jar with Spring Boot’s packaging. This correctly merges metadata
> and produces an executable boot-jar.
> In pom.xml, add the Spring Boot repackage plugin and remove the assembly fat-jar execution
> for runtime distribution.
> Keep your existing plain jar if you need it, but deploy/run the boot-jar.
>
> Example plugin block (replace the assembly usage for runtime with this):
>
> - Add spring-boot-maven-plugin:
>     - groupId: org.springframework.boot
>     - artifactId: spring-boot-maven-plugin
>     - execution: repackage
>
>     Alternative fix (if you must keep an uber JAR)
>
> Switch to maven-shade-plugin and add resource transformers that merge Boot 3’s metadata:
> Merge META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
> Merge META-INF/spring/org.springframework.boot.actuate.autoconfigure/… if present
> For any libs still using Spring Boot 2-style, also merge META-INF/spring.factories This
> ensures all auto-configurations remain discoverable in the shaded jar.
>
> --------------------------------------
>
> Interim workaround (not recommended long-term)
>
> Manually provide a registry bean so injection succeeds, e.g., define a PrometheusMeterRegistry
> bean in a configuration class and keep the parameter type as MeterRegistry. This unblocks
> startup but bypasses Boot’s CompositeMeterRegistry and can lead to double registration once
> packaging is fixed. Use only while migrating packaging.
