### PR TITLE
Remove map render rate limiting and update button handling

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -3521,7 +3521,6 @@ public class ButtonHelper {
         if (deleteMessage && !hasRealButton) {
             event.getHook().deleteOriginal().queue(Consumers.nop(), BotLogger::catchRestError);
         } else {
-            // event.getHook().editOriginalComponents(updatedTree)
             event.getMessage().editMessageComponents(updatedTree).queue(Consumers.nop(), BotLogger::catchRestError);
         }
     }

--- a/src/main/java/ti4/service/ShowGameService.java
+++ b/src/main/java/ti4/service/ShowGameService.java
@@ -6,6 +6,8 @@ import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import org.apache.commons.lang3.function.Consumers;
 import ti4.buttons.Buttons;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.DisplayType;
@@ -13,6 +15,7 @@ import ti4.image.MapRenderPipeline;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
+import ti4.message.logging.BotLogger;
 import ti4.service.fow.UserOverridenGenericInteractionCreateEvent;
 
 @UtilityClass
@@ -37,6 +40,9 @@ public class ShowGameService {
             } else {
                 MessageChannel channel = sendMessage(game, event);
                 MessageHelper.sendFileUploadToChannel(channel, fileUpload);
+            }
+            if (event instanceof ButtonInteractionEvent buttonEvent) {
+                buttonEvent.getHook().deleteOriginal().queue(Consumers.nop(), BotLogger::catchRestError);
             }
         });
     }


### PR DESCRIPTION
Removed the per-game map render rate limiting logic from MapRenderPipeline, allowing more frequent renders. Updated ShowGameService to delete the original message after a button interaction, and cleaned up unused imports and commented code in related files.