### PR TITLE
Ensure circuit breaker returns 503 before security

### DIFF
--- a/src/main/java/ti4/spring/README.md
+++ b/src/main/java/ti4/spring/README.md
@@ -5,8 +5,9 @@ This package exposes the REST API used by the TI4 map generator bot. Controllers
 
 ## Request flow
 
-1. **CircuitBreakerFilter** – runs first (`@Order(1)`). If the global circuit breaker
-   is open it throws `ServiceUnavailableException`, returning a `503` response.
+1. **CircuitBreakerFilter** – runs before Spring Security (`@Order(Ordered.HIGHEST_PRECEDENCE)`).
+   If the global circuit breaker is open it throws `ServiceUnavailableException`, returning
+   a `503` response.
 2. **Spring Security** – authenticates the request using `DiscordOpaqueTokenIntrospector`
    and builds the security context.
 3. **ErrorLoggingFilter** – executes after authentication (`@Order(3)`) and logs any

--- a/src/main/java/ti4/spring/resilience/CircuitBreakerFilter.java
+++ b/src/main/java/ti4/spring/resilience/CircuitBreakerFilter.java
@@ -7,13 +7,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import ti4.AsyncTI4DiscordBot;
 import ti4.executors.CircuitBreaker;
 
-@Order(1)
+// Run before Spring Security so that service availability is reported as 503
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
 @Component
 public class CircuitBreakerFilter extends OncePerRequestFilter {


### PR DESCRIPTION
## Summary
- Run CircuitBreakerFilter with highest precedence so unavailable service returns 503 instead of 401
- Document filter order in Spring module README

## Testing
- `mvn -q test` *(fails: Network is unreachable; Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c043635164832d9217b45475c08ca4