### PR TITLE
Add migration to strip pi_ faction prefix and mark as homebrew

### DIFF
--- a/src/main/java/ti4/map/persistence/GameSaveService.java
+++ b/src/main/java/ti4/map/persistence/GameSaveService.java
@@ -1058,7 +1058,7 @@ class GameSaveService {
         }
     }
 
-    public static boolean delete(String gameName) {
+    static boolean delete(String gameName) {
         return GameFileLockManager.wrapWithWriteLock(gameName, () -> {
             File mapStorage = Storage.getGameFile(gameName + Constants.TXT);
             if (!mapStorage.exists()) {

--- a/src/main/java/ti4/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/migration/DataMigrationManager.java
@@ -44,13 +44,6 @@ public class DataMigrationManager {
 
     static {
         migrations = new HashMap<>();
-        migrations.put("cleanupFactionEmojis_110525", MigrationHelper::cleanupFactionEmojis);
-        migrations.put(
-                "removeWekkersAbsolsPoliticalSecret_220125", MigrationHelper::removeWekkersAbsolsPoliticalSecrets);
-        migrations.put(
-                "removeWekkersAbsolsPoliticalSecretAgain_220125",
-                MigrationHelper::removeWekkersAbsolsPoliticalSecretsAgain);
-        migrations.put("warnGamesWithOldDisplaceMap_270525", MigrationHelper::warnGamesWithOldDisplaceMap);
         migrations.put("piFactionsHomebrew_010625", MigrationHelper::setPiFactionsHomebrew);
         // migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
     }

--- a/src/main/java/ti4/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/migration/DataMigrationManager.java
@@ -51,6 +51,7 @@ public class DataMigrationManager {
                 "removeWekkersAbsolsPoliticalSecretAgain_220125",
                 MigrationHelper::removeWekkersAbsolsPoliticalSecretsAgain);
         migrations.put("warnGamesWithOldDisplaceMap_270525", MigrationHelper::warnGamesWithOldDisplaceMap);
+        migrations.put("piFactionsHomebrew_010625", MigrationHelper::setPiFactionsHomebrew);
         // migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
     }
 

--- a/src/main/java/ti4/migration/MigrationHelper.java
+++ b/src/main/java/ti4/migration/MigrationHelper.java
@@ -220,4 +220,19 @@ class MigrationHelper {
         }
         return true;
     }
+
+    public static boolean setPiFactionsHomebrew(Game game) {
+        boolean changed = false;
+        for (Player player : game.getPlayers().values()) {
+            String faction = player.getFaction();
+            if (faction != null && faction.startsWith("pi_")) {
+                player.setFaction(faction.substring(3));
+                changed = true;
+            }
+        }
+        if (changed) {
+            game.setHomebrew(true);
+        }
+        return changed;
+    }
 }

--- a/src/main/java/ti4/migration/MigrationHelper.java
+++ b/src/main/java/ti4/migration/MigrationHelper.java
@@ -112,6 +112,7 @@ class MigrationHelper {
         bag.Contents.remove(index);
         bag.Contents.add(index, newItem);
     }
+
     public static boolean setPiFactionsHomebrew(Game game) {
         boolean changed = false;
         for (Player player : game.getPlayers().values()) {

--- a/src/main/java/ti4/migration/MigrationHelper.java
+++ b/src/main/java/ti4/migration/MigrationHelper.java
@@ -232,6 +232,7 @@ class MigrationHelper {
         }
         if (changed) {
             game.setHomebrew(true);
+            BotLogger.info("Changed factions from 'pi_' in game: " + game.getName());
         }
         return changed;
     }

--- a/src/main/java/ti4/migration/MigrationHelper.java
+++ b/src/main/java/ti4/migration/MigrationHelper.java
@@ -1,24 +1,17 @@
 package ti4.migration;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
-import net.dv8tion.jda.api.entities.emoji.Emoji;
 import ti4.draft.DraftBag;
 import ti4.draft.DraftItem;
-import ti4.helpers.Units;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.map.Tile;
 import ti4.map.UnitHolder;
-import ti4.message.MessageHelper;
 import ti4.message.logging.BotLogger;
-import ti4.service.fow.GMService;
 
 @UtilityClass
 class MigrationHelper {
@@ -118,131 +111,6 @@ class MigrationHelper {
                 "Draft Bag replacing %s with %s", bag.Contents.get(index).getAlias(), newItem.getAlias()));
         bag.Contents.remove(index);
         bag.Contents.add(index, newItem);
-    }
-
-    public static boolean renameBlaheoUnitHolder(Game game) {
-        boolean changed = false;
-        for (Tile tile : game.getTileMap().values()) {
-            if (!"d17".equalsIgnoreCase(tile.getTileID())) continue;
-            Map<String, UnitHolder> holders = tile.getUnitHolders();
-            if (!holders.containsKey("blaheo")) continue;
-            UnitHolder holder = holders.remove("blaheo");
-            try {
-                Field nameField = UnitHolder.class.getDeclaredField("name");
-                nameField.setAccessible(true);
-                nameField.set(holder, "biaheo");
-            } catch (Exception e) {
-                BotLogger.error("Failed to rename blaheo unit holder", e);
-            }
-            holders.put("biaheo", holder);
-            changed = true;
-        }
-        if (changed) {
-            BotLogger.info("Renamed Blaheo as Biaheo in game " + game.getName());
-        }
-        return changed;
-    }
-
-    public static boolean cleanupFactionEmojis(Game game) {
-        if (game.isFrankenGame()) return false;
-
-        boolean anyChanged = false;
-        for (Player p : game.getPlayers().values()) {
-            String rawEmoji = p.getFactionEmojiRaw();
-            if (rawEmoji == null || "null".equals(rawEmoji)) continue;
-
-            Emoji e = Emoji.fromFormatted(rawEmoji);
-            if (e.getName().equalsIgnoreCase(p.getFaction())) {
-                p.setFactionEmoji(null);
-                anyChanged = true;
-            }
-        }
-        return anyChanged;
-    }
-
-    public static boolean removeWekkersAbsolsPoliticalSecrets(Game game) {
-        if ("g14".equals(game.getName())) {
-            return false;
-        }
-        boolean removed = false;
-        for (Player player : game.getPlayers().values()) {
-            for (String ownedPN : new ArrayList<>(player.getPromissoryNotesOwned())) {
-                if (ownedPN.startsWith("wekkerabsol_")) {
-                    player.removeOwnedPromissoryNoteByID(ownedPN);
-                    removed = true;
-                }
-            }
-        }
-        return removed;
-    }
-
-    public static boolean removeWekkersAbsolsPoliticalSecretsAgain(Game game) {
-        if ("g14".equals(game.getName())) {
-            return false;
-        }
-        boolean removed = false;
-        for (Player player : game.getPlayers().values()) {
-            for (String pn : new ArrayList<>(player.getPromissoryNotes().keySet())) {
-                if (pn.startsWith("wekkerabsol_")) {
-                    player.removePromissoryNote(pn);
-                    removed = true;
-                }
-            }
-        }
-        return removed;
-    }
-
-    public static boolean warnGamesWithOldDisplaceMap(Game game) {
-        if (game.getMovedUnitsFromCurrentActivation().isEmpty()) return false;
-        Player player = game.getActivePlayer();
-        if (player == null) return false;
-
-        Map<String, Integer> moved = game.getMovedUnitsFromCurrentActivation();
-        for (String unit : moved.keySet()) {
-            Integer amt = moved.get(unit);
-
-            // Get the state
-            Units.UnitState st = Units.UnitState.none;
-            if (unit.contains("damaged")) {
-                unit = unit.replace("damaged", "");
-                st = Units.UnitState.dmg;
-            }
-
-            Units.UnitKey key = Units.getUnitKey(unit, player.getColorID());
-            if (key != null) {
-                // Add the unit to "unk"
-                if (!game.getTacticalActionDisplacement().containsKey("unk"))
-                    game.getTacticalActionDisplacement().put("unk", new HashMap<>());
-                Map<Units.UnitKey, List<Integer>> uh =
-                        game.getTacticalActionDisplacement().get("unk");
-                if (!uh.containsKey(key)) uh.put(key, Units.UnitState.emptyList());
-                int mv = uh.get(key).get(st.ordinal());
-                uh.get(key).set(st.ordinal(), mv + amt);
-            }
-        }
-        game.resetCurrentMovedUnitsFrom1System();
-        game.resetCurrentMovedUnitsFrom1TacticalAction();
-
-        String msg =
-                "Hey %s, I redid a lot of the tactical action buttons, and because of this a little bit of information has been lost. ";
-        msg +=
-                "**__All your units are still accounted for__**, but any units that you moved won't be able to be put back unless you use `undo`. ";
-        msg +=
-                "Apologies for the inconvenience. Let me know if anything breaks during this tactical action and you need help fixing it.\n\n";
-        msg +=
-                "Good news though, future tactical actions you'll be able to freely edit your unit movement from each system as much as you like!\n";
-        msg += "\\- Jazzxhands";
-        String playerMsg = String.format(msg, player.getRepresentationUnfogged());
-        if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(player.getCorrectChannel(), playerMsg);
-
-            String gmMsg =
-                    String.format(msg, "GM (on behalf of " + player.getRepresentationUnfoggedNoPing() + ")") + "\n";
-            GMService.logActivity(game, gmMsg, true);
-        } else if (game.getTableTalkChannel() != null) {
-            MessageHelper.sendMessageToChannel(game.getTableTalkChannel(), playerMsg);
-        }
-        return true;
     }
 
     public static boolean setPiFactionsHomebrew(Game game) {


### PR DESCRIPTION
## Summary
- add migration to remove `pi_` prefix from player factions
- mark game as homebrew when such factions are present

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68abf8be86d4832d8f43903892246302