### PR TITLE
Refactor game end handling and update filters

### DIFF
--- a/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
@@ -1,20 +1,20 @@
 package ti4.commands.developer;
 
-import java.lang.reflect.Field;
-import java.util.Map;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.commands.Subcommand;
 import ti4.commands.statistics.GameStatisticsFilterer;
 import ti4.map.Game;
-import ti4.map.Player;
-import ti4.map.Tile;
-import ti4.map.UnitHolder;
 import ti4.map.persistence.GameManager;
 import ti4.map.persistence.GamesPage;
 import ti4.message.MessageHelper;
 import ti4.message.logging.BotLogger;
 
 class RunAgainstAllGames extends Subcommand {
+
+    private static final int DAYS_AFTER_CREATION_TO_DEFAULT_END = 60;
 
     RunAgainstAllGames() {
         super("run_against_all_games", "Runs this custom code against all games.");
@@ -26,50 +26,38 @@ class RunAgainstAllGames extends Subcommand {
         MessageHelper.sendMessageToChannel(event.getChannel(), "Running custom command against all games.");
 
         GamesPage.consumeAllGames(GameStatisticsFilterer.getGamesFilter(event), game -> {
-            boolean changed = setPiFactionsHomebrew(game);
-            changed |= renameBlaheoUnitHolder(game);
-            if (changed) {
+            boolean changed = update1(game);
+            boolean changed2 = update2(game);
+            if (changed || changed2) {
                 GameManager.save(game, "Developer ran custom command against this game, probably migration related.");
             }
         });
+
+        BotLogger.info("Finished custom command against all games.");
     }
 
-    private static boolean setPiFactionsHomebrew(Game game) {
-        boolean changed = false;
-        for (Player player : game.getPlayers().values()) {
-            String faction = player.getFaction();
-            if (faction != null && faction.startsWith("pi_")) {
-                player.setFaction(faction.substring(3));
-                changed = true;
-            }
+    private static boolean update1(Game game) {
+        if (game.hasWinner() && !game.isHasEnded()) {
+            game.setHasEnded(true);
+            BotLogger.info(String.format("Ended game %s", game.getName()));
+            return true;
         }
-        if (changed) {
-            game.setHomebrew(true);
-            BotLogger.info("Changed factions from 'pi_' in game: " + game.getName());
-        }
-        return changed;
+        return false;
     }
 
-    private static boolean renameBlaheoUnitHolder(Game game) {
-        boolean changed = false;
-        for (Tile tile : game.getTileMap().values()) {
-            if (!"d17".equalsIgnoreCase(tile.getTileID())) continue;
-            Map<String, UnitHolder> holders = tile.getUnitHolders();
-            if (!holders.containsKey("blaheo")) continue;
-            UnitHolder holder = holders.remove("blaheo");
-            try {
-                Field nameField = UnitHolder.class.getDeclaredField("name");
-                nameField.setAccessible(true);
-                nameField.set(holder, "biaheo");
-            } catch (Exception e) {
-                BotLogger.error("Failed to rename blaheo unit holder", e);
-            }
-            holders.put("biaheo", holder);
-            changed = true;
+    private static boolean update2(Game game) {
+        if (game.isHasEnded() && game.getEndedDate() == 0) {
+            DateTimeFormatter FMT = DateTimeFormatter.ofPattern("uuuu.MM.dd", Locale.ROOT);
+            LocalDate creationDate = LocalDate.parse(game.getCreationDate(), FMT);
+            long endDateMilliseconds = creationDate
+                    .plusDays(DAYS_AFTER_CREATION_TO_DEFAULT_END)
+                    .atStartOfDay(java.time.ZoneOffset.UTC)
+                    .toInstant()
+                    .toEpochMilli();
+            game.setEndedDate(endDateMilliseconds);
+            BotLogger.info(String.format("Set game %s ended date to %d", game.getName(), game.getEndedDate()));
+            return true;
         }
-        if (changed) {
-            BotLogger.info("Renamed Blaheo as Biaheo in game " + game.getName());
-        }
-        return changed;
+        return false;
     }
 }

--- a/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
+++ b/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
@@ -111,7 +111,7 @@ public class GameStatisticsFilterer {
     public static Predicate<Game> getNormalFinishedGamesFilter(
             Integer playerCountFilter, Integer victoryPointGoalFilter) {
         return getFinishedGamesFilter(playerCountFilter, victoryPointGoalFilter)
-                .and(game -> filterOnHasWinner(Boolean.TRUE, game));
+                .and(game -> filterOnIsNormal(Boolean.TRUE, game));
     }
 
     public static Predicate<Game> getFinishedGamesFilter(Integer playerCountFilter, Integer victoryPointGoalFilter) {

--- a/src/main/java/ti4/cron/EndOldGamesCron.java
+++ b/src/main/java/ti4/cron/EndOldGamesCron.java
@@ -6,11 +6,13 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneId;
+import java.util.List;
 import lombok.experimental.UtilityClass;
 import ti4.executors.ExecutionLockManager;
 import ti4.map.Game;
 import ti4.map.persistence.GameManager;
 import ti4.map.persistence.ManagedGame;
+import ti4.message.GameMessageManager;
 import ti4.message.logging.BotLogger;
 
 @UtilityClass
@@ -49,7 +51,12 @@ public class EndOldGamesCron {
         if (lastModifiedDate.isBefore(oldestLastModifiedDateBeforeEnding)) {
             BotLogger.info("Game: " + game.getName() + " has not been modified since ~" + lastModifiedDate
                     + " - the game flag `hasEnded` has been set to true");
+            // TODO: It'd be better if we could just call EndGameService
             game.setHasEnded(true);
+            game.setEndedDate(System.currentTimeMillis());
+            game.setAutoPing(false);
+            game.setAutoPingSpacer(0);
+            GameMessageManager.remove(List.of(game.getName()));
             GameManager.save(game, "Ended old game.");
         }
     }

--- a/src/main/java/ti4/helpers/FoWHelper.java
+++ b/src/main/java/ti4/helpers/FoWHelper.java
@@ -132,6 +132,8 @@ public class FoWHelper {
             return;
         }
 
+        player.setFogInitialized(true);
+
         // Get all tiles with the player in it
         Set<String> tilesWithPlayerUnitsPlanets = new HashSet<>();
         for (Map.Entry<String, Tile> tileEntry : new HashMap<>(game.getTileMap()).entrySet()) {
@@ -156,7 +158,6 @@ public class FoWHelper {
         }
 
         updatePlayerFogTiles(game, player);
-        player.setFogInitialized(true);
     }
 
     public static Set<String> getTilePositionsToShow(Game game, @NotNull Player player) {
@@ -189,6 +190,7 @@ public class FoWHelper {
 
     private static void updatePlayerFogTiles(Game game, Player player) {
         for (Tile tileToUpdate : game.getTileMap().values()) {
+            if (!tileToUpdate.isValid()) continue;
             if (!tileToUpdate.hasFog(player)
                     || tileToUpdate.isSupernova() && game.getFowOption(FOWOption.BRIGHT_NOVAS)) {
                 player.updateFogTile(tileToUpdate, "Rnd " + game.getRound());

--- a/src/main/java/ti4/helpers/FoWHelper.java
+++ b/src/main/java/ti4/helpers/FoWHelper.java
@@ -27,6 +27,7 @@ import ti4.map.Tile;
 import ti4.map.UnitHolder;
 import ti4.map.persistence.GameManager;
 import ti4.message.MessageHelper;
+import ti4.message.logging.BotLogger;
 import ti4.model.BorderAnomalyHolder;
 import ti4.model.WormholeModel;
 import ti4.service.combat.StartCombatService;
@@ -190,7 +191,11 @@ public class FoWHelper {
 
     private static void updatePlayerFogTiles(Game game, Player player) {
         for (Tile tileToUpdate : game.getTileMap().values()) {
-            if (!tileToUpdate.isValid()) continue;
+            if (!tileToUpdate.isValid()) {
+                BotLogger.warning(
+                        String.format("Tile %s is not valid in game %s", tileToUpdate.getTileID(), game.getName()));
+                continue;
+            }
             if (!tileToUpdate.hasFog(player)
                     || tileToUpdate.isSupernova() && game.getFowOption(FOWOption.BRIGHT_NOVAS)) {
                 player.updateFogTile(tileToUpdate, "Rnd " + game.getRound());

--- a/src/main/java/ti4/map/Tile.java
+++ b/src/main/java/ti4/map/Tile.java
@@ -2,7 +2,7 @@ package ti4.map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.awt.*;
+import java.awt.Point;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -464,6 +464,11 @@ public class Tile {
             }
         }
         return planetsWithSleepers;
+    }
+
+    @JsonIgnore
+    public boolean isValid() {
+        return getTileModel() != null;
     }
 
     @JsonIgnore

--- a/src/main/java/ti4/map/persistence/ManagedGame.java
+++ b/src/main/java/ti4/map/persistence/ManagedGame.java
@@ -1,6 +1,6 @@
 package ti4.map.persistence;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.util.List;
 import java.util.Map;
@@ -17,8 +17,8 @@ import ti4.map.Game;
 import ti4.map.Player;
 
 @Getter
-public class ManagedGame { // BE CAREFUL ADDING FIELDS TO THIS CLASS, AS IT CAN EASILY BALLOON THE DATA ON THE HEAP BY
-    // MEGABYTES PER FIELD
+public class ManagedGame {
+    // BE CAREFUL ADDING FIELDS TO THIS CLASS, AS IT CAN EASILY BALLOON THE DATA ON THE HEAP BY MEGABYTES PER FIELD
 
     private final String name;
     private final boolean hasEnded;

--- a/src/main/java/ti4/service/game/EndGameService.java
+++ b/src/main/java/ti4/service/game/EndGameService.java
@@ -204,7 +204,7 @@ public class EndGameService {
     }
 
     private static void writeChronicle(Game game, GenericInteractionCreateEvent event, boolean publish) {
-        String gameEndText = getGameEndText(game, event);
+        String gameEndText = getGameEndText(game);
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), gameEndText);
         TextChannel summaryChannel = getGameSummaryChannel(game);
         if (!game.isFowMode()) {
@@ -315,8 +315,8 @@ public class EndGameService {
         return textChannels.isEmpty() ? null : textChannels.getFirst();
     }
 
-    private static void appendUserName(StringBuilder sb, Player player, GenericInteractionCreateEvent event) {
-        Optional<User> user = Optional.ofNullable(event.getJDA().getUserById(player.getUserID()));
+    private static void appendUserName(StringBuilder sb, Player player) {
+        Optional<User> user = Optional.ofNullable(AsyncTI4DiscordBot.jda.getUserById(player.getUserID()));
         if (user.isPresent()) {
             sb.append(user.get().getAsMention());
         } else {
@@ -324,7 +324,7 @@ public class EndGameService {
         }
     }
 
-    private static String getGameEndText(Game game, GenericInteractionCreateEvent event) {
+    private static String getGameEndText(Game game) {
         StringBuilder sb = new StringBuilder();
         sb.append("**Game: __").append(game.getName()).append("__**");
         if (!game.getCustomName().isEmpty()) {
@@ -343,7 +343,7 @@ public class EndGameService {
             sb.append("> `").append(index).append(".` ");
             sb.append(player.getFactionEmoji());
             sb.append(ColorEmojis.getColorEmojiWithName(player.getColor())).append(" ");
-            appendUserName(sb, player, event);
+            appendUserName(sb, player);
             sb.append(" - *");
             if (player.isEliminated()) {
                 sb.append("ELIMINATED*");
@@ -364,7 +364,7 @@ public class EndGameService {
         if (game.isFowMode()) {
             sb.append("**GM:** ");
             for (Player gm : game.getPlayersWithGMRole()) {
-                appendUserName(sb, gm, event);
+                appendUserName(sb, gm);
                 sb.append(" ");
             }
             sb.append("\n");

--- a/src/main/java/ti4/service/statistics/MatchmakingRatingService.java
+++ b/src/main/java/ti4/service/statistics/MatchmakingRatingService.java
@@ -1,5 +1,7 @@
 package ti4.service.statistics;
 
+import static java.util.function.Predicate.not;
+
 import de.gesundkrank.jskills.GameInfo;
 import de.gesundkrank.jskills.IPlayer;
 import de.gesundkrank.jskills.ITeam;
@@ -37,7 +39,10 @@ public class MatchmakingRatingService {
 
         List<Game> games = new ArrayList<>();
         GamesPage.consumeAllGames(GameStatisticsFilterer.getFinishedGamesFilter(6, null), games::add);
-        games.sort(Comparator.comparingLong(Game::getEndedDate));
+        games = games.stream()
+                .filter(not(Game::isAllianceMode))
+                .sorted(Comparator.comparingLong(Game::getEndedDate))
+                .toList();
 
         var calculator = new FactorGraphTrueSkillCalculator();
         for (Game game : games) {

--- a/src/main/java/ti4/service/statistics/game/WinningPathPersistenceService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathPersistenceService.java
@@ -21,12 +21,12 @@ public class WinningPathPersistenceService {
         BotLogger.info("**Recomputing win paths file**");
         Map<String, Map<String, Integer>> data = new HashMap<>();
         GamesPage.consumeAllGames(
-                GameStatisticsFilterer.getNormalFinishedGamesFilter(null, null), game -> addGameToMap(game, data));
+                GameStatisticsFilterer.getNormalFinishedGamesFilter(null, null), game -> computeWinPath(game, data));
         writeData(data);
         BotLogger.info("**Finished recomputing win paths file**");
     }
 
-    private static void addGameToMap(Game game, Map<String, Map<String, Integer>> data) {
+    private static void computeWinPath(Game game, Map<String, Map<String, Integer>> data) {
         game.getWinner().ifPresent(winner -> {
             String key = key(game.getRealAndEliminatedPlayers().size(), game.getVp());
             Map<String, Integer> map = data.computeIfAbsent(key, k -> new HashMap<>());
@@ -38,7 +38,7 @@ public class WinningPathPersistenceService {
     public static synchronized void addGame(Game game) {
         game.getWinner().ifPresent(winner -> {
             Map<String, Map<String, Integer>> data = readData();
-            addGameToMap(game, data);
+            computeWinPath(game, data);
             writeData(data);
         });
     }


### PR DESCRIPTION
Refactored developer command to set hasEnded and endedDate for games, and improved old game ending logic in EndOldGamesCron. Updated GameStatisticsFilterer to use isNormal filter, excluded alliance games from rating calculations, and improved fog initialization and tile validation. Renamed methods for clarity in WinningPathPersistenceService and EndGameService, and made minor code style improvements.