### PR TITLE
Refactor request context setup and add UtilityClass

### DIFF
--- a/src/main/java/ti4/service/async/TourneyWinnersService.java
+++ b/src/main/java/ti4/service/async/TourneyWinnersService.java
@@ -6,12 +6,14 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.entities.User;
 import org.jetbrains.annotations.NotNull;
 import ti4.AsyncTI4DiscordBot;
 import ti4.json.PersistenceManager;
 import ti4.message.logging.BotLogger;
 
+@UtilityClass
 public class TourneyWinnersService {
 
     private static final String fileName = "tourneyWinners.json";


### PR DESCRIPTION
TourneyWinnersService is now annotated with @UtilityClass for static utility usage. GameLockAndRequestContextInterceptor's setupGameRequestContext now returns a boolean to indicate if context was set, and game locking is conditional on this result, improving control flow and clarity.