### PR TITLE
Add breakthrough support to Franken ban options

### DIFF
--- a/src/main/java/ti4/commands/franken/DraftLimits.java
+++ b/src/main/java/ti4/commands/franken/DraftLimits.java
@@ -30,6 +30,7 @@ class DraftLimits extends GameStateSubcommand {
             new LimitConfig(Constants.STARTINGFLEET_LIMIT, "Starting fleet Limit", -1),
             new LimitConfig(Constants.BLUETILE_LIMIT, "Blue Tile Limit", -1),
             new LimitConfig(Constants.REDTILE_LIMIT, "Red tile Limit", -1),
+            new LimitConfig(Constants.BREAKTHROUGH_LIMIT, "Breakthrough Limit", -1),
             new LimitConfig(Constants.FIRSTPICK_LIMIT, "First Pick Limit", 0),
             new LimitConfig(Constants.LATERPICK_LIMIT, "Later Pick Limit", 0));
 

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1171,6 +1171,7 @@ public final class Constants {
     public static final String STARTINGFLEET_LIMIT = "startingfleet_limit";
     public static final String BLUETILE_LIMIT = "bluetile_limit";
     public static final String REDTILE_LIMIT = "redtile_limit";
+    public static final String BREAKTHROUGH_LIMIT = "breakthrough_limit";
     public static final String FIRSTPICK_LIMIT = "firstpick_limit";
     public static final String LATERPICK_LIMIT = "laterpick_limit";
 

--- a/src/test/java/ti4/commands/franken/DraftLimitsTest.java
+++ b/src/test/java/ti4/commands/franken/DraftLimitsTest.java
@@ -1,0 +1,18 @@
+package ti4.commands.franken;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import ti4.helpers.Constants;
+
+class DraftLimitsTest {
+
+    @Test
+    void registersBreakthroughLimitOption() {
+        DraftLimits command = new DraftLimits();
+
+        assertTrue(
+                command.getOptions().stream().anyMatch(option -> Constants.BREAKTHROUGH_LIMIT.equals(option.getName())),
+                "Draft limits should expose a breakthrough limit option");
+    }
+}


### PR DESCRIPTION
## Summary
- allow the Franken `ban` command to accept breakthrough ids
- add a focused regression test for banning breakthroughs

## Testing
- mvn -q -DskipTests compile