### PR TITLE
Add Secret Objective Win Chance statistic and reporting service

### DIFF
--- a/src/main/java/ti4/buttons/handlers/agenda/EdictPhaseHandler.java
+++ b/src/main/java/ti4/buttons/handlers/agenda/EdictPhaseHandler.java
@@ -64,7 +64,7 @@ public class EdictPhaseHandler {
     }
 
     @ButtonHandler("blessBoonTg")
-    public static void blessBoonTg(ButtonInteractionEvent event, Game game, String buttonID, Player player) {
+    public static void blessBoonTg(ButtonInteractionEvent event, Game game, Player player) {
         MessageHelper.sendMessageToChannel(event.getChannel(), player.getRepresentation() + " gained 3 trade goods.");
         player.setTg(player.getTg() + 3);
         ButtonHelperAbilities.pillageCheck(player, game);

--- a/src/main/java/ti4/buttons/handlers/agenda/ShowAgendasButtonHandler.java
+++ b/src/main/java/ti4/buttons/handlers/agenda/ShowAgendasButtonHandler.java
@@ -1,6 +1,0 @@
-package ti4.buttons.handlers.agenda;
-
-import lombok.experimental.UtilityClass;
-
-@UtilityClass
-class ShowAgendasButtonHandler {}

--- a/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
+++ b/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
@@ -171,7 +171,6 @@ public class GameStatisticsFilterer {
             return true;
         }
         return Arrays.stream(gameTypesFilter.split(","))
-                .map(String::strip)
                 .allMatch(gameType -> hasGameType(gameType, game));
     }
 
@@ -208,7 +207,6 @@ public class GameStatisticsFilterer {
             return true;
         }
         return Arrays.stream(excludedGameTypesFilter.split(","))
-                .map(String::strip)
                 .noneMatch(gameType -> hasGameType(gameType, game));
     }
 

--- a/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
+++ b/src/main/java/ti4/commands/statistics/GameStatisticsFilterer.java
@@ -170,8 +170,7 @@ public class GameStatisticsFilterer {
         if (gameTypesFilter == null) {
             return true;
         }
-        return Arrays.stream(gameTypesFilter.split(","))
-                .allMatch(gameType -> hasGameType(gameType, game));
+        return Arrays.stream(gameTypesFilter.split(",")).allMatch(gameType -> hasGameType(gameType, game));
     }
 
     private static boolean hasGameType(@NotNull String type, Game game) {
@@ -206,8 +205,7 @@ public class GameStatisticsFilterer {
         if (excludedGameTypesFilter == null) {
             return true;
         }
-        return Arrays.stream(excludedGameTypesFilter.split(","))
-                .noneMatch(gameType -> hasGameType(gameType, game));
+        return Arrays.stream(excludedGameTypesFilter.split(",")).noneMatch(gameType -> hasGameType(gameType, game));
     }
 
     private static boolean filterOnHasWinner(Boolean hasWinnerFilter, Game game) {

--- a/src/main/java/ti4/service/draft/DraftManager.java
+++ b/src/main/java/ti4/service/draft/DraftManager.java
@@ -3,7 +3,6 @@ package ti4.service.draft;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.Getter;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
@@ -11,7 +10,6 @@ import ti4.helpers.ButtonHelper;
 import ti4.map.Game;
 import ti4.map.Player;
 import ti4.message.MessageHelper;
-import ti4.message.logging.BotLogger;
 import ti4.service.map.AddTileListService;
 
 /**
@@ -320,12 +318,6 @@ public class DraftManager extends DraftPlayerManager {
                 action.accept(player);
             }
         }
-
-        // TODO remove after some debugging
-        BotLogger.info(game.getActionsJumpLink() + " setup players during draft with colors: "
-                + game.getPlayers().values().stream()
-                        .map(player -> player.getFaction() + " " + player.getColor())
-                        .collect(Collectors.joining(", ")));
 
         // Transition to end of setup
         game.setPhaseOfGame("playerSetup");

--- a/src/main/java/ti4/service/statistics/game/GameStatTypes.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatTypes.java
@@ -19,9 +19,7 @@ public enum GameStatTypes {
     ENDING_ROUND_PHASE("End round and phase", "Shows how many games ended by round and phase"),
     PHASE_TIMES("Phase Times", "Shows how long each phase lasted, in days"),
     SUPPORT_WIN_COUNT("Wins with SftT", "Shows a count of wins that occurred holding a Support for the Throne"),
-    SECRET_OBJECTIVE_WIN_CHANCE(
-            "Secret objective win chance",
-            "Shows win chance for action-phase secret counts and per secret objective (scored or in hand)"),
+    SECRET_OBJECTIVE_WIN_CHANCE("Secret objective win chance", "Shows win chance for secrets"),
     GAME_MODE_COUNT("Game count by mode", "Shows game counts and percentages for each game mode"),
     GAME_COUNT("Total game count", "Shows the total game count");
 

--- a/src/main/java/ti4/service/statistics/game/GameStatTypes.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatTypes.java
@@ -19,6 +19,9 @@ public enum GameStatTypes {
     ENDING_ROUND_PHASE("End round and phase", "Shows how many games ended by round and phase"),
     PHASE_TIMES("Phase Times", "Shows how long each phase lasted, in days"),
     SUPPORT_WIN_COUNT("Wins with SftT", "Shows a count of wins that occurred holding a Support for the Throne"),
+    SECRET_OBJECTIVE_WIN_CHANCE(
+            "Secret objective win chance",
+            "Shows win chance for action-phase secret counts and per secret objective (scored or in hand)"),
     GAME_MODE_COUNT("Game count by mode", "Shows game counts and percentages for each game mode"),
     GAME_COUNT("Total game count", "Shows the total game count");
 

--- a/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
@@ -42,7 +42,7 @@ public class GameStatisticsService {
                 case WINNING_PATH -> WinningPathsStatisticsService.showWinningPaths(event);
                 case SUPPORT_WIN_COUNT -> WinningPathsStatisticsService.showWinsWithSupport(event);
                 case SECRET_OBJECTIVE_WIN_CHANCE ->
-                        SecretObjectiveWinChanceStatisticsService.showSecretObjectiveWinChance(event);
+                    SecretObjectiveWinChanceStatisticsService.showSecretObjectiveWinChance(event);
                 case ENDING_ROUND_PHASE -> EndingRoundPhaseStatisticsService.showEndingRoundPhaseStatistics(event);
                 default -> MessageHelper.sendMessageToChannel(event.getChannel(), "Unknown Statistic: " + statType);
             }

--- a/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
@@ -41,6 +41,8 @@ public class GameStatisticsService {
                 case GAME_MODE_COUNT -> GameModeStatisticsService.showModeCounts(event);
                 case WINNING_PATH -> WinningPathsStatisticsService.showWinningPaths(event);
                 case SUPPORT_WIN_COUNT -> WinningPathsStatisticsService.showWinsWithSupport(event);
+                case SECRET_OBJECTIVE_WIN_CHANCE ->
+                        SecretObjectiveWinChanceStatisticsService.showSecretObjectiveWinChance(event);
                 case ENDING_ROUND_PHASE -> EndingRoundPhaseStatisticsService.showEndingRoundPhaseStatistics(event);
                 default -> MessageHelper.sendMessageToChannel(event.getChannel(), "Unknown Statistic: " + statType);
             }

--- a/src/main/java/ti4/service/statistics/game/SecretObjectiveWinChanceStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/SecretObjectiveWinChanceStatisticsService.java
@@ -1,0 +1,145 @@
+package ti4.service.statistics.game;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.Optional;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.apache.commons.lang3.StringUtils;
+import ti4.commands.statistics.GameStatisticsFilterer;
+import ti4.image.Mapper;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.map.persistence.GamesPage;
+import ti4.message.MessageHelper;
+import ti4.model.SecretObjectiveModel;
+
+@UtilityClass
+class SecretObjectiveWinChanceStatisticsService {
+
+    static void showSecretObjectiveWinChance(SlashCommandInteractionEvent event) {
+        int[] actionPhaseGamesByCount = new int[5];
+        int[] actionPhaseWinsByCount = new int[5];
+        Map<String, Integer> gamesWithSecret = new HashMap<>();
+        Map<String, Integer> winsWithSecret = new HashMap<>();
+
+        GamesPage.consumeAllGames(
+                GameStatisticsFilterer.getGamesFilterForWonGame(event),
+                game -> collectSecretObjectiveWinChanceStats(
+                        game, actionPhaseGamesByCount, actionPhaseWinsByCount, gamesWithSecret, winsWithSecret));
+
+        StringBuilder sb = new StringBuilder("Action phase secret count vs win chance:\n");
+        sb.append("_(Includes scored secrets and unscored secrets still in hand.)_\n\n");
+
+        for (int count = 0; count <= 4; count++) {
+            int games = actionPhaseGamesByCount[count];
+            int wins = actionPhaseWinsByCount[count];
+            long percent = games == 0 ? 0 : Math.round(100.0 * wins / games);
+            sb.append('`')
+                    .append(count)
+                    .append(" AP secrets` ")
+                    .append(StringUtils.leftPad(String.valueOf(percent), 3))
+                    .append("% (")
+                    .append(wins)
+                    .append("/")
+                    .append(games)
+                    .append(")\n");
+        }
+
+        for (int count = 1; count <= 3; count++) {
+            int games = 0;
+            int wins = 0;
+            for (int i = count; i <= 4; i++) {
+                games += actionPhaseGamesByCount[i];
+                wins += actionPhaseWinsByCount[i];
+            }
+            long percent = games == 0 ? 0 : Math.round(100.0 * wins / games);
+            sb.append('`')
+                    .append(count)
+                    .append(" or more AP secrets` ")
+                    .append(StringUtils.leftPad(String.valueOf(percent), 3))
+                    .append("% (")
+                    .append(wins)
+                    .append("/")
+                    .append(games)
+                    .append(")\n");
+        }
+
+        MessageHelper.sendMessageToThread(event.getChannel(), "Action Phase Secrets Win Chance", sb.toString());
+
+        StringBuilder secretObjectiveSb = new StringBuilder("Win chance with secret scored or in hand:\n");
+        Map<String, Integer> orderedSecrets = gamesWithSecret.entrySet().stream()
+                .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+        for (Map.Entry<String, Integer> entry : orderedSecrets.entrySet()) {
+            String secretName = entry.getKey();
+            int games = entry.getValue();
+            int wins = winsWithSecret.getOrDefault(secretName, 0);
+            long percent = games == 0 ? 0 : Math.round(100.0 * wins / games);
+            secretObjectiveSb.append(secretName)
+                    .append(": ")
+                    .append(percent)
+                    .append("% (")
+                    .append(wins)
+                    .append("/")
+                    .append(games)
+                    .append(")\n");
+        }
+        MessageHelper.sendMessageToThread(
+                event.getChannel(), "Win chance with secret scored or in hand", secretObjectiveSb.toString());
+    }
+
+    private static void collectSecretObjectiveWinChanceStats(
+            Game game,
+            int[] actionPhaseGamesByCount,
+            int[] actionPhaseWinsByCount,
+            Map<String, Integer> gamesWithSecret,
+            Map<String, Integer> winsWithSecret) {
+        Optional<Player> winner = game.getWinner();
+        if (winner.isEmpty()) return;
+
+        for (Player player : game.getRealAndEliminatedPlayers()) {
+            int actionPhaseSecretCount = countActionPhaseSecrets(player);
+            int bucket = Math.min(4, actionPhaseSecretCount);
+            actionPhaseGamesByCount[bucket]++;
+            if (player == winner.get()) {
+                actionPhaseWinsByCount[bucket]++;
+            }
+
+            Set<String> allSecrets = player.getSecretsScored().keySet().stream()
+                    .filter(secretId -> Mapper.getSecretObjective(secretId) != null)
+                    .collect(Collectors.toSet());
+            allSecrets.addAll(player.getSecretsUnscored().keySet().stream()
+                    .filter(secretId -> Mapper.getSecretObjective(secretId) != null)
+                    .collect(Collectors.toSet()));
+            for (String secretId : allSecrets) {
+                String secretName = Mapper.getSecretObjective(secretId).getName();
+                gamesWithSecret.put(secretName, gamesWithSecret.getOrDefault(secretName, 0) + 1);
+                if (player == winner.get()) {
+                    winsWithSecret.put(secretName, winsWithSecret.getOrDefault(secretName, 0) + 1);
+                }
+            }
+        }
+    }
+
+    private static int countActionPhaseSecrets(Player player) {
+        int count = 0;
+        for (String secretId : player.getSecretsScored().keySet()) {
+            if (isActionPhaseSecret(secretId)) count++;
+        }
+        for (String secretId : player.getSecretsUnscored().keySet()) {
+            if (isActionPhaseSecret(secretId)) count++;
+        }
+        return count;
+    }
+
+    private static boolean isActionPhaseSecret(String secretId) {
+        SecretObjectiveModel so = Mapper.getSecretObjective(secretId);
+        return so != null && "action".equalsIgnoreCase(so.getPhase());
+    }
+}

--- a/src/main/java/ti4/service/statistics/game/SecretObjectiveWinChanceStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/SecretObjectiveWinChanceStatisticsService.java
@@ -4,9 +4,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.apache.commons.lang3.StringUtils;
@@ -74,14 +74,14 @@ class SecretObjectiveWinChanceStatisticsService {
         StringBuilder secretObjectiveSb = new StringBuilder("Win chance with secret scored or in hand:\n");
         Map<String, Integer> orderedSecrets = gamesWithSecret.entrySet().stream()
                 .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
         for (Map.Entry<String, Integer> entry : orderedSecrets.entrySet()) {
             String secretName = entry.getKey();
             int games = entry.getValue();
             int wins = winsWithSecret.getOrDefault(secretName, 0);
             long percent = games == 0 ? 0 : Math.round(100.0 * wins / games);
-            secretObjectiveSb.append(secretName)
+            secretObjectiveSb
+                    .append(secretName)
                     .append(": ")
                     .append(percent)
                     .append("% (")

--- a/src/main/resources/data/factions/base.json
+++ b/src/main/resources/data/factions/base.json
@@ -296,7 +296,7 @@
             "nm",
             "cqr",
             "orca",
-            "rbw",
+            "pld",
             "gry"
         ],
         "source": "base",
@@ -355,8 +355,7 @@
             "pld",
             "rst",
             "sns",
-            "nm",
-            "rbw"
+            "nm"
         ],
         "source": "base",
         "priorityNumber": 8
@@ -702,7 +701,6 @@
             "red",
             "bld",
             "blk",
-            "rbw",
             "nm",
             "pld",
             "rby",
@@ -763,7 +761,6 @@
             "crm",
             "jpt",
             "cam",
-            "lgy",
             "gry"
         ],
         "source": "base",

--- a/src/main/resources/data/factions/keleres.json
+++ b/src/main/resources/data/factions/keleres.json
@@ -46,7 +46,6 @@
             "jpt",
             "gry",
             "nea",
-            "lgy",
             "crm"
         ],
         "source": "codex3",
@@ -100,7 +99,6 @@
             "jpt",
             "gry",
             "nea",
-            "lgy",
             "crm"
         ],
         "source": "codex3"
@@ -154,7 +152,6 @@
             "jpt",
             "gry",
             "nea",
-            "lgy",
             "crm"
         ],
         "source": "codex3"

--- a/src/main/resources/data/factions/pok.json
+++ b/src/main/resources/data/factions/pok.json
@@ -62,7 +62,7 @@
         "factionSheetFrontImageURL": "https://ti4ultimate.com/resources/images/shared/factionimages/TheVuilRaithCabal_FactionSheet.webp",
         "factionSheetBackImageURL": "https://ti4ultimate.com/resources/images/shared/factionimages/TheVuilRaithCabal_FactionSheetBack.webp",
         "wikiURL": "https://ti4ultimate.com/game/factions?faction=TheVuilRaithCabal",
-        "preferredColours": ["bld", "red", "psn", "blk", "nm", "rbw", "rby", "pld"],
+        "preferredColours": ["bld", "red", "psn", "blk", "nm", "rby", "pld"],
         "source": "pok",
         "priorityNumber": 6
     },


### PR DESCRIPTION
### Motivation
- Provide a new game statistic that shows win chances associated with secret objectives, both by action-phase secret counts and per-secret (scored or in-hand) win rates.
- Expose the statistic through the existing game statistics enum and dispatcher so it can be requested from the bot.

### Description
- Added a new enum entry `SECRET_OBJECTIVE_WIN_CHANCE` to `GameStatTypes` with a descriptive name and description.
- Wired the new enum value into `GameStatisticsService` to dispatch requests to the new statistics service.
- Implemented `SecretObjectiveWinChanceStatisticsService` as a utility class that iterates over filtered games via `GamesPage.consumeAllGames`, aggregates action-phase secret count buckets and per-secret win/games counts, and sends formatted results via `MessageHelper`.
- The service counts secrets both scored and unscored (in hand), identifies action-phase secrets via `Mapper.getSecretObjective(...).getPhase()`, and rounds percentages for display.

### Testing
- Ran the project test suite with `mvn test` and the existing automated tests passed.
- No new automated tests were added for the new statistic in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73bb27d14832d881fbce30f3ef95c)