### PR TITLE
Remove references to 'neutral' source (changed to 'thunders_edge')

### DIFF
--- a/src/main/java/ti4/buttons/UnfiledButtonHandlers.java
+++ b/src/main/java/ti4/buttons/UnfiledButtonHandlers.java
@@ -269,7 +269,6 @@ public class UnfiledButtonHandlers {
                             .toList();
                     String color = new SetupNeutralPlayer().pickNeutralColor(unusedColors);
                     game.setupNeutralPlayer(color);
-                    neutral = game.getPlayerFromColorOrFaction("neutral");
                 }
             }
         }

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -1,7 +1,7 @@
 package ti4.map;
 
-import static java.util.function.Predicate.*;
-import static org.apache.commons.collections4.CollectionUtils.*;
+import static java.util.function.Predicate.not;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -4642,11 +4642,6 @@ public class Game extends GameProperties {
             return null;
         }
         return tile_.getUnitHolderFromPlanet(planetName);
-    }
-
-    public boolean isPlanetSpaceStation(String planet) {
-        return getUnitHolderFromPlanet(planet) != null
-                && getUnitHolderFromPlanet(planet).isSpaceStation();
     }
 
     @Nullable

--- a/src/main/java/ti4/map/Player.java
+++ b/src/main/java/ti4/map/Player.java
@@ -2807,9 +2807,6 @@ public class Player extends PlayerProperties {
 
     @JsonIgnore
     public String getNextAvailableColour() {
-        // if (getColor() != null && !getColor().equals("null")) {
-        //     return getColor();
-        // }
         return getNextAvailableColorIgnoreCurrent();
     }
 

--- a/src/main/java/ti4/model/Source.java
+++ b/src/main/java/ti4/model/Source.java
@@ -42,7 +42,6 @@ public class Source {
         keleresplus,
         little_omega,
         project_pi,
-        neutral,
         lost_star_charts_of_ixth,
         flagshipping,
         promises_promises,
@@ -146,7 +145,6 @@ public class Source {
                         case promises_promises -> SourceEmojis.PromisesPromises;
                         case miltymod -> SourceEmojis.MiltyMod;
                         case lazax -> FactionEmojis.Lazax;
-                        case neutral -> FactionEmojis.Neutral;
                         case salliance -> SourceEmojis.StrategicAlliance;
                         case monuments -> SourceEmojis.Monuments;
                         default -> null;

--- a/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
@@ -74,6 +74,7 @@ public class WinningPathHelper {
         if (normalized.contains("censure")) return "censure";
         if (normalized.contains("crown") || normalized.contains("emph")) return "crown";
         if (normalized.contains("latvinia")) return "latvinia";
+        if (normalized.contains("song")) return "styx";
         return "other (probably _Classified Document Leaks_)";
     }
 }

--- a/src/main/java/ti4/service/tactical/TacticalActionService.java
+++ b/src/main/java/ti4/service/tactical/TacticalActionService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
@@ -20,7 +19,6 @@ import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
 import ti4.helpers.Units.UnitState;
 import ti4.helpers.Units.UnitType;
-import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.map.Planet;
 import ti4.map.Player;
@@ -415,53 +413,6 @@ public class TacticalActionService {
 
     private boolean shouldSkipLandingOnPlanet(Planet planet) {
         return planet.getTokenList().stream().anyMatch(token -> token.contains(Constants.DMZ_LARGE));
-    }
-
-    /**
-     * Check if a game is standard PoK or only uses 4/4/4 homebrew.
-     * Duplicated here to mirror URL selection logic used for the Website View button.
-     */
-    private static boolean isStandardPoKOrOnly444(Game game) {
-        if (game == null) return false;
-
-        if (game.isHomebrew()
-                || game.isExtraSecretMode()
-                || game.isFowMode()
-                || game.isAgeOfExplorationMode()
-                || game.isFacilitiesMode()
-                || game.isMinorFactionsMode()
-                || game.isLightFogMode()
-                || game.isRedTapeMode()
-                || game.isDiscordantStarsMode()
-                || game.isFrankenGame()
-                || game.isMiltyModMode()
-                || game.isAbsolMode()
-                || game.isVotcMode()
-                || game.isPromisesPromisesMode()
-                || game.isFlagshippingMode()
-                || game.isAllianceMode()
-                || (game.getSpinMode() != null && !"OFF".equalsIgnoreCase(game.getSpinMode()))
-                || game.isHomebrewSCMode()
-                || game.isCommunityMode()
-                || game.getPlayerCountForMap() < 3
-                || game.getPlayerCountForMap() > 8) {
-            return false;
-        }
-
-        try {
-            if (!game.checkAllDecksAreOfficial()
-                    || !game.checkAllTilesAreOfficial()
-                    || game.getFactions().stream()
-                            .map(Mapper::getFaction)
-                            .filter(Objects::nonNull)
-                            .anyMatch(faction -> !faction.getSource().isOfficial())) {
-                return false;
-            }
-        } catch (Exception e) {
-            return false;
-        }
-
-        return true;
     }
 
     private void addLandingAndUnlandingButtonsForPlanet(

--- a/src/main/resources/data/action_cards/legacy_data.json
+++ b/src/main/resources/data/action_cards/legacy_data.json
@@ -10,15 +10,6 @@
         "source": "deprecated"
     },
     {
-        "alias": "blackmail",
-        "name": "Blackmail",
-        "phase": "Agenda",
-        "window": "After an agenda is revealed",
-        "text": "Choose another player. That player may give you 1 random promissory note from their hand; otherwise, they must cast at least 1 vote for an outcome of your choice during this agenda, if able.",
-        "flavorText": "Dirzuga Ohao stood next to the leader of the revolutionaries, his pale eyes full of accusation. \"Not every secret is lost in death, Brother Milor,\" they said in unison.",
-        "source": "deprecated"
-    },
-    {
         "alias": "adrenaline_shots",
         "name": "Adrenaline Shots",
         "phase": "Action",
@@ -826,15 +817,6 @@
         "source": "deprecated"
     },
     {
-        "alias": "liberation",
-        "name": "Liberation",
-        "phase": "Any",
-        "window": "After you gain control of a planet",
-        "text": "Place 3 infantry from your reinforcements on that planet.",
-        "flavorText": "Harsh penal colonies were all too common, always filled with hardy folk eager for a chance at revenge.",
-        "source": "deprecated"
-    },
-    {
         "alias": "last_minute_deliberation",
         "name": "Last Minute Deliberation",
         "phase": "Agenda",
@@ -1079,15 +1061,6 @@
         "source": "deprecated"
     },
     {
-        "alias": "opportunists",
-        "name": "Opportunists",
-        "phase": "Action",
-        "window": "ACTION",
-        "text": "Choose 1 system that contains another player's ships and no planets. Place 1 cruiser and 1 destroyer from your reinforcements in that system and resolve a space combat.",
-        "flavorText": "The sensors of the lead ship exploded with an array of alarms and damage alerts as a fleet of unmarked ships poured forth from the wormhole. Reports be damned, these were no mere pirates.",
-        "source": "deprecated"
-    },
-    {
         "alias": "miraculous_escape",
         "name": "Miraculous Escape",
         "phase": "Any",
@@ -1133,15 +1106,6 @@
         "source": "deprecated"
     },
     {
-        "alias": "flawless_strategy",
-        "name": "Flawless Strategy",
-        "phase": "Action",
-        "window": "After you exhaust your strategy card",
-        "text": "Resolve the secondary ability of that strategy card; do not spend or place a command token to resolve that ability.",
-        "flavorText": "PROTOCOL SUCCESSFUL<< [ID:NULL] DEFEAT INEVITABLE<< PEERLESS MANY<< INFINITE ONE<< [ID:NIITAKA]<< QUEUED1<< QUEUED2<< QUEUED3...",
-        "source": "deprecated"
-    },
-    {
         "alias": "skilled_retreat1_acd2",
         "name": "Skilled Retreat",
         "phase": "Action",
@@ -1179,15 +1143,6 @@
         "text": "Move all of your ships from the active system into an adjacent system that does not contain another player's ships. The space combat ends in a draw. Then, place a command token from your reinforcements in that system.",
         "automationID": "skilled_retreat",
         "flavorText": "The armada followed the Hil Colish into the fading wormhole.",
-        "source": "deprecated"
-    },
-    {
-        "alias": "strategic_focus",
-        "name": "Strategic Focus",
-        "phase": "Action",
-        "window": "After you pass",
-        "text": "Resolve the secondary ability of 1 readied or unchosen strategy card; do not spend or place a command token to resolve that ability.",
-        "flavorText": "\"With every imaginable incarnation of death at our doorsteps, they still reach for more,\" Rinn sighed. \"We must remain focused. Steady.\"",
         "source": "deprecated"
     },
     {

--- a/src/main/resources/data/factions/other.json
+++ b/src/main/resources/data/factions/other.json
@@ -51,7 +51,7 @@
             "pds",
             "spacedock"
         ],
-        "source": "neutral"
+        "source": "thunders_edge"
     },
     {
         "alias": "admins",


### PR DESCRIPTION
Eliminated the 'neutral' source from Source.java and related emoji mapping, updated faction data to use 'thunders_edge' instead, and removed code and data referencing 'neutral' where no longer needed. Also removed deprecated or unused methods and cleaned up imports and comments for clarity. Updated WinningPathHelper to recognize 'song' as 'styx' and pruned deprecated action cards from legacy_data.json.