### PR TITLE
Separate hero removal from purge semantics

### DIFF
--- a/src/main/java/ti4/buttons/handlers/leader/hero/OtherHeroButtonHandler.java
+++ b/src/main/java/ti4/buttons/handlers/leader/hero/OtherHeroButtonHandler.java
@@ -17,7 +17,6 @@ import ti4.helpers.RandomHelper;
 import ti4.helpers.Units;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
-import ti4.helpers.thundersedge.DSHelperBreakthroughs;
 import ti4.image.Mapper;
 import ti4.listeners.annotations.ButtonHandler;
 import ti4.map.Game;
@@ -28,6 +27,7 @@ import ti4.map.Tile;
 import ti4.map.UnitHolder;
 import ti4.message.MessageHelper;
 import ti4.model.LeaderModel;
+import ti4.service.leader.PlayHeroService;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.DestroyUnitService;
 import ti4.service.unit.RemoveUnitService;
@@ -54,10 +54,9 @@ class OtherHeroButtonHandler {
                     player.getRepresentation() + " is playing " + heroTitle + ".\n"
                             + Helper.getLeaderFullRepresentation(playerLeader));
         }
-        boolean purged = player.removeLeader(playerLeader);
+        boolean purged = PlayHeroService.removeLeader(game, player, playerLeader);
         if (purged) {
             MessageHelper.sendMessageToChannel(player.getCorrectChannel(), heroTitle + ", has been purged.");
-            DSHelperBreakthroughs.doLanefirBtCheck(game, player);
         } else {
             MessageHelper.sendMessageToChannel(
                     event.getMessageChannel(), heroTitle + ", was not purged - something went wrong.");

--- a/src/main/java/ti4/commands/ds/ZelianHero.java
+++ b/src/main/java/ti4/commands/ds/ZelianHero.java
@@ -12,7 +12,6 @@ import ti4.helpers.ButtonHelperAgents;
 import ti4.helpers.Constants;
 import ti4.helpers.DisasterWatchHelper;
 import ti4.helpers.Helper;
-import ti4.helpers.thundersedge.DSHelperBreakthroughs;
 import ti4.image.TileHelper;
 import ti4.map.Game;
 import ti4.map.Leader;
@@ -21,6 +20,7 @@ import ti4.map.Player;
 import ti4.map.Tile;
 import ti4.map.UnitHolder;
 import ti4.message.MessageHelper;
+import ti4.service.leader.PlayHeroService;
 
 class ZelianHero extends GameStateSubcommand {
 
@@ -93,8 +93,7 @@ class ZelianHero extends GameStateSubcommand {
             StringBuilder message = new StringBuilder(player.getRepresentation())
                     .append(" played ")
                     .append(Helper.getLeaderFullRepresentation(playerLeader));
-            boolean purged = player.removeLeader(playerLeader);
-            DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+            boolean purged = PlayHeroService.removeLeader(game, player, playerLeader);
             if (purged) {
                 MessageHelper.sendMessageToChannel(
                         event.getMessageChannel(), message + " - Zelian R, the Zelian heRo, has been purged.");

--- a/src/main/java/ti4/commands/status/PersonalCleanup.java
+++ b/src/main/java/ti4/commands/status/PersonalCleanup.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.commands.GameStateSubcommand;
 import ti4.helpers.Constants;
-import ti4.helpers.thundersedge.DSHelperBreakthroughs;
 import ti4.image.Mapper;
 import ti4.map.Game;
 import ti4.map.Leader;
@@ -18,6 +17,7 @@ import ti4.map.Player;
 import ti4.map.Tile;
 import ti4.map.UnitHolder;
 import ti4.message.MessageHelper;
+import ti4.service.leader.PlayHeroService;
 import ti4.service.leader.RefreshLeaderService;
 
 class PersonalCleanup extends GameStateSubcommand {
@@ -78,8 +78,7 @@ class PersonalCleanup extends GameStateSubcommand {
         for (Leader leader : leads) {
             if (!leader.isLocked()) {
                 if (leader.isActive()) {
-                    player.removeLeader(leader.getId());
-                    DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+                    PlayHeroService.removeLeader(game, player, player.unsafeGetLeader(leader.getId()));
                 } else {
                     RefreshLeaderService.refreshLeader(player, leader, game);
                 }

--- a/src/main/java/ti4/helpers/ButtonHelperHeroes.java
+++ b/src/main/java/ti4/helpers/ButtonHelperHeroes.java
@@ -22,7 +22,6 @@ import ti4.buttons.handlers.agenda.VoteButtonHandler;
 import ti4.helpers.DiceHelper.Die;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
-import ti4.helpers.thundersedge.DSHelperBreakthroughs;
 import ti4.image.Mapper;
 import ti4.listeners.annotations.ButtonHandler;
 import ti4.map.Game;
@@ -1181,8 +1180,7 @@ public final class ButtonHelperHeroes {
         StringBuilder message = new StringBuilder(player.getRepresentation())
                 .append(" played ")
                 .append(Helper.getLeaderFullRepresentation(playerLeader));
-        boolean purged = player.removeLeader(playerLeader);
-        DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+        boolean purged = PlayHeroService.removeLeader(game, player, playerLeader);
         if (purged) {
             MessageHelper.sendMessageToChannel(
                     event.getMessageChannel(), message + " - Titus Flavius, the Celdauri hero, has been purged.");
@@ -1237,8 +1235,7 @@ public final class ButtonHelperHeroes {
         StringBuilder message = new StringBuilder(player.getRepresentation())
                 .append(" played ")
                 .append(Helper.getLeaderFullRepresentation(playerLeader));
-        boolean purged = player.removeLeader(playerLeader);
-        DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+        boolean purged = PlayHeroService.removeLeader(game, player, playerLeader);
         if (purged) {
             MessageHelper.sendMessageToChannel(
                     event.getMessageChannel(),
@@ -2177,8 +2174,7 @@ public final class ButtonHelperHeroes {
         StringBuilder message2 = new StringBuilder(player.getRepresentation())
                 .append(" played ")
                 .append(Helper.getLeaderFullRepresentation(playerLeader));
-        boolean purged = player.removeLeader(playerLeader);
-        DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+        boolean purged = PlayHeroService.removeLeader(game, player, playerLeader);
         if (purged) {
             MessageHelper.sendMessageToChannel(
                     player.getCorrectChannel(),
@@ -2206,8 +2202,7 @@ public final class ButtonHelperHeroes {
         StringBuilder message2 = new StringBuilder(player.getRepresentation())
                 .append(" played ")
                 .append(Helper.getLeaderFullRepresentation(playerLeader));
-        boolean purged = player.removeLeader(playerLeader);
-        DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+        boolean purged = PlayHeroService.removeLeader(game, player, playerLeader);
         if (purged) {
             MessageHelper.sendMessageToChannel(
                     player.getCorrectChannel(), message2 + " - The Oracle, the Poison hero, has been purged. \n\n ");
@@ -2225,8 +2220,7 @@ public final class ButtonHelperHeroes {
         StringBuilder message2 = new StringBuilder(player.getRepresentation())
                 .append(" played ")
                 .append(Helper.getLeaderFullRepresentation(playerLeader));
-        boolean purged = player.removeLeader(playerLeader);
-        DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+        boolean purged = PlayHeroService.removeLeader(game, player, playerLeader);
         if (purged) {
             MessageHelper.sendMessageToChannel(
                     player.getCorrectChannel(), message2 + " - Speygh, the Kyro hero, has been purged. \n\n");

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -33,7 +33,6 @@ import ti4.helpers.PromissoryNoteHelper;
 import ti4.helpers.StatusHelper;
 import ti4.helpers.omega_phase.PriorityTrackHelper;
 import ti4.helpers.omega_phase.PriorityTrackHelper.PriorityTrackMode;
-import ti4.helpers.thundersedge.DSHelperBreakthroughs;
 import ti4.image.BannerGenerator;
 import ti4.image.MapRenderPipeline;
 import ti4.image.Mapper;
@@ -63,6 +62,7 @@ import ti4.service.fow.FowCommunicationThreadService;
 import ti4.service.fow.GMService;
 import ti4.service.info.ListPlayerInfoService;
 import ti4.service.info.ListTurnOrderService;
+import ti4.service.leader.PlayHeroService;
 import ti4.service.map.SpinService;
 import ti4.service.planet.PlanetService;
 import ti4.service.strategycard.PickStrategyCardService;
@@ -302,8 +302,7 @@ public class StartPhaseService {
                         player2.getCorrectChannel(), msg + "the first technology.", buttons);
                 MessageHelper.sendMessageToChannelWithButtons(
                         player2.getCorrectChannel(), msg + "the second technology.", buttons);
-                player2.removeLeader("zealotshero");
-                DSHelperBreakthroughs.doLanefirBtCheck(game, player2);
+                PlayHeroService.removeLeader(game, player2, player2.unsafeGetLeader("zealotshero"));
                 ButtonHelperHeroes.checkForMykoHero(game, "zealotshero", player2);
                 game.setStoredValue("zealotsHeroTechs", "");
                 game.setStoredValue("zealotsHeroPurged", "true");

--- a/src/main/java/ti4/service/leader/LeaderRemovalReason.java
+++ b/src/main/java/ti4/service/leader/LeaderRemovalReason.java
@@ -1,0 +1,105 @@
+package ti4.service.leader;
+
+/**
+ * Describes why a hero is removed from a player's leader area after use.
+ *
+ * <p>The bot removes heroes from the player's leader list once they are spent so they cannot be used again, but
+ * that removal is not always the same as a rules purge. Some heroes are attached to another game element instead
+ * of being purged, while others remain active for a while and are only purged later during cleanup.
+ *
+ * <p>This distinction matters because other effects, such as the Lanefir breakthrough, care about actual purge
+ * events rather than the bot's internal act of removing a leader from the player's available leaders.
+ */
+public enum LeaderRemovalReason {
+    PURGED,
+    ATTACHED,
+    STATUS_CLEANUP;
+
+    public static LeaderRemovalReason fromHeroId(String leaderId) {
+        return switch (leaderId) {
+            case "titanshero", "kyrohero", "toldarhero", "freesystemshero" -> ATTACHED;
+
+            case "letnevhero", "nomadhero", "zealotshero", "nokarhero", "kolumehero", "qhethero", "nivynhero" ->
+                STATUS_CLEANUP;
+
+            case "arborechero",
+                    "argenthero",
+                    "atokerahero",
+                    "augershero",
+                    "axishero",
+                    "bastionhero",
+                    "bentorhero",
+                    "brilliancehero",
+                    "cabalhero",
+                    "celdaurihero",
+                    "cheiranhero",
+                    "cymiaehero",
+                    "deepwroughthero",
+                    "devourhero",
+                    "dihmohnhero",
+                    "edynhero",
+                    "empyreanhero",
+                    "eternityhero",
+                    "eventhero",
+                    "firmamenthero",
+                    "florzenhero",
+                    "forgehero",
+                    "ghosthero",
+                    "ghotihero",
+                    "gledgehero",
+                    "hacanhero",
+                    "jolnarhero",
+                    "kaltrimhero",
+                    "keleresherokuuasi",
+                    "khraskhero",
+                    "kjalengardhero",
+                    "kollecchero",
+                    "kortalihero",
+                    "l1z1xhero",
+                    "lanefirhero",
+                    "lawshero",
+                    "lizhohero",
+                    "mahacthero",
+                    "mentakhero",
+                    "mirvedahero",
+                    "mortheushero",
+                    "muaathero",
+                    "naaluhero",
+                    "naazhero",
+                    "nekrohero",
+                    "obsidianhero",
+                    "olradinhero",
+                    "onyxxahero",
+                    "orlandohero",
+                    "pharadnhero",
+                    "poisonhero",
+                    "ralnelhero",
+                    "redcreusshero",
+                    "rohdhnahero",
+                    "saarhero",
+                    "sanctionhero",
+                    "sardakkhero",
+                    "solhero",
+                    "uydaihero",
+                    "vadenhero",
+                    "vaylerianhero",
+                    "veldyrhero",
+                    "voicehero",
+                    "winnuhero",
+                    "witchinghero",
+                    "xanhero",
+                    "yinhero",
+                    "yssarilhero",
+                    "zelianhero" -> PURGED;
+
+            default -> PURGED;
+        };
+    }
+
+    public String getRemovalMessage(String leaderName) {
+        return switch (this) {
+            case PURGED, STATUS_CLEANUP -> leaderName + " has been purged.";
+            case ATTACHED -> leaderName + " is being attached to a planet.";
+        };
+    }
+}

--- a/src/main/java/ti4/service/leader/PlayHeroService.java
+++ b/src/main/java/ti4/service/leader/PlayHeroService.java
@@ -61,6 +61,15 @@ import ti4.service.unit.CheckUnitContainmentService;
 @UtilityClass
 public class PlayHeroService {
 
+    public static boolean removeLeader(Game game, Player player, Leader leader) {
+        LeaderRemovalReason reason = LeaderRemovalReason.fromHeroId(leader.getId());
+        boolean removed = player.removeLeader(leader);
+        if (removed && (reason == LeaderRemovalReason.PURGED || reason == LeaderRemovalReason.STATUS_CLEANUP)) {
+            DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+        }
+        return removed;
+    }
+
     public static void playHero(GenericInteractionCreateEvent event, Game game, Player player, Leader playerLeader) {
         LeaderModel leaderModel = playerLeader.getLeaderModel().orElse(null);
         boolean showFlavourText = Constants.VERBOSITY_VERBOSE.equals(game.getOutputVerbosity());
@@ -81,12 +90,8 @@ public class PlayHeroService {
             BotLogger.warning(new LogOrigin(event), "Missing LeaderModel: " + playerLeader.getId());
         }
 
-        if ("letnevhero".equals(playerLeader.getId())
-                || "nomadhero".equals(playerLeader.getId())
-                || "zealotshero".equals(playerLeader.getId())
-                || "nokarhero".equals(playerLeader.getId())
-                || "kolumehero".equals(playerLeader.getId())
-                || "qhethero".equals(playerLeader.getId())) {
+        LeaderRemovalReason removalReason = LeaderRemovalReason.fromHeroId(playerLeader.getId());
+        if (removalReason == LeaderRemovalReason.STATUS_CLEANUP) {
             playerLeader.setLocked(false);
             playerLeader.setActive(true);
             sb.append("\nLeader will be purged after status cleanup.");
@@ -112,10 +117,9 @@ public class PlayHeroService {
                     ? "Hero " + playerLeader.getId()
                     : playerLeaderModel.getName() + ", the " + StringUtils.capitalize(playerLeaderModel.getFaction())
                             + " hero,";
-            String msg = leaderName + " has been purged.";
+            String msg = removalReason.getRemovalMessage(leaderName);
             if (!"mykomentorihero".equals(playerLeader.getId())) {
-                purged = player.removeLeader(playerLeader);
-                DSHelperBreakthroughs.doLanefirBtCheck(game, player);
+                purged = removeLeader(game, player, playerLeader);
                 ButtonHelperHeroes.checkForMykoHero(game, playerLeader.getId(), player);
             } else {
                 msg = "Coprinus Comatus, the Myko-Mentori hero, was used to copy another hero.";


### PR DESCRIPTION
## Summary
- add a dedicated `LeaderRemovalReason` model for hero removal semantics
- classify attach-style and delayed-purge heroes separately from immediate purge heroes
- derive Lanefir triggers and user-facing removal text from the removal reason

## Testing
- mvn -q spotless:apply
- mvn -q -DskipTests compile