### PR TITLE
Handle null user when adding async player role

### DIFF
--- a/src/main/java/ti4/service/async/RoleService.java
+++ b/src/main/java/ti4/service/async/RoleService.java
@@ -81,6 +81,9 @@ public class RoleService {
     }
 
     public void checkIfNewUserIsInAnyGamesAndAddRole(User user) {
+        if (user == null) {
+            return;
+        }
         ManagedPlayer player = GameManager.getManagedPlayer(user.getId());
         if (player != null && !player.getGames().isEmpty()) {
             for (Guild guild : JdaService.guilds) {


### PR DESCRIPTION
## Summary
- prevent null user from causing errors when adding async player roles

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391803b624832da934ac8fa34ddfda)