### PR TITLE
Twilight's Fall: fix genome paradigm searches including extra entries

### DIFF
--- a/src/main/java/ti4/autocomplete/AutoCompleteProvider.java
+++ b/src/main/java/ti4/autocomplete/AutoCompleteProvider.java
@@ -801,7 +801,7 @@ public class AutoCompleteProvider {
                 List<Command.Choice> options = mapTo25ChoicesThatContain(leaderIDs, enteredValue);
                 event.replyChoices(options).queue();
             }
-            case Constants.PARADIGM -> {
+            case Constants.TF_PARADIGM -> {
                 List<String> paradigms = Mapper.getDeck("tf_paradigm").getNewDeck();
                 String enteredValue = event.getFocusedOption().getValue().toLowerCase();
                 List<Command.Choice> options = mapTo25ChoicesThatContain(paradigms, enteredValue);

--- a/src/main/java/ti4/commands/search/SearchGenomesSubcommand.java
+++ b/src/main/java/ti4/commands/search/SearchGenomesSubcommand.java
@@ -31,8 +31,8 @@ class SearchGenomesSubcommand extends SearchComponentModelSubcommand {
                 return;
             }
         }
-        List<MessageEmbed> messageEmbeds = Mapper.getLeaders().values().stream()
-                .filter(LeaderModel::isGenome)
+        List<MessageEmbed> messageEmbeds = Mapper.getDeck(Constants.TF_GENOME).getNewDeck().stream()
+                .map(Mapper::getLeader)
                 .filter(model -> model.search(searchString, source))
                 .sorted(Comparator.comparing(LeaderModel::getID))
                 .map(model -> model.getRepresentationEmbed(true, true, false, true, true))

--- a/src/main/java/ti4/commands/search/SearchParadigmsSubcommand.java
+++ b/src/main/java/ti4/commands/search/SearchParadigmsSubcommand.java
@@ -31,8 +31,8 @@ class SearchParadigmsSubcommand extends SearchComponentModelSubcommand {
                 return;
             }
         }
-        List<MessageEmbed> messageEmbeds = Mapper.getLeaders().values().stream()
-                .filter(LeaderModel::isParadigm)
+        List<MessageEmbed> messageEmbeds = Mapper.getDeck(Constants.TF_PARADIGM).getNewDeck().stream()
+                .map(Mapper::getLeader)
                 .filter(model -> model.search(searchString, source))
                 .sorted(Comparator.comparing(LeaderModel::getID))
                 .map(model -> model.getRepresentationEmbed(true, true, false, true, true))

--- a/src/main/java/ti4/commands/tf/DrawSpecificParadigm.java
+++ b/src/main/java/ti4/commands/tf/DrawSpecificParadigm.java
@@ -14,7 +14,7 @@ class DrawSpecificParadigm extends GameStateSubcommand {
 
     DrawSpecificParadigm() {
         super("draw_specific_paradigm", "Draw a specific Twilight's Fall Paradigm", true, true);
-        addOptions(new OptionData(OptionType.STRING, Constants.PARADIGM, "Name of the paradigm you wish to draw")
+        addOptions(new OptionData(OptionType.STRING, Constants.TF_PARADIGM, "Name of the paradigm you wish to draw")
                 .setRequired(true)
                 .setAutoComplete(true));
         addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Faction or Color for which you draw")
@@ -26,7 +26,7 @@ class DrawSpecificParadigm extends GameStateSubcommand {
         Game game = getGame();
         Player player = getPlayer();
 
-        String paradigm = event.getOption(Constants.PARADIGM).getAsString();
+        String paradigm = event.getOption(Constants.TF_PARADIGM).getAsString();
         boolean success = ButtonHelperTwilightsFall.drawSpecificParadigm(game, player, paradigm, true, false);
 
         String msg = player.getRepresentationNoPing() + " ";

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -979,9 +979,9 @@ public class Constants {
     // Twilight's Fall
     public static final String TF_ABILITY = "tf_ability";
     public static final String TF_UNIT_UPGRADE = "tf_unit_upgrade";
-    public static final String GENOME = "genome";
-    public static final String PARADIGM = "paradigm";
-    public static final String EDICT = "edict";
+    public static final String TF_GENOME = "tf_genome";
+    public static final String TF_PARADIGM = "tf_paradigm";
+    public static final String TF_EDICT = "tf_edict";
 
     public static final String HS_TILE_POSITION = "hs_tile_position";
 

--- a/src/main/java/ti4/model/LeaderModel.java
+++ b/src/main/java/ti4/model/LeaderModel.java
@@ -110,20 +110,12 @@ public class LeaderModel implements ModelInterface, EmbeddableModel {
         return Optional.ofNullable(tfAbilityText);
     }
 
-    private boolean isTFCard() {
-        return source == ComponentSource.twilights_fall
-                || tfName != null
-                || tfTitle != null
-                || tfAbilityWindow != null
-                || tfAbilityText != null;
-    }
-
     public boolean isGenome() {
-        return Constants.AGENT.equalsIgnoreCase(type) && isTFCard();
+        return Mapper.getDeck(Constants.TF_GENOME).getNewDeck().contains(ID);
     }
 
     public boolean isParadigm() {
-        return Constants.HERO.equalsIgnoreCase(type) && isTFCard();
+        return Mapper.getDeck(Constants.TF_PARADIGM).getNewDeck().contains(ID);
     }
 
     private Optional<String> getFlavourText() {


### PR DESCRIPTION
use genome/paradigm deck directly instead of mucking around with tfname/tftitle/etc.