### PR TITLE
Clarify Ancient Trade Routes transaction rules

### DIFF
--- a/src/main/java/ti4/buttons/handlers/actioncards/ActionCardDeck2ButtonHandler.java
+++ b/src/main/java/ti4/buttons/handlers/actioncards/ActionCardDeck2ButtonHandler.java
@@ -281,7 +281,7 @@ class ActionCardDeck2ButtonHandler {
         ButtonHelperAgents.toldarAgentInitiation(game, p2, 2);
         MessageHelper.sendMessageToChannel(
                 p2.getCorrectChannel(),
-                p2.getFactionEmoji() + " gained 2 commodities due to _Ancient Trade Routes_ and is neighbors with "
+                p2.getFactionEmoji() + " gained 2 commodities due to _Ancient Trade Routes_ and may transact with "
                         + player.getFactionEmojiOrColor() + " for this turn.");
         event.getMessage().delete().queue();
     }

--- a/src/main/resources/data/action_cards/acd2.json
+++ b/src/main/resources/data/action_cards/acd2.json
@@ -4,7 +4,7 @@
         "name": "Ancient Trade Routes",
         "phase": "Action",
         "window": "At the start of your turn",
-        "text": "Choose up to 2 other players. You and each of those players gain 2 commodities. During this turn, treat those players as if they were your neighbors.",
+        "text": "Choose up to 2 other players; you do not have to be neighbors to perform transactions with those players during this turn. You and each of those players gain 2 commodities.",
         "flavorText": "\"Stationmaster,\" Kier said nervously, \"these routes have been dead for centuries.\" Artuno smirked. \"See to it that they are reinstated, then. The Memoria will accompany you if necessary.\"",
         "source": "action_deck_2"
     },


### PR DESCRIPTION
Updated the message and action card text for Ancient Trade Routes to specify that players may transact without being neighbors for the turn, improving clarity and consistency with game rules.