### PR TITLE
Add Thunder's Edge demo tag support

### DIFF
--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -829,6 +829,7 @@ public class Game extends GameProperties {
         gameModes.put(SourceEmojis.TI4PoK + "Normal", isNormalGame);
         gameModes.put(SourceEmojis.TI4BaseGame + "Base Game", isBaseGameMode());
         gameModes.put("Thunder's Edge", isThundersEdge());
+        gameModes.put("Thunder's Edge Demo", isThundersEdgeDemo());
         gameModes.put(SourceEmojis.MiltyMod + "MiltyMod", isMiltyModMode());
         gameModes.put(MiscEmojis.TIGL + "TIGL", isCompetitiveTIGLGame());
         gameModes.put("Community", isCommunityMode());
@@ -4807,6 +4808,11 @@ public class Game extends GameProperties {
     }
 
     @JsonIgnore
+    public boolean isThundersEdgeDemo() {
+        return getTags().contains("ThundersEdgeDemo");
+    }
+
+    @JsonIgnore
     public boolean hasHomebrew() {
         return isHomebrew()
                 || isExtraSecretMode()
@@ -4817,6 +4823,7 @@ public class Game extends GameProperties {
                 || isDiscordantStarsMode()
                 || isFrankenGame()
                 || isMiltyModMode()
+                || isThundersEdgeDemo()
                 || isAbsolMode()
                 || isVotcMode()
                 || isPromisesPromisesMode()


### PR DESCRIPTION
## Summary
- add a helper for Thunder's Edge demo tag detection
- display Thunder's Edge demo in game mode descriptions and treat it as homebrew

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0b494794832db4380fa12ceee643)