### PR TITLE
Fix prioritize damaged option in remove unit service

### DIFF
--- a/src/main/java/ti4/service/unit/RemoveUnitService.java
+++ b/src/main/java/ti4/service/unit/RemoveUnitService.java
@@ -162,7 +162,8 @@ public class RemoveUnitService {
             Game game,
             ParsedUnit parsedUnit,
             boolean prioritizeDamagedUnits) {
-        return removeUnit(event, tile, game, parsedUnit, UnitState.dmg);
+        UnitState preferredState = prioritizeDamagedUnits ? UnitState.dmg : UnitState.none;
+        return removeUnit(event, tile, game, parsedUnit, preferredState);
     }
 
     public static List<RemovedUnit> removeUnit(


### PR DESCRIPTION
## Summary
- honor the prioritizeDamagedUnits flag when removing units so the preferred unit state is chosen appropriately

## Testing
- not run (network access to Maven Central blocked in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a53f1008832d9108f35cdf33d581)