### PR TITLE
Revert "Bump software.amazon.awssdk:s3 from 2.32.13 to 2.33.0 (#3633)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.33.0</version>
+      <version>2.32.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This reverts commit 51b5b6d6a0656b8868fa982a08c7ea382b6be742.