### PR TITLE
Improve error handling in Yssaril hero AC offer

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperHeroes.java
+++ b/src/main/java/ti4/helpers/ButtonHelperHeroes.java
@@ -2808,33 +2808,39 @@ public class ButtonHelperHeroes {
         String acID = buttonID.split("_")[0];
         String yssarilFaction = buttonID.split("_")[1];
         Player yssaril = game.getPlayerFromColorOrFaction(yssarilFaction);
-        if (yssaril != null) {
-            String offerName = player.getRepresentationNoPing();
-            if (game.isFowMode()) {
-                offerName = player.getColor();
-            }
-            ButtonHelper.deleteMessage(event);
-            acButtons.add(Buttons.green(
-                    "takeAC_" + acID + "_" + player.getFaction(), "Take " + buttonLabel, CardEmojis.ActionCard));
-            acButtons.add(Buttons.red(
-                    "yssarilHeroRejection_" + player.getFaction(), "Reject " + buttonLabel + " and Force Discard"));
-            String message = yssaril.getRepresentationUnfogged() + " " + offerName + " has offered you the action card "
-                    + buttonLabel
-                    + " for Kyver, Blade and Key, the Yssaril hero. Use buttons to accept it, or to reject it and force them to discard 3 random action cards.";
-            MessageHelper.sendMessageToChannelWithButtons(yssaril.getCardsInfoThread(), message, acButtons);
-            String acStringID = "";
-            for (String acStrId : player.getActionCards().keySet()) {
-                if ((player.getActionCards().get(acStrId) + "").equalsIgnoreCase(acID)) {
-                    acStringID = acStrId;
-                }
-            }
-
-            ActionCardModel ac = Mapper.getActionCard(acStringID);
-            MessageHelper.sendMessageToChannelWithEmbed(
-                    yssaril.getCardsInfoThread(),
-                    "For your reference, the text of the action cards offered reads as:",
-                    ac.getRepresentationEmbed());
+        if (yssaril == null) {
+            return;
         }
+
+        String offerName = player.getRepresentationNoPing();
+        if (game.isFowMode()) {
+            offerName = player.getColor();
+        }
+        ButtonHelper.deleteMessage(event);
+        acButtons.add(Buttons.green(
+                "takeAC_" + acID + "_" + player.getFaction(), "Take " + buttonLabel, CardEmojis.ActionCard));
+        acButtons.add(Buttons.red(
+                "yssarilHeroRejection_" + player.getFaction(), "Reject " + buttonLabel + " and Force Discard"));
+        String message = yssaril.getRepresentationUnfogged() + " " + offerName + " has offered you the action card "
+                + buttonLabel
+                + " for Kyver, Blade and Key, the Yssaril hero. Use buttons to accept it, or to reject it and force them to discard 3 random action cards.";
+        MessageHelper.sendMessageToChannelWithButtons(yssaril.getCardsInfoThread(), message, acButtons);
+        String acStringID = null;
+        for (String acStrId : player.getActionCards().keySet()) {
+            if ((player.getActionCards().get(acStrId) + "").equalsIgnoreCase(acID)) {
+                acStringID = acStrId;
+            }
+        }
+        if (acStringID == null) {
+            MessageHelper.sendMessageToChannel(
+                    game.getMainGameChannel(), "Unable to find AC with id " + acID + " for " + player.getUserName());
+            return;
+        }
+        ActionCardModel ac = Mapper.getActionCard(acStringID);
+        MessageHelper.sendMessageToChannelWithEmbed(
+                yssaril.getCardsInfoThread(),
+                "For your reference, the text of the action cards offered reads as:",
+                ac.getRepresentationEmbed());
     }
 
     @ButtonHandler("creussHeroStep2_")


### PR DESCRIPTION
Refactored logic to return early if the Yssaril player or the action card ID is not found, and added a message to the main game channel when the action card cannot be located. This prevents null pointer exceptions and improves user feedback during the Kyver, Blade and Key hero action card offer process.