### PR TITLE
Clarify Creuss hero tile limitations

### DIFF
--- a/src/main/resources/data/leaders/pok.json
+++ b/src/main/resources/data/leaders/pok.json
@@ -746,7 +746,7 @@
         "tfTitle": "",
         "abilityName": "Singularity Reactor: Changing the Ways",
         "abilityWindow": "ACTION:",
-        "abilityText": "Swap the positions of any 2 systems that contain wormholes or your units, other than the Creuss system and the wormhole nexus. Then, purge this card.",
+        "abilityText": "Swap the positions of any 2 systems that contain wormholes or your units, other than the Creuss system and the wormhole nexus. Then, purge this card. [Note: Cannot be used on irregularly sized tiles like Creuxx or The Fracture.]",
         "unlockCondition": "Have 3 scored objectives.",
         "source": "pok",
         "shortName": "Riftwlkr\nMeian"


### PR DESCRIPTION
## Summary
- add a bracketed note to the Creuss hero indicating it cannot be used on irregularly sized tiles such as Creuxx or The Fracture

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943de098244832dacba6446ce1578ca)