### PR TITLE
Add red "Kingmaker" title option

### DIFF
--- a/src/main/java/ti4/helpers/PlayerTitleHelper.java
+++ b/src/main/java/ti4/helpers/PlayerTitleHelper.java
@@ -58,6 +58,7 @@ public class PlayerTitleHelper {
                     Buttons.red("bestowTitleStep1_A Vuil'Raith In Xxcha Clothing", "A Vuil'Raith In Xxcha Clothing"));
             // buttons.add(Buttons.red("bestowTitleStep1_Space Risker", "Space Risker"));
             buttons.add(Buttons.red("bestowTitleStep1_A Warlord", "A Warlord"));
+            buttons.add(Buttons.red("bestowTitleStep1_Kingmaker", "Kingmaker"));
             buttons.add(Buttons.red("bestowTitleStep1_Word Breaker", "Word Breaker"));
             buttons.add(Buttons.red("bestowTitleStep1_One To Be Feared", "One To Be Feared"));
             buttons.add(Buttons.red("bestowTitleStep1_Spice Bringer", "Spice Bringer"));


### PR DESCRIPTION
### Motivation
- Provide a new red bestowable title called `Kingmaker` in the post-game title selection so players can gift that title.

### Description
- Added a single line `Buttons.red("bestowTitleStep1_Kingmaker", "Kingmaker")` to `PlayerTitleHelper.offerEveryoneTitlePossibilities` so the `Kingmaker` button appears in the red-title group.

### Testing
- Attempted to compile with `mvn -q -DskipTests compile`, but the build failed due to external dependency resolution for `org.springframework.boot:spring-boot-starter-parent:4.0.3` returning HTTP 403, so no successful local build was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad959b5980832d95ea293a2a9f8c79)