### PR TITLE
Handle empty splice deck when drawing

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -1112,7 +1112,14 @@ public class ButtonHelperTwilightsFall {
         if (buttonID.contains("_")) {
             type = buttonID.split("_")[1];
         }
-        String cardID = getDeckForSplicing(game, type, 1).getFirst();
+        List<String> cardsToDraw = getDeckForSplicing(game, type, 1);
+        if (cardsToDraw.isEmpty()) {
+            String messageText = "There are no more cards in the " + type + " deck.";
+            MessageHelper.sendMessageToChannel(player.getCorrectChannel(), messageText);
+            ButtonHelper.deleteMessage(event);
+            return;
+        }
+        String cardID = cardsToDraw.getFirst();
         if (buttonID.split("_").length > 2) {
             cardID = buttonID.split("_")[2];
             ButtonHelper.deleteMessage(event);


### PR DESCRIPTION
## Summary
- prevent crashes when drawing singular splice cards by handling empty decks
- notify players when no splice cards remain and clean up the interaction

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69247d8b5064832d88d781f13219a994)