### PR TITLE
Include eliminated players in TIGL report and zero their scores

### DIFF
--- a/src/main/java/ti4/service/tigl/TiglReportService.java
+++ b/src/main/java/ti4/service/tigl/TiglReportService.java
@@ -2,7 +2,6 @@ package ti4.service.tigl;
 
 import static ti4.helpers.Constants.TIGL_FRACTURED_TAG;
 
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,8 +20,6 @@ import ti4.website.UltimateStatisticsWebsiteHelper;
 
 @UtilityClass
 public class TiglReportService {
-
-    private static final DateTimeFormatter CREATION_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
     public static void handleTiglReporting(Game game, GenericInteractionCreateEvent event) {
         if (!game.isCompetitiveTIGLGame() || game.getWinner().isEmpty()) {
@@ -52,8 +49,8 @@ public class TiglReportService {
                 .append("\n");
         sb.append("Players:").append("\n");
         int index = 1;
-        for (Player player : game.getRealPlayers()) {
-            int playerVP = player.getTotalVictoryPoints();
+        for (Player player : game.getRealAndEliminatedPlayers()) {
+            int playerVP = player.isEliminated() ? 0 : player.getTotalVictoryPoints();
             Optional<User> user = Optional.ofNullable(event.getJDA().getUserById(player.getUserID()));
             sb.append("  ").append(index).append(". ");
             sb.append(player.getFaction()).append(" - ");


### PR DESCRIPTION
### Motivation
- Ensure TIGL reports include eliminated players so external league reporting has the complete player list.
- Treat eliminated players as scoring 0 to avoid reporting stale victory point values for eliminated participants.

### Description
- Use `game.getRealAndEliminatedPlayers()` when building the TIGL player results instead of `game.getRealPlayers()`.
- Set each `TiglPlayerResult` score to `0` when `player.isEliminated()` and otherwise use `player.getTotalVictoryPoints()`.
- Preserve existing faction, Discord id/tag, and winner flag logic when mapping players into `TiglPlayerResult` objects.
- Player count resolution remains based on `getRealAndEliminatedPlayers()`.

### Testing
- No automated tests were executed as part of this change.
- No test failures reported because test suite was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514923548c832d9993fee9eed7e572)