### PR TITLE
Handle missing expedition token owners when switching to Obsidian

### DIFF
--- a/src/main/java/ti4/service/PuppetSoftHeBladeService.java
+++ b/src/main/java/ti4/service/PuppetSoftHeBladeService.java
@@ -352,7 +352,7 @@ public class PuppetSoftHeBladeService {
 
             if (newKey != null || newValue != null) {
                 newKey = newKey == null ? entry.getKey() : newKey;
-                newValue = newValue == null ? entry.getKey() : newValue;
+                newValue = newValue == null ? entry.getValue() : newValue;
                 game.getMessagesThatICheckedForAllReacts().remove(entry.getKey());
                 game.getMessagesThatICheckedForAllReacts().put(newKey, newValue);
             }


### PR DESCRIPTION
## Summary
- avoid null pointer exceptions when updating expedition token ownership during the Obsidian conversion by comparing aliases in a null-safe order
- reuse the old and new faction aliases when updating the expedition tracker

## Testing
- `mvn -q -DskipTests package` *(fails: cannot download the Spring Boot parent POM from Maven Central in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a054b7060832db55a83628ae3ea8c)