### PR TITLE
Update Oracle action card text

### DIFF
--- a/src/main/resources/data/action_cards/acd2.json
+++ b/src/main/resources/data/action_cards/acd2.json
@@ -998,7 +998,7 @@
         "name": "Oracle",
         "phase": "Action",
         "window": "ACTION",
-        "text": "Look at each unrevealed stage II public objective.",
+        "text": "You may look at each unrevealed public objective. If you do not, look at the top 5 cards of the secret objective deck; purge up to 2 of those cards and shuffle that deck.",
         "flavorText": "The Memoria loomed above Mecatol Rex, as it must. \"It is wrong,\" the Nomad said softly. \"Infinity before me, yet every choice I make collapses it. Foreknowledge diverts me onto a finite path and traps me in those deadly corridors.\"",
         "source": "action_deck_2"
     },


### PR DESCRIPTION
Revised the Oracle card's text to allow players to look at all unrevealed public objectives or, alternatively, interact with the secret objective deck. This change clarifies and expands the card's functionality.