### PR TITLE
Nucleus demo fixes

### DIFF
--- a/src/main/java/ti4/helpers/thundersedge/TeHelperDemo.java
+++ b/src/main/java/ti4/helpers/thundersedge/TeHelperDemo.java
@@ -1,0 +1,11 @@
+package ti4.helpers.thundersedge;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TeHelperDemo {
+    @Getter
+    private static final List<String> ExcludedFactions = List.of("titans", "keleresm", "cabal", "argent");
+}

--- a/src/main/java/ti4/service/draft/DraftSetupService.java
+++ b/src/main/java/ti4/service/draft/DraftSetupService.java
@@ -67,7 +67,11 @@ public class DraftSetupService {
 
         FactionDraftable factionDraftable = new FactionDraftable();
         factionDraftable.initialize(
-                specs.numFactions, specs.factionSources, specs.priorityFactions, specs.bannedFactions);
+                specs.numFactions,
+                specs.factionSources,
+                specs.priorityFactions,
+                specs.bannedFactions,
+                game.isThundersEdge());
         draftManager.addDraftable(factionDraftable);
 
         SpeakerOrderDraftable speakerOrderDraftable = new SpeakerOrderDraftable();
@@ -157,9 +161,17 @@ public class DraftSetupService {
             return "Error: Could not find source settings.";
         }
 
+        List<ComponentSource> tileSources = new ArrayList<>(sourceSettings.getTileSources());
+        if (game.isDiscordantStarsMode() || game.isUnchartedSpaceStuff()) {
+            tileSources.add(ComponentSource.ds);
+            tileSources.add(ComponentSource.uncharted_space);
+        }
+        if (game.isThundersEdge() || !game.getStoredValue("useEntropicScar").isEmpty()) {
+            tileSources.add(ComponentSource.thunders_edge);
+        }
         DraftTileManager tileManager = game.getDraftTileManager();
         tileManager.clear();
-        tileManager.addAllDraftTiles(sourceSettings.getTileSources());
+        tileManager.addAllDraftTiles(tileSources);
 
         for (String draftableKey : settings.getDraftablesList().getKeys()) {
             Draftable draftable = DraftComponentFactory.createDraftable(draftableKey);

--- a/src/main/java/ti4/service/draft/DraftSpec.java
+++ b/src/main/java/ti4/service/draft/DraftSpec.java
@@ -10,6 +10,7 @@ import ti4.helpers.settingsFramework.menus.MiltySliceDraftableSettings;
 import ti4.helpers.settingsFramework.menus.PlayerFactionSettings;
 import ti4.helpers.settingsFramework.menus.SliceGenerationSettings;
 import ti4.helpers.settingsFramework.menus.SourceSettings;
+import ti4.helpers.thundersedge.TeHelperDemo;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.model.MapTemplateModel;
@@ -85,10 +86,8 @@ public class DraftSpec {
         PlayerFactionSettings pfSettings = settings.getPlayerSettings();
         specs.bannedFactions.addAll(pfSettings.getBanFactions().getKeys());
         if (game.isThundersEdge()) {
-            List<String> newKeys = new ArrayList<>();
-            newKeys.addAll(List.of("titans", "keleresm", "cabal", "argent"));
-            specs.bannedFactions.addAll(newKeys);
-            specs.numFactions = Math.min(25 - newKeys.size(), specs.numFactions);
+            specs.bannedFactions.addAll(TeHelperDemo.getExcludedFactions());
+            specs.numFactions = Math.min(25 - TeHelperDemo.getExcludedFactions().size(), specs.numFactions);
         }
 
         specs.priorityFactions.addAll(pfSettings.getPriFactions().getKeys());

--- a/src/main/java/ti4/service/milty/MiltyDraftSpec.java
+++ b/src/main/java/ti4/service/milty/MiltyDraftSpec.java
@@ -8,6 +8,7 @@ import ti4.helpers.settingsFramework.menus.MiltySettings;
 import ti4.helpers.settingsFramework.menus.PlayerFactionSettings;
 import ti4.helpers.settingsFramework.menus.SliceGenerationSettings;
 import ti4.helpers.settingsFramework.menus.SourceSettings;
+import ti4.helpers.thundersedge.TeHelperDemo;
 import ti4.map.Game;
 import ti4.model.MapTemplateModel;
 import ti4.model.Source;
@@ -68,10 +69,8 @@ public class MiltyDraftSpec {
         PlayerFactionSettings pfSettings = settings.getPlayerSettings();
         specs.bannedFactions.addAll(pfSettings.getBanFactions().getKeys());
         if (game.isThundersEdge()) {
-            List<String> newKeys = new ArrayList<>();
-            newKeys.addAll(List.of("titans", "keleres", "cabal", "argent"));
-            specs.bannedFactions.addAll(newKeys);
-            specs.numFactions = Math.min(25 - newKeys.size(), specs.numFactions);
+            specs.bannedFactions.addAll(TeHelperDemo.getExcludedFactions());
+            specs.numFactions = Math.min(25 - TeHelperDemo.getExcludedFactions().size(), specs.numFactions);
         }
         specs.priorityFactions.addAll(pfSettings.getPriFactions().getKeys());
         specs.setPlayerIDs(new ArrayList<>(pfSettings.getGamePlayers().getKeys()));

--- a/src/main/java/ti4/service/milty/MiltyService.java
+++ b/src/main/java/ti4/service/milty/MiltyService.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-import lombok.Data;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
@@ -37,7 +36,6 @@ import ti4.map.Tile;
 import ti4.map.persistence.GameManager;
 import ti4.message.MessageHelper;
 import ti4.model.FactionModel;
-import ti4.model.MapTemplateModel;
 import ti4.model.Source;
 import ti4.model.Source.ComponentSource;
 import ti4.model.TechnologyModel;
@@ -239,40 +237,6 @@ public class MiltyService {
         }
         menu.postMessageAndButtons(event);
         ButtonHelper.deleteMessage(event);
-    }
-
-    @Data
-    public static class DraftSpec {
-        Game game;
-        List<String> playerIDs, bannedFactions, priorityFactions, playerDraftOrder;
-        MapTemplateModel template;
-        List<Source.ComponentSource> tileSources, factionSources;
-        Integer numSlices, numFactions;
-
-        // slice generation settings
-        Boolean anomaliesCanTouch = false, extraWHs = true;
-        Double minRes = 2.0, minInf = 3.0;
-        Integer minTot = 9, maxTot = 13;
-        Integer minLegend = 1, maxLegend = 2;
-
-        // other
-        List<MiltyDraftSlice> presetSlices;
-
-        public DraftSpec(Game game) {
-            this.game = game;
-            playerIDs = new ArrayList<>(game.getPlayerIDs());
-            bannedFactions = new ArrayList<>();
-            priorityFactions = new ArrayList<>();
-
-            tileSources = new ArrayList<>();
-            tileSources.add(Source.ComponentSource.base);
-            tileSources.add(Source.ComponentSource.pok);
-            tileSources.add(Source.ComponentSource.codex1);
-            tileSources.add(Source.ComponentSource.codex2);
-            tileSources.add(Source.ComponentSource.codex3);
-            tileSources.add(Source.ComponentSource.codex4);
-            factionSources = new ArrayList<>(tileSources);
-        }
     }
 
     public static void secondHalfOfPlayerSetup(


### PR DESCRIPTION
- Moves the ban list to a single helper, so it only needs to be updated one place
- Adds TE tiles to Nucleus drafting; they get removed by the settings integration
- Remove the **third** DraftSpec class that snuck in when merging in some changes

I hit "Start Draft" w/ 15 factions a bunch of times to make sure I did it right, both for Nucleus and Milty