### PR TITLE
Track Dragon Hoard achievements

### DIFF
--- a/src/main/java/ti4/spring/service/achievement/PlayerAchievement.java
+++ b/src/main/java/ti4/spring/service/achievement/PlayerAchievement.java
@@ -1,0 +1,58 @@
+package ti4.spring.service.achievement;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "player_achievement",
+        uniqueConstraints =
+                @UniqueConstraint(columnNames = {"user_id", "achievement_key", "game_mode"}))
+public class PlayerAchievement {
+
+    PlayerAchievement(
+            String userId, String userName, String achievementKey, String achievementName, String gameMode) {
+        this.userId = userId;
+        this.userName = userName;
+        this.achievementKey = achievementKey;
+        this.achievementName = achievementName;
+        this.gameMode = gameMode;
+        this.count = 0;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "user_name", nullable = false)
+    private String userName;
+
+    @Column(name = "achievement_key", nullable = false)
+    private String achievementKey;
+
+    @Column(name = "achievement_name", nullable = false)
+    private String achievementName;
+
+    @Column(name = "game_mode", nullable = false)
+    private String gameMode;
+
+    @Column(name = "count", nullable = false)
+    private int count;
+
+    void incrementCount(String latestUserName) {
+        this.userName = latestUserName;
+        this.count++;
+    }
+}

--- a/src/main/java/ti4/spring/service/achievement/PlayerAchievementRepository.java
+++ b/src/main/java/ti4/spring/service/achievement/PlayerAchievementRepository.java
@@ -1,0 +1,9 @@
+package ti4.spring.service.achievement;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayerAchievementRepository extends JpaRepository<PlayerAchievement, Long> {
+    Optional<PlayerAchievement> findByUserIdAndAchievementKeyAndGameMode(
+            String userId, String achievementKey, String gameMode);
+}

--- a/src/main/java/ti4/spring/service/achievement/PlayerAchievementService.java
+++ b/src/main/java/ti4/spring/service/achievement/PlayerAchievementService.java
@@ -1,0 +1,51 @@
+package ti4.spring.service.achievement;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ti4.map.Game;
+import ti4.map.Player;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerAchievementService {
+
+    public static final String DRAGON_HOARD_KEY = "DRAGON_HOARD";
+    public static final String DRAGON_HOARD_NAME = "Dragon Hoard";
+
+    private final PlayerAchievementRepository playerAchievementRepository;
+
+    @Transactional
+    public void recordDragonHoard(Player player, Game game) {
+        if (player == null || game == null) {
+            return;
+        }
+        String gameMode = resolveGameMode(game);
+        recordAchievement(player, DRAGON_HOARD_KEY, DRAGON_HOARD_NAME, gameMode);
+    }
+
+    private void recordAchievement(Player player, String achievementKey, String achievementName, String gameMode) {
+        PlayerAchievement achievement = playerAchievementRepository
+                .findByUserIdAndAchievementKeyAndGameMode(player.getUserID(), achievementKey, gameMode)
+                .orElseGet(() -> new PlayerAchievement(
+                        player.getUserID(), player.getUserName(), achievementKey, achievementName, gameMode));
+        achievement.incrementCount(player.getUserName());
+        playerAchievementRepository.save(achievement);
+    }
+
+    private String resolveGameMode(Game game) {
+        if (game.isThundersEdge()) {
+            return "TE";
+        }
+        if (game.isDiscordantStarsMode()) {
+            return "DS";
+        }
+        if (game.isAbsolMode()) {
+            return "Absol";
+        }
+        if (game.hasHomebrew()) {
+            return "other homebrew";
+        }
+        return game.isBaseGameMode() ? "base" : "PoK";
+    }
+}


### PR DESCRIPTION
## Summary
- add a persistent PlayerAchievement entity, repository, and service for tracking achievement counts by game mode
- categorize supported game modes (Base, PoK, TE, DS, Absol, other homebrew) for achievement storage
- award the Dragon Hoard achievement to winners with at least 40 unspent trade goods during end-game processing

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download parent POM due to 403 from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e048c78ee0832d980951cb45d410e0