### PR TITLE
Add logging for missing action cards in Mapper

### DIFF
--- a/src/main/java/ti4/image/Mapper.java
+++ b/src/main/java/ti4/image/Mapper.java
@@ -403,6 +403,10 @@ public class Mapper {
             id = id.replace("extra1", "");
             id = id.replace("extra2", "");
         }
+        if (!actionCards.containsKey(id)) {
+            BotLogger.critical("Action card not found: " + id);
+            return null;
+        }
         return actionCards.get(id);
     }
 
@@ -1185,7 +1189,6 @@ public class Mapper {
     }
 
     public static String getTokenID(String tokenID) {
-
         return tokensFromProperties.getProperty(tokenID);
     }
 


### PR DESCRIPTION
Adds a critical log message when an action card ID is not found in the actionCards map, returning null in such cases. This improves error visibility for missing or incorrect action card references.