### PR TITLE
Add Thunder's Edge demo mode support

### DIFF
--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -877,6 +877,12 @@ public class Game extends GameProperties {
                 .collect(Collectors.joining(", "));
     }
 
+    public boolean isThundersEdgeDemo() {
+        return getTags().stream()
+                .map(String::trim)
+                .anyMatch(tag -> "Thunder's Edge Demo".equalsIgnoreCase(tag));
+    }
+
     public boolean isAcd2() {
         return getAcDeckID().startsWith("action_deck_2");
     }

--- a/src/main/java/ti4/website/model/stats/GameStatsDashboardPayload.java
+++ b/src/main/java/ti4/website/model/stats/GameStatsDashboardPayload.java
@@ -211,6 +211,7 @@ public class GameStatsDashboardPayload {
                         Map.entry("Base Game", (Supplier<Boolean>) game::isBaseGameMode),
                         Map.entry("Prophecy of Kings", (Supplier<Boolean>) game::isProphecyOfKings),
                         Map.entry("Thunder's Edge", (Supplier<Boolean>) game::isThundersEdge),
+                        Map.entry("Thunder's Edge Demo", (Supplier<Boolean>) game::isThundersEdgeDemo),
                         Map.entry("Twilight's Fall", (Supplier<Boolean>) game::isTwilightsFallMode),
                         Map.entry("Age of Exploration", (Supplier<Boolean>) game::isAgeOfExplorationMode),
                         Map.entry("Facilities", (Supplier<Boolean>) game::isFacilitiesMode),


### PR DESCRIPTION
## Summary
- add the Thunder's Edge Demo entry to the dashboard mode list
- expose a Game helper to surface the Thunder's Edge Demo tag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0b4a9d90832d9b6c9b916f8ac884)