### PR TITLE
Serve web game data via Spring endpoint with cache

### DIFF
--- a/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
@@ -1,0 +1,31 @@
+package ti4.spring.api.webdata;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ti4.map.Game;
+import ti4.spring.context.RequestContext;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/public/game/{gameName}")
+public class GameWebDataController {
+
+    private final GameWebDataService gameWebDataService;
+
+    @GetMapping(value = "/web-data", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> get(@PathVariable String gameName) {
+        Game game = RequestContext.getGame();
+        if (game == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (game.isFowMode()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(gameWebDataService.getOrCompute(gameName));
+    }
+}

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
@@ -1,0 +1,139 @@
+package ti4.spring.api.webdata;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import ti4.cache.CacheManager;
+import ti4.json.JsonMapperManager;
+import ti4.map.Game;
+import ti4.map.Player;
+import ti4.map.persistence.GameManager;
+import ti4.website.model.WebBorderAnomalies;
+import ti4.website.model.WebCardPool;
+import ti4.website.model.WebExpeditions;
+import ti4.website.model.WebLaw;
+import ti4.website.model.WebObjectives;
+import ti4.website.model.WebPlayerArea;
+import ti4.website.model.WebScoreBreakdown;
+import ti4.website.model.WebStatTilePositions;
+import ti4.website.model.WebStrategyCard;
+import ti4.website.model.WebTilePositions;
+import ti4.website.model.WebTileUnitData;
+
+@Service
+public class GameWebDataService {
+
+    private static final Duration WEB_DATA_TTL = Duration.ofMinutes(30);
+    private static final String CACHE_NAME = "gameWebDataCache";
+    private static final int MAX_GAMES_IN_MEMORY = 500;
+
+    private final Cache<String, String> webDataCache = createCache();
+
+    public String getOrCompute(String gameName) {
+        return webDataCache.get(gameName, this::computeForGameName);
+    }
+
+    public void put(String gameName, Game game) {
+        webDataCache.put(gameName, serialize(game));
+    }
+
+    private String computeForGameName(String gameName) {
+        var managedGame = GameManager.getManagedGame(gameName);
+        if (managedGame == null || managedGame.getGame() == null) {
+            throw new IllegalArgumentException("Unknown game: " + gameName);
+        }
+        return serialize(managedGame.getGame());
+    }
+
+    private static Cache<String, String> createCache() {
+        Cache<String, String> cache = Caffeine.newBuilder()
+                .maximumSize(MAX_GAMES_IN_MEMORY)
+                .expireAfterWrite(WEB_DATA_TTL)
+                .recordStats()
+                .build();
+        CacheManager.registerCache(CACHE_NAME, cache);
+        return cache;
+    }
+
+    private static String serialize(Game game) {
+        try {
+            return JsonMapperManager.basic().writeValueAsString(buildWebData(game));
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not serialize web data for game " + game.getName(), e);
+        }
+    }
+
+    private static Map<String, Object> buildWebData(Game game) {
+        List<WebPlayerArea> playerDataList = new ArrayList<>();
+        for (Player player : game.getRealPlayersNNeutral()) {
+            playerDataList.add(WebPlayerArea.fromPlayer(player, game));
+        }
+
+        WebTilePositions webTilePositions = WebTilePositions.fromGame(game);
+        Map<String, WebTileUnitData> tileUnitData = WebTileUnitData.fromGame(game);
+        WebStatTilePositions webStatTilePositions = WebStatTilePositions.fromGame(game);
+        WebObjectives webObjectives = WebObjectives.fromGame(game);
+        WebCardPool webCardPool = WebCardPool.fromGame(game);
+        WebExpeditions webExpeditions = WebExpeditions.fromGame(game);
+        WebBorderAnomalies webBorderAnomalies = WebBorderAnomalies.fromGame(game);
+
+        Map<String, WebScoreBreakdown> playerScoreBreakdowns = new HashMap<>();
+        for (Player player : game.getRealPlayersNNeutral()) {
+            playerScoreBreakdowns.put(player.getFaction(), WebScoreBreakdown.fromPlayer(player, game));
+        }
+
+        List<WebLaw> lawsInPlay = new ArrayList<>();
+        for (Map.Entry<String, Integer> lawEntry : game.getLaws().entrySet()) {
+            lawsInPlay.add(WebLaw.fromGameLaw(lawEntry.getKey(), lawEntry.getValue(), game));
+        }
+
+        List<WebStrategyCard> strategyCards = new ArrayList<>();
+        for (Integer scNumber : game.getScTradeGoods().keySet()) {
+            if (scNumber == 0) continue;
+            strategyCards.add(WebStrategyCard.fromGameStrategyCard(scNumber, game));
+        }
+
+        Map<Integer, String> strategyCardIdMap = new HashMap<>();
+        var strategyCardSet = game.getStrategyCardSet();
+        if (strategyCardSet != null) {
+            for (var scModel : strategyCardSet.getStrategyCardModels()) {
+                strategyCardIdMap.put(scModel.getInitiative(), scModel.getId());
+            }
+        }
+
+        Map<String, Object> webData = new LinkedHashMap<>();
+        webData.put("versionSchema", 7);
+        webData.put("objectives", webObjectives);
+        webData.put("playerData", playerDataList);
+        webData.put("lawsInPlay", lawsInPlay);
+        webData.put("cardPool", webCardPool);
+        webData.put("strategyCards", strategyCards);
+        webData.put("strategyCardIdMap", strategyCardIdMap);
+        webData.put("scoreBreakdowns", playerScoreBreakdowns);
+        webData.put("tilePositions", webTilePositions.getTilePositions());
+        webData.put("tileUnitData", tileUnitData);
+        webData.put("statTilePositions", webStatTilePositions.getStatTilePositions());
+        webData.put("ringCount", game.getRingCount());
+        webData.put("vpsToWin", game.getVp());
+        webData.put("gameRound", game.getRound());
+        webData.put("gameName", game.getName());
+        webData.put("gameCustomName", game.getCustomName());
+        webData.put("tableTalkJumpLink", game.getTabletalkJumpLink());
+        webData.put("actionsJumpLink", game.getActionsJumpLink());
+        webData.put("expeditions", webExpeditions != null ? webExpeditions.getExpeditions() : null);
+        webData.put(
+                "borderAnomalies",
+                webBorderAnomalies.getBorderAnomalies() != null
+                                && !webBorderAnomalies.getBorderAnomalies().isEmpty()
+                        ? webBorderAnomalies.getBorderAnomalies()
+                        : null);
+        webData.put("isTwilightsFallMode", game.isTwilightsFallMode());
+        return webData;
+    }
+}

--- a/src/main/java/ti4/website/AsyncTi4WebsiteHelper.java
+++ b/src/main/java/ti4/website/AsyncTi4WebsiteHelper.java
@@ -1,6 +1,5 @@
 package ti4.website;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,24 +8,13 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import ti4.json.JsonMapperManager;
 import ti4.map.Game;
-import ti4.map.Player;
 import ti4.message.logging.BotLogger;
 import ti4.message.logging.LogOrigin;
 import ti4.settings.GlobalSettings;
 import ti4.spring.api.image.GameImageService;
+import ti4.spring.api.webdata.GameWebDataService;
 import ti4.spring.context.SpringContext;
 import ti4.spring.websocket.WebSocketNotifier;
-import ti4.website.model.WebBorderAnomalies;
-import ti4.website.model.WebCardPool;
-import ti4.website.model.WebExpeditions;
-import ti4.website.model.WebLaw;
-import ti4.website.model.WebObjectives;
-import ti4.website.model.WebPlayerArea;
-import ti4.website.model.WebScoreBreakdown;
-import ti4.website.model.WebStatTilePositions;
-import ti4.website.model.WebStrategyCard;
-import ti4.website.model.WebTilePositions;
-import ti4.website.model.WebTileUnitData;
 import ti4.website.model.WebsiteOverlay;
 
 @UtilityClass
@@ -42,95 +30,10 @@ public class AsyncTi4WebsiteHelper {
         boolean isDevMode = !uploadsEnabled() || bucket == null || bucket.isEmpty();
 
         try {
-            List<WebPlayerArea> playerDataList = new ArrayList<>();
-            for (Player player : game.getRealPlayersNNeutral()) {
-                playerDataList.add(WebPlayerArea.fromPlayer(player, game));
-            }
+            SpringContext.getBean(GameWebDataService.class).put(gameId, game);
 
-            WebTilePositions webTilePositions = WebTilePositions.fromGame(game);
-            Map<String, WebTileUnitData> tileUnitData = WebTileUnitData.fromGame(game);
-            WebStatTilePositions webStatTilePositions = WebStatTilePositions.fromGame(game);
-            WebObjectives webObjectives = WebObjectives.fromGame(game);
-            WebCardPool webCardPool = WebCardPool.fromGame(game);
-            WebExpeditions webExpeditions = WebExpeditions.fromGame(game);
-            WebBorderAnomalies webBorderAnomalies = WebBorderAnomalies.fromGame(game);
-
-            // Create score breakdowns for each player
-            Map<String, WebScoreBreakdown> playerScoreBreakdowns = new HashMap<>();
-            for (Player player : game.getRealPlayersNNeutral()) {
-                playerScoreBreakdowns.put(player.getFaction(), WebScoreBreakdown.fromPlayer(player, game));
-            }
-
-            // Create laws with metadata
-            List<WebLaw> lawsInPlay = new ArrayList<>();
-            for (Map.Entry<String, Integer> lawEntry : game.getLaws().entrySet()) {
-                WebLaw webLaw = WebLaw.fromGameLaw(lawEntry.getKey(), lawEntry.getValue(), game);
-                lawsInPlay.add(webLaw);
-            }
-
-            // Create strategy cards with trade goods and pick status
-            List<WebStrategyCard> strategyCards = new ArrayList<>();
-            for (Integer scNumber : game.getScTradeGoods().keySet()) {
-                if (scNumber == 0) continue; // Skip the special "0" SC (Naalu's zero token)
-                WebStrategyCard webSC = WebStrategyCard.fromGameStrategyCard(scNumber, game);
-                strategyCards.add(webSC);
-            }
-
-            // Create map of initiative -> strategy card ID
-            Map<Integer, String> strategyCardIdMap = new HashMap<>();
-            var strategyCardSet = game.getStrategyCardSet();
-            if (strategyCardSet != null) {
-                for (var scModel : strategyCardSet.getStrategyCardModels()) {
-                    strategyCardIdMap.put(scModel.getInitiative(), scModel.getId());
-                }
-            }
-
-            Map<String, Object> webData = new HashMap<>();
-            webData.put("versionSchema", 7);
-            webData.put("objectives", webObjectives);
-            webData.put("playerData", playerDataList);
-            webData.put("lawsInPlay", lawsInPlay);
-            webData.put("cardPool", webCardPool);
-            webData.put("strategyCards", strategyCards);
-            webData.put("strategyCardIdMap", strategyCardIdMap);
-            webData.put("scoreBreakdowns", playerScoreBreakdowns);
-            webData.put("tilePositions", webTilePositions.getTilePositions());
-            webData.put("tileUnitData", tileUnitData);
-            webData.put("statTilePositions", webStatTilePositions.getStatTilePositions());
-            webData.put("ringCount", game.getRingCount());
-            webData.put("vpsToWin", game.getVp());
-            webData.put("gameRound", game.getRound());
-            webData.put("gameName", game.getName());
-            webData.put("gameCustomName", game.getCustomName());
-            webData.put("tableTalkJumpLink", game.getTabletalkJumpLink());
-            webData.put("actionsJumpLink", game.getActionsJumpLink());
-            webData.put("expeditions", webExpeditions != null ? webExpeditions.getExpeditions() : null);
-            webData.put(
-                    "borderAnomalies",
-                    webBorderAnomalies.getBorderAnomalies() != null
-                                    && !webBorderAnomalies.getBorderAnomalies().isEmpty()
-                            ? webBorderAnomalies.getBorderAnomalies()
-                            : null);
-            webData.put("isTwilightsFallMode", game.isTwilightsFallMode());
-
-            String json = JsonMapperManager.basic().writeValueAsString(webData);
-
-            if (isDevMode) {
-                // Dev/local mode - print to console instead of uploading
-
-                // Uncomment if this is what you're into
-                // System.out.println("=== DEV MODE: Web Player Data for game " + gameId + " ===");
-                // System.out.println(json);
-                // System.out.println("=== END Web Player Data ===");
-            } else {
-                // Production mode - upload to S3
-                putObjectInBucket(
-                        String.format("webdata/%s/%s.json", gameId, gameId),
-                        AsyncRequestBody.fromString(json),
-                        "application/json",
-                        "no-cache, no-store, must-revalidate");
-
-                // Upload latest image name if available
+            if (!isDevMode) {
+                // Upload latest image name if available for legacy consumers.
                 try {
                     GameImageService gameImageService = SpringContext.getBean(GameImageService.class);
                     String latestImageName = gameImageService.getLatestMapImageName(game.getName());
@@ -147,9 +50,9 @@ public class AsyncTi4WebsiteHelper {
                 } catch (Exception e) {
                     BotLogger.error(new LogOrigin(game), "Could not upload latest image name to web server", e);
                 }
-
-                notifyGameRefreshWebsocket(gameId);
             }
+
+            notifyGameRefreshWebsocket(gameId);
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Could not put data to web server", e);
         }


### PR DESCRIPTION
## Summary
- replace the S3 web-data JSON upload path with a Spring-managed cached payload for non-FoW games
- add a public `/api/public/game/{gameName}/web-data` endpoint that returns cached JSON and computes on cache miss
- keep websocket refresh behavior and refresh the cache at the existing write point used after map renders

## Testing
- mvn spotless:apply
- mvn -q -DskipTests compile