### PR TITLE
Remove replacement check from TIGL report sending

### DIFF
--- a/src/main/java/ti4/service/tigl/TiglReportService.java
+++ b/src/main/java/ti4/service/tigl/TiglReportService.java
@@ -28,14 +28,7 @@ public class TiglReportService {
 
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), getTIGLFormattedGameEndText(game, event));
 
-        if (!game.isReplacementMade()) {
-            UltimateStatisticsWebsiteHelper.sendTiglGameReport(buildTiglReport(game), event.getMessageChannel());
-        } else {
-            MessageHelper.sendMessageToChannel(
-                    event.getMessageChannel(),
-                    "This game had a replacement. Please report the results manually: "
-                            + "https://www.ti4ultimate.com/community/tigl/report-game");
-        }
+        UltimateStatisticsWebsiteHelper.sendTiglGameReport(buildTiglReport(game), event.getMessageChannel());
     }
 
     private static String getTIGLFormattedGameEndText(Game game, GenericInteractionCreateEvent event) {


### PR DESCRIPTION
Simplifies the report sending logic by always sending the TIGL game report, regardless of whether a replacement was made. The manual reporting message for replacement games has been removed.