### PR TITLE
Comment out empties display logic and add image load check

### DIFF
--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -1389,14 +1389,15 @@ public class MapGenerator implements AutoCloseable {
                     }
                     offBoardHighlighting++;
                 }
-            // } else if (displayType == DisplayType.empties) {
+                // } else if (displayType == DisplayType.empties) {
                 // boolean hasStellar = false; // not working
                 // String relicFile = ResourceHelper.getInstance().getGeneralFile("Relic.png");
                 // boolean hasHero = false; // was not working
                 // String heroFile = ResourceHelper.getResourceFromFolder("emojis/leaders/", "Hero.png");
                 // if (player.hasLeaderUnlocked("muaathero")) {
                 //     heroFile =
-                //             ResourceHelper.getResourceFromFolder("emojis/leaders/pok/Emoji Farm 4/", "MuaatHero.png");
+                //             ResourceHelper.getResourceFromFolder("emojis/leaders/pok/Emoji Farm 4/",
+                // "MuaatHero.png");
                 // }
                 // BufferedImage bufferedImage;
                 // if (hasStellar && hasHero) {


### PR DESCRIPTION
The empties displayType block has been commented out, disabling related image drawing logic. Additionally, a null check for loaded trait images was added to prevent errors and log failures when trait files cannot be loaded.