### PR TITLE
Handle empty save file backups

### DIFF
--- a/.github/workflows/force-backup-of-savefiles.yml
+++ b/.github/workflows/force-backup-of-savefiles.yml
@@ -27,7 +27,11 @@ jobs:
             echo "FORCING BACKUP OF SAVE FILES"
             rm -f .git/index.lock
             git add -A
-            git commit -m "save files"
+            if git diff-index --quiet HEAD; then
+              echo "No changes to commit"
+            else
+              git commit -m "save files"
+            fi
             git push
             curl -X POST -H 'Content-Type: application/json' -d '{"content":"Backup Successful"}' $DISCORD_WEBHOOK_URL
             echo "DONE!"


### PR DESCRIPTION
## Summary
- Skip `git commit` in force-backup workflow when no save files changed to avoid action failure

## Testing
- `find . -name "*.json" -print0 | while IFS= read -r -d $'\0' file; do if ! python -mjson.tool "$file" > /dev/null; then echo "INVALID $file" >&2; exit 1; fi; done`
- `mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5e3e5f4832d918014f967b6ea12