### PR TITLE
Send ForceSaveFileBackup failures to error channel

### DIFF
--- a/.github/workflows/force-backup-of-savefiles.yml
+++ b/.github/workflows/force-backup-of-savefiles.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Notify Discord on failure
         if: ${{ always() && (failure() || cancelled()) }}
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK_ERROR_URL: ${{ secrets.DISCORD_WEBHOOK_ERROR_URL }}
         run: |
           curl -sS -X POST -H 'Content-Type: application/json' \
             -d "{\"content\":\"⚠️ ForceSaveFileBackup failed or was cancelled for ${{ github.repository }} on ref ${{ github.ref_name }}. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
-            "$DISCORD_WEBHOOK_URL"
+            "$DISCORD_WEBHOOK_ERROR_URL"


### PR DESCRIPTION
## Summary
- Route ForceSaveFileBackup failures to #bot-log-error by using a dedicated webhook secret.

## Testing
- `mvn -q test` *(fails: Network is unreachable for Maven repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a31f0428832db78b9cfeabdf396d