### PR TITLE
Annotate Mapper with @UtilityClass and update legacy action cards

### DIFF
--- a/src/main/java/ti4/image/Mapper.java
+++ b/src/main/java/ti4/image/Mapper.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.NotNull;
 import ti4.ResourceHelper;
 import ti4.helpers.AliasHandler;
@@ -77,6 +78,7 @@ import ti4.model.UnitModel;
 import ti4.model.WormholeModel;
 import ti4.service.emoji.CardEmojis;
 
+@UtilityClass
 public class Mapper {
 
     // private static final Properties colors = new Properties();

--- a/src/main/resources/data/action_cards/legacy_data.json
+++ b/src/main/resources/data/action_cards/legacy_data.json
@@ -1480,5 +1480,14 @@
         "text": "Look at the top 2 cards of the deck that matches that objective; you may replace that objective with 1 of those cards. Then, shuffle that deck.",
         "flavorText": "Just as the charges went public, over half of the Council's staff were arrested. The Winnu, meanwhile, secreted the true loyalist off of Mecatol and delivered their reward.",
         "source": "deprecated"
+    },
+    {
+        "alias": "corruption_acd2",
+        "name": "Corruption",
+        "phase": "Any",
+        "window": "When a public objective is revealed",
+        "text": "Look at the top 2 cards of the deck that matches that objective; you may replace that objective with 1 of those cards. Then, shuffle that deck.",
+        "flavorText": "Just as the charges went public, over half of the Council's staff were arrested. The Winnu, meanwhile, secreted the true loyalist off of Mecatol and delivered their reward.",
+        "source": "deprecated"
     }
 ]


### PR DESCRIPTION
Added the @UtilityClass annotation to the Mapper class for improved utility handling. Also appended a new deprecated action card entry 'corruption_acd2' to legacy_data.json.