### PR TITLE
Remove 'bounty' from action_deck_2.json

### DIFF
--- a/src/main/resources/data/decks/action_deck_2.json
+++ b/src/main/resources/data/decks/action_deck_2.json
@@ -217,7 +217,6 @@
 
             "artifact_hunters",
             "artifact_research",
-            "bounty",
             "black_market_raid",
             "data_archive",
             "derelict_station",
@@ -479,7 +478,6 @@
             "artifact_hunters",
             "artifact_research",
             "black_market_raid",
-            "bounty",
             "data_archive",
             "derelict_station",
             "exploration_rider",


### PR DESCRIPTION
The 'bounty' entry was removed from two lists in action_deck_2.json, likely to update the deck composition or fix an inconsistency.