### PR TITLE
Add RunAgainstAllGames developer command

### DIFF
--- a/src/main/java/ti4/commands/developer/DeveloperCommand.java
+++ b/src/main/java/ti4/commands/developer/DeveloperCommand.java
@@ -19,7 +19,8 @@ public class DeveloperCommand implements ParentCommand {
                     new ButtonProcessingStatistics(),
                     new CacheStatistics(),
                     new RestoreGame(),
-                    new RunCron())
+                    new RunCron(),
+                    new RunAgainstAllGames())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override

--- a/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
@@ -1,0 +1,73 @@
+package ti4.commands.developer;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.commands.Subcommand;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.map.Tile;
+import ti4.map.UnitHolder;
+import ti4.map.persistence.GameManager;
+import ti4.map.persistence.GamesPage;
+import ti4.message.MessageHelper;
+import ti4.message.logging.BotLogger;
+
+class RunAgainstAllGames extends Subcommand {
+
+    RunAgainstAllGames() {
+        super("run_against_all_games", "Runs this custom code against all games.");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        MessageHelper.sendMessageToChannel(event.getChannel(), "Running custom command against all games.");
+
+        GamesPage.consumeAllGames(game -> {
+            boolean changed = setPiFactionsHomebrew(game);
+            changed |= renameBlaheoUnitHolder(game);
+            if (changed) {
+                GameManager.save(game, "Developer ran custom command against this game, probably migration related.");
+            }
+        });
+    }
+
+    private static boolean setPiFactionsHomebrew(Game game) {
+        boolean changed = false;
+        for (Player player : game.getPlayers().values()) {
+            String faction = player.getFaction();
+            if (faction != null && faction.startsWith("pi_")) {
+                player.setFaction(faction.substring(3));
+                changed = true;
+            }
+        }
+        if (changed) {
+            game.setHomebrew(true);
+            BotLogger.info("Changed factions from 'pi_' in game: " + game.getName());
+        }
+        return changed;
+    }
+
+    private static boolean renameBlaheoUnitHolder(Game game) {
+        boolean changed = false;
+        for (Tile tile : game.getTileMap().values()) {
+            if (!"d17".equalsIgnoreCase(tile.getTileID())) continue;
+            Map<String, UnitHolder> holders = tile.getUnitHolders();
+            if (!holders.containsKey("blaheo")) continue;
+            UnitHolder holder = holders.remove("blaheo");
+            try {
+                Field nameField = UnitHolder.class.getDeclaredField("name");
+                nameField.setAccessible(true);
+                nameField.set(holder, "biaheo");
+            } catch (Exception e) {
+                BotLogger.error("Failed to rename blaheo unit holder", e);
+            }
+            holders.put("biaheo", holder);
+            changed = true;
+        }
+        if (changed) {
+            BotLogger.info("Renamed Blaheo as Biaheo in game " + game.getName());
+        }
+        return changed;
+    }
+}

--- a/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.commands.Subcommand;
+import ti4.commands.statistics.GameStatisticsFilterer;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.map.Tile;
@@ -17,13 +18,14 @@ class RunAgainstAllGames extends Subcommand {
 
     RunAgainstAllGames() {
         super("run_against_all_games", "Runs this custom code against all games.");
+        addOptions(GameStatisticsFilterer.gameStatsFilters());
     }
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
         MessageHelper.sendMessageToChannel(event.getChannel(), "Running custom command against all games.");
 
-        GamesPage.consumeAllGames(game -> {
+        GamesPage.consumeAllGames(GameStatisticsFilterer.getGamesFilter(event), game -> {
             boolean changed = setPiFactionsHomebrew(game);
             changed |= renameBlaheoUnitHolder(game);
             if (changed) {

--- a/src/main/java/ti4/commands/statistics/ExportToCSV.java
+++ b/src/main/java/ti4/commands/statistics/ExportToCSV.java
@@ -8,7 +8,7 @@ import ti4.service.statistics.ExportToCsvService;
 
 class ExportToCSV extends Subcommand {
 
-    public ExportToCSV() {
+    ExportToCSV() {
         super("export_games_to_csv", "Export game data to a CSV file");
         addOptions(GameStatisticsFilterer.gameStatsFilters());
         addOptions(new OptionData(

--- a/src/main/java/ti4/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/migration/DataMigrationManager.java
@@ -44,7 +44,6 @@ public class DataMigrationManager {
 
     static {
         migrations = new HashMap<>();
-        migrations.put("piFactionsHomebrew_010625", MigrationHelper::setPiFactionsHomebrew);
         // migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
     }
 

--- a/src/main/java/ti4/migration/MigrationHelper.java
+++ b/src/main/java/ti4/migration/MigrationHelper.java
@@ -112,20 +112,4 @@ class MigrationHelper {
         bag.Contents.remove(index);
         bag.Contents.add(index, newItem);
     }
-
-    public static boolean setPiFactionsHomebrew(Game game) {
-        boolean changed = false;
-        for (Player player : game.getPlayers().values()) {
-            String faction = player.getFaction();
-            if (faction != null && faction.startsWith("pi_")) {
-                player.setFaction(faction.substring(3));
-                changed = true;
-            }
-        }
-        if (changed) {
-            game.setHomebrew(true);
-            BotLogger.info("Changed factions from 'pi_' in game: " + game.getName());
-        }
-        return changed;
-    }
 }

--- a/src/main/java/ti4/service/statistics/game/GameCountStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/GameCountStatisticsService.java
@@ -10,7 +10,7 @@ import ti4.message.MessageHelper;
 @UtilityClass
 class GameCountStatisticsService {
 
-    public static void getGameCount(SlashCommandInteractionEvent event) {
+    static void getGameCount(SlashCommandInteractionEvent event) {
         AtomicInteger count = new AtomicInteger();
 
         GamesPage.consumeAllGames(GameStatisticsFilterer.getGamesFilter(event), game -> count.getAndIncrement());


### PR DESCRIPTION
Introduces a new developer command to run custom migration logic across all games, including setting homebrew for 'pi_' factions and renaming 'blaheo' unit holders. Removes the setPiFactionsHomebrew migration from MigrationHelper and DataMigrationManager, consolidating this logic into the new command.