### PR TITLE
Handle null player in wormhole adjacency check

### DIFF
--- a/src/main/java/ti4/helpers/FoWHelper.java
+++ b/src/main/java/ti4/helpers/FoWHelper.java
@@ -664,9 +664,11 @@ public class FoWHelper {
             }
         }
 
+        boolean hasQuantumEntanglement = player != null && player.hasAbility("quantum_entanglement");
+
         if (player != null && player.hasAbility("sundered")) {
             Set<String> keepers = new HashSet<>(Set.of("epsilon"));
-            if (player.hasAbility("quantum_entanglement") || wh_recon || absol_recon) {
+            if (hasQuantumEntanglement || wh_recon || absol_recon) {
                 keepers.addAll(Set.of("alpha", "beta"));
             }
             wormholeIDs.removeIf(wh -> !keepers.contains(wh.toLowerCase()));
@@ -674,7 +676,7 @@ public class FoWHelper {
 
         if (tile.getSpaceUnitHolder().getTokenList().contains(Constants.TOKEN_SEVERED)) {
             Set<String> keepers = new HashSet<>();
-            if (player.hasAbility("quantum_entanglement") || wh_recon || absol_recon) {
+            if (hasQuantumEntanglement || wh_recon || absol_recon) {
                 keepers.addAll(Set.of("alpha", "beta"));
             }
             wormholeIDs.removeIf(wh -> !keepers.contains(wh.toLowerCase()));
@@ -686,7 +688,7 @@ public class FoWHelper {
             wormholeIDs.removeIf("epsilon"::equalsIgnoreCase);
         }
 
-        if ((player != null && player.hasAbility("quantum_entanglement")) || wh_recon || absol_recon) {
+        if (hasQuantumEntanglement || wh_recon || absol_recon) {
             if (wormholeIDs.contains(Constants.ALPHA)) {
                 wormholeIDs.add(Constants.BETA);
             } else if (wormholeIDs.contains(Constants.BETA)) {


### PR DESCRIPTION
## Summary
- avoid null pointer errors when evaluating wormhole adjacencies without an active player
- reuse a single quantum entanglement flag for repeated checks

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69306a38388c832db09bcf4ea0b95e16)