### PR TITLE
Add cron to publish abbreviated dashboard updates

### DIFF
--- a/src/main/java/ti4/cron/AbbreviatedDashboardCron.java
+++ b/src/main/java/ti4/cron/AbbreviatedDashboardCron.java
@@ -1,0 +1,49 @@
+package ti4.cron;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.experimental.UtilityClass;
+import ti4.map.persistence.GameManager;
+import ti4.map.persistence.ManagedGame;
+import ti4.message.logging.BotLogger;
+import ti4.website.AsyncTi4WebsiteHelper;
+
+@UtilityClass
+public class AbbreviatedDashboardCron {
+
+    private static final long CHANGE_WINDOW_MILLIS = ChronoUnit.DAYS.getDuration().multipliedBy(7).toMillis();
+
+    public static void register() {
+        CronManager.schedulePeriodically(
+                AbbreviatedDashboardCron.class,
+                AbbreviatedDashboardCron::postAbbreviatedDashboards,
+                5,
+                60,
+                TimeUnit.MINUTES);
+    }
+
+    private static void postAbbreviatedDashboards() {
+        BotLogger.logCron("Running AbbreviatedDashboardCron.");
+        try {
+            long cutoff = Instant.now().toEpochMilli() - CHANGE_WINDOW_MILLIS;
+            List<ManagedGame> recentGames = GameManager.getManagedGames().stream()
+                    .filter(game -> game.getLastModifiedDate() >= cutoff)
+                    .toList();
+
+            if (recentGames.isEmpty()) {
+                BotLogger.logCron("No games updated in the last 7 days. Skipping abbreviated dashboard upload.");
+                return;
+            }
+
+            BotLogger.logCron(
+                    String.format("Posting abbreviated dashboard payloads for %d game(s).", recentGames.size()));
+            AsyncTi4WebsiteHelper.postAbbreviatedDashboardPayloads(recentGames);
+        } catch (Exception e) {
+            BotLogger.error("**AbbreviatedDashboardCron failed.**", e);
+        } finally {
+            BotLogger.logCron("Finished AbbreviatedDashboardCron.");
+        }
+    }
+}

--- a/src/main/java/ti4/spring/jda/JdaService.java
+++ b/src/main/java/ti4/spring/jda/JdaService.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.stereotype.Service;
 import ti4.commands.CommandManager;
+import ti4.cron.AbbreviatedDashboardCron;
 import ti4.cron.AutoPingCron;
 import ti4.cron.CloseLaunchThreadsCron;
 import ti4.cron.CronManager;
@@ -287,6 +288,7 @@ public class JdaService {
 
         // START CRONS
         AutoPingCron.register();
+        AbbreviatedDashboardCron.register();
         ReuploadStaleEmojisCron.register();
         LogCacheStatsCron.register();
         WinningPathCron.register();

--- a/src/main/java/ti4/website/model/stats/AbbreviatedGameDashboardPayload.java
+++ b/src/main/java/ti4/website/model/stats/AbbreviatedGameDashboardPayload.java
@@ -1,0 +1,91 @@
+package ti4.website.model.stats;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.util.List;
+import ti4.map.Game;
+import ti4.map.Player;
+
+public class AbbreviatedGameDashboardPayload {
+
+    private final Game game;
+
+    public AbbreviatedGameDashboardPayload(Game game) {
+        this.game = game;
+    }
+
+    @JsonIgnore
+    public Game getGame() {
+        return game;
+    }
+
+    public String getAsyncGameID() {
+        return game.getID();
+    }
+
+    public String getAsyncFunGameName() {
+        return game.getCustomName();
+    }
+
+    public String getPlatform() {
+        return "asyncti4";
+    }
+
+    public boolean isPoK() {
+        return !game.isBaseGameMode();
+    }
+
+    public String getPhaseOfGame() {
+        return game.getPhaseOfGame();
+    }
+
+    public int getRound() {
+        return game.getRound();
+    }
+
+    public int getScoreboard() {
+        return game.getVp();
+    }
+
+    public boolean isHasEnded() {
+        return game.isHasEnded();
+    }
+
+    public long getTimestamp() {
+        try {
+            return Instant.ofEpochMilli(game.getLastModifiedDate()).getEpochSecond();
+        } catch (DateTimeException e) {
+            return Instant.now().getEpochSecond();
+        }
+    }
+
+    public Long getEndedTimestamp() {
+        if (!game.isHasEnded()) {
+            return null;
+        }
+        return Instant.ofEpochMilli(game.getEndedDate()).getEpochSecond();
+    }
+
+    public String getTurn() {
+        Player activePlayer = game.getActivePlayer();
+        if (activePlayer == null) {
+            return null;
+        }
+        return activePlayer.getColor();
+    }
+
+    public String getSpeaker() {
+        Player speaker = game.getSpeaker();
+        if (speaker == null) {
+            return null;
+        }
+        return speaker.getColor();
+    }
+
+    public List<AbbreviatedPlayerDashboardPayload> getPlayers() {
+        return game.getRealAndEliminatedPlayers().stream()
+                .map(AbbreviatedPlayerDashboardPayload::new)
+                .toList();
+    }
+}

--- a/src/main/java/ti4/website/model/stats/AbbreviatedPlayerDashboardPayload.java
+++ b/src/main/java/ti4/website/model/stats/AbbreviatedPlayerDashboardPayload.java
@@ -1,0 +1,67 @@
+package ti4.website.model.stats;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import ti4.map.Player;
+import ti4.model.FactionModel;
+
+public class AbbreviatedPlayerDashboardPayload {
+
+    private final Player player;
+
+    AbbreviatedPlayerDashboardPayload(Player player) {
+        this.player = player;
+    }
+
+    @JsonIgnore
+    Player getPlayer() {
+        return player;
+    }
+
+    public String getDiscordUserID() {
+        return player.getUserID();
+    }
+
+    public String getDiscordUsername() {
+        return player.getUserName();
+    }
+
+    public String getColor() {
+        return player.getColor();
+    }
+
+    public String getFaction() {
+        FactionModel factionModel = player.getFactionModel();
+        if (factionModel != null) {
+            return factionModel.getFactionName();
+        }
+        return player.getFaction();
+    }
+
+    public int getVictoryPoints() {
+        return player.getTotalVictoryPoints();
+    }
+
+    public boolean isEliminated() {
+        return player.isEliminated();
+    }
+
+    public boolean isRealPlayer() {
+        return player.isRealPlayer();
+    }
+
+    public boolean isNpc() {
+        return player.isNpc();
+    }
+
+    public int getInitiative() {
+        return player.getInitiative();
+    }
+
+    public boolean isActive() {
+        return player.equals(player.getGame().getActivePlayer());
+    }
+
+    public boolean isSpeaker() {
+        return player.equals(player.getGame().getSpeaker());
+    }
+}

--- a/src/main/resources/web/web.properties
+++ b/src/main/resources/web/web.properties
@@ -3,3 +3,6 @@ website.bucket=asyncti4.com
 # Configurable API endpoints for posting game data
 # Multiple URLs can be specified, separated by commas
 gamestate.api.urls=https://qw2j1lld43.execute-api.us-east-1.amazonaws.com/Production/map/{gameName}
+
+# Configurable API endpoints for abbreviated dashboard payloads
+abbreviated.dashboard.api.urls=

--- a/src/test/java/ti4/website/model/stats/AbbreviatedGameDashboardPayloadTest.java
+++ b/src/test/java/ti4/website/model/stats/AbbreviatedGameDashboardPayloadTest.java
@@ -1,0 +1,72 @@
+package ti4.website.model.stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.testUtils.BaseTi4Test;
+
+class AbbreviatedGameDashboardPayloadTest extends BaseTi4Test {
+
+    @Test
+    void basicFieldsAreIncluded() {
+        Game game = new Game();
+        game.setName("pbd123");
+        game.setCustomName("Test Game");
+        game.setRound(3);
+        game.setVp(12);
+        game.setPhaseOfGame("action");
+        game.setLastModifiedDate(Instant.parse("2024-05-01T12:34:56Z").toEpochMilli());
+
+        Player player = game.addPlayer("user1", "Alice");
+        player.setColor("blue");
+        player.setFaction("mentak");
+
+        game.setActivePlayerID(player.getUserID());
+        game.setSpeakerUserID(player.getUserID());
+
+        AbbreviatedGameDashboardPayload payload = new AbbreviatedGameDashboardPayload(game);
+
+        assertThat(payload.getAsyncGameID()).isEqualTo("pbd123");
+        assertThat(payload.getAsyncFunGameName()).isEqualTo("Test Game");
+        assertThat(payload.getRound()).isEqualTo(3);
+        assertThat(payload.getScoreboard()).isEqualTo(12);
+        assertThat(payload.getPhaseOfGame()).isEqualTo("action");
+        assertThat(payload.getTurn()).isEqualTo("blue");
+        assertThat(payload.getSpeaker()).isEqualTo("blue");
+        assertThat(payload.getTimestamp()).isEqualTo(Instant.parse("2024-05-01T12:34:56Z").getEpochSecond());
+
+        assertThat(payload.getPlayers()).hasSize(1);
+        AbbreviatedPlayerDashboardPayload playerPayload = payload.getPlayers().get(0);
+        assertThat(playerPayload.getDiscordUserID()).isEqualTo("user1");
+        assertThat(playerPayload.getDiscordUsername()).isEqualTo("Alice");
+        assertThat(playerPayload.getColor()).isEqualTo("blue");
+        assertThat(playerPayload.getFaction()).isEqualTo("The Mentak Coalition");
+        assertThat(playerPayload.isActive()).isTrue();
+        assertThat(playerPayload.isSpeaker()).isTrue();
+        assertThat(playerPayload.getVictoryPoints()).isZero();
+    }
+
+    @Test
+    void endedTimestampIsNullWhenGameIsOngoing() {
+        Game game = new Game();
+        game.setHasEnded(false);
+
+        AbbreviatedGameDashboardPayload payload = new AbbreviatedGameDashboardPayload(game);
+
+        assertThat(payload.getEndedTimestamp()).isNull();
+    }
+
+    @Test
+    void endedTimestampIsProvidedWhenGameHasEnded() {
+        Game game = new Game();
+        game.setHasEnded(true);
+        game.setEndedDate(Instant.parse("2024-06-02T08:30:00Z").toEpochMilli());
+
+        AbbreviatedGameDashboardPayload payload = new AbbreviatedGameDashboardPayload(game);
+
+        assertThat(payload.getEndedTimestamp()).isEqualTo(Instant.parse("2024-06-02T08:30:00Z").getEpochSecond());
+    }
+}


### PR DESCRIPTION
## Summary
- add an AbbreviatedDashboardCron that posts recently updated games to the abbreviated dashboard endpoint
- add helper models and configuration for building and sending the abbreviated dashboard payloads
- cover the new abbreviated payload with unit tests

## Testing
- mvn -q test *(fails: unable to resolve the Spring Boot parent POM from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e96a20c2c4832da3defc6ed0575c7e