### PR TITLE
Add "Agent Of Chaos" to end-game player titles

### DIFF
--- a/src/main/java/ti4/helpers/PlayerTitleHelper.java
+++ b/src/main/java/ti4/helpers/PlayerTitleHelper.java
@@ -60,6 +60,7 @@ public class PlayerTitleHelper {
             buttons.add(Buttons.red("bestowTitleStep1_A Warlord", "A Warlord"));
             buttons.add(Buttons.red("bestowTitleStep1_Word Breaker", "Word Breaker"));
             buttons.add(Buttons.red("bestowTitleStep1_One To Be Feared", "One To Be Feared"));
+            buttons.add(Buttons.red("bestowTitleStep1_Agent Of Chaos", "Agent Of Chaos"));
             buttons.add(Buttons.red("bestowTitleStep1_Spice Bringer", "Spice Bringer"));
 
             MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), msg);


### PR DESCRIPTION
### Motivation
- Provide players an additional selectable end-game title by adding the "Agent Of Chaos" option to the existing title bestowal UI.

### Description
- Inserted a new red title button `Buttons.red("bestowTitleStep1_Agent Of Chaos", "Agent Of Chaos")` into `PlayerTitleHelper.offerEveryoneTitlePossibilities` in `src/main/java/ti4/helpers/PlayerTitleHelper.java` so the title appears alongside other end-game title options.

### Testing
- Ran `./gradlew -q compileJava`, which was not available in the repository and therefore failed. 
- Ran `mvn -q -DskipTests compile`, which failed due to external dependency resolution (Spring Boot parent POM download returned HTTP 403), so a full compile could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad85de1958832d8993d486c8f36fef)