### PR TITLE
Fix Visionaria fallback tech picker

### DIFF
--- a/src/main/java/ti4/service/tech/ListTechService.java
+++ b/src/main/java/ti4/service/tech/ListTechService.java
@@ -192,10 +192,10 @@ public class ListTechService {
             buttons.addAll(getTechButtons(techs, player, payType));
         }
 
-        if (game.isComponentAction()) {
-            buttons.add(Buttons.gray("acquireATech", "Get Other Technology"));
-        } else if (dwsBt) {
+        if (dwsBt) {
             buttons.add(Buttons.gray("acquireATechWithDwsBt_second", "Get Other Technology"));
+        } else if (game.isComponentAction()) {
+            buttons.add(Buttons.gray("acquireATech", "Get Other Technology"));
         } else {
             buttons.add(Buttons.gray("acquireATechWithSC_second", "Get Other Technology"));
         }


### PR DESCRIPTION
## Summary
- preserve the Visionaria-specific fallback button when the tech picker is opened in component-action mode
- keep the  context on the second tech-selection path so Deepwrought still copies the chosen technology

## Testing
- 