### PR TITLE
Add Sardakk breakthrough reminder in cards info

### DIFF
--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -873,6 +873,17 @@ public class StartCombatService {
                                 + otherPlayer.getColor() + ") command token to your fleet pool.",
                         buttons);
             }
+            if (player.hasUnlockedBreakthrough("sardakkbt")) {
+                buttons = new ArrayList<>();
+                buttons.add(Buttons.gray(
+                        player.getFinsFactionCheckerPrefix() + "sardakkbtRes",
+                        "Resolve Sardakk Breakthrough (Upon Win)",
+                        FactionEmojis.Sardakk));
+                MessageHelper.sendMessageToChannelWithButtons(
+                        player.getCardsInfoThread(),
+                        msg + ", a reminder that if you win this combat, you may resolve your breakthrough.",
+                        buttons);
+            }
             if (player.hasTechReady("dskortg") && CommandCounterHelper.hasCC(player, tile)) {
                 buttons = new ArrayList<>();
                 buttons.add(Buttons.gray(


### PR DESCRIPTION
### Motivation
- Players with the Sardakk breakthrough sometimes miss the "Resolve Sardakk Breakthrough (Upon Win)" button in combat threads, so the bot should remind them in their Cards Info thread similar to other reminders.
- The reminder helps ensure players know they can resolve their breakthrough upon winning a combat without relying on the combat thread UI.

### Description
- Added a check for `player.hasUnlockedBreakthrough("sardakkbt")` inside `StartCombatService` to send a reminder into the player's `cardsInfoThread` at combat start.
- The change uses `MessageHelper.sendMessageToChannelWithButtons` to post a message and a gray button with id `player.getFinsFactionCheckerPrefix() + "sardakkbtRes"` and label `"Resolve Sardakk Breakthrough (Upon Win)"` using `FactionEmojis.Sardakk`.
- The new block is inserted alongside other combat-start reminders in `src/main/java/ti4/service/combat/StartCombatService.java` and appends to the existing `msg` text.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e4cecff00832d8c236d3820422908)