### PR TITLE
Replace java.util.Date with java.time Instant

### DIFF
--- a/src/main/java/ti4/commands/fow/PingActivePlayer.java
+++ b/src/main/java/ti4/commands/fow/PingActivePlayer.java
@@ -39,7 +39,7 @@ class PingActivePlayer extends GameStateSubcommand {
         if (autoPing != null) {
             latestPingMilliseconds = autoPing.lastPingTimeEpochMilliseconds();
         } else if (game.getLastActivePlayerChange() != null) {
-            latestPingMilliseconds = game.getLastActivePlayerChange().getTime();
+            latestPingMilliseconds = game.getLastActivePlayerChange().toEpochMilli();
         }
 
         long milliSinceLastPing = System.currentTimeMillis() - latestPingMilliseconds;

--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -1,12 +1,10 @@
 package ti4.helpers;
 
 import java.awt.Point;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -19,6 +17,9 @@ import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
@@ -586,15 +587,13 @@ public class Helper {
     }
 
     public static String getDateRepresentation(long dateInfo) {
-        Date date = new Date(dateInfo);
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy.MM.dd");
-        return simpleDateFormat.format(date);
+        Instant instant = Instant.ofEpochMilli(dateInfo);
+        return DateTimeFormatter.ofPattern("yyyy.MM.dd").withZone(ZoneId.systemDefault()).format(instant);
     }
 
     public static String getDateRepresentationTIGL(long dateInfo) {
-        Date date = new Date(dateInfo);
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM.dd.yyyy");
-        return simpleDateFormat.format(date);
+        Instant instant = Instant.ofEpochMilli(dateInfo);
+        return DateTimeFormatter.ofPattern("MM.dd.yyyy").withZone(ZoneId.systemDefault()).format(instant);
     }
 
     public static int getDateDifference(String date1, String date2) {

--- a/src/main/java/ti4/listeners/UserLeaveServerListener.java
+++ b/src/main/java/ti4/listeners/UserLeaveServerListener.java
@@ -140,9 +140,8 @@ public class UserLeaveServerListener extends ListenerAdapter {
         String header = String.format("> %s %s %s %s %s", websiteLink, faction, tabletalkLink, actionsLink, round);
 
         // Last player turn start
-        game.getLastActivePlayerChange().getTime();
         String lastTurnStart =
-                "> -- Last turn started <t:" + (game.getLastActivePlayerChange().getTime() / 1000) + ":R>";
+                "> -- Last turn started <t:" + game.getLastActivePlayerChange().getEpochSecond() + ":R>";
 
         // Some other player stats to show...
         float value = player.getTotalResourceValueOfUnits("space") + player.getTotalResourceValueOfUnits("ground");
@@ -166,13 +165,13 @@ public class UserLeaveServerListener extends ListenerAdapter {
         boolean foundOne = false;
         for (Game g : games) {
             Player p = g.getPlayer(player.getId());
-            if (p != null && g.getLastActivePlayerChange().toString() != null) {
+            if (p != null && g.getLastActivePlayerChange() != null) {
                 float value = p.getTotalResourceValueOfUnits("space") + p.getTotalResourceValueOfUnits("ground");
                 if (!foundOne
                         && value > 0
                         && Helper.getDateDifference(
                                         Helper.getDateRepresentation(
-                                                g.getLastActivePlayerChange().getTime()),
+                                                g.getLastActivePlayerChange().toEpochMilli()),
                                         Helper.getDateRepresentation(System.currentTimeMillis()))
                                 < 15) {
                     foundOne = true;

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,6 +30,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import java.time.Duration;
+import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
 import net.dv8tion.jda.api.entities.Guild;
@@ -133,7 +134,7 @@ public class Game extends GameProperties {
     private DisplayType displayTypeForced;
 
     private final BorderAnomalyManager borderAnomalyManager = new BorderAnomalyManager();
-    private Date lastActivePlayerChange = new Date(0);
+    private Instant lastActivePlayerChange = Instant.EPOCH;
 
     @JsonProperty("autoPingStatus")
     private boolean autoPingEnabled;
@@ -1162,12 +1163,12 @@ public class Game extends GameProperties {
 
     public void updateActivePlayer(Player player) {
         /// update previous active player stats
-        Date newTime = new Date();
+        Instant newTime = Instant.now();
         String factionsInCombat = getStoredValue("factionsInCombat");
         Player prevPlayer = getActivePlayer();
         String prevFaction =
                 (prevPlayer != null && prevPlayer.getFaction() != null) ? prevPlayer.getFaction() : "jazzwuzhere&p1too";
-        long elapsedTime = newTime.getTime() - lastActivePlayerChange.getTime();
+        long elapsedTime = Duration.between(lastActivePlayerChange, newTime).toMillis();
         if (prevPlayer != null && !factionsInCombat.contains(prevFaction) && !isTemporaryPingDisable()) {
             prevPlayer.updateTurnStats(elapsedTime);
         } else {
@@ -1191,11 +1192,11 @@ public class Game extends GameProperties {
         return autoPingEnabled;
     }
 
-    public Date getLastActivePlayerChange() {
+    public Instant getLastActivePlayerChange() {
         return lastActivePlayerChange;
     }
 
-    public void setLastActivePlayerChange(Date time) {
+    public void setLastActivePlayerChange(Instant time) {
         lastActivePlayerChange = time;
     }
 

--- a/src/main/java/ti4/map/persistence/GameLoadService.java
+++ b/src/main/java/ti4/map/persistence/GameLoadService.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -47,6 +46,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import java.time.Instant;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.internal.utils.tuple.ImmutablePair;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
@@ -452,7 +452,7 @@ class GameLoadService {
                 case Constants.LAST_ACTIVE_PLAYER_CHANGE -> {
                     try {
                         long millis = Long.parseLong(info);
-                        Date lastChange = new Date(millis);
+                        Instant lastChange = Instant.ofEpochMilli(millis);
                         game.setLastActivePlayerChange(lastChange);
                     } catch (Exception e) {
                     }

--- a/src/main/java/ti4/map/persistence/GameSaveService.java
+++ b/src/main/java/ti4/map/persistence/GameSaveService.java
@@ -190,7 +190,7 @@ class GameSaveService {
         writer.write(System.lineSeparator());
 
         writer.write(Constants.LAST_ACTIVE_PLAYER_CHANGE + " "
-                + game.getLastActivePlayerChange().getTime());
+                + game.getLastActivePlayerChange().toEpochMilli());
         writer.write(System.lineSeparator());
 
         Map<Integer, Boolean> scPlayed = game.getScPlayed();

--- a/src/main/java/ti4/map/persistence/ManagedGame.java
+++ b/src/main/java/ti4/map/persistence/ManagedGame.java
@@ -62,7 +62,7 @@ public class ManagedGame { // BE CAREFUL ADDING FIELDS TO THIS CLASS, AS IT CAN 
         activePlayerId = sanitizeToNull(game.getActivePlayerID());
         lastActivePlayerChange = game.getLastActivePlayerChange() == null
                 ? 0
-                : game.getLastActivePlayerChange().getTime();
+                : game.getLastActivePlayerChange().toEpochMilli();
         endedDate = game.getEndedDate();
         round = game.getRound();
         guild = game.getGuild();


### PR DESCRIPTION
## Summary
- Replace legacy `Date` usage with `Instant` and `Duration` in game state tracking
- Move date formatting to `java.time` APIs and persist instants via epoch milliseconds

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad88b71e14832d8ff270fd679f7096