### PR TITLE
Veiled Heart: Include Veiled Cards in Show Decks List; Unlock Paradigms on Reveal [skip ci]

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -24,6 +24,7 @@ import ti4.message.MessageHelper;
 import ti4.message.logging.BotLogger;
 import ti4.message.logging.LogOrigin;
 import ti4.model.FactionModel;
+import ti4.model.LeaderModel;
 import ti4.model.MapTemplateModel;
 import ti4.model.Source.ComponentSource;
 import ti4.model.StrategyCardModel;


### PR DESCRIPTION
- Some minor refactors.

- When clicking one of the "Show Deck" buttons, veiled cards should now be included in the list of cards that are printed. 
This way, players do not gain information they should not have by using the "Show Deck" buttons.

- Genomes and Paradigms were previously handled the same way in the revealVeiledCards menu. Now, they are handled separately. The buttons for revealing genomes are still blue. The buttons for revealing paradigms are red.

- Paradigms should now be unlocked immediately upon revealing them from the revealVeiledCards menu.