### PR TITLE
Refactor object mapper usage and improve logging

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -30,6 +30,7 @@ jobs:
             port: ${{ secrets.HOSTINGER_SSH_PORT }}
             envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY
             script: |
+              set -Eeuo pipefail
               echo "Pulling changes from GitHub..."
               cd ${{ vars.HOST_TI4_REPO_DIR }}
               git pull

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -24,6 +24,7 @@ jobs:
         port: ${{ secrets.HOSTINGER_SSH_PORT }}
         envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY
         script: |
+          set -Eeuo pipefail
           cd /app
           ./scheduled_upload.sh
           cd ${{ vars.HOST_TI4_REPO_DIR }}

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -24,6 +24,7 @@ jobs:
         port: ${{ secrets.HOSTINGER_SSH_PORT }}
         envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY
         script: |
+          set -Eeuo pipefail
           cd ${{ vars.HOST_TI4_REPO_DIR }}
           echo "Building docker image..."
           docker version

--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -266,13 +266,13 @@ public class AsyncTI4DiscordBot {
 
         jda.getPresence().setActivity(Activity.customStatus("STARTING UP: Loading Games"));
 
-        // LOAD GAMES NAMES
         BotLogger.info("LOADING GAMES");
-        GameManager.initialize(); // load games, into 2 ConcurrentHashMaps: 1 for games and 1 for players
+        GameManager.initialize();
+        BotLogger.info("FINISHED LOADING GAMES");
 
-        // RUN DATA MIGRATIONS
+        BotLogger.info("RUNNING MIGRATIONS");
         if (DataMigrationManager.runMigrations()) {
-            BotLogger.info("RAN MIGRATIONS");
+            BotLogger.info("FINISHED RUNNING MIGRATIONS");
         }
 
         // START CRONS
@@ -295,7 +295,7 @@ public class AsyncTI4DiscordBot {
         GlobalSettings.setSetting(ImplementedSettings.READY_TO_RECEIVE_COMMANDS, true);
         jda.getPresence().setPresence(OnlineStatus.ONLINE, Activity.playing("Async TI4"));
         updatePresence();
-        BotLogger.info("FINISHED LOADING GAMES");
+        BotLogger.info("BOT IS READY TO RECEIVE COMMANDS");
 
         // Register Shutdown Hook to run when SIGTERM is received from docker stop
         Thread mainThread = Thread.currentThread();

--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -270,7 +270,6 @@ public class AsyncTI4DiscordBot {
         GameManager.initialize();
         BotLogger.info("FINISHED LOADING GAMES");
 
-        BotLogger.info("RUNNING MIGRATIONS");
         if (DataMigrationManager.runMigrations()) {
             BotLogger.info("FINISHED RUNNING MIGRATIONS");
         }

--- a/src/main/java/ti4/commands/user/ShowUserSettings.java
+++ b/src/main/java/ti4/commands/user/ShowUserSettings.java
@@ -19,7 +19,7 @@ class ShowUserSettings extends Subcommand {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    public ShowUserSettings() {
+    ShowUserSettings() {
         super("show_settings", "Show your User Settings");
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
     }

--- a/src/main/java/ti4/image/TileHelper.java
+++ b/src/main/java/ti4/image/TileHelper.java
@@ -27,7 +27,8 @@ import ti4.model.TileModel;
 
 public class TileHelper {
 
-    public static final Pattern TILE_WITH_NAME_PATTERN = Pattern.compile("^\\s*\\d{3} \\(\\w+\\)\\s*$");
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Pattern TILE_WITH_NAME_PATTERN = Pattern.compile("^\\s*\\d{3} \\(\\w+\\)\\s*$");
     private static final Map<String, TileModel> tileIdsToTileModels = new HashMap<>();
     private static final Map<String, PlanetModel> planetIdsToPlanetModels = new HashMap<>();
     private static final Map<String, List<PlanetModel>> tileIdsToPlanetModels = new HashMap<>();
@@ -64,7 +65,6 @@ public class TileHelper {
     }
 
     private static void initPlanetsFromJson() {
-        ObjectMapper objectMapper = new ObjectMapper();
         String resourcePath = Storage.getResourcePath() + File.separator + "planets" + File.separator;
         String storagePath = Storage.getStoragePath() + File.separator + "planets" + File.separator;
         List<File> files = new ArrayList<>();
@@ -99,7 +99,6 @@ public class TileHelper {
     }
 
     private static void initTilesFromJson() {
-        ObjectMapper objectMapper = new ObjectMapper();
         String resourcePath = Storage.getResourcePath() + File.separator + "systems" + File.separator;
         String storagePath = Storage.getStoragePath() + File.separator + "systems" + File.separator;
         List<File> files = new ArrayList<>();

--- a/src/main/java/ti4/website/model/stats/GameStatsDashboardPayload.java
+++ b/src/main/java/ti4/website/model/stats/GameStatsDashboardPayload.java
@@ -2,7 +2,6 @@ package ti4.website.model.stats;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -27,6 +26,7 @@ import ti4.message.logging.BotLogger;
 import ti4.model.AgendaModel;
 import ti4.model.PublicObjectiveModel;
 import ti4.model.SecretObjectiveModel;
+import ti4.website.EgressClientManager;
 
 public class GameStatsDashboardPayload {
 
@@ -38,9 +38,8 @@ public class GameStatsDashboardPayload {
 
     @JsonIgnore
     public String getJson() {
-        ObjectMapper mapper = new ObjectMapper();
         try {
-            return mapper.writeValueAsString(this);
+            return EgressClientManager.getObjectMapper().writeValueAsString(this);
         } catch (Exception e) {
             BotLogger.error("Could not get GameStatsDashboardPayload JSON for Game ", e);
             return null;

--- a/src/main/java/ti4/website/model/stats/PlayerStatsDashboardPayload.java
+++ b/src/main/java/ti4/website/model/stats/PlayerStatsDashboardPayload.java
@@ -1,7 +1,6 @@
 package ti4.website.model.stats;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,22 +25,22 @@ import ti4.model.StrategyCardModel;
 import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
 import ti4.service.agenda.IsPlayerElectedService;
+import ti4.website.EgressClientManager;
 
 public class PlayerStatsDashboardPayload {
 
     private final Player player;
     private final Game game;
 
-    public PlayerStatsDashboardPayload(Player player) {
+    PlayerStatsDashboardPayload(Player player) {
         this.player = player;
         game = player.getGame();
     }
 
     @JsonIgnore
     public String getJson() {
-        ObjectMapper mapper = new ObjectMapper();
         try {
-            return mapper.writeValueAsString(this);
+            return EgressClientManager.getObjectMapper().writeValueAsString(this);
         } catch (Exception e) {
             BotLogger.error(
                     "Could not get PlayerStatsDashboardPayload JSON for Game: "


### PR DESCRIPTION
Centralized ObjectMapper usage in stats payload classes by using EgressClientManager, reducing redundant instantiations. Improved bot startup logging for clarity, made ShowUserSettings constructor package-private, and updated workflow scripts to use 'set -Eeuo pipefail' for safer shell execution. Also refactored TileHelper to use a single ObjectMapper instance.