### PR TITLE
Refactor developer commands for game modification

### DIFF
--- a/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/commands/developer/RunAgainstAllGames.java
@@ -1,14 +1,10 @@
 package ti4.commands.developer;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.commands.Subcommand;
 import ti4.map.Game;
-import ti4.map.helper.GameHelper;
 import ti4.map.persistence.GameManager;
 import ti4.map.persistence.GamesPage;
 import ti4.message.MessageHelper;
@@ -40,18 +36,7 @@ class RunAgainstAllGames extends Subcommand {
     }
 
     private static boolean makeChanges(Game game) {
-        int gameNameHash = game.getName().hashCode();
-        int hours = Math.floorMod(gameNameHash, 24);
-        int minutes = Math.floorMod(gameNameHash, 60);
-
-        int customNameHash = game.getCustomName().hashCode();
-        int seconds = Math.floorMod(customNameHash, 60);
-        int nanoseconds = Math.floorMod(gameNameHash, 1_000_000_000);
-
-        LocalDate creationDate = GameHelper.getCreationDateAsLocalDate(game);
-        LocalDateTime creationDateWithFakeTime = creationDate.atTime(hours, minutes, seconds, nanoseconds);
-        game.setCreationDateTime(
-                creationDateWithFakeTime.toInstant(ZoneOffset.UTC).toEpochMilli());
-        return true;
+        // Developer's Delight
+        return false;
     }
 }

--- a/src/main/java/ti4/commands/developer/RunAgainstSpecificGame.java
+++ b/src/main/java/ti4/commands/developer/RunAgainstSpecificGame.java
@@ -42,10 +42,7 @@ class RunAgainstSpecificGame extends Subcommand {
     }
 
     private static boolean makeChanges(Game game) {
-        if (!game.isThundersEdge()) {
-            return false;
-        }
-        game.setThundersEdge(false);
+        game.setCreationDateTime(1765323420000L);
         return true;
     }
 }


### PR DESCRIPTION
Simplifies the makeChanges logic in RunAgainstAllGames and RunAgainstSpecificGame. Removes custom date/time generation and sets a fixed creation date time in RunAgainstSpecificGame, while RunAgainstAllGames now returns false by default.