### PR TITLE
Add scheduled matchmaking rating calculation

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -43,6 +43,7 @@ import ti4.cron.SabotageAutoReactCron;
 import ti4.cron.TechSummaryCron;
 import ti4.cron.UploadStatsCron;
 import ti4.cron.WinningPathCron;
+import ti4.cron.MatchmakingRatingCron;
 import ti4.executors.ExecutorServiceManager;
 import ti4.helpers.AliasHandler;
 import ti4.helpers.Constants;
@@ -290,6 +291,7 @@ public class AsyncTI4DiscordBot {
         CloseLaunchThreadsCron.register();
         InteractionLogCron.register();
         LongExecutionHistoryCron.register();
+        MatchmakingRatingCron.register();
 
         // BOT IS READY
         GlobalSettings.setSetting(ImplementedSettings.READY_TO_RECEIVE_COMMANDS, true);

--- a/src/main/java/ti4/commands/statistics/MatchMakingRatingCommand.java
+++ b/src/main/java/ti4/commands/statistics/MatchMakingRatingCommand.java
@@ -2,7 +2,11 @@ package ti4.commands.statistics;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.commands.Subcommand;
+import ti4.json.PersistenceManager;
+import ti4.message.MessageHelper;
+import ti4.message.logging.BotLogger;
 import ti4.service.statistics.MatchmakingRatingService;
+import ti4.service.statistics.MatchmakingRatingService.MatchmakingRatingData;
 
 class MatchMakingRatingCommand extends Subcommand {
 
@@ -12,6 +16,20 @@ class MatchMakingRatingCommand extends Subcommand {
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        MatchmakingRatingService.queueReply(event);
+        try {
+            MatchmakingRatingData data = PersistenceManager.readObjectFromJsonFile(
+                    MatchmakingRatingService.MATCHMAKING_RATING_FILE, MatchmakingRatingData.class);
+            if (data == null) {
+                MessageHelper.sendMessageToThread(event.getChannel(), "Player Matchmaking Ratings",
+                        "Matchmaking ratings have not been calculated yet.");
+                return;
+            }
+            String message = MatchmakingRatingService.buildMessage(data, event.getUser().getId());
+            MessageHelper.sendMessageToThread(event.getChannel(), "Player Matchmaking Ratings", message);
+        } catch (Exception e) {
+            BotLogger.error("Failed to load matchmaking rating data.", e);
+            MessageHelper.sendMessageToThread(
+                    event.getChannel(), "Player Matchmaking Ratings", "Failed to load matchmaking ratings.");
+        }
     }
 }

--- a/src/main/java/ti4/commands/statistics/MatchmakingRatingCommand.java
+++ b/src/main/java/ti4/commands/statistics/MatchmakingRatingCommand.java
@@ -6,19 +6,19 @@ import ti4.json.PersistenceManager;
 import ti4.message.MessageHelper;
 import ti4.message.logging.BotLogger;
 import ti4.service.statistics.MatchmakingRatingService;
-import ti4.service.statistics.MatchmakingRatingService.MatchmakingRatingData;
+import ti4.service.statistics.MatchmakingRatingService.MatchmakingData;
 
-class MatchMakingRatingCommand extends Subcommand {
+class MatchmakingRatingCommand extends Subcommand {
 
-    MatchMakingRatingCommand() {
+    MatchmakingRatingCommand() {
         super("matchmaking_rating", "Calculates the top 50 high confidence MMRs using the TrueSkill algorithm");
     }
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
         try {
-            MatchmakingRatingData data = PersistenceManager.readObjectFromJsonFile(
-                    MatchmakingRatingService.MATCHMAKING_RATING_FILE, MatchmakingRatingData.class);
+            MatchmakingData data = PersistenceManager.readObjectFromJsonFile(
+                    MatchmakingRatingService.MATCHMAKING_RATING_FILE, MatchmakingData.class);
             if (data == null) {
                 MessageHelper.sendMessageToThread(event.getChannel(), "Player Matchmaking Ratings",
                         "Matchmaking ratings have not been calculated yet.");

--- a/src/main/java/ti4/cron/MatchmakingRatingCron.java
+++ b/src/main/java/ti4/cron/MatchmakingRatingCron.java
@@ -5,7 +5,7 @@ import lombok.experimental.UtilityClass;
 import ti4.json.PersistenceManager;
 import ti4.message.logging.BotLogger;
 import ti4.service.statistics.MatchmakingRatingService;
-import ti4.service.statistics.MatchmakingRatingService.MatchmakingRatingData;
+import ti4.service.statistics.MatchmakingRatingService.MatchmakingData;
 
 @UtilityClass
 public class MatchmakingRatingCron {
@@ -22,7 +22,7 @@ public class MatchmakingRatingCron {
     private static void calculateAndPersist() {
         BotLogger.logCron("Running MatchmakingRatingCron.");
         try {
-            MatchmakingRatingData data = MatchmakingRatingService.calculateRatingsData();
+            MatchmakingData data = MatchmakingRatingService.calculateRatingsData();
             PersistenceManager.writeObjectToJsonFile(MatchmakingRatingService.MATCHMAKING_RATING_FILE, data);
         } catch (Exception e) {
             BotLogger.error("**MatchmakingRatingCron failed.**", e);

--- a/src/main/java/ti4/cron/MatchmakingRatingCron.java
+++ b/src/main/java/ti4/cron/MatchmakingRatingCron.java
@@ -1,0 +1,32 @@
+package ti4.cron;
+
+import java.time.ZoneId;
+import lombok.experimental.UtilityClass;
+import ti4.json.PersistenceManager;
+import ti4.message.logging.BotLogger;
+import ti4.service.statistics.MatchmakingRatingService;
+import ti4.service.statistics.MatchmakingRatingService.MatchmakingRatingData;
+
+@UtilityClass
+public class MatchmakingRatingCron {
+
+    public static void register() {
+        CronManager.schedulePeriodicallyAtTime(
+                MatchmakingRatingCron.class,
+                MatchmakingRatingCron::calculateAndPersist,
+                6,
+                0,
+                ZoneId.of("America/New_York"));
+    }
+
+    private static void calculateAndPersist() {
+        BotLogger.logCron("Running MatchmakingRatingCron.");
+        try {
+            MatchmakingRatingData data = MatchmakingRatingService.calculateRatingsData();
+            PersistenceManager.writeObjectToJsonFile(MatchmakingRatingService.MATCHMAKING_RATING_FILE, data);
+        } catch (Exception e) {
+            BotLogger.error("**MatchmakingRatingCron failed.**", e);
+        }
+        BotLogger.logCron("Finished MatchmakingRatingCron.");
+    }
+}

--- a/src/main/java/ti4/service/statistics/MatchmakingRatingService.java
+++ b/src/main/java/ti4/service/statistics/MatchmakingRatingService.java
@@ -18,12 +18,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
-import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.commands.statistics.GameStatisticsFilterer;
 import ti4.map.Game;
 import ti4.map.persistence.GameManager;
 import ti4.map.persistence.GamesPage;
-import ti4.message.MessageHelper;
 
 @UtilityClass
 public class MatchmakingRatingService {
@@ -34,54 +32,45 @@ public class MatchmakingRatingService {
     private static final DateTimeFormatter TIME_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z").withZone(ZoneId.of("UTC"));
 
-    public void queueReply(SlashCommandInteractionEvent event) {
-        StatisticsPipeline.queue(event, () -> {
-            MatchmakingRatingData data = calculateRatingsData();
-            String message = buildMessage(data, event.getUser().getId());
-            MessageHelper.sendMessageToThread(event.getChannel(), "Player Matchmaking Ratings", message);
-        });
-    }
-
-    public MatchmakingRatingData calculateRatingsData() {
+    public MatchmakingData calculateRatingsData() {
         GameInfo gameInfo = GameInfo.getDefaultGameInfo();
         Map<IPlayer, Rating> ratings = new HashMap<>();
         Map<String, Player<String>> players = new HashMap<>();
 
-        List<Game> games = new ArrayList<>();
-        GamesPage.consumeAllGames(GameStatisticsFilterer.getFinishedGamesFilter(6, null), games::add);
-        games = games.stream()
-                .filter(not(Game::isAllianceMode))
-                .sorted(Comparator.comparingLong(Game::getEndedDate))
-                .toList();
+        List<MatchmakingGame> games = new ArrayList<>();
+        GamesPage.consumeAllGames(
+            GameStatisticsFilterer.getFinishedGamesFilter(6, null).and(not(Game::isAllianceMode)),
+            game -> games.add(MatchmakingGame.from(game)));
+        games.sort(Comparator.comparingLong(MatchmakingGame::endedDate));
 
         var calculator = new FactorGraphTrueSkillCalculator();
-        for (Game game : games) {
-            List<ti4.map.Player> gamePlayers = game.getRealAndEliminatedPlayers();
+        for (MatchmakingGame game : games) {
+            List<MatchmakingPlayer> gamePlayers = game.players();
             var teams = new ArrayList<ITeam>();
             int[] ranks = new int[gamePlayers.size()];
             for (int i = 0; i < gamePlayers.size(); i++) {
-                ti4.map.Player gamePlayer = gamePlayers.get(i);
-                String userId = gamePlayer.getUserID();
+                MatchmakingPlayer gamePlayer = gamePlayers.get(i);
+                String userId = gamePlayer.userId();
                 var tsPlayer = players.computeIfAbsent(userId, Player::new);
                 Rating rating = ratings.computeIfAbsent(tsPlayer, id -> gameInfo.getDefaultRating());
                 var team = new Team();
                 team.addPlayer(tsPlayer, rating);
                 teams.add(team);
-                ranks[i] = getRank(game, gamePlayer);
+                ranks[i] = gamePlayer.rank();
             }
             Map<IPlayer, Rating> newRatings = calculator.calculateNewRatings(gameInfo, teams, ranks);
             ratings.putAll(newRatings);
         }
 
-        List<PlayerRating> playerRatings = buildPlayerRatings(players, ratings);
+        List<PlayerData> playerRatings = buildPlayerRatings(players, ratings);
         double averageRating = playerRatings.stream()
-                .mapToDouble(PlayerRating::rating)
+                .mapToDouble(PlayerData::rating)
                 .average()
                 .orElse(Double.NaN);
-        return new MatchmakingRatingData(playerRatings, averageRating, Instant.now());
+        return new MatchmakingData(playerRatings, averageRating, Instant.now());
     }
 
-    private List<PlayerRating> buildPlayerRatings(
+    private List<PlayerData> buildPlayerRatings(
             Map<String, Player<String>> players, Map<IPlayer, Rating> ratings) {
         return players.entrySet().stream()
                 .map(entry -> {
@@ -89,26 +78,14 @@ public class MatchmakingRatingService {
                     String username = GameManager.getManagedPlayer(entry.getKey()).getName();
                     double calibrationPercent =
                             SIGMA_CALIBRATION_THRESHOLD / rating.getStandardDeviation() * 100;
-                    return new PlayerRating(entry.getKey(), username, rating.getMean(), calibrationPercent);
+                    return new PlayerData(entry.getKey(), username, rating.getMean(), calibrationPercent);
                 })
-                .sorted(Comparator.comparing(PlayerRating::rating).reversed())
+                .sorted(Comparator.comparing(PlayerData::rating).reversed())
                 .toList();
     }
 
-    private int getRank(Game game, ti4.map.Player player) {
-        boolean isWinner =
-                game.getWinners().stream().anyMatch(w -> w.getUserID().equals(player.getUserID()));
-        if (isWinner) {
-            return 1;
-        }
-        if (game.getVp() - player.getTotalVictoryPoints() <= 3) {
-            return 2;
-        }
-        return 3;
-    }
-
-    public String buildMessage(MatchmakingRatingData data, String userId) {
-        List<PlayerRating> playerRatings = data.playerRatings();
+    public String buildMessage(MatchmakingData data, String userId) {
+        List<PlayerData> playerRatings = data.playerRatings();
         int maxListSize = Math.min(MAX_LIST_SIZE, playerRatings.size());
         StringBuilder sb = new StringBuilder();
         sb.append("__**Player Matchmaking Ratings:**__\n");
@@ -139,8 +116,29 @@ public class MatchmakingRatingService {
         return sb.toString();
     }
 
-    public static record PlayerRating(String userId, String username, double rating, double calibrationPercent) {}
+    private record PlayerData(String userId, String username, double rating, double calibrationPercent) {}
 
-    public static record MatchmakingRatingData(
-            List<PlayerRating> playerRatings, double averageRating, Instant lastCalculated) {}
+    public record MatchmakingData(
+        List<PlayerData> playerRatings, double averageRating, Instant lastCalculated) {}
+
+
+    private record PlayerRating(String userId, String username, double rating, double calibrationPercent) {}
+
+    private record MatchmakingGame(long endedDate, List<MatchmakingPlayer> players) {
+
+        static MatchmakingGame from(Game game) {
+            List<MatchmakingPlayer> players = game.getRealAndEliminatedPlayers().stream()
+                .map(player -> {
+                    boolean isWinner = game.getWinners().stream()
+                        .anyMatch(gamePlayer -> gamePlayer.getUserID().equals(player.getUserID()));
+                    int rank = isWinner ? 1 : game.getVp() - player.getTotalVictoryPoints() <= 3 ? 2 : 3;
+                    return new MatchmakingPlayer(player.getUserID(), rank);
+                })
+                .toList();
+            return new MatchmakingGame(game.getEndedDate(), players);
+        }
+    }
+
+    private record MatchmakingPlayer(String userId, int rank) {}
+}
 }


### PR DESCRIPTION
## Summary
- schedule daily matchmaking rating calculation and persistence
- refactor rating service to compute and format stored data
- add command to read persisted ratings and report last calculation time

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a12761bc832dbcb73ae6bfb9b01d