### PR TITLE
Add TIGL filter to matchmaking rating command

### DIFF
--- a/src/main/java/ti4/commands/statistics/MatchmakingRatingCommand.java
+++ b/src/main/java/ti4/commands/statistics/MatchmakingRatingCommand.java
@@ -4,14 +4,13 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.commands.Subcommand;
-import ti4.helpers.Constants;
 import ti4.service.statistics.matchmaking.MatchmakingRatingEventService;
 
 class MatchmakingRatingCommand extends Subcommand {
 
     MatchmakingRatingCommand() {
         super("matchmaking_rating", "Calculates the top 50 high confidence MMRs using the TrueSkill algorithm");
-        addOptions(new OptionData(OptionType.BOOLEAN, Constants.TIGL_GAME, "True to only include TIGL games"));
+        addOptions(new OptionData(OptionType.BOOLEAN, "tigl_only", "True to only include TIGL games"));
     }
 
     @Override

--- a/src/main/java/ti4/commands/statistics/MatchmakingRatingCommand.java
+++ b/src/main/java/ti4/commands/statistics/MatchmakingRatingCommand.java
@@ -1,13 +1,17 @@
 package ti4.commands.statistics;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.commands.Subcommand;
+import ti4.helpers.Constants;
 import ti4.service.statistics.matchmaking.MatchmakingRatingEventService;
 
 class MatchmakingRatingCommand extends Subcommand {
 
     MatchmakingRatingCommand() {
         super("matchmaking_rating", "Calculates the top 50 high confidence MMRs using the TrueSkill algorithm");
+        addOptions(new OptionData(OptionType.BOOLEAN, Constants.TIGL_GAME, "True to only include TIGL games"));
     }
 
     @Override

--- a/src/main/java/ti4/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import ti4.commands.statistics.GameStatisticsFilterer;
-import ti4.helpers.Constants;
 import ti4.map.Game;
 import ti4.map.persistence.GamesPage;
 import ti4.message.MessageHelper;
@@ -27,8 +26,9 @@ public class MatchmakingRatingEventService {
 
     private static void calculateRatings(SlashCommandInteractionEvent event) {
         List<MatchmakingGame> games = new ArrayList<>();
-        boolean onlyTiglGames = event.getOption(Constants.TIGL_GAME, false, OptionMapping::getAsBoolean);
-        Predicate<Game> filter = GameStatisticsFilterer.getFinishedGamesFilter(6, null).and(not(Game::isAllianceMode));
+        boolean onlyTiglGames = event.getOption("TIGL_only", false, OptionMapping::getAsBoolean);
+        Predicate<Game> filter =
+                GameStatisticsFilterer.getFinishedGamesFilter(6, null).and(not(Game::isAllianceMode));
         if (onlyTiglGames) {
             filter = filter.and(Game::isCompetitiveTIGLGame);
         }

--- a/src/main/java/ti4/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -26,7 +26,7 @@ public class MatchmakingRatingEventService {
 
     private static void calculateRatings(SlashCommandInteractionEvent event) {
         List<MatchmakingGame> games = new ArrayList<>();
-        boolean onlyTiglGames = event.getOption("TIGL_only", false, OptionMapping::getAsBoolean);
+        boolean onlyTiglGames = event.getOption("tigl_only", false, OptionMapping::getAsBoolean);
         Predicate<Game> filter =
                 GameStatisticsFilterer.getFinishedGamesFilter(6, null).and(not(Game::isAllianceMode));
         if (onlyTiglGames) {


### PR DESCRIPTION
## Summary
- allow matchmaking rating command to request only competitive TIGL games
- filter matchmaking rating computation based on TIGL option

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b4fed740832da5a3317ec0fbc2b2