### PR TITLE
Trade SC debts are placed into an appropriately named (Trade R{round}…

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -5454,8 +5454,9 @@ public class ButtonHelper {
             }
             msg += "trade good to " + tradeHolder.getRepresentation() + ".";
         } else {
-            SendDebtService.sendDebt(player, tradeHolder, 1);
-            msg += "debt token to " + tradeHolder.getRepresentation() + ", for their \"Debt Account\" pool.";
+            String tradePool = "Trade R" + game.getRound();
+            SendDebtService.sendDebt(player, tradeHolder, 1, tradePool);
+            msg += "debt token to " + tradeHolder.getRepresentation() + ", for their \"" + tradePool + "\" pool.";
         }
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), msg);
         CommanderUnlockCheckService.checkPlayer(tradeHolder, "hacan");


### PR DESCRIPTION
…) pool by default

Simple QoL change. "Sent 1 debt" from following trade sc goes into a pool named `Trade R<round>`. Separates trade sc debt from regular trade debt, and for what few games don't always pay back trade at agenda (hidden agenda games in particular) it's nice to know where the debt came from.