### PR TITLE
prevent NullPointerExceptions when trying to invite an observer that is not on that server

### DIFF
--- a/src/main/java/ti4/commands/game/Observer.java
+++ b/src/main/java/ti4/commands/game/Observer.java
@@ -57,9 +57,9 @@ class Observer extends Subcommand {
         }
 
         // INVITE TO GAME SERVER IF MISSING
-        if (member == null 
+        if (member == null
                 || !CreateGameService.inviteUsersToServer(guild, List.of(member), event.getChannel())
-                .isEmpty()) {
+                        .isEmpty()) {
             MessageHelper.sendMessageToChannel(
                     event.getChannel(),
                     "User was not a member of the Game's server (" + guild.getName()


### PR DESCRIPTION
fixes this NullPointerException:
https://discord.com/channels/943410040369479690/1440549409589825729/1440549412412850197