### PR TITLE
Handle missing home system for neural parasite reminder

### DIFF
--- a/src/main/java/ti4/helpers/StatusHelper.java
+++ b/src/main/java/ti4/helpers/StatusHelper.java
@@ -571,6 +571,9 @@ public class StatusHelper {
 
         for (Player player : firmaments) {
             Tile home = player.getHomeSystemTile();
+            if (home == null) {
+                continue;
+            }
             List<Button> buttons = new ArrayList<>();
             for (Planet planet : home.getPlanetUnitHolders()) {
                 String id = player.finChecker() + "placeOneNDone_skipbuild_gf_" + planet.getName();


### PR DESCRIPTION
## Summary
- avoid null pointer when sending neural parasite buttons by skipping players without a home system

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272ead576c832db4d3ac5bf6eddc08)