### PR TITLE
Improve ban cleanup logging and null safety

### DIFF
--- a/src/main/java/ti4/service/async/BanCleanupService.java
+++ b/src/main/java/ti4/service/async/BanCleanupService.java
@@ -155,10 +155,9 @@ public class BanCleanupService {
 
     private boolean authorIsUser(User author, User user) {
         String authorNameLower = author.getName().toLowerCase();
-        List<String> names =
-                Stream.of(user.getName(), user.getEffectiveName(), user.getGlobalName())
-                        .filter(Objects::nonNull)
-                        .toList();
+        List<String> names = Stream.of(user.getName(), user.getEffectiveName(), user.getGlobalName())
+                .filter(Objects::nonNull)
+                .toList();
         for (String n : names) {
             if (authorNameLower.startsWith(n.toLowerCase())) return true;
         }


### PR DESCRIPTION
## Summary
- extract shared bot-question channel names constant and fix typo in user identification
- reuse a helper for consistent guild error logging and clarify cleanup messages
- avoid null-pointer risks when matching users by name in spam cleanup

## Testing
- mvn spotless:check *(fails: unable to resolve spring-boot-starter-parent from Maven Central: 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694944fa7ffc832d89df57f21473c6ed)