### PR TITLE
Move isSuspicious override to TechAdd and TechUnpurge

### DIFF
--- a/src/main/java/ti4/commands/fow/Whisper.java
+++ b/src/main/java/ti4/commands/fow/Whisper.java
@@ -14,7 +14,7 @@ import ti4.service.fow.WhisperService;
 
 class Whisper extends GameStateSubcommand {
 
-    public Whisper() {
+    Whisper() {
         super(Constants.WHISPER, "Send a private message to a player in fog mode", true, true);
         addOptions(new OptionData(
                         OptionType.STRING,

--- a/src/main/java/ti4/commands/franken/FactionTechAdd.java
+++ b/src/main/java/ti4/commands/franken/FactionTechAdd.java
@@ -8,7 +8,7 @@ import ti4.service.franken.FrankenFactionTechService;
 
 class FactionTechAdd extends FactionTechAddRemove {
 
-    public FactionTechAdd() {
+    FactionTechAdd() {
         super(Constants.FACTION_TECH_ADD, "Add a faction technology to your faction");
     }
 

--- a/src/main/java/ti4/commands/franken/FactionTechRemove.java
+++ b/src/main/java/ti4/commands/franken/FactionTechRemove.java
@@ -8,7 +8,7 @@ import ti4.service.franken.FrankenFactionTechService;
 
 class FactionTechRemove extends FactionTechAddRemove {
 
-    public FactionTechRemove() {
+    FactionTechRemove() {
         super(Constants.FACTION_TECH_REMOVE, "Remove a faction technology from your faction");
     }
 

--- a/src/main/java/ti4/commands/tech/TechAdd.java
+++ b/src/main/java/ti4/commands/tech/TechAdd.java
@@ -15,4 +15,9 @@ class TechAdd extends TechAddRemove {
     public void doAction(Player player, String techID, SlashCommandInteractionEvent event) {
         PlayerTechService.addTech(event, getGame(), player, techID);
     }
+
+    @Override
+    public boolean isSuspicious(SlashCommandInteractionEvent event) {
+        return true;
+    }
 }

--- a/src/main/java/ti4/commands/tech/TechAddRemove.java
+++ b/src/main/java/ti4/commands/tech/TechAddRemove.java
@@ -75,9 +75,4 @@ abstract class TechAddRemove extends GameStateSubcommand {
     }
 
     protected abstract void doAction(Player player, String techID, SlashCommandInteractionEvent event);
-
-    @Override
-    public boolean isSuspicious(SlashCommandInteractionEvent event) {
-        return true;
-    }
 }

--- a/src/main/java/ti4/commands/tech/TechUnpurge.java
+++ b/src/main/java/ti4/commands/tech/TechUnpurge.java
@@ -15,4 +15,9 @@ class TechUnpurge extends TechAddRemove {
     public void doAction(Player player, String techID, SlashCommandInteractionEvent event) {
         PlayerTechService.unpurgeTech(event, player, techID);
     }
+
+    @Override
+    public boolean isSuspicious(SlashCommandInteractionEvent event) {
+        return true;
+    }
 }


### PR DESCRIPTION
The isSuspicious method is now overridden in TechAdd and TechUnpurge instead of TechAddRemove, allowing more granular control. Also removed redundant public modifiers from constructors for consistency.