### PR TITLE
Set POSIX permissions on saved game files

### DIFF
--- a/src/main/java/ti4/map/persistence/GameSaveService.java
+++ b/src/main/java/ti4/map/persistence/GameSaveService.java
@@ -81,6 +81,8 @@ class GameSaveService {
 
             saveGame(game, temporarySavePath);
 
+            PosixFileSystemUtility.setPermissionsIfPosix(temporarySavePath);
+
             Files.move(temporarySavePath, gameSavePath, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Could not save map: " + game.getName(), e);

--- a/src/main/java/ti4/map/persistence/PosixFileSystemUtility.java
+++ b/src/main/java/ti4/map/persistence/PosixFileSystemUtility.java
@@ -1,0 +1,28 @@
+package ti4.map.persistence;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import lombok.experimental.UtilityClass;
+import ti4.message.logging.BotLogger;
+
+@UtilityClass
+class PosixFileSystemUtility {
+
+  private static final Set<PosixFilePermission> FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-rw-r--"); // 0664
+  private static final boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+
+  static void setPermissionsIfPosix(Path path) {
+    try {
+      if (isPosix) {
+        Files.setPosixFilePermissions(path, FILE_PERMISSIONS);
+      }
+    } catch (IOException e) {
+      BotLogger.error("Failed to set Posix permissions", e);
+    }
+  }
+}

--- a/src/main/java/ti4/map/persistence/PosixFileSystemUtility.java
+++ b/src/main/java/ti4/map/persistence/PosixFileSystemUtility.java
@@ -13,16 +13,18 @@ import ti4.message.logging.BotLogger;
 @UtilityClass
 class PosixFileSystemUtility {
 
-  private static final Set<PosixFilePermission> FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-rw-r--"); // 0664
-  private static final boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    private static final Set<PosixFilePermission> FILE_PERMISSIONS =
+            PosixFilePermissions.fromString("rw-rw-r--"); // 0664
+    private static final boolean isPosix =
+            FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 
-  static void setPermissionsIfPosix(Path path) {
-    try {
-      if (isPosix) {
-        Files.setPosixFilePermissions(path, FILE_PERMISSIONS);
-      }
-    } catch (IOException e) {
-      BotLogger.error("Failed to set Posix permissions", e);
+    static void setPermissionsIfPosix(Path path) {
+        try {
+            if (isPosix) {
+                Files.setPosixFilePermissions(path, FILE_PERMISSIONS);
+            }
+        } catch (IOException e) {
+            BotLogger.error("Failed to set Posix permissions", e);
+        }
     }
-  }
 }


### PR DESCRIPTION
Introduced PosixFileSystemUtility to set file permissions to 0664 on POSIX systems after saving game files. This ensures correct file access rights and improves compatibility with multi-user environments.