### PR TITLE
Handle Sabotages stored outside the discard pile

### DIFF
--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -1,7 +1,7 @@
 package ti4.map;
 
-import static java.util.function.Predicate.*;
-import static org.apache.commons.collections4.CollectionUtils.*;
+import static java.util.function.Predicate.not;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -2778,8 +2778,8 @@ public class Game extends GameProperties {
                 .toList();
         getActionCards().addAll(acsToShuffle);
         Collections.shuffle(getActionCards());
-        acsToShuffle.stream().forEach(ac -> getDiscardActionCards().remove(ac)); // clear out the shuffled back cards
-        acsToShuffle.stream().forEach(ac -> getDiscardACStatus().remove(ac)); // just in case
+        acsToShuffle.forEach(ac -> getDiscardActionCards().remove(ac)); // clear out the shuffled back cards
+        acsToShuffle.forEach(ac -> getDiscardACStatus().remove(ac)); // just in case
         String msg = "# " + getPing()
                 + ", the action card deck has run out of cards, and so the discard pile has been shuffled to form a new action card deck.";
         MessageHelper.sendMessageToChannel(getMainGameChannel(), msg);

--- a/src/main/java/ti4/service/actioncard/SabotageService.java
+++ b/src/main/java/ti4/service/actioncard/SabotageService.java
@@ -41,7 +41,7 @@ public class SabotageService {
             "tf-shatter1",
             "tf-shatter2");
 
-    private static final Set<ACStatus> NON_HAND_SABOTAGE_LOCATIONS =
+    private static final Set<ACStatus> AC_STATUS_TO_IGNORE =
             EnumSet.of(ACStatus.garbozia, ACStatus.ralnelbt, ACStatus.purged);
 
     public static boolean couldFeasiblySabotage(Player player, Game game) {
@@ -179,20 +179,16 @@ public class SabotageService {
     }
 
     private static boolean checkForAllSabotagesDiscarded(Game game) {
-        return SABOTAGE_CARD_ALIASES.stream().allMatch(alias -> isSabotageAccountedFor(game, alias));
+        return SABOTAGE_CARD_ALIASES.stream().allMatch(alias -> isActionCardNotInDeckOrHand(game, alias));
     }
 
     private static boolean checkAcd2ForAllSabotagesDiscarded(Game game) {
         return game.isAcd2()
-                && ACD2_SABOTAGE_CARD_ALIASES.stream().allMatch(alias -> isSabotageAccountedFor(game, alias));
+                && ACD2_SABOTAGE_CARD_ALIASES.stream().allMatch(alias -> isActionCardNotInDeckOrHand(game, alias));
     }
 
-    private static boolean isSabotageAccountedFor(Game game, String sabotageAlias) {
-        if (!game.getDiscardActionCards().containsKey(sabotageAlias)) {
-            return false;
-        }
-        ACStatus status = game.getDiscardACStatus().get(sabotageAlias);
-        return status == null || NON_HAND_SABOTAGE_LOCATIONS.contains(status);
+    private static boolean isActionCardNotInDeckOrHand(Game game, String sabotageAlias) {
+        return game.getDiscardACStatus().containsKey(sabotageAlias);
     }
 
     public static void startOfTurnSaboWindowReminders(Game game, Player player) {


### PR DESCRIPTION
## Summary
- ensure Sabotage availability checks also treat cards stored on Garbozia or the Ral Nel breakthrough as out of circulation

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to download parent POM due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691516d11338832d90e4b095b0ebc87f)