### PR TITLE
Reorder tile addition to process extras after tiles

### DIFF
--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -311,8 +311,8 @@ public class MapGenerator implements AutoCloseable {
                 .map(BorderAnomalyHolder::getTile)
                 .collect(Collectors.toSet()));
 
-        tilesWithExtra.forEach(key -> addTile(tileMap.get(key), TileStep.Extras));
         sortedTiles.forEach(key -> addTile(tileMap.get(key), TileStep.Tile));
+        tilesWithExtra.forEach(key -> addTile(tileMap.get(key), TileStep.Extras));
         sortedTiles.forEach(key -> addTile(tileMap.get(key), TileStep.Units));
         if (!game.getTileDistances().isEmpty()) {
             sortedTiles.forEach(key -> addTile(tileMap.get(key), TileStep.Distance));


### PR DESCRIPTION
Moved the addition of tiles with extras to occur after the main tiles are added, ensuring correct processing order in the map generation sequence.