### PR TITLE
refactor: replace deprecated URL constructor

### DIFF
--- a/src/main/java/ti4/helpers/DiscordWebhook.java
+++ b/src/main/java/ti4/helpers/DiscordWebhook.java
@@ -4,6 +4,7 @@ import java.awt.*;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -163,7 +164,7 @@ public class DiscordWebhook {
             json.put("embeds", embedObjects.toArray());
         }
 
-        URL url = new URL(this.url);
+        URL url = URI.create(this.url).toURL();
         HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
         connection.addRequestProperty("Content-Type", "application/json");
         connection.addRequestProperty("User-Agent", "Java-DiscordWebhook-BY-Gelox_");


### PR DESCRIPTION
## Summary
- avoid deprecated `URL` constructor by creating a `URI` and converting to `URL`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bdc39ab0832d8cb1b1c36c7fec6f