### PR TITLE
refactor deprecated removeEnd usage

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -5666,7 +5666,9 @@ public class ButtonHelper {
         int h = Integer.parseInt(hits);
 
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), sb);
-        message = removeEnd(message, ";\n");
+        if (message != null && message.endsWith(";\n")) {
+            message = message.substring(0, message.length() - 2);
+        }
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
         if (!game.isFowMode() && combatOnHolder instanceof Planet && h > 0 && opponent != player) {
             String msg = opponent.getRepresentationUnfogged() + " you may autoassign " + h + " hit"

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -290,7 +290,9 @@ public class CombatRollService {
         }
 
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), sb);
-        message = removeEnd(message, ";\n");
+        if (message != null && message.endsWith(";\n")) {
+            message = message.substring(0, message.length() - 2);
+        }
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
         if (game.isFowMode() && isFoWPrivateChannelRoll(player, event)) {
             if (rollType == CombatRollType.SpaceCannonOffence) {


### PR DESCRIPTION
## Summary
- replace deprecated StringUtils.removeEnd usage with manual suffix trimming
- guard manual trimming with null checks to match previous behavior

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `mvn -q -e spotless:apply` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bdd0ecec832daf734087c65f18d8