### PR TITLE
Count X89c4 for player stats area

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -2360,7 +2360,7 @@ public class ButtonHelper {
                         hitChance = 1 - ((1 - hitChance) * (1 - hitChance));
                     }
                     float combatValue = removedUnit.getBombardDieCount() * hitChance * uh.getUnitCount(unit);
-                    if(player.hasTech("x89c4")) {
+                    if (player.hasTech("x89c4")) {
                         combatValue *= 2.0f;
                     }
                     count += combatValue;


### PR DESCRIPTION
Without X-89, Mentak's starting infantry average 1.2 hits. With X-89, it's 2.4 hits. This PR ensures the player area shows that upgrade correctly:
<img width="473" height="306" alt="image" src="https://github.com/user-attachments/assets/7c9725f6-08a5-4bf7-9600-94a42988e996" />
