### PR TITLE
Fixing TF Scarab bug (Keleres cruiser not recognised) 

### DIFF
--- a/src/main/resources/data/units/twilights_fall.json
+++ b/src/main/resources/data/units/twilights_fall.json
@@ -383,7 +383,7 @@
         "asyncId": "ca",
         "name": "Saggitaria",
         "source": "twilights_fall",
-        "faction": "keleresm",
+        "faction": "keleres",
         "moveValue": 3,
         "capacityValue": 1,
         "capacityUsed": 1,

--- a/src/test/java/ti4/model/UnitModelTest.java
+++ b/src/test/java/ti4/model/UnitModelTest.java
@@ -42,7 +42,8 @@ class UnitModelTest extends BaseTi4Test {
 
     private static boolean validateFaction(UnitModel unitModel) {
         if (unitModel.getFaction().isEmpty()) return true;
-        if (Mapper.isValidFaction(unitModel.getFaction().get())) return true;
+        if (Mapper.isValidFaction(unitModel.getFaction().get())
+                || "keleres".equals(unitModel.getFaction().get())) return true;
         System.out.println("[TEST FAILURE] Unit **" + unitModel.getId()
                 + "** failed validation due to invalid Faction ID: `"
                 + unitModel.getFaction().get() + "`");


### PR DESCRIPTION
Keleres Cruiser faction was set to `keleresm`, all the abilities and genomes have faction set to `keleres`, so Scarab wasn't picking up the cruiser. 

Setting the faction to `keleres` and copying faction check from the Technologies unit test.