### PR TITLE
Switch map image format from JPG to WebP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,11 @@
       <artifactId>jskills</artifactId>
       <version>1.1</version>
     </dependency>
-      <dependency>
-          <groupId>com.github.usefulness</groupId>
-          <artifactId>webp-imageio</artifactId>
-          <version>0.10.2</version>
-      </dependency>
+    <dependency>
+      <groupId>com.github.usefulness</groupId>
+      <artifactId>webp-imageio</artifactId>
+      <version>0.10.2</version>
+    </dependency>
     <!-- TEST -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
       <artifactId>jskills</artifactId>
       <version>1.1</version>
     </dependency>
+      <dependency>
+          <groupId>com.github.usefulness</groupId>
+          <artifactId>webp-imageio</artifactId>
+          <version>0.10.2</version>
+      </dependency>
     <!-- TEST -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/ti4/image/ImageHelper.java
+++ b/src/main/java/ti4/image/ImageHelper.java
@@ -181,8 +181,8 @@ public class ImageHelper {
             writeParam.setCompressionType(CompressionType.Lossy);
             writeParam.setUseSharpYUV(false);
             writeParam.setAlphaCompressionAlgorithm(0);
-            //writeParam.setCompressionQuality(.5f);
-            //writeParam.setMethod(1); //0-6, lower is faster, higher is better quality
+            // writeParam.setCompressionQuality(.5f);
+            // writeParam.setMethod(1); //0-6, lower is faster, higher is better quality
 
             writer.setOutput(imageOutputStream);
 

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -312,6 +312,7 @@ public class MapGenerator implements AutoCloseable {
                 .collect(Collectors.toSet()));
 
         tilesWithExtra.forEach(key -> addTile(tileMap.get(key), TileStep.Extras));
+        sortedTiles.forEach(key -> addTile(tileMap.get(key), TileStep.Tile));
         sortedTiles.forEach(key -> addTile(tileMap.get(key), TileStep.Units));
         if (!game.getTileDistances().isEmpty()) {
             sortedTiles.forEach(key -> addTile(tileMap.get(key), TileStep.Distance));

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -404,14 +404,14 @@ public class MapGenerator implements AutoCloseable {
         try {
             String testing = System.getenv("TESTING");
             if (testing == null && displayTypeBasic == DisplayType.all && !isFoWPrivate) {
-                AsyncTi4WebsiteHelper.putMap(game.getName(), mainImageBytes, false, null);
+                AsyncTi4WebsiteHelper.putMap(game.getName(), imageFormat, mainImageBytes, false, null);
                 AsyncTi4WebsiteHelper.putData(game.getName(), game);
                 AsyncTi4WebsiteHelper.putOverlays(game.getID(), websiteOverlays);
                 AsyncTi4WebsiteHelper.putPlayerData(game.getID(), game);
             } else if (isFoWPrivate) {
                 Player player = CommandHelper.getPlayerFromGame(
                         game, event.getMember(), event.getUser().getId());
-                AsyncTi4WebsiteHelper.putMap(game.getName(), mainImageBytes, true, player);
+                AsyncTi4WebsiteHelper.putMap(game.getName(), imageFormat, mainImageBytes, true, player);
             }
         } catch (Exception e) {
             BotLogger.error("Failed to send to game info to website", e);

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -427,7 +427,7 @@ public class MapGenerator implements AutoCloseable {
 
         if (debug) debugImageGraphicsTime = StopWatch.createStarted();
         drawImage();
-        mainImageBytes = ImageHelper.writeJpg(mainImage);
+        mainImageBytes = ImageHelper.writeWebp(mainImage);
         if (debug) debugImageGraphicsTime.stop();
     }
 

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -82,6 +82,7 @@ public class MapGenerator implements AutoCloseable {
     private final Graphics graphics;
     private final BufferedImage mainImage;
     private byte[] mainImageBytes;
+    private String imageFormat = "webp";
     private final GenericInteractionCreateEvent event;
     private final int scoreTokenSpacing;
     private final Game game;
@@ -193,7 +194,7 @@ public class MapGenerator implements AutoCloseable {
         }
 
         // Create image
-        mainImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        mainImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         graphics = mainImage.getGraphics();
     }
 
@@ -237,7 +238,7 @@ public class MapGenerator implements AutoCloseable {
     FileUpload createFileUpload() {
         if (debug) debugDiscordTime = StopWatch.createStarted();
         game.incrementMapImageGenerationCount();
-        FileUpload fileUpload = FileUploadService.createFileUpload(mainImageBytes, game.getName());
+        FileUpload fileUpload = FileUploadService.createFileUpload(mainImageBytes, game.getName(), imageFormat);
         if (debug) debugDiscordTime.stop();
         if (debug && !AsyncTi4WebsiteHelper.uploadsEnabled()) FileUploadService.saveLocalPng(mainImage, "MapDebug");
         return fileUpload;
@@ -427,7 +428,13 @@ public class MapGenerator implements AutoCloseable {
 
         if (debug) debugImageGraphicsTime = StopWatch.createStarted();
         drawImage();
-        mainImageBytes = ImageHelper.writeWebp(mainImage);
+        if (mainImage.getWidth() > 16383 || mainImage.getHeight() > 16383) {
+            mainImageBytes = ImageHelper.writeJpg(mainImage);
+            imageFormat = "jpg";
+        } else {
+            mainImageBytes = ImageHelper.writeWebp(mainImage);
+            imageFormat = "webp";
+        }
         if (debug) debugImageGraphicsTime.stop();
     }
 

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -78,6 +78,7 @@ public class MapGenerator implements AutoCloseable {
     private static final BasicStroke stroke4 = new BasicStroke(4.0f);
     private static final BasicStroke stroke5 = new BasicStroke(5.0f);
     private static final BasicStroke stroke6 = new BasicStroke(6.0f);
+    private static final int WEBP_MAX_DIMENSION = 16383;
 
     private final Graphics graphics;
     private final BufferedImage mainImage;
@@ -303,7 +304,7 @@ public class MapGenerator implements AutoCloseable {
         tilesWithExtra.addAll(game.getBorderAnomalies().stream()
                 .map(BorderAnomalyHolder::getTile)
                 .collect(Collectors.toSet()));
-
+        
         tiles.stream().sorted().forEach(key -> addTile(tileMap.get(key), TileStep.Tile));
         tilesWithExtra.forEach(key -> addTile(tileMap.get(key), TileStep.Extras));
         tiles.stream().sorted().forEach(key -> addTile(tileMap.get(key), TileStep.Units));
@@ -428,7 +429,7 @@ public class MapGenerator implements AutoCloseable {
 
         if (debug) debugImageGraphicsTime = StopWatch.createStarted();
         drawImage();
-        if (mainImage.getWidth() > 16383 || mainImage.getHeight() > 16383) {
+        if (mainImage.getWidth() > WEBP_MAX_DIMENSION || mainImage.getHeight() > WEBP_MAX_DIMENSION) {
             mainImageBytes = ImageHelper.writeJpg(mainImage);
             imageFormat = "jpg";
         } else {

--- a/src/main/java/ti4/service/image/FileUploadService.java
+++ b/src/main/java/ti4/service/image/FileUploadService.java
@@ -20,7 +20,7 @@ public class FileUploadService {
 
     private static FileUpload createFileUpload(
             BufferedImage bufferedImage, String filenamePrefix, boolean saveLocalCopy) {
-        byte[] imageBytes = ImageHelper.writeJpg(bufferedImage);
+        byte[] imageBytes = ImageHelper.writeWebp(bufferedImage);
         return createFileUpload(imageBytes, filenamePrefix, saveLocalCopy);
     }
 
@@ -31,9 +31,9 @@ public class FileUploadService {
     private static FileUpload createFileUpload(byte[] bytes, String filenamePrefix, boolean saveLocalCopy) {
         if (bytes == null || bytes.length == 0) return null;
 
-        if (saveLocalCopy) optionallySaveToLocal(bytes, filenamePrefix, "jpg");
+        if (saveLocalCopy) optionallySaveToLocal(bytes, filenamePrefix, "webp");
 
-        String fileName = filenamePrefix + "_" + DateTimeHelper.getFormattedTimestamp() + ".jpg";
+        String fileName = filenamePrefix + "_" + DateTimeHelper.getFormattedTimestamp() + ".webp";
         return FileUpload.fromData(bytes, fileName);
     }
 

--- a/src/main/java/ti4/service/image/FileUploadService.java
+++ b/src/main/java/ti4/service/image/FileUploadService.java
@@ -14,26 +14,37 @@ import ti4.message.logging.BotLogger;
 @UtilityClass
 public class FileUploadService {
 
+    public static FileUpload createFileUpload(BufferedImage bufferedImage, String filenamePrefix, String fileFormat) {
+        return createFileUpload(bufferedImage, filenamePrefix, fileFormat, false);
+    }
+
     public static FileUpload createFileUpload(BufferedImage bufferedImage, String filenamePrefix) {
-        return createFileUpload(bufferedImage, filenamePrefix, false);
+        return createFileUpload(bufferedImage, filenamePrefix, "webp", false);
     }
 
     private static FileUpload createFileUpload(
-            BufferedImage bufferedImage, String filenamePrefix, boolean saveLocalCopy) {
-        byte[] imageBytes = ImageHelper.writeWebp(bufferedImage);
-        return createFileUpload(imageBytes, filenamePrefix, saveLocalCopy);
+            BufferedImage bufferedImage, String filenamePrefix, String fileFormat, boolean saveLocalCopy) {
+        byte[] imageBytes;
+        switch (fileFormat) {
+            case "png" -> imageBytes = ImageHelper.writePng(bufferedImage);
+            case "jpg" -> imageBytes = ImageHelper.writeJpg(bufferedImage);
+            case "webp" -> imageBytes = ImageHelper.writeWebp(bufferedImage);
+            default -> throw new IllegalArgumentException("Unsupported file format: " + fileFormat);
+        }
+        return createFileUpload(imageBytes, filenamePrefix, fileFormat, saveLocalCopy);
     }
 
-    public static FileUpload createFileUpload(byte[] bytes, String filenamePrefix) {
-        return createFileUpload(bytes, filenamePrefix, false);
+    public static FileUpload createFileUpload(byte[] bytes, String filenamePrefix, String fileFormat) {
+        return createFileUpload(bytes, filenamePrefix, fileFormat, false);
     }
 
-    private static FileUpload createFileUpload(byte[] bytes, String filenamePrefix, boolean saveLocalCopy) {
+    private static FileUpload createFileUpload(
+            byte[] bytes, String filenamePrefix, String fileFormat, boolean saveLocalCopy) {
         if (bytes == null || bytes.length == 0) return null;
 
-        if (saveLocalCopy) optionallySaveToLocal(bytes, filenamePrefix, "webp");
+        if (saveLocalCopy) optionallySaveToLocal(bytes, filenamePrefix, fileFormat);
 
-        String fileName = filenamePrefix + "_" + DateTimeHelper.getFormattedTimestamp() + ".webp";
+        String fileName = filenamePrefix + "_" + DateTimeHelper.getFormattedTimestamp() + "." + fileFormat;
         return FileUpload.fromData(bytes, fileName);
     }
 

--- a/src/main/java/ti4/website/AsyncTi4WebsiteHelper.java
+++ b/src/main/java/ti4/website/AsyncTi4WebsiteHelper.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.experimental.UtilityClass;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import ti4.map.Game;
@@ -35,6 +36,7 @@ import ti4.website.model.WebTileUnitData;
 import ti4.website.model.WebsiteOverlay;
 import ti4.website.model.stats.GameStatsDashboardPayload;
 
+@UtilityClass
 public class AsyncTi4WebsiteHelper {
 
     private static final int STAT_BATCH_SIZE = 200;
@@ -259,9 +261,9 @@ public class AsyncTi4WebsiteHelper {
         try {
             String mapPath;
             if (frog && player != null) {
-                mapPath = "fogmap/" + player.getUserID() + "/%s/%s.jpg";
+                mapPath = "fogmap/" + player.getUserID() + "/%s/%s.webp";
             } else {
-                mapPath = "map/%s/%s.jpg";
+                mapPath = "map/%s/%s.webp";
             }
 
             LocalDateTime date = LocalDateTime.now();
@@ -270,7 +272,7 @@ public class AsyncTi4WebsiteHelper {
             putObjectInBucket(
                     String.format(mapPath, gameName, dtstamp),
                     AsyncRequestBody.fromBytes(imageBytes),
-                    "image/jpg",
+                    "image/webp",
                     null);
         } catch (Exception e) {
             BotLogger.error(

--- a/src/main/java/ti4/website/AsyncTi4WebsiteHelper.java
+++ b/src/main/java/ti4/website/AsyncTi4WebsiteHelper.java
@@ -250,7 +250,7 @@ public class AsyncTi4WebsiteHelper {
                 });
     }
 
-    public static void putMap(String gameName, byte[] imageBytes, boolean frog, Player player) {
+    public static void putMap(String gameName, String fileFormat, byte[] imageBytes, boolean frog, Player player) {
         if (!uploadsEnabled()) return;
         String bucket = EgressClientManager.getWebProperties().getProperty("website.bucket");
         if (bucket == null || bucket.isEmpty()) {
@@ -261,9 +261,9 @@ public class AsyncTi4WebsiteHelper {
         try {
             String mapPath;
             if (frog && player != null) {
-                mapPath = "fogmap/" + player.getUserID() + "/%s/%s.webp";
+                mapPath = "fogmap/" + player.getUserID() + "/%s/%s." + fileFormat;
             } else {
-                mapPath = "map/%s/%s.webp";
+                mapPath = "map/%s/%s." + fileFormat;
             }
 
             LocalDateTime date = LocalDateTime.now();
@@ -272,7 +272,7 @@ public class AsyncTi4WebsiteHelper {
             putObjectInBucket(
                     String.format(mapPath, gameName, dtstamp),
                     AsyncRequestBody.fromBytes(imageBytes),
-                    "image/webp",
+                    "image/" + fileFormat,
                     null);
         } catch (Exception e) {
             BotLogger.error(


### PR DESCRIPTION
Replaces JPEG image generation and storage with WebP format for map images. Adds the webp-imageio dependency, implements WebP encoding in ImageHelper, updates MapGenerator and FileUploadService to use WebP, and adjusts file naming and content types accordingly. This change aims to improve image compression and quality.