### PR TITLE
Draft logic split

### DIFF
--- a/src/main/java/ti4/buttons/handlers/milty/MiltyDraftButtonHandlers.java
+++ b/src/main/java/ti4/buttons/handlers/milty/MiltyDraftButtonHandlers.java
@@ -13,9 +13,9 @@ import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
 import ti4.model.FactionModel;
+import ti4.service.draft.FactionExtraSetupHelper;
 import ti4.service.milty.DraftDisplayService;
 import ti4.service.milty.MiltyDraftManager;
-import ti4.service.milty.MiltyService;
 import ti4.service.regex.RegexService;
 
 @UtilityClass
@@ -67,7 +67,7 @@ class MiltyDraftButtonHandlers {
                 String keleresName =
                         Mapper.getFaction("keleres" + preset.charAt(0)).getFactionTitle();
                 MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Successfully preset " + keleresName);
-                MiltyService.offerKeleresSetupButtons(game.getMiltyDraftManager(), player);
+                FactionExtraSetupHelper.offerKeleresSetupButtons(game.getMiltyDraftManager(), player);
                 ButtonHelper.deleteMessage(event);
             }
         });

--- a/src/main/java/ti4/commands/game/StartScenario.java
+++ b/src/main/java/ti4/commands/game/StartScenario.java
@@ -17,10 +17,10 @@ import ti4.map.Player;
 import ti4.map.Tile;
 import ti4.message.MessageHelper;
 import ti4.model.RelicModel;
+import ti4.service.draft.PlayerSetupService;
 import ti4.service.emoji.FactionEmojis;
 import ti4.service.leader.CommanderUnlockCheckService;
 import ti4.service.map.AddTileListService;
-import ti4.service.milty.MiltyService;
 import ti4.service.objectives.DrawSecretService;
 import ti4.service.unit.AddUnitService;
 
@@ -76,7 +76,7 @@ public class StartScenario extends GameStateSubcommand {
                     speaker = chance == face;
                 }
                 if (tile != null) {
-                    MiltyService.secondHalfOfPlayerSetup(
+                    PlayerSetupService.secondHalfOfPlayerSetup(
                             players.get(face),
                             game,
                             players.get(face).getNextAvailableColour(),
@@ -144,7 +144,7 @@ public class StartScenario extends GameStateSubcommand {
                     default -> color;
                 };
                 if (tile != null) {
-                    MiltyService.secondHalfOfPlayerSetup(
+                    PlayerSetupService.secondHalfOfPlayerSetup(
                             players.get(face), game, color, faction, tile.getPosition(), event, speaker);
                     players.remove(face);
                 }

--- a/src/main/java/ti4/commands/milty/StartMilty.java
+++ b/src/main/java/ti4/commands/milty/StartMilty.java
@@ -13,7 +13,7 @@ import ti4.map.Game;
 import ti4.message.MessageHelper;
 import ti4.model.MapTemplateModel;
 import ti4.model.Source.ComponentSource;
-import ti4.service.draft.DraftSpec;
+import ti4.service.milty.MiltyDraftSpec;
 import ti4.service.milty.MiltyService;
 
 class StartMilty extends GameStateSubcommand {
@@ -32,7 +32,7 @@ class StartMilty extends GameStateSubcommand {
     @Override
     public void execute(SlashCommandInteractionEvent event) {
         Game game = getGame();
-        DraftSpec specs = new DraftSpec(game);
+        MiltyDraftSpec specs = new MiltyDraftSpec(game);
 
         // Map Template ---------------------------------------------------------------------------
         MapTemplateModel template = getMapTemplateFromOption(event, game);

--- a/src/main/java/ti4/commands/milty/StartMilty.java
+++ b/src/main/java/ti4/commands/milty/StartMilty.java
@@ -13,6 +13,7 @@ import ti4.map.Game;
 import ti4.message.MessageHelper;
 import ti4.model.MapTemplateModel;
 import ti4.model.Source.ComponentSource;
+import ti4.service.draft.DraftSpec;
 import ti4.service.milty.MiltyService;
 
 class StartMilty extends GameStateSubcommand {
@@ -31,7 +32,7 @@ class StartMilty extends GameStateSubcommand {
     @Override
     public void execute(SlashCommandInteractionEvent event) {
         Game game = getGame();
-        MiltyService.DraftSpec specs = new MiltyService.DraftSpec(game);
+        DraftSpec specs = new DraftSpec(game);
 
         // Map Template ---------------------------------------------------------------------------
         MapTemplateModel template = getMapTemplateFromOption(event, game);

--- a/src/main/java/ti4/commands/player/Setup.java
+++ b/src/main/java/ti4/commands/player/Setup.java
@@ -12,7 +12,7 @@ import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
-import ti4.service.milty.MiltyService;
+import ti4.service.draft.PlayerSetupService;
 
 class Setup extends GameStateSubcommand {
 
@@ -63,6 +63,6 @@ class Setup extends GameStateSubcommand {
         String positionHS = StringUtils.substringBefore(
                 event.getOption(Constants.HS_TILE_POSITION, "", OptionMapping::getAsString),
                 " "); // Substring to grab "305" from "305 Moll Primus (Mentak)" autocomplete
-        MiltyService.secondHalfOfPlayerSetup(player, game, color, faction, positionHS, event, setSpeaker);
+        PlayerSetupService.secondHalfOfPlayerSetup(player, game, color, faction, positionHS, event, setSpeaker);
     }
 }

--- a/src/main/java/ti4/draft/FrankenDraft.java
+++ b/src/main/java/ti4/draft/FrankenDraft.java
@@ -25,8 +25,7 @@ import ti4.map.Game;
 import ti4.message.logging.BotLogger;
 import ti4.message.logging.LogOrigin;
 import ti4.model.FactionModel;
-import ti4.service.milty.MiltyDraftHelper;
-import ti4.service.milty.MiltyDraftManager;
+import ti4.service.draft.DraftTileManager;
 
 public class FrankenDraft extends BagDraft {
 
@@ -187,12 +186,12 @@ public class FrankenDraft extends BagDraft {
 
         allDraftableItems.put(DraftItem.Category.DRAFTORDER, SpeakerOrderDraftItem.buildAllDraftableItems(game));
 
-        MiltyDraftManager draftManager = game.getMiltyDraftManager();
-        draftManager.clear();
-        MiltyDraftHelper.initDraftTiles(draftManager, game);
-        allDraftableItems.put(DraftItem.Category.REDTILE, RedTileDraftItem.buildAllDraftableItems(draftManager, game));
+        DraftTileManager draftTileManager = game.getDraftTileManager();
+        draftTileManager.reset(game);
         allDraftableItems.put(
-                DraftItem.Category.BLUETILE, BlueTileDraftItem.buildAllDraftableItems(draftManager, game));
+                DraftItem.Category.REDTILE, RedTileDraftItem.buildAllDraftableItems(draftTileManager, game));
+        allDraftableItems.put(
+                DraftItem.Category.BLUETILE, BlueTileDraftItem.buildAllDraftableItems(draftTileManager, game));
 
         List<DraftBag> bags = new ArrayList<>();
 

--- a/src/main/java/ti4/draft/StandardBagDraft.java
+++ b/src/main/java/ti4/draft/StandardBagDraft.java
@@ -13,8 +13,7 @@ import ti4.map.Game;
 import ti4.message.logging.BotLogger;
 import ti4.message.logging.LogOrigin;
 import ti4.model.FactionModel;
-import ti4.service.milty.MiltyDraftHelper;
-import ti4.service.milty.MiltyDraftManager;
+import ti4.service.draft.DraftTileManager;
 
 public class StandardBagDraft extends BagDraft {
     public StandardBagDraft(Game owner) {
@@ -73,10 +72,10 @@ public class StandardBagDraft extends BagDraft {
                 DraftItem.Category.HOMESYSTEM, HomeSystemDraftItem.buildAllDraftableItems(allDraftableFactions));
         allDraftableItems.put(DraftItem.Category.DRAFTORDER, SpeakerOrderDraftItem.buildAllDraftableItems(game));
 
-        MiltyDraftManager draftManager = game.getMiltyDraftManager();
-        MiltyDraftHelper.initDraftTiles(draftManager, game);
-        allDraftableItems.put(DraftItem.Category.REDTILE, RedTileDraftItem.buildAllDraftableItems(draftManager));
-        allDraftableItems.put(DraftItem.Category.BLUETILE, BlueTileDraftItem.buildAllDraftableItems(draftManager));
+        DraftTileManager.addAllDraftTiles(game);
+        DraftTileManager draftTileManager = game.getDraftTileManager();
+        allDraftableItems.put(DraftItem.Category.REDTILE, RedTileDraftItem.buildAllDraftableItems(draftTileManager));
+        allDraftableItems.put(DraftItem.Category.BLUETILE, BlueTileDraftItem.buildAllDraftableItems(draftTileManager));
 
         List<DraftBag> bags = new ArrayList<>();
 

--- a/src/main/java/ti4/draft/items/BlueTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/BlueTileDraftItem.java
@@ -14,10 +14,10 @@ import ti4.model.PlanetModel;
 import ti4.model.PlanetTypeModel;
 import ti4.model.TechSpecialtyModel;
 import ti4.model.TileModel;
+import ti4.service.draft.DraftTileManager;
 import ti4.service.emoji.MiscEmojis;
 import ti4.service.emoji.PlanetEmojis;
 import ti4.service.emoji.TI4Emoji;
-import ti4.service.milty.MiltyDraftManager;
 import ti4.service.milty.MiltyDraftTile;
 
 public class BlueTileDraftItem extends DraftItem {
@@ -78,19 +78,19 @@ public class BlueTileDraftItem extends DraftItem {
         return PlanetEmojis.SemLor;
     }
 
-    public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager) {
+    public static List<DraftItem> buildAllDraftableItems(DraftTileManager draftTileManager) {
         List<DraftItem> allItems = new ArrayList<>();
-        for (MiltyDraftTile tile : draftManager.getBlue()) {
+        for (MiltyDraftTile tile : draftTileManager.getBlue()) {
             allItems.add(generate(DraftItem.Category.BLUETILE, tile.getTile().getTileID()));
         }
         DraftErrataModel.filterUndraftablesAndShuffle(allItems, DraftItem.Category.BLUETILE);
         return allItems;
     }
 
-    public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager, Game game) {
+    public static List<DraftItem> buildAllDraftableItems(DraftTileManager draftTileManager, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
-        for (MiltyDraftTile tile : draftManager.getBlue()) {
+        for (MiltyDraftTile tile : draftTileManager.getBlue()) {
             if (Arrays.asList(results).contains(tile.getTile().getTileID())) {
                 continue;
             }

--- a/src/main/java/ti4/draft/items/RedTileDraftItem.java
+++ b/src/main/java/ti4/draft/items/RedTileDraftItem.java
@@ -14,9 +14,9 @@ import ti4.model.PlanetModel;
 import ti4.model.PlanetTypeModel;
 import ti4.model.TechSpecialtyModel;
 import ti4.model.TileModel;
+import ti4.service.draft.DraftTileManager;
 import ti4.service.emoji.MiscEmojis;
 import ti4.service.emoji.TI4Emoji;
-import ti4.service.milty.MiltyDraftManager;
 import ti4.service.milty.MiltyDraftTile;
 
 public class RedTileDraftItem extends DraftItem {
@@ -80,19 +80,19 @@ public class RedTileDraftItem extends DraftItem {
         return MiscEmojis.Supernova;
     }
 
-    public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager) {
+    public static List<DraftItem> buildAllDraftableItems(DraftTileManager draftTileManager) {
         List<DraftItem> allItems = new ArrayList<>();
-        for (MiltyDraftTile tile : draftManager.getRed()) {
+        for (MiltyDraftTile tile : draftTileManager.getRed()) {
             allItems.add(generate(Category.REDTILE, tile.getTile().getTileID()));
         }
         DraftErrataModel.filterUndraftablesAndShuffle(allItems, Category.REDTILE);
         return allItems;
     }
 
-    public static List<DraftItem> buildAllDraftableItems(MiltyDraftManager draftManager, Game game) {
+    public static List<DraftItem> buildAllDraftableItems(DraftTileManager draftTileManager, Game game) {
         List<DraftItem> allItems = new ArrayList<>();
         String[] results = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedTiles"));
-        for (MiltyDraftTile tile : draftManager.getRed()) {
+        for (MiltyDraftTile tile : draftTileManager.getRed()) {
             if (Arrays.asList(results).contains(tile.getTile().getTileID())) {
                 continue;
             }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -95,6 +95,7 @@ import ti4.service.button.ReactionService;
 import ti4.service.combat.CombatRollService;
 import ti4.service.combat.CombatRollType;
 import ti4.service.decks.ShowActionCardsService;
+import ti4.service.draft.PlayerSetupService;
 import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.ExploreEmojis;
 import ti4.service.emoji.FactionEmojis;
@@ -110,7 +111,6 @@ import ti4.service.fow.FOWPlusService;
 import ti4.service.fow.GMService;
 import ti4.service.leader.CommanderUnlockCheckService;
 import ti4.service.milty.MiltyDraftTile;
-import ti4.service.milty.MiltyService;
 import ti4.service.planet.AddPlanetService;
 import ti4.service.regex.RegexService;
 import ti4.service.tech.ShowTechDeckService;
@@ -5861,7 +5861,7 @@ public class ButtonHelper {
         }
         Collections.shuffle(colors);
         for (int i = 0; i < players.size() && i < 12; i++) {
-            MiltyService.secondHalfOfPlayerSetup(
+            PlayerSetupService.secondHalfOfPlayerSetup(
                     players.get(i), game, colors.get(i), "franken" + emojiNum.get(i), "20" + (i + 1), event, false);
         }
         MessageHelper.sendMessageToChannel(
@@ -6236,9 +6236,9 @@ public class ButtonHelper {
         if (game.getPlayerFromColorOrFaction(color) != null) color = player.getNextAvailableColour();
         if (buttonID.split("_").length == 6 || speaker != null) {
             if (speaker != null) {
-                MiltyService.secondHalfOfPlayerSetup(player, game, color, factionId, pos, event, false);
+                PlayerSetupService.secondHalfOfPlayerSetup(player, game, color, factionId, pos, event, false);
             } else {
-                MiltyService.secondHalfOfPlayerSetup(
+                PlayerSetupService.secondHalfOfPlayerSetup(
                         player, game, color, factionId, pos, event, "yes".equalsIgnoreCase(buttonID.split("_")[5]));
             }
         } else {

--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -71,6 +71,7 @@ import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
 import ti4.service.agenda.IsPlayerElectedService;
 import ti4.service.button.ReactionService;
+import ti4.service.draft.DraftTileManager;
 import ti4.service.emoji.ApplicationEmojiService;
 import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.ExploreEmojis;
@@ -85,7 +86,6 @@ import ti4.service.fow.GMService;
 import ti4.service.game.SetOrderService;
 import ti4.service.info.SecretObjectiveInfoService;
 import ti4.service.map.TokenPlanetService;
-import ti4.service.milty.MiltyDraftManager;
 import ti4.service.milty.MiltyDraftTile;
 import ti4.service.objectives.ScorePublicObjectiveService;
 import ti4.service.strategycard.PlayStrategyCardService;
@@ -223,14 +223,10 @@ public class Helper {
         return players;
     }
 
-    // TODO: (Jazz): This method *should* include base game + pok tiles (+ DS tiles if and only if DS mode is set)
-    //     - Once the bot is using milty draft settings, we can make this accurately pull in tiles
-    //     - from every source available to the active game
     public static List<MiltyDraftTile> getUnusedTiles(Game game) {
-        MiltyDraftManager draftManager = game.getMiltyDraftManager();
-        draftManager.init(game);
-
-        List<MiltyDraftTile> allTiles = new ArrayList<>(draftManager.getAll())
+        DraftTileManager draftTileManager = game.getDraftTileManager();
+        draftTileManager.reset(game);
+        List<MiltyDraftTile> allTiles = new ArrayList<>(draftTileManager.getAll())
                 .stream()
                         .filter(tile -> game.getTile(tile.getTile().getTileID()) == null)
                         .toList();
@@ -2512,7 +2508,7 @@ public class Helper {
     }
 
     /**
-     * @param text string to add spaces on the left
+     * @param text   string to add spaces on the left
      * @param length minimum length of string
      * @return left padded string
      */
@@ -2524,7 +2520,7 @@ public class Helper {
     }
 
     /**
-     * @param text string to add spaces on the right
+     * @param text   string to add spaces on the right
      * @param length minimum length of string
      * @return right padded string
      */
@@ -2982,10 +2978,10 @@ public class Helper {
                 MessageHelper.sendMessageToChannel(
                         game.getMainGameChannel(),
                         """
-                        ## Note about FoW
-                        When you press **End Game** all the game channels will be deleted immediately!
-                        A new thread will be generated under the **#fow-war-stories** channel.
-                        Round Summaries will be shared there. So it is advised to hold end-of-game chat until then.""");
+                                ## Note about FoW
+                                When you press **End Game** all the game channels will be deleted immediately!
+                                A new thread will be generated under the **#fow-war-stories** channel.
+                                Round Summaries will be shared there. So it is advised to hold end-of-game chat until then.""");
                 List<Button> titleButton = new ArrayList<>();
                 titleButton.add(Buttons.blue("offerToGiveTitles", "Offer to bestow a Title"));
                 titleButton.add(Buttons.gray("deleteButtons", "No titles for this game"));

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -95,6 +95,7 @@ import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
 import ti4.model.metadata.AutoPingMetadataManager;
 import ti4.service.agenda.IsPlayerElectedService;
+import ti4.service.draft.DraftTileManager;
 import ti4.service.emoji.MiscEmojis;
 import ti4.service.emoji.SourceEmojis;
 import ti4.service.leader.CommanderUnlockCheckService;
@@ -198,6 +199,7 @@ public class Game extends GameProperties {
     private Map<String, Integer> tileDistances = new HashMap<>();
 
     private MiltyDraftManager miltyDraftManager;
+    private DraftTileManager draftTileManager;
 
     @Getter
     private Expeditions expeditions = new Expeditions(this);
@@ -377,6 +379,16 @@ public class Game extends GameProperties {
 
     public void setMiltyDraftManager(MiltyDraftManager miltyDraftManager) {
         this.miltyDraftManager = miltyDraftManager;
+    }
+
+    @NotNull
+    @JsonIgnore
+    public DraftTileManager getDraftTileManager() {
+        if (draftTileManager == null) {
+            draftTileManager = new DraftTileManager();
+            draftTileManager.reset(this);
+        }
+        return draftTileManager;
     }
 
     @Nullable
@@ -1886,7 +1898,8 @@ public class Game extends GameProperties {
     }
 
     /**
-     * @param soToPoList - a list of Secret Objective IDs that have been turned into Public Objectives (typically via Classified Document Leaks)
+     * @param soToPoList - a list of Secret Objective IDs that have been turned into
+     *                   Public Objectives (typically via Classified Document Leaks)
      */
     public void setSoToPoList(List<String> soToPoList) {
         this.soToPoList = soToPoList;
@@ -1901,7 +1914,8 @@ public class Game extends GameProperties {
     }
 
     /**
-     * @return Map of (ObjectiveModelID or ProperName if Custom, List of ({@link Player#getUserID}))
+     * @return Map of (ObjectiveModelID or ProperName if Custom, List of
+     *         ({@link Player#getUserID}))
      */
     public Map<String, List<String>> getScoredPublicObjectives() {
         return scoredPublicObjectives;
@@ -3219,7 +3233,8 @@ public class Game extends GameProperties {
         DeckSettings deckSettings = miltySettings.getGameSettings().getDecks();
 
         boolean success = true;
-        // &= is the "and operator". It will assign true to success iff success is true and the result is true.
+        // &= is the "and operator". It will assign true to success iff success is true
+        // and the result is true.
         // Otherwise it will propagate a false value to the end
         success &= validateAndSetPublicObjectivesStage1Deck(
                 event, deckSettings.getStage1().getValue());
@@ -4018,7 +4033,8 @@ public class Game extends GameProperties {
 
     /**
      * @param scID
-     * @return true when the Game's SC Set contains a strategt card which uses a certain automation
+     * @return true when the Game's SC Set contains a strategt card which uses a
+     *         certain automation
      */
     public boolean usesStrategyCardAutomation(String scID) {
         return getStrategyCardSet().getStrategyCardModels().stream()
@@ -4487,10 +4503,12 @@ public class Game extends GameProperties {
                 .count();
         int round = getRound();
         String phaseOfGame = StringUtils.defaultString(getPhaseOfGame());
-        // if we're in action, we haven't revealed this round's public; can't filter on status because sometimes people
+        // if we're in action, we haven't revealed this round's public; can't filter on
+        // status because sometimes people
         // reveal despite game end
         int extraIfNotActionPhase = phaseOfGame.contains("action") ? 0 : 1;
-        // if neuraloop is in the deck, or we're not using Codex 4, we can make additional assumptions about number of
+        // if neuraloop is in the deck, or we're not using Codex 4, we can make
+        // additional assumptions about number of
         // publics
         if (relics.contains("neuraloop") || !isCodex4()) {
             // 5 revealed by round 5 and Incentive Program
@@ -4498,9 +4516,11 @@ public class Game extends GameProperties {
             if (round < 5) {
                 // We can't have less stage 1s than this
                 if (revealedStage1Count < round + 1) return true;
-                // Round + 1 revealed by this point, plus Incentive Program; 1 extra if we're not in action phase
+                // Round + 1 revealed by this point, plus Incentive Program; 1 extra if we're
+                // not in action phase
                 if (revealedStage1Count > round + 2 + extraIfNotActionPhase) return true;
-                // At most 1 Stage 2 can be revealed, by Incentive Program; 1 extra if we're not in action phase and its
+                // At most 1 Stage 2 can be revealed, by Incentive Program; 1 extra if we're not
+                // in action phase and its
                 // round 4
                 int extraIfRound4AndNotActionPhase = round != 4 ? 0 : extraIfNotActionPhase;
                 if (revealedStage2Count > 1 + extraIfRound4AndNotActionPhase) return true;
@@ -4509,12 +4529,14 @@ public class Game extends GameProperties {
                 // We can't have less stage 1s than this
                 if (revealedStage1Count < 5) return true;
                 if (revealedStage2Count < round - 4) return true;
-                // 1 revealed per round past round 4 and Incentive Program; 1 extra if we're not in action phase
+                // 1 revealed per round past round 4 and Incentive Program; 1 extra if we're not
+                // in action phase
                 if (revealedStage2Count > round - 3 + extraIfNotActionPhase) return true;
             }
         }
 
-        // Extra stage 1 on round 1, Incentive Program during agenda phase; 1 extra if we're not in action phase
+        // Extra stage 1 on round 1, Incentive Program during agenda phase; 1 extra if
+        // we're not in action phase
         return revealedStage1Count + revealedStage2Count > round + 2 + extraIfNotActionPhase;
     }
 

--- a/src/main/java/ti4/service/draft/DraftSliceHelper.java
+++ b/src/main/java/ti4/service/draft/DraftSliceHelper.java
@@ -1,0 +1,36 @@
+package ti4.service.draft;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+import lombok.experimental.UtilityClass;
+import ti4.helpers.AliasHandler;
+import ti4.service.milty.MiltyDraftSlice;
+import ti4.service.milty.MiltyDraftTile;
+
+@UtilityClass
+public class DraftSliceHelper {
+    public static List<MiltyDraftSlice> parseSlicesFromString(String str) {
+        int sliceIndex = 1;
+        StringTokenizer sliceTokenizer = new StringTokenizer(str, ";");
+        List<MiltyDraftSlice> slices = new ArrayList<>();
+        while (sliceTokenizer.hasMoreTokens()) {
+            slices.add(parseSliceFromString(sliceTokenizer.nextToken(), sliceIndex));
+            sliceIndex++;
+        }
+        return slices;
+    }
+
+    private static MiltyDraftSlice parseSliceFromString(String str, int index) {
+        List<String> tiles = Arrays.asList(str.split(","));
+        List<MiltyDraftTile> draftTiles = tiles.stream()
+                .map(AliasHandler::resolveTile)
+                .map(DraftTileManager::findTile)
+                .toList();
+        MiltyDraftSlice slice = new MiltyDraftSlice();
+        slice.setTiles(draftTiles);
+        slice.setName(Character.toString(index - 1 + 'A'));
+        return slice;
+    }
+}

--- a/src/main/java/ti4/service/draft/DraftSpec.java
+++ b/src/main/java/ti4/service/draft/DraftSpec.java
@@ -1,0 +1,95 @@
+package ti4.service.draft;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import ti4.helpers.settingsFramework.menus.GameSettings;
+import ti4.helpers.settingsFramework.menus.MiltySettings;
+import ti4.helpers.settingsFramework.menus.PlayerFactionSettings;
+import ti4.helpers.settingsFramework.menus.SliceGenerationSettings;
+import ti4.helpers.settingsFramework.menus.SourceSettings;
+import ti4.map.Game;
+import ti4.model.MapTemplateModel;
+import ti4.model.Source;
+import ti4.service.milty.MiltyDraftSlice;
+
+@Data
+public class DraftSpec {
+    public Game game;
+    public List<String> playerIDs, bannedFactions, priorityFactions, playerDraftOrder;
+    public MapTemplateModel template;
+    public List<Source.ComponentSource> tileSources, factionSources;
+    public Integer numSlices, numFactions;
+
+    // slice generation settings
+    public Boolean anomaliesCanTouch = false, extraWHs = true;
+    public Double minRes = 2.0, minInf = 3.0;
+    public Integer minTot = 9, maxTot = 13;
+    public Integer minLegend = 1, maxLegend = 2;
+
+    // other
+    public List<MiltyDraftSlice> presetSlices;
+
+    public DraftSpec(Game game) {
+        this.game = game;
+        playerIDs = new ArrayList<>(game.getPlayerIDs());
+        bannedFactions = new ArrayList<>();
+        priorityFactions = new ArrayList<>();
+
+        tileSources = new ArrayList<>();
+        tileSources.add(Source.ComponentSource.base);
+        tileSources.add(Source.ComponentSource.pok);
+        tileSources.add(Source.ComponentSource.codex1);
+        tileSources.add(Source.ComponentSource.codex2);
+        tileSources.add(Source.ComponentSource.codex3);
+        tileSources.add(Source.ComponentSource.codex4);
+        factionSources = new ArrayList<>(tileSources);
+    }
+
+    public static DraftSpec CreateFromMiltySettings(MiltySettings settings) {
+        Game game = settings.getGame();
+        DraftSpec specs = new DraftSpec(game);
+
+        // Load Game Specifications
+        GameSettings gameSettings = settings.getGameSettings();
+        specs.setTemplate(gameSettings.getMapTemplate().getValue());
+
+        // Load Slice Generation Specifications
+        SliceGenerationSettings sliceSettings = settings.getSliceSettings();
+        specs.numFactions = sliceSettings.getNumFactions().getVal();
+        specs.numSlices = sliceSettings.getNumSlices().getVal();
+        specs.anomaliesCanTouch = false;
+        specs.extraWHs = sliceSettings.getExtraWorms().isVal();
+        specs.minLegend = sliceSettings.getNumLegends().getValLow();
+        specs.maxLegend = sliceSettings.getNumLegends().getValHigh();
+        specs.minTot = sliceSettings.getTotalValue().getValLow();
+        specs.maxTot = sliceSettings.getTotalValue().getValHigh();
+
+        // Load Player & Faction Ban Specifications
+        PlayerFactionSettings pfSettings = settings.getPlayerSettings();
+        specs.bannedFactions.addAll(pfSettings.getBanFactions().getKeys());
+        if (game.isThundersEdge()) {
+            List<String> newKeys = new ArrayList<>();
+            newKeys.addAll(List.of("arborec", "ghost", "letnev", "winnu", "muaat", "yin"));
+            specs.priorityFactions.addAll(newKeys);
+            specs.numFactions = Math.min(6, specs.numFactions);
+        } else {
+            specs.priorityFactions.addAll(pfSettings.getPriFactions().getKeys());
+        }
+        specs.setPlayerIDs(new ArrayList<>(pfSettings.getGamePlayers().getKeys()));
+        if (pfSettings.getPresetDraftOrder().isVal()) {
+            specs.playerDraftOrder = new ArrayList<>(game.getPlayers().keySet());
+        }
+
+        // Load Sources Specifications
+        SourceSettings sources = settings.getSourceSettings();
+        specs.setTileSources(sources.getTileSources());
+        specs.setFactionSources(sources.getFactionSources());
+
+        if (sliceSettings.getParsedSlices() != null) {
+            specs.presetSlices = sliceSettings.getParsedSlices();
+        }
+
+        return specs;
+    }
+}

--- a/src/main/java/ti4/service/draft/DraftTileManager.java
+++ b/src/main/java/ti4/service/draft/DraftTileManager.java
@@ -1,0 +1,162 @@
+package ti4.service.draft;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Data;
+import ti4.image.TileHelper;
+import ti4.map.Game;
+import ti4.map.Planet;
+import ti4.map.Tile;
+import ti4.model.Source.ComponentSource;
+import ti4.model.TileModel;
+import ti4.model.TileModel.TileBack;
+import ti4.model.WormholeModel;
+import ti4.service.milty.MiltyDraftTile;
+import ti4.service.milty.TierList;
+
+@Data
+public class DraftTileManager {
+
+    private static final Map<String, MiltyDraftTile> tiles = new HashMap<>();
+
+    private final List<MiltyDraftTile> all = new ArrayList<>();
+    private final List<MiltyDraftTile> blue = new ArrayList<>();
+    private final List<MiltyDraftTile> red = new ArrayList<>();
+
+    public void addDraftTile(MiltyDraftTile draftTile) {
+        TierList draftTileTier = draftTile.getTierList();
+        switch (draftTileTier) {
+            case high, mid, low -> blue.add(draftTile);
+            case red, anomaly -> red.add(draftTile);
+        }
+        all.add(draftTile);
+    }
+
+    public List<MiltyDraftTile> getBlue() {
+        return new ArrayList<>(blue);
+    }
+
+    public List<MiltyDraftTile> getRed() {
+        return new ArrayList<>(red);
+    }
+
+    public void clear() {
+        all.clear();
+        blue.clear();
+        red.clear();
+    }
+
+    public void reset(Game game) {
+        clear();
+        addAllDraftTiles(getGameSources(game));
+    }
+
+    public void addAllDraftTiles(List<ComponentSource> sources) {
+        List<TileModel> allTiles = new ArrayList<>(TileHelper.getAllTileModels());
+        for (TileModel tileModel : allTiles) {
+            if (isNotDraftable(tileModel)) continue;
+            if (!sources.contains(tileModel.getSource())) continue;
+            if (tileModel.getTileBack() == TileBack.GREEN || tileModel.isHyperlane()) continue;
+
+            MiltyDraftTile draftTile = getDraftTileFromModel(tileModel);
+            addDraftTile(draftTile);
+        }
+    }
+
+    public static void resetForGame(Game game) {
+        DraftTileManager tileManager = game.getDraftTileManager();
+        tileManager.reset(game);
+    }
+
+    public static void addAllDraftTiles(Game game) {
+        List<ComponentSource> sources = getGameSources(game);
+        DraftTileManager tileManager = game.getDraftTileManager();
+        tileManager.addAllDraftTiles(sources);
+    }
+
+    public static MiltyDraftTile findTile(String tileId) {
+        MiltyDraftTile result = tiles.get(tileId);
+        if (result != null) {
+            return result;
+        }
+
+        TileModel tileRequested = TileHelper.getTileById(tileId);
+        if (tileRequested == null) {
+            throw new IllegalArgumentException("No such tile with ID: " + tileId);
+        }
+
+        result = getDraftTileFromModel(tileRequested);
+        return result;
+    }
+
+    private static List<ComponentSource> getGameSources(Game game) {
+        List<ComponentSource> sources = new ArrayList<>(Arrays.asList(
+                ComponentSource.base,
+                ComponentSource.codex1,
+                ComponentSource.codex2,
+                ComponentSource.codex3,
+                ComponentSource.codex4,
+                ComponentSource.pok));
+        if (game.isDiscordantStarsMode() || game.isUnchartedSpaceStuff()) {
+            sources.add(ComponentSource.ds);
+            sources.add(ComponentSource.uncharted_space);
+        }
+        return sources;
+    }
+
+    private static boolean isNotDraftable(TileModel tileModel) {
+        TileModel.TileBack back = tileModel.getTileBack();
+        if (back != TileBack.RED && back != TileBack.BLUE) {
+            return true;
+        }
+
+        String id = tileModel.getId().toLowerCase();
+        String path =
+                tileModel.getImagePath() == null ? "" : tileModel.getImagePath().toLowerCase();
+        List<String> disallowedTerms = List.of(
+                "corner", "lane", "mecatol", "blank", "border", "fow", "anomaly", "deltawh", "seed", "mr", "mallice",
+                "ethan", "prison", "kwon", "home", "hs", "red", "blue", "green", "gray", "gate", "setup");
+        return disallowedTerms.stream().anyMatch(term -> id.contains(term) || path.contains(term));
+    }
+
+    private static MiltyDraftTile getDraftTileFromModel(TileModel tileModel) {
+        String tileID = tileModel.getId();
+        if (tiles.containsKey(tileID)) return tiles.get(tileID);
+
+        Set<WormholeModel.Wormhole> wormholes = tileModel.getWormholes();
+        MiltyDraftTile draftTile = new MiltyDraftTile();
+        if (wormholes != null) {
+            for (WormholeModel.Wormhole wormhole : wormholes) {
+                if (wormhole == WormholeModel.Wormhole.ALPHA) {
+                    draftTile.setHasAlphaWH(true);
+                } else if (wormhole == WormholeModel.Wormhole.BETA) {
+                    draftTile.setHasBetaWH(true);
+                } else {
+                    draftTile.setHasOtherWH(true);
+                }
+            }
+        }
+
+        Tile tile = new Tile(tileID, "none");
+        draftTile.setTile(tile);
+
+        for (Planet planet : tile.getPlanetUnitHolders()) {
+            draftTile.addPlanet(planet);
+        }
+
+        if (tile.isAnomaly()) {
+            draftTile.setTierList(TierList.anomaly);
+        } else if (tile.getPlanetUnitHolders().isEmpty()) {
+            draftTile.setTierList(TierList.red);
+        } else {
+            draftTile.setTierList(TierList.high);
+        }
+
+        tiles.put(tileID, draftTile);
+        return draftTile;
+    }
+}

--- a/src/main/java/ti4/service/draft/FactionExtraSetupHelper.java
+++ b/src/main/java/ti4/service/draft/FactionExtraSetupHelper.java
@@ -1,0 +1,43 @@
+package ti4.service.draft;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import org.apache.commons.lang3.StringUtils;
+import ti4.buttons.Buttons;
+import ti4.image.Mapper;
+import ti4.map.Player;
+import ti4.message.MessageHelper;
+import ti4.model.FactionModel;
+import ti4.service.milty.MiltyDraftManager;
+
+@UtilityClass
+public class FactionExtraSetupHelper {
+    public static void offerKeleresSetupButtons(MiltyDraftManager manager, Player player) {
+        List<String> flavors = List.of("mentak", "xxcha", "argent");
+        List<Button> keleresPresets = new ArrayList<>();
+        boolean warn = false;
+        for (String f : flavors) {
+            if (manager.isFactionTaken(f)) continue;
+
+            FactionModel model = Mapper.getFaction(f);
+            String id = "draftPresetKeleres_" + f;
+            String label = StringUtils.capitalize(f);
+            if (manager.getFactionDraft().contains(f)) {
+                keleresPresets.add(Buttons.gray(id, label + " 🛑", model.getFactionEmoji()));
+                warn = true;
+            } else {
+                keleresPresets.add(Buttons.green(id, label, model.getFactionEmoji()));
+            }
+        }
+
+        String message = player.getPing()
+                + " Pre-select which flavor of Keleres to play in this game by clicking one of these buttons!";
+        message += " You can change your decision later by clicking a different button.";
+        if (warn)
+            message +=
+                    "\n- 🛑 Some of these factions are in the draft! 🛑 If you preset them and they get chosen, then the preset will be cancelled.";
+        MessageHelper.sendMessageToChannelWithButtonsAndNoUndo(player.getCardsInfoThread(), message, keleresPresets);
+    }
+}

--- a/src/main/java/ti4/service/draft/PlayerSetupService.java
+++ b/src/main/java/ti4/service/draft/PlayerSetupService.java
@@ -1,0 +1,461 @@
+package ti4.service.milty;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import org.apache.commons.lang3.StringUtils;
+import ti4.buttons.Buttons;
+import ti4.commands.tokens.AddTokenCommand;
+import ti4.helpers.AliasHandler;
+import ti4.helpers.ButtonHelperAbilities;
+import ti4.helpers.ButtonHelperHeroes;
+import ti4.helpers.ColorChangeHelper;
+import ti4.helpers.Constants;
+import ti4.helpers.PromissoryNoteHelper;
+import ti4.helpers.ThreadArchiveHelper;
+import ti4.helpers.TitlesHelper;
+import ti4.helpers.Units;
+import ti4.image.Mapper;
+import ti4.image.PositionMapper;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.map.Tile;
+import ti4.message.MessageHelper;
+import ti4.model.FactionModel;
+import ti4.model.Source;
+import ti4.model.TechnologyModel;
+import ti4.service.PlanetService;
+import ti4.service.emoji.MiscEmojis;
+import ti4.service.info.AbilityInfoService;
+import ti4.service.info.CardsInfoService;
+import ti4.service.info.LeaderInfoService;
+import ti4.service.info.SecretObjectiveInfoService;
+import ti4.service.info.TechInfoService;
+import ti4.service.info.UnitInfoService;
+import ti4.service.planet.AddPlanetService;
+import ti4.service.tech.ListTechService;
+
+@UtilityClass
+public class PlayerSetupService {
+    public static void secondHalfOfPlayerSetup(
+            Player player,
+            Game game,
+            String color,
+            String faction,
+            String positionHS,
+            GenericInteractionCreateEvent event,
+            boolean setSpeaker) {
+        Map<String, Player> players = game.getPlayers();
+        ThreadArchiveHelper.checkThreadLimitAndArchive(event.getGuild());
+        for (Player playerInfo : players.values()) {
+            if (playerInfo != player) {
+                if (color.equals(playerInfo.getColor())) {
+                    String newColor = player.getNextAvailableColour();
+                    String message = "Player:" + playerInfo.getUserName() + " already uses color:" + color
+                            + " - changing color to " + newColor;
+                    MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
+                    return;
+                } else if (faction.equals(playerInfo.getFaction())) {
+                    MessageHelper.sendMessageToChannel(
+                            event.getMessageChannel(),
+                            "Setup Failed - Player:" + playerInfo.getUserName() + " already uses faction:" + faction);
+                    return;
+                }
+                if ("franken1".equalsIgnoreCase(faction) || "franken2".equalsIgnoreCase(faction)) {
+                    MessageHelper.sendMessageToChannel(
+                            event.getMessageChannel(),
+                            "Setup Failed - Franken1 and Franken2 have issues and should not be used by anyone going forward. Try a different franken number");
+                    return;
+                }
+            }
+        }
+
+        if (ColorChangeHelper.colorIsExclusive(color, player)) {
+            color = player.getNextAvailableColorIgnoreCurrent();
+        }
+
+        if (player.isRealPlayer() && player.getSo() > 0) {
+            String message = player.getRepresentationNoPing()
+                    + "has secret objectives that would get lost to the void if they were setup again."
+                    + " If they wish to change color, use `/player change_color`. If they wish to setup as another faction, they must discard their secret objective first.";
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
+            SecretObjectiveInfoService.sendSecretObjectiveInfo(game, player);
+            return;
+        }
+
+        player.setColor(color);
+        player.setFaction(game, faction);
+        player.setFactionEmoji(null);
+        player.getPlanets().clear();
+        player.getTechs().clear();
+        player.getFactionTechs().clear();
+
+        FactionModel factionModel = player.getFactionSetupInfo();
+
+        if (game.isBaseGameMode()) {
+            player.setLeaders(new ArrayList<>());
+        }
+
+        if (factionModel.getSource() == Source.ComponentSource.miltymod && !game.isMiltyModMode()) {
+            MessageHelper.sendMessageToChannel(
+                    event.getMessageChannel(),
+                    "MiltyMod factions are a Homebrew Faction. Please enable the MiltyMod Game Mode first if you wish to use MiltyMod factions");
+            return;
+        }
+
+        // BREAKTHROUGH
+        if (game.isThundersEdge() && Mapper.getBreakthrough(factionModel.getAlias() + "bt") != null) {
+            player.setBreakthroughID(factionModel.getAlias() + "bt");
+            player.setBreakthroughUnlocked(false);
+            player.setBreakthroughExhausted(false);
+            player.setBreakthroughActive(false);
+            player.setBreakthroughTGs(0);
+        }
+
+        // HOME SYSTEM
+        if (!PositionMapper.isTilePositionValid(positionHS)) {
+            MessageHelper.sendMessageToChannel(
+                    event.getMessageChannel(), "Tile position: `" + positionHS + "` is not valid. Stopping Setup.");
+            return;
+        }
+
+        String hsTile = AliasHandler.resolveTile(factionModel.getHomeSystem());
+        Tile tile = new Tile(hsTile, positionHS);
+        if (!StringUtils.isBlank(hsTile)) {
+            game.setTile(tile);
+        }
+
+        // String statsAnchor =
+        // PositionMapper.getEquivalentPositionAtRing(game.getRingCount(), positionHS);
+        player.setPlayerStatsAnchorPosition(positionHS);
+
+        // HANDLE GHOSTS' HOME SYSTEM LOCATION
+        if ("ghost".equals(faction) || "miltymod_ghost".equals(faction)) {
+            tile.addToken(Mapper.getTokenID(Constants.FRONTIER), Constants.SPACE);
+            String pos = "tr";
+            if ("307".equalsIgnoreCase(positionHS) || "310".equalsIgnoreCase(positionHS)) {
+                pos = "br";
+            }
+            if ("313".equalsIgnoreCase(positionHS) || "316".equalsIgnoreCase(positionHS)) {
+                pos = "bl";
+            }
+            tile = new Tile("51", pos);
+            game.setTile(tile);
+        }
+
+        // STARTING COMMODITIES
+        player.setCommoditiesBase(factionModel.getCommodities());
+
+        // STARTING PLANETS
+        for (String planet : factionModel.getHomePlanets()) {
+            if (planet.isEmpty()) {
+                continue;
+            }
+            String planetResolved = AliasHandler.resolvePlanet(planet.toLowerCase());
+            AddPlanetService.addPlanet(player, planetResolved, game, event, true);
+            player.refreshPlanet(planetResolved);
+        }
+
+        player.getExhaustedPlanets().clear();
+
+        // STARTING UNITS
+        addUnits(factionModel, tile, color, event);
+
+        // STARTING TECH
+        List<String> startingTech = factionModel.getStartingTech();
+        if (startingTech != null) {
+            for (String tech : factionModel.getStartingTech()) {
+                if (tech.trim().isEmpty()) {
+                    continue;
+                }
+                player.addTech(tech);
+            }
+        }
+
+        Map<String, TechnologyModel> techReplacements = Mapper.getHomebrewTechReplaceMap(game.getTechnologyDeckID());
+        List<String> playerTechs = new ArrayList<>(player.getTechs());
+        for (String tech : playerTechs) {
+            TechnologyModel model = techReplacements.getOrDefault(tech, Mapper.getTech(tech));
+            if (!playerTechs.contains(model.getAlias())) {
+                player.addTech(model.getAlias());
+                player.removeTech(tech);
+            }
+        }
+
+        for (String tech : factionModel.getFactionTech()) {
+            if (tech.trim().isEmpty()) continue;
+
+            TechnologyModel factionTech = techReplacements.getOrDefault(tech, Mapper.getTech(tech));
+            player.addFactionTech(factionTech.getAlias());
+        }
+
+        if (setSpeaker) {
+            game.setSpeakerUserID(player.getUserID());
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    MiscEmojis.SpeakerToken + " Speaker assigned to: " + player.getRepresentation());
+        }
+
+        // STARTING PNs
+        player.initPNs();
+        Set<String> playerPNs = new HashSet<>(player.getPromissoryNotes().keySet());
+        playerPNs.addAll(factionModel.getPromissoryNotes());
+        player.setPromissoryNotesOwned(playerPNs);
+        if (game.isBaseGameMode()) {
+            Set<String> pnsOwned = new HashSet<>(player.getPromissoryNotesOwned());
+            for (String pnID : pnsOwned) {
+                if (pnID.endsWith("_an")
+                        && "Alliance".equals(Mapper.getPromissoryNote(pnID).getName())) {
+                    player.removeOwnedPromissoryNoteByID(pnID);
+                }
+            }
+        }
+        if (game.isAbsolMode()) {
+            Set<String> pnsOwned = new HashSet<>(player.getPromissoryNotesOwned());
+            for (String pnID : pnsOwned) {
+                if (pnID.endsWith("_ps")
+                        && "Political Secret"
+                                .equals(Mapper.getPromissoryNote(pnID).getName())) {
+                    player.removeOwnedPromissoryNoteByID(pnID);
+                    player.addOwnedPromissoryNoteByID("absol_" + pnID);
+                }
+            }
+        }
+
+        // STARTING OWNED UNITS
+        Set<String> playerOwnedUnits = new HashSet<>(factionModel.getUnits());
+        player.setUnitsOwned(playerOwnedUnits);
+
+        // Don't do special stuff if Franken Faction
+        if (faction.startsWith("franken")) {
+            return;
+        }
+
+        // SEND STUFF
+        MessageHelper.sendMessageToPlayerCardsInfoThread(player, factionModel.getFactionSheetMessage());
+        AbilityInfoService.sendAbilityInfo(player, event);
+        TechInfoService.sendTechInfo(game, player, event);
+        LeaderInfoService.sendLeadersInfo(game, player, event);
+        UnitInfoService.sendUnitInfo(game, player, event, false);
+        PromissoryNoteHelper.sendPromissoryNoteInfo(game, player, false, event);
+
+        if (player.getTechs().isEmpty() && !player.getFaction().contains("sardakk")) {
+            if (player.getFaction().contains("keleres")) {
+                Button getTech = Buttons.green("getKeleresTechOptions", "Get Keleres Technology Options");
+                String msg = player.getRepresentationUnfogged()
+                        + " after every other faction gets their starting technologies,"
+                        + " press this button to for Keleres to get their starting technologies.";
+                MessageHelper.sendMessageToChannelWithButton(player.getCorrectChannel(), msg, getTech);
+            } else {
+                // STARTING TECH OPTIONS
+                Integer bonusOptions = factionModel.getStartingTechAmount();
+                List<String> startingTechOptions = factionModel.getStartingTechOptions();
+                if (startingTechOptions != null && bonusOptions != null && bonusOptions > 0) {
+                    List<TechnologyModel> techs = new ArrayList<>();
+                    if (!startingTechOptions.isEmpty()) {
+                        for (String tech : game.getTechnologyDeck()) {
+                            TechnologyModel model = Mapper.getTech(tech);
+                            boolean homebrewReplacesAnOption = model.getHomebrewReplacesID()
+                                    .map(startingTechOptions::contains)
+                                    .orElse(false);
+                            if (startingTechOptions.contains(model.getAlias()) || homebrewReplacesAnOption) {
+                                techs.add(model);
+                            }
+                        }
+                    }
+
+                    List<Button> buttons = ListTechService.getTechButtons(techs, player, "free");
+                    String msg =
+                            player.getRepresentationUnfogged() + " use the buttons to choose your starting technology:";
+                    if (techs.isEmpty()) {
+                        buttons = List.of(Buttons.GET_A_FREE_TECH, Buttons.DONE_DELETE_BUTTONS);
+                        MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), msg, buttons);
+                    } else {
+                        for (int x = 0; x < bonusOptions; x++) {
+                            MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), msg, buttons);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (String fTech : player.getFactionTechs()) {
+            if (!game.getTechnologyDeck().contains(fTech) && fTech.contains("ds")) {
+                game.setTechnologyDeckID("techs_ds");
+                break;
+            }
+        }
+
+        if (player.hasAbility("diplomats")) {
+            ButtonHelperAbilities.resolveFreePeopleAbility(game);
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    "Set up **Free People** ability markers. " + player.getRepresentationUnfogged()
+                            + " any planet with a **Free People** token on it will show up as spendable in your various spends. Once spent, the token will be removed.");
+        }
+        if (player.hasAbility("ancient_empire")) {
+            List<Button> buttons = new ArrayList<>();
+            buttons.add(Buttons.green("startAncientEmpire", "Place a tomb token"));
+            MessageHelper.sendMessageToChannelWithButtons(
+                    player.getCorrectChannel(),
+                    player.getRepresentation() + ", please place up to 14 Tomb tokens for **Ancient Empire**.",
+                    buttons);
+        }
+
+        if (player.hasAbility("private_fleet")) {
+            String unitID = AliasHandler.resolveUnit("destroyer");
+            player.setUnitCap(unitID, 12);
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    "Set destroyer max to 12 for " + player.getRepresentation()
+                            + ", due to the **Private Fleet** ability,");
+        }
+        if (player.hasAbility("industrialists")) {
+            String unitID = AliasHandler.resolveUnit("spacedock");
+            player.setUnitCap(unitID, 4);
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    "Set space dock max to 4 for " + player.getRepresentation()
+                            + ", due to the **Industrialists** ability,");
+        }
+        if (player.hasAbility("teeming")) {
+            String unitID = AliasHandler.resolveUnit("dreadnought");
+            player.setUnitCap(unitID, 7);
+            unitID = AliasHandler.resolveUnit("mech");
+            player.setUnitCap(unitID, 5);
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    "Set dreadnought unit max to 7 and mech unit max to 5 for " + player.getRepresentation()
+                            + ", due to the **Teeming** ability.");
+        }
+        if (player.hasAbility("machine_cult")) {
+            String unitID = AliasHandler.resolveUnit("mech");
+            player.setUnitCap(unitID, 6);
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    "Set mech unit maximum to 6 for " + player.getRepresentation()
+                            + ", due to their **Machine Cult** ability.");
+        }
+        if (game.isAgeOfFightersMode()) {
+            String tech = "ff2";
+            for (String factionTech : player.getNotResearchedFactionTechs()) {
+                TechnologyModel fTech = Mapper.getTech(factionTech);
+                if (fTech != null
+                        && !fTech.getAlias()
+                                .equalsIgnoreCase(Mapper.getTech(tech).getAlias())
+                        && fTech.isUnitUpgrade()
+                        && fTech.getBaseUpgrade()
+                                .orElse("bleh")
+                                .equalsIgnoreCase(Mapper.getTech(tech).getAlias())) {
+                    tech = fTech.getAlias();
+                    break;
+                }
+            }
+            player.addTech(tech);
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    player.getRepresentation() + " gained the "
+                            + Mapper.getTech(tech).getNameRepresentation()
+                            + " technology due to the _Age of Fighters_ galactic event.");
+        }
+        if (game.isStellarAtomicsMode()) {
+            if (game.getRevealedPublicObjectives().get("Stellar Atomics") != null) {
+                int stellarID = game.getRevealedPublicObjectives().get("Stellar Atomics");
+                game.scorePublicObjective(player.getUserID(), stellarID);
+            } else {
+                int poIndex = game.addCustomPO("Stellar Atomics", 0);
+                for (Player playerWL : game.getRealPlayers()) {
+                    game.scorePublicObjective(playerWL.getUserID(), poIndex);
+                }
+            }
+        }
+        if (player.hasAbility("policies")) {
+            player.removeAbility("policies");
+            player.addAbility("policy_the_people_connect");
+            player.addAbility("policy_the_environment_preserve");
+            player.addAbility("policy_the_economy_empower");
+            player.removeOwnedUnitByID("olradin_mech");
+            player.addOwnedUnitByID("olradin_mech_positive");
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    player.getRepresentationUnfogged()
+                            + ", I have automatically set all of your Policies to the positive side, but you can flip any of them now with these buttons.");
+            ButtonHelperHeroes.offerOlradinHeroFlips(game, player);
+            ButtonHelperHeroes.offerOlradinHeroFlips(game, player);
+            ButtonHelperHeroes.offerOlradinHeroFlips(game, player);
+        }
+        if (player.hasAbility("oracle_ai")) {
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    player.getRepresentationUnfogged()
+                            + " you may peek at the next objective in your `#cards-info` thread (by your promissory note). "
+                            + "This holds true for anyone with _Read the Fates_. Don't do this until after secret objectives are dealt and discarded.");
+        }
+        CardsInfoService.sendVariousAdditionalButtons(game, player);
+
+        if (!game.isFowMode()) {
+            MessageHelper.sendMessageToChannel(
+                    game.getMainGameChannel(), "Player: " + player.getRepresentation() + " has been set up");
+        } else {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Player was set up.");
+        }
+
+        if (!game.isFowMode()) {
+            StringBuilder sb = TitlesHelper.getPlayerTitles(player.getUserID(), player.getUserName(), false);
+            if (!sb.toString().contains("No titles yet")) {
+                String msg = "In previous games, " + player.getUserName() + " has earned the titles of: \n" + sb;
+                MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msg);
+            }
+        }
+        if ("d11".equalsIgnoreCase(hsTile)) {
+            AddTokenCommand.addToken(event, tile, Constants.FRONTIER, game);
+        }
+        if ("true".equalsIgnoreCase(game.getStoredValue("removeSupports"))) {
+            player.removeOwnedPromissoryNoteByID(player.getColor() + "_sftt");
+            player.removePromissoryNote(player.getColor() + "_sftt");
+        }
+    }
+
+    private static void addUnits(FactionModel setupInfo, Tile tile, String color, GenericInteractionCreateEvent event) {
+        String units = setupInfo.getStartingFleet();
+        units = units.replace(", ", ",");
+        StringTokenizer tokenizer = new StringTokenizer(units, ",");
+        while (tokenizer.hasMoreTokens()) {
+            StringTokenizer unitInfoTokenizer = new StringTokenizer(tokenizer.nextToken(), " ");
+
+            int count = 1;
+            boolean numberIsSet = false;
+            String planetName = Constants.SPACE;
+            String unit = "";
+            if (unitInfoTokenizer.hasMoreTokens()) {
+                String ifNumber = unitInfoTokenizer.nextToken();
+                try {
+                    count = Integer.parseInt(ifNumber);
+                    numberIsSet = true;
+                } catch (Exception e) {
+                    unit = AliasHandler.resolveUnit(ifNumber);
+                }
+            }
+            if (unitInfoTokenizer.hasMoreTokens() && numberIsSet) {
+                unit = AliasHandler.resolveUnit(unitInfoTokenizer.nextToken());
+            }
+            Units.UnitKey unitID = Mapper.getUnitKey(unit, color);
+            if (unitID == null) {
+                MessageHelper.sendMessageToChannel(
+                        event.getMessageChannel(), "Unit: " + unit + " is not valid and not supported.");
+                continue;
+            }
+            if (unitInfoTokenizer.hasMoreTokens()) {
+                planetName = AliasHandler.resolvePlanet(unitInfoTokenizer.nextToken());
+            }
+            planetName = PlanetService.getPlanet(tile, planetName);
+            tile.addUnit(planetName, unitID, count);
+        }
+    }
+}

--- a/src/main/java/ti4/service/draft/PlayerSetupService.java
+++ b/src/main/java/ti4/service/draft/PlayerSetupService.java
@@ -1,4 +1,4 @@
-package ti4.service.milty;
+package ti4.service.draft;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/src/main/java/ti4/service/franken/FrankenDraftBagService.java
+++ b/src/main/java/ti4/service/franken/FrankenDraftBagService.java
@@ -26,8 +26,8 @@ import ti4.map.Player;
 import ti4.message.GameMessageManager;
 import ti4.message.GameMessageType;
 import ti4.message.MessageHelper;
+import ti4.service.draft.PlayerSetupService;
 import ti4.service.game.SetOrderService;
-import ti4.service.milty.MiltyService;
 
 @UtilityClass
 public class FrankenDraftBagService {
@@ -364,7 +364,7 @@ public class FrankenDraftBagService {
             if (!Mapper.isValidFaction(faction) || !PositionMapper.isTilePositionValid(tempHomeSystemLocation)) {
                 continue;
             }
-            MiltyService.secondHalfOfPlayerSetup(
+            PlayerSetupService.secondHalfOfPlayerSetup(
                     player, game, player.getNextAvailableColour(), faction, tempHomeSystemLocation, event, false);
             sb.append("\n> ").append(player.getRepresentationNoPing());
             index++;

--- a/src/main/java/ti4/service/milty/FinishDraftService.java
+++ b/src/main/java/ti4/service/milty/FinishDraftService.java
@@ -21,30 +21,18 @@ import ti4.message.MessageHelper;
 import ti4.message.logging.BotLogger;
 import ti4.message.logging.LogOrigin;
 import ti4.model.FactionModel;
+import ti4.service.draft.PlayerSetupService;
 import ti4.service.map.AddTileListService;
 import ti4.service.milty.MiltyDraftManager.PlayerDraft;
 
 @UtilityClass
 class FinishDraftService {
 
-    private FactionModel determineKeleresFlavor(MiltyDraftManager manager, Game game) {
-        List<String> flavors = List.of("mentak", "xxcha", "argent");
-        List<String> valid =
-                flavors.stream().filter(Predicate.not(manager::isFactionTaken)).toList();
-        String preset = game.getStoredValue("keleresFlavorPreset");
-        if (valid.contains(preset)) return Mapper.getFaction("keleres" + preset.charAt(0));
-        if (valid.size() == 1) {
-            preset = valid.getFirst();
-            return Mapper.getFaction("keleres" + preset.charAt(0));
-        }
-        return null;
-    }
-
     public void finishDraft(GenericInteractionCreateEvent event, MiltyDraftManager manager, Game game) {
         MessageChannel mainGameChannel = game.getMainGameChannel();
         try {
             MiltyDraftHelper.buildPartialMap(game, event);
-            boolean keleresExists = false;
+            boolean keleresSettingUp = false;
             for (String playerId : manager.getPlayers()) {
                 Player player = game.getPlayer(playerId);
                 PlayerDraft picks = manager.getPlayerDraft(playerId);
@@ -58,46 +46,19 @@ class FinishDraftService {
                 boolean speaker = picks.getPosition() == 1;
 
                 if (faction.startsWith("keleres")) {
-                    FactionModel preset = determineKeleresFlavor(manager, game);
-                    if (preset != null) {
-                        faction = preset.getAlias();
-                    } else {
-                        faction = null;
-                        keleresExists = true;
-                        Set<String> allowed = new HashSet<>(Set.of("mentak", "xxcha", "argent"));
-                        for (PlayerDraft pd : manager.getDraft().values()) {
-                            allowed.remove(pd.getFaction());
-                        }
-                        List<Button> buttons = new ArrayList<>();
-                        String message = player.getPing() + " choose a flavor of keleres:";
-                        if (allowed.isEmpty()) {
-                            MessageHelper.sendMessageToPlayerCardsInfoThread(
-                                    player,
-                                    "*Hrrnnggh*\nThis is awkward, all of the Keleres flavors got drafted. I'll let you pick any of them, but don't do that again!");
-                            allowed.addAll(Set.of("mentak", "xxcha", "argent"));
-                        }
-                        for (String flavor : allowed) {
-                            String emoji = Mapper.getFaction(flavor).getFactionEmoji();
-                            String keleres = "keleres" + flavor.charAt(0);
-                            String id = String.format(
-                                    "setupStep5_%s_%s_%s_%s_%s",
-                                    player.getUserID(), keleres, color, pos, speaker ? "yes" : "no");
-                            String msg = "Keleres (" + flavor + ")";
-                            Button butt = Buttons.green(id, msg).withEmoji(Emoji.fromFormatted(emoji));
-                            buttons.add(butt);
-                        }
-                        MessageHelper.sendMessageToChannelWithButtonsAndNoUndo(
-                                player.getCardsInfoThread(), message, buttons);
+                    faction = getKeleresAlias(player, manager, game, color, pos, speaker);
+                    if (faction == null) {
+                        keleresSettingUp = true;
                     }
                 }
 
                 if (faction != null) {
-                    MiltyService.secondHalfOfPlayerSetup(player, game, color, faction, pos, event, speaker);
+                    PlayerSetupService.secondHalfOfPlayerSetup(player, game, color, faction, pos, event, speaker);
                 }
             }
             game.setPhaseOfGame("playerSetup");
             AddTileListService.finishSetup(game, event);
-            if (keleresExists) {
+            if (keleresSettingUp) {
                 MessageHelper.sendMessageToChannel(
                         game.getActionsChannel(),
                         "## " + game.getPing()
@@ -120,5 +81,49 @@ class FinishDraftService {
             MessageHelper.sendMessageToChannel(mainGameChannel, error.toString());
             BotLogger.error(new LogOrigin(event, game), e.getMessage(), e);
         }
+    }
+
+    private String getKeleresAlias(
+            Player player, MiltyDraftManager manager, Game game, String color, String pos, boolean speaker) {
+        FactionModel preset = determineKeleresFlavor(manager, game);
+        if (preset != null) {
+            return preset.getAlias();
+        }
+        Set<String> allowed = new HashSet<>(Set.of("mentak", "xxcha", "argent"));
+        for (PlayerDraft pd : manager.getDraft().values()) {
+            allowed.remove(pd.getFaction());
+        }
+        List<Button> buttons = new ArrayList<>();
+        String message = player.getPing() + " choose a flavor of keleres:";
+        if (allowed.isEmpty()) {
+            MessageHelper.sendMessageToPlayerCardsInfoThread(
+                    player,
+                    "*Hrrnnggh*\nThis is awkward, all of the Keleres flavors got drafted. I'll let you pick any of them, but don't do that again!");
+            allowed.addAll(Set.of("mentak", "xxcha", "argent"));
+        }
+        for (String flavor : allowed) {
+            String emoji = Mapper.getFaction(flavor).getFactionEmoji();
+            String keleres = "keleres" + flavor.charAt(0);
+            String id = String.format(
+                    "setupStep5_%s_%s_%s_%s_%s", player.getUserID(), keleres, color, pos, speaker ? "yes" : "no");
+            String msg = "Keleres (" + flavor + ")";
+            Button butt = Buttons.green(id, msg).withEmoji(Emoji.fromFormatted(emoji));
+            buttons.add(butt);
+        }
+        MessageHelper.sendMessageToChannelWithButtonsAndNoUndo(player.getCardsInfoThread(), message, buttons);
+        return null;
+    }
+
+    private FactionModel determineKeleresFlavor(MiltyDraftManager manager, Game game) {
+        List<String> flavors = List.of("mentak", "xxcha", "argent");
+        List<String> valid =
+                flavors.stream().filter(Predicate.not(manager::isFactionTaken)).toList();
+        String preset = game.getStoredValue("keleresFlavorPreset");
+        if (valid.contains(preset)) return Mapper.getFaction("keleres" + preset.charAt(0));
+        if (valid.size() == 1) {
+            preset = valid.getFirst();
+            return Mapper.getFaction("keleres" + preset.charAt(0));
+        }
+        return null;
     }
 }

--- a/src/main/java/ti4/service/milty/GenerateSlicesService.java
+++ b/src/main/java/ti4/service/milty/GenerateSlicesService.java
@@ -17,7 +17,6 @@ import ti4.image.PositionMapper;
 import ti4.message.logging.BotLogger;
 import ti4.message.logging.LogOrigin;
 import ti4.model.MapTemplateModel;
-import ti4.service.draft.DraftSpec;
 import ti4.service.draft.DraftTileManager;
 import ti4.settings.GlobalSettings;
 
@@ -28,7 +27,7 @@ class GenerateSlicesService {
             GenericInteractionCreateEvent event,
             DraftTileManager tileManager,
             MiltyDraftManager draftManager,
-            DraftSpec specs) {
+            MiltyDraftSpec specs) {
         int sliceCount = specs.numSlices;
         boolean anomaliesCanTouch = specs.anomaliesCanTouch;
 
@@ -191,7 +190,8 @@ class GenerateSlicesService {
         return slice;
     }
 
-    private static boolean checkIfSliceIsGood(DraftSpec spec, MiltyDraftSlice slice, Map<String, Integer> failReasons) {
+    private static boolean checkIfSliceIsGood(
+            MiltyDraftSpec spec, MiltyDraftSlice slice, Map<String, Integer> failReasons) {
         Function<String, Integer> addReason =
                 reason -> failReasons.put(reason, failReasons.getOrDefault(reason, 0) + 1);
 

--- a/src/main/java/ti4/service/milty/MiltyDraftManager.java
+++ b/src/main/java/ti4/service/milty/MiltyDraftManager.java
@@ -7,11 +7,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import lombok.Data;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
@@ -19,19 +16,18 @@ import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.buttons.Buttons;
-import ti4.helpers.AliasHandler;
 import ti4.helpers.Helper;
 import ti4.helpers.StringHelper;
 import ti4.image.Mapper;
-import ti4.image.TileHelper;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
 import ti4.message.logging.BotLogger;
 import ti4.message.logging.LogOrigin;
 import ti4.model.FactionModel;
-import ti4.model.Source.ComponentSource;
-import ti4.model.TileModel;
+import ti4.service.draft.DraftSliceHelper;
+import ti4.service.draft.DraftTileManager;
+import ti4.service.draft.FactionExtraSetupHelper;
 import ti4.service.emoji.FactionEmojis;
 import ti4.service.emoji.MiltyDraftEmojis;
 import ti4.service.emoji.TI4Emoji;
@@ -39,13 +35,8 @@ import ti4.service.emoji.TI4Emoji;
 @Data
 public class MiltyDraftManager {
     private static final String SUMMARY_START = "# **__Draft Picks So Far__**:";
-    private static final Pattern PATTERN = Pattern.compile("e\\d{1,3}");
-    private static final Pattern REGEX = Pattern.compile("d\\d{1,3}");
     private static final Pattern MILTY_ = Pattern.compile("milty_");
 
-    private final List<MiltyDraftTile> all = new ArrayList<>();
-    private final List<MiltyDraftTile> blue = new ArrayList<>();
-    private final List<MiltyDraftTile> red = new ArrayList<>();
     private final List<MiltyDraftSlice> slices = new ArrayList<>();
     private final Map<String, PlayerDraft> draft = new HashMap<>(); // userID
 
@@ -93,15 +84,6 @@ public class MiltyDraftManager {
         }
     }
 
-    public void addDraftTile(MiltyDraftTile draftTile) {
-        TierList draftTileTier = draftTile.getTierList();
-        switch (draftTileTier) {
-            case high, mid, low -> blue.add(draftTile);
-            case red, anomaly -> red.add(draftTile);
-        }
-        all.add(draftTile);
-    }
-
     private String getCurrentDraftPlayer() {
         if (draftOrder.size() <= draftIndex) return null;
         return draftOrder.get(draftIndex);
@@ -146,14 +128,6 @@ public class MiltyDraftManager {
         draft.forEach((k, v) -> newDraft.put(k.equals(oldUID) ? newUID : k, v));
         draft.clear();
         draft.putAll(newDraft);
-    }
-
-    public List<MiltyDraftTile> getBlue() {
-        return new ArrayList<>(blue);
-    }
-
-    public List<MiltyDraftTile> getRed() {
-        return new ArrayList<>(red);
     }
 
     public void addSlice(MiltyDraftSlice slice) {
@@ -233,13 +207,7 @@ public class MiltyDraftManager {
 
     public void init(Game game) {
         clear();
-        MiltyDraftHelper.initDraftTiles(this, game);
-    }
-
-    // TODO (Jazz): Integrate this directly in the manager. For now, it's just dumb and hacky
-    public void init(List<ComponentSource> sources) {
-        clear();
-        MiltyDraftHelper.initDraftTiles(this, sources);
+        DraftTileManager.resetForGame(game);
     }
 
     @JsonIgnore
@@ -250,9 +218,6 @@ public class MiltyDraftManager {
     @JsonIgnore
     public void clear() {
         clearSlices();
-        all.clear();
-        blue.clear();
-        red.clear();
         draft.clear();
         draftOrder.clear();
         players.clear();
@@ -369,7 +334,7 @@ public class MiltyDraftManager {
         }
 
         if ("faction".equals(category) && item.contains("keleres")) {
-            MiltyService.offerKeleresSetupButtons(this, player);
+            FactionExtraSetupHelper.offerKeleresSetupButtons(this, player);
         }
 
         try {
@@ -544,7 +509,7 @@ public class MiltyDraftManager {
 
         // Slices
         String slices = bigTokenizer.nextToken();
-        loadSlicesFromString(slices);
+        this.slices.addAll(DraftSliceHelper.parseSlicesFromString(slices));
 
         // Factions
         String factionStr = bigTokenizer.nextToken();
@@ -584,49 +549,5 @@ public class MiltyDraftManager {
         // Map Template
         String savedTemplate = bigTokenizer.nextToken();
         setMapTemplate(savedTemplate);
-    }
-
-    public void loadSlicesFromString(String str) {
-        int sliceIndex = 1;
-        StringTokenizer sliceTokenizer = new StringTokenizer(str, ";");
-        while (sliceTokenizer.hasMoreTokens()) {
-            loadSliceFromString(sliceTokenizer.nextToken(), sliceIndex);
-            sliceIndex++;
-        }
-    }
-
-    private void loadSliceFromString(String str, int index) {
-        List<String> tiles = Arrays.asList(str.split(","));
-        List<MiltyDraftTile> draftTiles = tiles.stream()
-                .map(AliasHandler::resolveTile)
-                .map(this::findTile)
-                .toList();
-        MiltyDraftSlice slice = new MiltyDraftSlice();
-        slice.setTiles(draftTiles);
-        slice.setName(Character.toString(index - 1 + 'A'));
-        slices.add(slice);
-    }
-
-    private MiltyDraftTile findTile(String tileId) {
-        MiltyDraftTile result = all.stream()
-                .filter(t -> t.getTile().getTileID().equals(tileId))
-                .findFirst()
-                .orElse(null);
-        if (result == null) {
-            TileModel tileRequested = TileHelper.getTileById(tileId);
-            Set<ComponentSource> currentsources = all.stream()
-                    .map(t -> t.getTile().getTileModel().getSource())
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
-            if (tileRequested.getSource() != null) currentsources.add(tileRequested.getSource());
-            if (REGEX.matcher(tileId).matches()) currentsources.add(ComponentSource.uncharted_space);
-            if (PATTERN.matcher(tileId).matches()) currentsources.add(ComponentSource.eronous);
-            MiltyDraftHelper.initDraftTiles(this, new ArrayList<>(currentsources));
-            result = all.stream()
-                    .filter(t -> t.getTile().getTileID().equals(tileId))
-                    .findFirst()
-                    .orElseThrow();
-        }
-        return result;
     }
 }

--- a/src/main/java/ti4/service/milty/MiltyDraftSpec.java
+++ b/src/main/java/ti4/service/milty/MiltyDraftSpec.java
@@ -1,4 +1,4 @@
-package ti4.service.draft;
+package ti4.service.milty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,10 +11,9 @@ import ti4.helpers.settingsFramework.menus.SourceSettings;
 import ti4.map.Game;
 import ti4.model.MapTemplateModel;
 import ti4.model.Source;
-import ti4.service.milty.MiltyDraftSlice;
 
 @Data
-public class DraftSpec {
+public class MiltyDraftSpec {
     public Game game;
     public List<String> playerIDs, bannedFactions, priorityFactions, playerDraftOrder;
     public MapTemplateModel template;
@@ -30,7 +29,7 @@ public class DraftSpec {
     // other
     public List<MiltyDraftSlice> presetSlices;
 
-    public DraftSpec(Game game) {
+    public MiltyDraftSpec(Game game) {
         this.game = game;
         playerIDs = new ArrayList<>(game.getPlayerIDs());
         bannedFactions = new ArrayList<>();
@@ -46,9 +45,9 @@ public class DraftSpec {
         factionSources = new ArrayList<>(tileSources);
     }
 
-    public static DraftSpec CreateFromMiltySettings(MiltySettings settings) {
+    public static MiltyDraftSpec CreateFromMiltySettings(MiltySettings settings) {
         Game game = settings.getGame();
-        DraftSpec specs = new DraftSpec(game);
+        MiltyDraftSpec specs = new MiltyDraftSpec(game);
 
         // Load Game Specifications
         GameSettings gameSettings = settings.getGameSettings();

--- a/src/main/java/ti4/service/milty/MiltyService.java
+++ b/src/main/java/ti4/service/milty/MiltyService.java
@@ -2,89 +2,24 @@ package ti4.service.milty;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-import lombok.Data;
 import lombok.experimental.UtilityClass;
-import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
-import org.apache.commons.lang3.StringUtils;
-import ti4.buttons.Buttons;
-import ti4.commands.tokens.AddTokenCommand;
-import ti4.helpers.AliasHandler;
 import ti4.helpers.ButtonHelper;
-import ti4.helpers.ButtonHelperAbilities;
-import ti4.helpers.ButtonHelperHeroes;
-import ti4.helpers.ColorChangeHelper;
-import ti4.helpers.Constants;
-import ti4.helpers.PromissoryNoteHelper;
 import ti4.helpers.TIGLHelper;
-import ti4.helpers.ThreadArchiveHelper;
-import ti4.helpers.TitlesHelper;
-import ti4.helpers.Units;
-import ti4.helpers.settingsFramework.menus.GameSettings;
 import ti4.helpers.settingsFramework.menus.MiltySettings;
-import ti4.helpers.settingsFramework.menus.PlayerFactionSettings;
-import ti4.helpers.settingsFramework.menus.SliceGenerationSettings;
-import ti4.helpers.settingsFramework.menus.SourceSettings;
 import ti4.image.Mapper;
-import ti4.image.PositionMapper;
 import ti4.map.Game;
-import ti4.map.Player;
-import ti4.map.Tile;
 import ti4.map.persistence.GameManager;
 import ti4.message.MessageHelper;
 import ti4.model.FactionModel;
-import ti4.model.MapTemplateModel;
-import ti4.model.Source;
-import ti4.model.TechnologyModel;
-import ti4.service.PlanetService;
-import ti4.service.emoji.MiscEmojis;
-import ti4.service.info.AbilityInfoService;
-import ti4.service.info.CardsInfoService;
-import ti4.service.info.LeaderInfoService;
-import ti4.service.info.SecretObjectiveInfoService;
-import ti4.service.info.TechInfoService;
-import ti4.service.info.UnitInfoService;
-import ti4.service.planet.AddPlanetService;
-import ti4.service.tech.ListTechService;
+import ti4.service.draft.DraftSpec;
+import ti4.service.draft.DraftTileManager;
 
 @UtilityClass
 public class MiltyService {
-
-    public static void offerKeleresSetupButtons(MiltyDraftManager manager, Player player) {
-        List<String> flavors = List.of("mentak", "xxcha", "argent");
-        List<Button> keleresPresets = new ArrayList<>();
-        boolean warn = false;
-        for (String f : flavors) {
-            if (manager.isFactionTaken(f)) continue;
-
-            FactionModel model = Mapper.getFaction(f);
-            String id = "draftPresetKeleres_" + f;
-            String label = StringUtils.capitalize(f);
-            if (manager.getFactionDraft().contains(f)) {
-                keleresPresets.add(Buttons.gray(id, label + " 🛑", model.getFactionEmoji()));
-                warn = true;
-            } else {
-                keleresPresets.add(Buttons.green(id, label, model.getFactionEmoji()));
-            }
-        }
-
-        String message = player.getPing()
-                + " Pre-select which flavor of Keleres to play in this game by clicking one of these buttons!";
-        message += " You can change your decision later by clicking a different button.";
-        if (warn)
-            message +=
-                    "\n- 🛑 Some of these factions are in the draft! 🛑 If you preset them and they get chosen, then the preset will be cancelled.";
-        MessageHelper.sendMessageToChannelWithButtonsAndNoUndo(player.getCardsInfoThread(), message, keleresPresets);
-    }
-
     public static String startFromSettings(GenericInteractionCreateEvent event, MiltySettings settings) {
         Game game = settings.getGame();
-        DraftSpec specs = new DraftSpec(game);
 
         // Load the general game settings
         boolean success = game.loadGameSettingsFromSettings(event, settings);
@@ -93,47 +28,7 @@ public class MiltyService {
             TIGLHelper.sendTIGLSetupText(game);
         }
 
-        // Load Game Specifications
-        GameSettings gameSettings = settings.getGameSettings();
-        specs.setTemplate(gameSettings.getMapTemplate().getValue());
-
-        // Load Slice Generation Specifications
-        SliceGenerationSettings sliceSettings = settings.getSliceSettings();
-        specs.numFactions = sliceSettings.getNumFactions().getVal();
-        specs.numSlices = sliceSettings.getNumSlices().getVal();
-        specs.anomaliesCanTouch = false;
-        specs.extraWHs = sliceSettings.getExtraWorms().isVal();
-        specs.minLegend = sliceSettings.getNumLegends().getValLow();
-        specs.maxLegend = sliceSettings.getNumLegends().getValHigh();
-        specs.minTot = sliceSettings.getTotalValue().getValLow();
-        specs.maxTot = sliceSettings.getTotalValue().getValHigh();
-
-        // Load Player & Faction Ban Specifications
-        PlayerFactionSettings pfSettings = settings.getPlayerSettings();
-        specs.bannedFactions.addAll(pfSettings.getBanFactions().getKeys());
-        if (game.isThundersEdge()) {
-            List<String> newKeys = new ArrayList<>();
-            newKeys.addAll(List.of("arborec", "ghost", "letnev", "winnu", "muaat", "yin"));
-            specs.priorityFactions.addAll(newKeys);
-            specs.numFactions = Math.min(6, specs.numFactions);
-        } else {
-            specs.priorityFactions.addAll(pfSettings.getPriFactions().getKeys());
-        }
-        specs.setPlayerIDs(new ArrayList<>(pfSettings.getGamePlayers().getKeys()));
-        if (pfSettings.getPresetDraftOrder().isVal()) {
-            specs.playerDraftOrder = new ArrayList<>(game.getPlayers().keySet());
-        }
-
-        // Load Sources Specifications
-        SourceSettings sources = settings.getSourceSettings();
-        specs.setTileSources(sources.getTileSources());
-        specs.setFactionSources(sources.getFactionSources());
-
-        if (sliceSettings.getParsedSlices() != null) {
-            if (sliceSettings.getParsedSlices().size() < specs.playerIDs.size())
-                return "Not enough slices for the number of players. Please remove the preset slice string or include enough slices";
-            specs.presetSlices = sliceSettings.getParsedSlices();
-        }
+        DraftSpec specs = DraftSpec.CreateFromMiltySettings(settings);
 
         return startFromSpecs(event, specs);
     }
@@ -141,9 +36,16 @@ public class MiltyService {
     public static String startFromSpecs(GenericInteractionCreateEvent event, DraftSpec specs) {
         Game game = specs.game;
 
-        // Milty Draft Manager Setup --------------------------------------------------------------
+        if (specs.presetSlices != null) {
+            if (specs.presetSlices.size() < specs.playerIDs.size())
+                return "Not enough slices for the number of players. Please remove the preset slice string or include enough slices";
+        }
+
+        // Milty Draft Manager Setup
+        // --------------------------------------------------------------
+        DraftTileManager tileManager = game.getDraftTileManager();
+        tileManager.addAllDraftTiles(specs.tileSources);
         MiltyDraftManager draftManager = game.getMiltyDraftManager();
-        draftManager.init(specs.tileSources);
         draftManager.setMapTemplate(specs.template.getAlias());
         game.setMapTemplateID(specs.template.getAlias());
         List<String> players = new ArrayList<>(specs.playerIDs);
@@ -166,8 +68,8 @@ public class MiltyService {
         draftManager.setFactionDraft(factionDraft);
 
         // validate slice count + sources
-        int redTiles = draftManager.getRed().size();
-        int blueTiles = draftManager.getBlue().size();
+        int redTiles = tileManager.getRed().size();
+        int blueTiles = tileManager.getBlue().size();
         int maxSlices = Math.min(redTiles / 2, blueTiles / 3);
         if (specs.numSlices > maxSlices) {
             String msg = "Milty draft in this bot does not support " + specs.numSlices
@@ -199,7 +101,7 @@ public class MiltyService {
             DraftDisplayService.repostDraftInformation(draftManager, game);
         } else {
             event.getMessageChannel().sendMessage(startMsg).queue((ignore) -> {
-                boolean slicesCreated = GenerateSlicesService.generateSlices(event, draftManager, specs);
+                boolean slicesCreated = GenerateSlicesService.generateSlices(event, tileManager, draftManager, specs);
                 if (!slicesCreated) {
                     String msg = "Generating slices was too hard so I gave up.... Please try again.";
                     if (specs.numSlices == maxSlices) {
@@ -256,454 +158,5 @@ public class MiltyService {
         MiltySettings menu = game.initializeMiltySettings();
         menu.postMessageAndButtons(event);
         ButtonHelper.deleteMessage(event);
-    }
-
-    @Data
-    public static class DraftSpec {
-        Game game;
-        List<String> playerIDs, bannedFactions, priorityFactions, playerDraftOrder;
-        MapTemplateModel template;
-        List<Source.ComponentSource> tileSources, factionSources;
-        Integer numSlices, numFactions;
-
-        // slice generation settings
-        Boolean anomaliesCanTouch = false, extraWHs = true;
-        Double minRes = 2.0, minInf = 3.0;
-        Integer minTot = 9, maxTot = 13;
-        Integer minLegend = 1, maxLegend = 2;
-
-        // other
-        List<MiltyDraftSlice> presetSlices;
-
-        public DraftSpec(Game game) {
-            this.game = game;
-            playerIDs = new ArrayList<>(game.getPlayerIDs());
-            bannedFactions = new ArrayList<>();
-            priorityFactions = new ArrayList<>();
-
-            tileSources = new ArrayList<>();
-            tileSources.add(Source.ComponentSource.base);
-            tileSources.add(Source.ComponentSource.pok);
-            tileSources.add(Source.ComponentSource.codex1);
-            tileSources.add(Source.ComponentSource.codex2);
-            tileSources.add(Source.ComponentSource.codex3);
-            tileSources.add(Source.ComponentSource.codex4);
-            factionSources = new ArrayList<>(tileSources);
-        }
-    }
-
-    public static void secondHalfOfPlayerSetup(
-            Player player,
-            Game game,
-            String color,
-            String faction,
-            String positionHS,
-            GenericInteractionCreateEvent event,
-            boolean setSpeaker) {
-        Map<String, Player> players = game.getPlayers();
-        ThreadArchiveHelper.checkThreadLimitAndArchive(event.getGuild());
-        for (Player playerInfo : players.values()) {
-            if (playerInfo != player) {
-                if (color.equals(playerInfo.getColor())) {
-                    String newColor = player.getNextAvailableColour();
-                    String message = "Player:" + playerInfo.getUserName() + " already uses color:" + color
-                            + " - changing color to " + newColor;
-                    MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
-                    return;
-                } else if (faction.equals(playerInfo.getFaction())) {
-                    MessageHelper.sendMessageToChannel(
-                            event.getMessageChannel(),
-                            "Setup Failed - Player:" + playerInfo.getUserName() + " already uses faction:" + faction);
-                    return;
-                }
-                if ("franken1".equalsIgnoreCase(faction) || "franken2".equalsIgnoreCase(faction)) {
-                    MessageHelper.sendMessageToChannel(
-                            event.getMessageChannel(),
-                            "Setup Failed - Franken1 and Franken2 have issues and should not be used by anyone going forward. Try a different franken number");
-                    return;
-                }
-            }
-        }
-
-        if (ColorChangeHelper.colorIsExclusive(color, player)) {
-            color = player.getNextAvailableColorIgnoreCurrent();
-        }
-
-        if (player.isRealPlayer() && player.getSo() > 0) {
-            String message = player.getRepresentationNoPing()
-                    + "has secret objectives that would get lost to the void if they were setup again."
-                    + " If they wish to change color, use `/player change_color`. If they wish to setup as another faction, they must discard their secret objective first.";
-            MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
-            SecretObjectiveInfoService.sendSecretObjectiveInfo(game, player);
-            return;
-        }
-
-        player.setColor(color);
-        player.setFaction(game, faction);
-        player.setFactionEmoji(null);
-        player.getPlanets().clear();
-        player.getTechs().clear();
-        player.getFactionTechs().clear();
-
-        FactionModel factionModel = player.getFactionSetupInfo();
-
-        if (game.isBaseGameMode()) {
-            player.setLeaders(new ArrayList<>());
-        }
-
-        if (factionModel.getSource() == Source.ComponentSource.miltymod && !game.isMiltyModMode()) {
-            MessageHelper.sendMessageToChannel(
-                    event.getMessageChannel(),
-                    "MiltyMod factions are a Homebrew Faction. Please enable the MiltyMod Game Mode first if you wish to use MiltyMod factions");
-            return;
-        }
-
-        // BREAKTHROUGH
-        if (game.isThundersEdge() && Mapper.getBreakthrough(factionModel.getAlias() + "bt") != null) {
-            player.setBreakthroughID(factionModel.getAlias() + "bt");
-            player.setBreakthroughUnlocked(false);
-            player.setBreakthroughExhausted(false);
-            player.setBreakthroughActive(false);
-            player.setBreakthroughTGs(0);
-        }
-
-        // HOME SYSTEM
-        if (!PositionMapper.isTilePositionValid(positionHS)) {
-            MessageHelper.sendMessageToChannel(
-                    event.getMessageChannel(), "Tile position: `" + positionHS + "` is not valid. Stopping Setup.");
-            return;
-        }
-
-        String hsTile = AliasHandler.resolveTile(factionModel.getHomeSystem());
-        Tile tile = new Tile(hsTile, positionHS);
-        if (!StringUtils.isBlank(hsTile)) {
-            game.setTile(tile);
-        }
-
-        // String statsAnchor = PositionMapper.getEquivalentPositionAtRing(game.getRingCount(), positionHS);
-        player.setPlayerStatsAnchorPosition(positionHS);
-
-        // HANDLE GHOSTS' HOME SYSTEM LOCATION
-        if ("ghost".equals(faction) || "miltymod_ghost".equals(faction)) {
-            tile.addToken(Mapper.getTokenID(Constants.FRONTIER), Constants.SPACE);
-            String pos = "tr";
-            if ("307".equalsIgnoreCase(positionHS) || "310".equalsIgnoreCase(positionHS)) {
-                pos = "br";
-            }
-            if ("313".equalsIgnoreCase(positionHS) || "316".equalsIgnoreCase(positionHS)) {
-                pos = "bl";
-            }
-            tile = new Tile("51", pos);
-            game.setTile(tile);
-        }
-
-        // STARTING COMMODITIES
-        player.setCommoditiesBase(factionModel.getCommodities());
-
-        // STARTING PLANETS
-        for (String planet : factionModel.getHomePlanets()) {
-            if (planet.isEmpty()) {
-                continue;
-            }
-            String planetResolved = AliasHandler.resolvePlanet(planet.toLowerCase());
-            AddPlanetService.addPlanet(player, planetResolved, game, event, true);
-            player.refreshPlanet(planetResolved);
-        }
-
-        player.getExhaustedPlanets().clear();
-
-        // STARTING UNITS
-        addUnits(factionModel, tile, color, event);
-
-        // STARTING TECH
-        List<String> startingTech = factionModel.getStartingTech();
-        if (startingTech != null) {
-            for (String tech : factionModel.getStartingTech()) {
-                if (tech.trim().isEmpty()) {
-                    continue;
-                }
-                player.addTech(tech);
-            }
-        }
-
-        Map<String, TechnologyModel> techReplacements = Mapper.getHomebrewTechReplaceMap(game.getTechnologyDeckID());
-        List<String> playerTechs = new ArrayList<>(player.getTechs());
-        for (String tech : playerTechs) {
-            TechnologyModel model = techReplacements.getOrDefault(tech, Mapper.getTech(tech));
-            if (!playerTechs.contains(model.getAlias())) {
-                player.addTech(model.getAlias());
-                player.removeTech(tech);
-            }
-        }
-
-        for (String tech : factionModel.getFactionTech()) {
-            if (tech.trim().isEmpty()) continue;
-
-            TechnologyModel factionTech = techReplacements.getOrDefault(tech, Mapper.getTech(tech));
-            player.addFactionTech(factionTech.getAlias());
-        }
-
-        if (setSpeaker) {
-            game.setSpeakerUserID(player.getUserID());
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    MiscEmojis.SpeakerToken + " Speaker assigned to: " + player.getRepresentation());
-        }
-
-        // STARTING PNs
-        player.initPNs();
-        Set<String> playerPNs = new HashSet<>(player.getPromissoryNotes().keySet());
-        playerPNs.addAll(factionModel.getPromissoryNotes());
-        player.setPromissoryNotesOwned(playerPNs);
-        if (game.isBaseGameMode()) {
-            Set<String> pnsOwned = new HashSet<>(player.getPromissoryNotesOwned());
-            for (String pnID : pnsOwned) {
-                if (pnID.endsWith("_an")
-                        && "Alliance".equals(Mapper.getPromissoryNote(pnID).getName())) {
-                    player.removeOwnedPromissoryNoteByID(pnID);
-                }
-            }
-        }
-        if (game.isAbsolMode()) {
-            Set<String> pnsOwned = new HashSet<>(player.getPromissoryNotesOwned());
-            for (String pnID : pnsOwned) {
-                if (pnID.endsWith("_ps")
-                        && "Political Secret"
-                                .equals(Mapper.getPromissoryNote(pnID).getName())) {
-                    player.removeOwnedPromissoryNoteByID(pnID);
-                    player.addOwnedPromissoryNoteByID("absol_" + pnID);
-                }
-            }
-        }
-
-        // STARTING OWNED UNITS
-        Set<String> playerOwnedUnits = new HashSet<>(factionModel.getUnits());
-        player.setUnitsOwned(playerOwnedUnits);
-
-        // Don't do special stuff if Franken Faction
-        if (faction.startsWith("franken")) {
-            return;
-        }
-
-        // SEND STUFF
-        MessageHelper.sendMessageToPlayerCardsInfoThread(player, factionModel.getFactionSheetMessage());
-        AbilityInfoService.sendAbilityInfo(player, event);
-        TechInfoService.sendTechInfo(game, player, event);
-        LeaderInfoService.sendLeadersInfo(game, player, event);
-        UnitInfoService.sendUnitInfo(game, player, event, false);
-        PromissoryNoteHelper.sendPromissoryNoteInfo(game, player, false, event);
-
-        if (player.getTechs().isEmpty() && !player.getFaction().contains("sardakk")) {
-            if (player.getFaction().contains("keleres")) {
-                Button getTech = Buttons.green("getKeleresTechOptions", "Get Keleres Technology Options");
-                String msg = player.getRepresentationUnfogged()
-                        + " after every other faction gets their starting technologies,"
-                        + " press this button to for Keleres to get their starting technologies.";
-                MessageHelper.sendMessageToChannelWithButton(player.getCorrectChannel(), msg, getTech);
-            } else {
-                // STARTING TECH OPTIONS
-                Integer bonusOptions = factionModel.getStartingTechAmount();
-                List<String> startingTechOptions = factionModel.getStartingTechOptions();
-                if (startingTechOptions != null && bonusOptions != null && bonusOptions > 0) {
-                    List<TechnologyModel> techs = new ArrayList<>();
-                    if (!startingTechOptions.isEmpty()) {
-                        for (String tech : game.getTechnologyDeck()) {
-                            TechnologyModel model = Mapper.getTech(tech);
-                            boolean homebrewReplacesAnOption = model.getHomebrewReplacesID()
-                                    .map(startingTechOptions::contains)
-                                    .orElse(false);
-                            if (startingTechOptions.contains(model.getAlias()) || homebrewReplacesAnOption) {
-                                techs.add(model);
-                            }
-                        }
-                    }
-
-                    List<Button> buttons = ListTechService.getTechButtons(techs, player, "free");
-                    String msg =
-                            player.getRepresentationUnfogged() + " use the buttons to choose your starting technology:";
-                    if (techs.isEmpty()) {
-                        buttons = List.of(Buttons.GET_A_FREE_TECH, Buttons.DONE_DELETE_BUTTONS);
-                        MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), msg, buttons);
-                    } else {
-                        for (int x = 0; x < bonusOptions; x++) {
-                            MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), msg, buttons);
-                        }
-                    }
-                }
-            }
-        }
-
-        for (String fTech : player.getFactionTechs()) {
-            if (!game.getTechnologyDeck().contains(fTech) && fTech.contains("ds")) {
-                game.setTechnologyDeckID("techs_ds");
-                break;
-            }
-        }
-
-        if (player.hasAbility("diplomats")) {
-            ButtonHelperAbilities.resolveFreePeopleAbility(game);
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    "Set up **Free People** ability markers. " + player.getRepresentationUnfogged()
-                            + " any planet with a **Free People** token on it will show up as spendable in your various spends. Once spent, the token will be removed.");
-        }
-        if (player.hasAbility("ancient_empire")) {
-            List<Button> buttons = new ArrayList<>();
-            buttons.add(Buttons.green("startAncientEmpire", "Place a tomb token"));
-            MessageHelper.sendMessageToChannelWithButtons(
-                    player.getCorrectChannel(),
-                    player.getRepresentation() + ", please place up to 14 Tomb tokens for **Ancient Empire**.",
-                    buttons);
-        }
-
-        if (player.hasAbility("private_fleet")) {
-            String unitID = AliasHandler.resolveUnit("destroyer");
-            player.setUnitCap(unitID, 12);
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    "Set destroyer max to 12 for " + player.getRepresentation()
-                            + ", due to the **Private Fleet** ability,");
-        }
-        if (player.hasAbility("industrialists")) {
-            String unitID = AliasHandler.resolveUnit("spacedock");
-            player.setUnitCap(unitID, 4);
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    "Set space dock max to 4 for " + player.getRepresentation()
-                            + ", due to the **Industrialists** ability,");
-        }
-        if (player.hasAbility("teeming")) {
-            String unitID = AliasHandler.resolveUnit("dreadnought");
-            player.setUnitCap(unitID, 7);
-            unitID = AliasHandler.resolveUnit("mech");
-            player.setUnitCap(unitID, 5);
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    "Set dreadnought unit max to 7 and mech unit max to 5 for " + player.getRepresentation()
-                            + ", due to the **Teeming** ability.");
-        }
-        if (player.hasAbility("machine_cult")) {
-            String unitID = AliasHandler.resolveUnit("mech");
-            player.setUnitCap(unitID, 6);
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    "Set mech unit maximum to 6 for " + player.getRepresentation()
-                            + ", due to their **Machine Cult** ability.");
-        }
-        if (game.isAgeOfFightersMode()) {
-            String tech = "ff2";
-            for (String factionTech : player.getNotResearchedFactionTechs()) {
-                TechnologyModel fTech = Mapper.getTech(factionTech);
-                if (fTech != null
-                        && !fTech.getAlias()
-                                .equalsIgnoreCase(Mapper.getTech(tech).getAlias())
-                        && fTech.isUnitUpgrade()
-                        && fTech.getBaseUpgrade()
-                                .orElse("bleh")
-                                .equalsIgnoreCase(Mapper.getTech(tech).getAlias())) {
-                    tech = fTech.getAlias();
-                    break;
-                }
-            }
-            player.addTech(tech);
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    player.getRepresentation() + " gained the "
-                            + Mapper.getTech(tech).getNameRepresentation()
-                            + " technology due to the _Age of Fighters_ galactic event.");
-        }
-        if (game.isStellarAtomicsMode()) {
-            if (game.getRevealedPublicObjectives().get("Stellar Atomics") != null) {
-                int stellarID = game.getRevealedPublicObjectives().get("Stellar Atomics");
-                game.scorePublicObjective(player.getUserID(), stellarID);
-            } else {
-                int poIndex = game.addCustomPO("Stellar Atomics", 0);
-                for (Player playerWL : game.getRealPlayers()) {
-                    game.scorePublicObjective(playerWL.getUserID(), poIndex);
-                }
-            }
-        }
-        if (player.hasAbility("policies")) {
-            player.removeAbility("policies");
-            player.addAbility("policy_the_people_connect");
-            player.addAbility("policy_the_environment_preserve");
-            player.addAbility("policy_the_economy_empower");
-            player.removeOwnedUnitByID("olradin_mech");
-            player.addOwnedUnitByID("olradin_mech_positive");
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    player.getRepresentationUnfogged()
-                            + ", I have automatically set all of your Policies to the positive side, but you can flip any of them now with these buttons.");
-            ButtonHelperHeroes.offerOlradinHeroFlips(game, player);
-            ButtonHelperHeroes.offerOlradinHeroFlips(game, player);
-            ButtonHelperHeroes.offerOlradinHeroFlips(game, player);
-        }
-        if (player.hasAbility("oracle_ai")) {
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    player.getRepresentationUnfogged()
-                            + " you may peek at the next objective in your `#cards-info` thread (by your promissory note). "
-                            + "This holds true for anyone with _Read the Fates_. Don't do this until after secret objectives are dealt and discarded.");
-        }
-        CardsInfoService.sendVariousAdditionalButtons(game, player);
-
-        if (!game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(
-                    game.getMainGameChannel(), "Player: " + player.getRepresentation() + " has been set up");
-        } else {
-            MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Player was set up.");
-        }
-
-        if (!game.isFowMode()) {
-            StringBuilder sb = TitlesHelper.getPlayerTitles(player.getUserID(), player.getUserName(), false);
-            if (!sb.toString().contains("No titles yet")) {
-                String msg = "In previous games, " + player.getUserName() + " has earned the titles of: \n" + sb;
-                MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msg);
-            }
-        }
-        if ("d11".equalsIgnoreCase(hsTile)) {
-            AddTokenCommand.addToken(event, tile, Constants.FRONTIER, game);
-        }
-        if ("true".equalsIgnoreCase(game.getStoredValue("removeSupports"))) {
-            player.removeOwnedPromissoryNoteByID(player.getColor() + "_sftt");
-            player.removePromissoryNote(player.getColor() + "_sftt");
-        }
-    }
-
-    private static void addUnits(FactionModel setupInfo, Tile tile, String color, GenericInteractionCreateEvent event) {
-        String units = setupInfo.getStartingFleet();
-        units = units.replace(", ", ",");
-        StringTokenizer tokenizer = new StringTokenizer(units, ",");
-        while (tokenizer.hasMoreTokens()) {
-            StringTokenizer unitInfoTokenizer = new StringTokenizer(tokenizer.nextToken(), " ");
-
-            int count = 1;
-            boolean numberIsSet = false;
-            String planetName = Constants.SPACE;
-            String unit = "";
-            if (unitInfoTokenizer.hasMoreTokens()) {
-                String ifNumber = unitInfoTokenizer.nextToken();
-                try {
-                    count = Integer.parseInt(ifNumber);
-                    numberIsSet = true;
-                } catch (Exception e) {
-                    unit = AliasHandler.resolveUnit(ifNumber);
-                }
-            }
-            if (unitInfoTokenizer.hasMoreTokens() && numberIsSet) {
-                unit = AliasHandler.resolveUnit(unitInfoTokenizer.nextToken());
-            }
-            Units.UnitKey unitID = Mapper.getUnitKey(unit, color);
-            if (unitID == null) {
-                MessageHelper.sendMessageToChannel(
-                        event.getMessageChannel(), "Unit: " + unit + " is not valid and not supported.");
-                continue;
-            }
-            if (unitInfoTokenizer.hasMoreTokens()) {
-                planetName = AliasHandler.resolvePlanet(unitInfoTokenizer.nextToken());
-            }
-            planetName = PlanetService.getPlanet(tile, planetName);
-            tile.addUnit(planetName, unitID, count);
-        }
     }
 }

--- a/src/main/java/ti4/service/milty/MiltyService.java
+++ b/src/main/java/ti4/service/milty/MiltyService.java
@@ -13,7 +13,6 @@ import ti4.map.Game;
 import ti4.map.persistence.GameManager;
 import ti4.message.MessageHelper;
 import ti4.model.FactionModel;
-import ti4.service.draft.DraftSpec;
 import ti4.service.draft.DraftTileManager;
 
 @UtilityClass
@@ -28,12 +27,12 @@ public class MiltyService {
             TIGLHelper.sendTIGLSetupText(game);
         }
 
-        DraftSpec specs = DraftSpec.CreateFromMiltySettings(settings);
+        MiltyDraftSpec specs = MiltyDraftSpec.CreateFromMiltySettings(settings);
 
         return startFromSpecs(event, specs);
     }
 
-    public static String startFromSpecs(GenericInteractionCreateEvent event, DraftSpec specs) {
+    public static String startFromSpecs(GenericInteractionCreateEvent event, MiltyDraftSpec specs) {
         Game game = specs.game;
 
         if (specs.presetSlices != null) {


### PR DESCRIPTION
This PR should have no functional impact, it's just some organizing I thought would be helpful for future changes.

Separates various drafting concepts a bit more cleanly:
- Milty Service: Only for setting up a draft
- Milty Draft Manager: Only for managing an active draft

New files:
- Draft Tile Manager: Handles what tiles could be used to set up a game
- Draft Slice Helper: Utility functions for loading slices
- Faction Extra Setup Service: Faction stuff that drafting needs to integrate with (Keleres)
- Player Setup Service: Actually set up a player

The tile-related "init" methods meant either "add all" or "clear then add all" depending on context, so I've tried to name them more specifically.