### PR TITLE
Add two-column layout for player areas in large games

### DIFF
--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -209,8 +209,12 @@ public class MapGenerator implements AutoCloseable {
     private static int getHeightOfPlayerAreasSection(Game game, int playerCountForMap, int objectivesY) {
         final int typicalPlayerAreaHeight = 340;
         final int unrealPlayerHeight = 35;
-        int playersY = playerCountForMap * typicalPlayerAreaHeight;
+        int rows = playerCountForMap > 8 ? (playerCountForMap + 1) / 2 : playerCountForMap;
+        int playersY = rows * typicalPlayerAreaHeight;
         int unrealPlayers = game.getNotRealPlayers().size();
+        if (playerCountForMap > 8) {
+            unrealPlayers = (unrealPlayers + 1) / 2;
+        }
         playersY += unrealPlayers * unrealPlayerHeight;
         for (Player player : game.getPlayers().values()) {
             if ("neutral".equalsIgnoreCase(player.getFaction()) || (player.isNpc() && player.isDummy())) {

--- a/src/main/java/ti4/image/PlayerAreaGenerator.java
+++ b/src/main/java/ti4/image/PlayerAreaGenerator.java
@@ -120,10 +120,29 @@ class PlayerAreaGenerator {
         int x = topLeftOfAllPAs.x;
         int y = topLeftOfAllPAs.y;
 
-        for (Player player : game.getRealAndEliminatedPlayers()) {
-            Point tl = new Point(x, y);
-            Rectangle rect = drawPlayerAreaOLD(player, tl);
-            if (rect.height > 0) y += rect.height + 15;
+        List<Player> players = new ArrayList<>(game.getRealAndEliminatedPlayers());
+        if (players.size() <= 8) {
+            for (Player player : players) {
+                Point tl = new Point(x, y);
+                Rectangle rect = drawPlayerAreaOLD(player, tl, mapWidth);
+                if (rect.height > 0) y += rect.height + 15;
+            }
+        } else {
+            int spacing = 15;
+            int columnWidth = (mapWidth - x - spacing) / 2;
+            int leftMapWidth = x + columnWidth;
+            int rightX = x + columnWidth + spacing;
+            int rows = (players.size() + 1) / 2;
+            for (int i = 0; i < rows; i++) {
+                int yStart = y;
+                Rectangle leftRect = drawPlayerAreaOLD(players.get(i), new Point(x, yStart), leftMapWidth);
+                Rectangle rightRect = new Rectangle();
+                int rightIndex = i + rows;
+                if (rightIndex < players.size()) {
+                    rightRect = drawPlayerAreaOLD(players.get(rightIndex), new Point(rightX, yStart), mapWidth);
+                }
+                y += Math.max(leftRect.height, rightRect.height) + 15;
+            }
         }
 
         String spectatorNames = game.getPlayers().values().stream()
@@ -155,7 +174,7 @@ class PlayerAreaGenerator {
         }
     }
 
-    private Rectangle drawPlayerAreaOLD(Player player, Point topLeft) {
+    private Rectangle drawPlayerAreaOLD(Player player, Point topLeft, int mapWidth) {
         int x = topLeft.x;
         int y = topLeft.y;
         Graphics2D g2 = (Graphics2D) graphics;


### PR DESCRIPTION
## Summary
- Split player areas into two columns once a game has more than eight players
- Allow player area drawing to use custom widths for column placement
- Adjust height calculation to accommodate two-column layouts

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d98e86c4832da147d5a86d4cfdfe