### PR TITLE
Remove neutral faction from Milty Draft

### DIFF
--- a/src/main/java/ti4/helpers/settingsFramework/menus/PlayerFactionSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/PlayerFactionSettings.java
@@ -178,7 +178,7 @@ public class PlayerFactionSettings extends SettingsMenu {
     }
 
     private String prioritizeTEFactions() {
-        if (parent != null && parent instanceof MiltySettings ms) {
+        if (parent != null && parent instanceof MiltySettings) {
 
             List<String> newKeys = new ArrayList<>();
             for (FactionModel model : priFactions.getAllValues().values()) {

--- a/src/main/java/ti4/service/draft/draftables/FactionDraftable.java
+++ b/src/main/java/ti4/service/draft/draftables/FactionDraftable.java
@@ -58,6 +58,7 @@ public class FactionDraftable extends SinglePickDraftable {
                 .filter(f -> !effBannedFactions.contains(f.getAlias()))
                 .filter(f -> sources.contains(f.getSource()))
                 .filter(f -> !f.getAlias().contains("obsidian"))
+                .filter(f -> !f.getAlias().contains("neutral"))
                 .filter(f -> !f.getAlias().contains("keleres")
                         || "keleresm".equals(f.getAlias())) // Limit the pool to only 1 keleres flavor
                 .map(FactionModel::getAlias)

--- a/src/main/java/ti4/service/emoji/FactionEmojis.java
+++ b/src/main/java/ti4/service/emoji/FactionEmojis.java
@@ -43,6 +43,7 @@ public enum FactionEmojis implements TI4Emoji {
     Deepwrought,
     Firmament,
     Obsidian,
+    Neutral,
 
     // Twilight's Fall
 
@@ -172,7 +173,6 @@ public enum FactionEmojis implements TI4Emoji {
     saera,
     shadows, // Eronous
     Lazax,
-    Neutral,
     RandomFaction,
     AdminsFaction,
     netharii,
@@ -225,7 +225,6 @@ public enum FactionEmojis implements TI4Emoji {
             case "yin" -> Yin;
 
             case "lazax" -> Lazax;
-            case "neutral" -> Neutral;
 
             case "keleres", "keleresx", "keleresm", "keleresa" -> Keleres;
             case "redcreuss", "redghost" -> RedCreuss;
@@ -236,6 +235,8 @@ public enum FactionEmojis implements TI4Emoji {
             case "deepwrought" -> Deepwrought;
             case "obsidian" -> Obsidian;
             case "firmament" -> Firmament;
+            case "neutral" -> Neutral;
+
             case "augers" -> augers;
             case "axis" -> axis;
             case "bentor" -> bentor;

--- a/src/main/java/ti4/service/milty/MiltyService.java
+++ b/src/main/java/ti4/service/milty/MiltyService.java
@@ -134,6 +134,7 @@ public class MiltyService {
                 .filter(f -> specs.factionSources.contains(f.getSource()))
                 .filter(f -> !specs.bannedFactions.contains(f.getAlias()))
                 .filter(f -> !f.getAlias().contains("obsidian"))
+                .filter(f -> !f.getAlias().contains("neutral"))
                 .filter(f -> !f.getAlias().contains("keleres")
                         || "keleresm".equals(f.getAlias())) // Limit the pool to only 1 keleres flavor
                 .map(FactionModel::getAlias)


### PR DESCRIPTION
Introduces 'neutral' as an official source in the Source enum and updates the relevant faction in other.json to use 'neutral' as its source instead of 'thunders_edge'.