### PR TITLE
Limit HTTP error logging to exception summary

### DIFF
--- a/src/main/java/ti4/spring/resilience/ErrorLoggingFilter.java
+++ b/src/main/java/ti4/spring/resilience/ErrorLoggingFilter.java
@@ -33,8 +33,11 @@ public class ErrorLoggingFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, cachingResponse);
         } catch (Exception e) {
+            String exceptionMessage = e.getMessage() != null ? e.getMessage() : "(no message)";
+            String exceptionSummary = e.getClass().getName() + ": " + exceptionMessage;
             BotLogger.errorToThread(
-                    "Exception during request to " + request.getRequestURI(), e, HTTP_ERROR_THREAD_NAME);
+                    "Exception during request to " + request.getRequestURI() + ": " + exceptionSummary,
+                    HTTP_ERROR_THREAD_NAME);
             SREStats.incrementWebserverRequestErrorCount();
             throw e;
         }


### PR DESCRIPTION
## Summary
- update HTTP error logging to record only the exception type and message when requests fail
- avoid attaching stack traces to the http-errors logging thread

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fefdc1dd8832db7ebeb3592986fe5)