### PR TITLE
Update UltimateStatisticsWebsiteHelper.java

### DIFF
--- a/src/main/java/ti4/website/UltimateStatisticsWebsiteHelper.java
+++ b/src/main/java/ti4/website/UltimateStatisticsWebsiteHelper.java
@@ -19,7 +19,7 @@ public class UltimateStatisticsWebsiteHelper {
     private static final String PLAYER_SETTINGS_URL = "https://api.ti4ultimate.com/api/Async/player-settings";
     private static final String TIGL_REPORT_GAMES_URL = "https://api.ti4ultimate.com/api/Tigl/report-game";
     private static final String TIGL_CHANGE_USERNAME_URL = "https://api.ti4ultimate.com/api/Tigl/change-username";
-    private static final String TIGL_REPORT_GAMES_SUCCESS_MESSAGE = "TIGL game successfully reported.";
+    private static final String TIGL_REPORT_GAMES_SUCCESS_MESSAGE = "TIGL game test upload successful. Please log game as normal using the form.";
     private static final String TIGL_REPORT_GAMES_FAILURE_MESSAGE =
             "Failed to report TIGL game. Please report manually: https://www.ti4ultimate.com/community/tigl/report-game";
     private static final String TIGL_CHANGE_USERNAME_SUCCESS_MESSAGE = "TIGL nickname successfully updated.";


### PR DESCRIPTION
changed message it gives when TIGL game is successfully uploaded, as it is causing users to incorrectly think they don't need to fill in the form.