### PR TITLE
fix: handle savefile permissions during backup

### DIFF
--- a/.github/workflows/force-backup-of-savefiles.yml
+++ b/.github/workflows/force-backup-of-savefiles.yml
@@ -27,7 +27,7 @@ jobs:
             echo "FORCING BACKUP OF SAVE FILES"
             rm -f ${{ vars.HOST_TI4_SAVES_DIR }}/.git/index.lock
             # ensure all save files are readable before committing
-            chmod -R u+rwX . || true
+            chmod -R u+rw . || true
             git add . -A
             git commit -m "save files"
             git push


### PR DESCRIPTION
## Summary
- ensure save files are readable before committing backup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b096a72dc0832da27e162521fff84c