### PR TITLE
Use Map.merge for strategy card pick counts

### DIFF
--- a/src/main/java/ti4/service/statistics/FactionRecordOfStrategyCardPickService.java
+++ b/src/main/java/ti4/service/statistics/FactionRecordOfStrategyCardPickService.java
@@ -16,6 +16,7 @@ import ti4.map.Player;
 import ti4.map.persistence.GamesPage;
 import ti4.message.MessageHelper;
 import ti4.model.FactionModel;
+import ti4.model.StrategyCardModel;
 
 @UtilityClass
 public class FactionRecordOfStrategyCardPickService {
@@ -99,21 +100,20 @@ public class FactionRecordOfStrategyCardPickService {
             gamesThatHadThem.incrementAndGet();
             String[] scList = scs.split("_");
             for (String sc : scList) {
-                sc = game.getStrategyCardModelByInitiative(Integer.parseInt(sc))
-                        .get()
-                        .getName();
-                if (scsPicked.containsKey(sc)) {
-                    scsPicked.put(sc, scsPicked.get(sc) + 1);
-                } else {
-                    scsPicked.put(sc, 1);
+                if (!Helper.isInteger(sc)) {
+                    continue;
                 }
+                int scInitiative = Integer.parseInt(sc);
+                String scName = game.getStrategyCardModelByInitiative(scInitiative)
+                        .map(StrategyCardModel::getName)
+                        .orElse(null);
+                if (scName == null) {
+                    continue;
+                }
+                scsPicked.merge(scName, 1, Integer::sum);
                 if (game.getCustodiansTaker() != null
                         && game.getCustodiansTaker().equalsIgnoreCase(faction)) {
-                    if (custodians.containsKey(sc)) {
-                        custodians.put(sc, custodians.get(sc) + 1);
-                    } else {
-                        custodians.put(sc, 1);
-                    }
+                    custodians.merge(scName, 1, Integer::sum);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Prevent exceptions from malformed stored strategy card tokens and missing strategy card models by validating tokens and avoiding `Optional.get()` usage.
- Simplify and centralize the counting logic for strategy card picks and custodians to reduce boilerplate.
- Ensure statistics aggregation is resilient to invalid or non-integer stored values.

### Description
- Replace manual `containsKey`/`get`/`put` increment logic with `Map.merge(..., 1, Integer::sum)` for both `scsPicked` and `custodians` counters.
- Continue to skip non-integer tokens using `Helper.isInteger` and parse initiatives with `Integer.parseInt` only after validation.
- Resolve strategy card names safely via `game.getStrategyCardModelByInitiative(...).map(StrategyCardModel::getName).orElse(null)` and skip missing models.
- Add `StrategyCardModel` import and use the resolved `scName` as the key for counting.

### Testing
- No automated tests were run for this change.
- A local commit was created containing the modifications (no CI/test results available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695354327cec832d9cfb918fa3b8cef7)