### PR TITLE
Cap displayed victory points to game goal

### DIFF
--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -677,7 +677,7 @@ public class MapGenerator implements AutoCloseable {
                     int centreHorizontally = Math.max(0, (availableSpacePerColumn - tokenWidth) / 2);
                     int centreVertically = Math.max(0, (availableSpacePerRow - tokenHeight) / 2);
 
-                    int vpCount = player.getTotalVictoryPoints();
+                    int vpCount = Math.min(player.getTotalVictoryPoints(), game.getScoreTrackMax());
                     int tokenX = vpCount * boxWidth
                             + Math.min(
                                     boxBuffer + (availableSpacePerColumn * col) + centreHorizontally,
@@ -1191,7 +1191,7 @@ public class MapGenerator implements AutoCloseable {
 
         { // PAINT VICTORY POINTS
             graphics.setFont(Storage.getFont32());
-            String vpCount = "VP: " + player.getTotalVictoryPoints() + " / " + game.getVp();
+            String vpCount = "VP: " + player.getTotalVictoryPointsCapped() + " / " + game.getVp();
             point = PositionMapper.getPlayerStats("newvp");
             point.translate(statTileMid.x, statTileMid.y);
             DrawingUtil.superDrawString(
@@ -1930,7 +1930,7 @@ public class MapGenerator implements AutoCloseable {
         graphics.drawString(player.getColor(), point.x + deltaX, point.y + deltaY);
 
         // PAIN VICTORY POINTS
-        int vpCount = player.getTotalVictoryPoints();
+        int vpCount = player.getTotalVictoryPointsCapped();
         point = PositionMapper.getPlayerStats(Constants.STATS_VP);
         graphics.drawString("VP: " + vpCount, point.x + deltaX, point.y + deltaY);
 

--- a/src/main/java/ti4/map/Game.java
+++ b/src/main/java/ti4/map/Game.java
@@ -723,6 +723,18 @@ public class Game extends GameProperties {
         setButtonPressCount(getButtonPressCount() + 1);
     }
 
+    @JsonIgnore
+    public int getScoreTrackMax() {
+        int max = getVp();
+        if (isLiberationC4Mode()) {
+            max = Math.max(max, 12);
+        }
+        if (isAllianceMode()) {
+            max = Math.max(max, 14);
+        }
+        return max;
+    }
+
     public int getSlashCommandsRunCount() {
         return slashCommandsUsed.values().stream().mapToInt(Integer::intValue).sum();
     }

--- a/src/main/java/ti4/map/Player.java
+++ b/src/main/java/ti4/map/Player.java
@@ -2086,6 +2086,11 @@ public class Player extends PlayerProperties {
         return getPublicVictoryPoints(true) + getSecretVictoryPoints() + getSupportForTheThroneVictoryPoints();
     }
 
+    @JsonIgnore
+    public int getTotalVictoryPointsCapped() {
+        return Math.min(getTotalVictoryPoints(), game.getVp());
+    }
+
     @Override
     public void setTg(int tg) {
         super.setTg(Math.max(0, tg));

--- a/src/main/java/ti4/service/tigl/TiglReportService.java
+++ b/src/main/java/ti4/service/tigl/TiglReportService.java
@@ -50,7 +50,7 @@ public class TiglReportService {
         sb.append("Players:").append("\n");
         int index = 1;
         for (Player player : game.getRealAndEliminatedPlayers()) {
-            int playerVP = player.isEliminated() ? 0 : player.getTotalVictoryPoints();
+            int playerVP = player.isEliminated() ? 0 : player.getTotalVictoryPointsCapped();
             Optional<User> user = Optional.ofNullable(event.getJDA().getUserById(player.getUserID()));
             sb.append("  ").append(index).append(". ");
             sb.append(player.getFaction()).append(" - ");
@@ -88,7 +88,7 @@ public class TiglReportService {
         var tiglPlayerResults = game.getRealAndEliminatedPlayers().stream()
                 .map(player -> {
                     var tiglPlayerResult = new TiglPlayerResult();
-                    tiglPlayerResult.setScore(player.isEliminated() ? 0 : player.getTotalVictoryPoints());
+                    tiglPlayerResult.setScore(player.isEliminated() ? 0 : player.getTotalVictoryPointsCapped());
                     if (player.getFactionModel() != null) {
                         tiglPlayerResult.setFaction(player.getFactionModel().getFactionName());
                     } else {

--- a/src/main/java/ti4/website/model/WebPlayerArea.java
+++ b/src/main/java/ti4/website/model/WebPlayerArea.java
@@ -350,7 +350,7 @@ public class WebPlayerArea {
         webPlayerArea.setPnCount(player.getPnCount());
 
         // victory points
-        webPlayerArea.setTotalVps(player.getTotalVictoryPoints());
+        webPlayerArea.setTotalVps(player.getTotalVictoryPointsCapped());
 
         // secret objectives
         webPlayerArea.setNumScoreableSecrets(player.getMaxSOCount());

--- a/src/main/java/ti4/website/model/stats/PlayerStatsDashboardPayload.java
+++ b/src/main/java/ti4/website/model/stats/PlayerStatsDashboardPayload.java
@@ -275,7 +275,7 @@ public class PlayerStatsDashboardPayload {
     }
 
     public int getScore() {
-        return player.getTotalVictoryPoints();
+        return player.getTotalVictoryPointsCapped();
     }
 
     public List<String> getStrategyCards() {


### PR DESCRIPTION
### Motivation
- Fix incorrect displays and exports where players could show more victory points than the game goal (e.g. 11 VP in a 10 VP game) which also caused control tokens to render outside the score track. 
- Ensure TIGL reports, website statistics, and map rendering reflect the official rule that players cannot have more than the game VP goal. 
- Preserve correct behavior for special modes that extend the score track length (Liberation C4 and Alliance). 

### Description
- Add `getTotalVictoryPointsCapped()` on `Player` to return `min(totalVP, game.getVp())` and `getScoreTrackMax()` on `Game` to compute track bounds with special modes. 
- Use the capped VP in TIGL exports (`TiglReportService`), dashboard payload (`PlayerStatsDashboardPayload`), and web player area (`WebPlayerArea`) so external reports never exceed the game VP. 
- Update map rendering (`MapGenerator`) to place control tokens using `Math.min(player.getTotalVictoryPoints(), game.getScoreTrackMax())` and to display capped VP strings so tokens and displayed values stay within the visible score track. 

### Testing
- No automated tests were run on these changes. 
- The change was compiled and committed locally as a code update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d36319d0832d96fd2b2bb9b77e0f)