### PR TITLE
Remove unofficial objectives and alliance mode checks

### DIFF
--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -4837,7 +4837,6 @@ public class Game extends GameProperties {
                         .anyMatch(leader -> !leader.getSource().isOfficial());
     }
 
-
     public boolean checkAllDecksAreOfficial() {
         // Decks
         List<String> deckIDs = new ArrayList<>();


### PR DESCRIPTION
Refactored the game mode validation logic by removing checks for alliance mode, unofficial number of revealed objectives, and secret victory points. Also removed the hasUnofficialNumberOfRevealedObjectives and isCodex4 helper methods, simplifying the code and focusing validation on official sources and player count.