### PR TITLE
Update ghemina commander to match newest version

### DIFF
--- a/src/main/resources/data/leaders/ds.json
+++ b/src/main/resources/data/leaders/ds.json
@@ -547,7 +547,7 @@
         "type": "commander",
         "name": "Jarl Vel & Jarl Jotrun",
         "title": "Raid Leaders",
-        "abilityWindow": "After you win a space combat in a system that contains no planets or a planet with a structure",
+        "abilityWindow": "After you win a space combat in a system that contains no planets or on a planet with a structure",
         "abilityText": "You may gain 1 trade good.",
         "unlockCondition": "Have 2 flagships on the game board.",
         "source": "ds",


### PR DESCRIPTION
Discordant Stars Reference document posted by tactic blue has the most up to date information on each faction and thus the bot should reflect this