### PR TITLE
Shuffle exposed web card decks

### DIFF
--- a/src/main/java/ti4/website/model/WebCardPool.java
+++ b/src/main/java/ti4/website/model/WebCardPool.java
@@ -1,6 +1,7 @@
 package ti4.website.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,7 +66,7 @@ public class WebCardPool {
                     .filter(so -> !scoredSecrets.contains(so))
                     .collect(Collectors.toList());
         }
-        cardPool.setSecretObjectiveDeck(unscoredSecrets);
+        cardPool.setSecretObjectiveDeck(shuffledCopy(unscoredSecrets));
         cardPool.setSecretObjectiveFullDeckSize(game.getSecretObjectiveFullDeckSize());
 
         // Action Cards
@@ -75,31 +76,37 @@ public class WebCardPool {
         cardPool.setActionCardFullDeckSize(game.getActionCardFullDeckSize());
 
         // Exploration Cards
-        cardPool.setCulturalExploreDeck(new ArrayList<>(game.getExploreDeck(Constants.CULTURAL)));
+        cardPool.setCulturalExploreDeck(shuffledCopy(game.getExploreDeck(Constants.CULTURAL)));
         cardPool.setCulturalExploreDiscard(new ArrayList<>(game.getExploreDiscard(Constants.CULTURAL)));
         cardPool.setCulturalExploreFullDeckSize(game.getCulturalExploreFullDeckSize());
 
-        cardPool.setIndustrialExploreDeck(new ArrayList<>(game.getExploreDeck(Constants.INDUSTRIAL)));
+        cardPool.setIndustrialExploreDeck(shuffledCopy(game.getExploreDeck(Constants.INDUSTRIAL)));
         cardPool.setIndustrialExploreDiscard(new ArrayList<>(game.getExploreDiscard(Constants.INDUSTRIAL)));
         cardPool.setIndustrialExploreFullDeckSize(game.getIndustrialExploreFullDeckSize());
 
-        cardPool.setHazardousExploreDeck(new ArrayList<>(game.getExploreDeck(Constants.HAZARDOUS)));
+        cardPool.setHazardousExploreDeck(shuffledCopy(game.getExploreDeck(Constants.HAZARDOUS)));
         cardPool.setHazardousExploreDiscard(new ArrayList<>(game.getExploreDiscard(Constants.HAZARDOUS)));
         cardPool.setHazardousExploreFullDeckSize(game.getHazardousExploreFullDeckSize());
 
-        cardPool.setFrontierExploreDeck(new ArrayList<>(game.getExploreDeck(Constants.FRONTIER)));
+        cardPool.setFrontierExploreDeck(shuffledCopy(game.getExploreDeck(Constants.FRONTIER)));
         cardPool.setFrontierExploreDiscard(new ArrayList<>(game.getExploreDiscard(Constants.FRONTIER)));
         cardPool.setFrontierExploreFullDeckSize(game.getFrontierExploreFullDeckSize());
 
         // Relics
-        cardPool.setRelicDeck(new ArrayList<>(game.getAllRelics()));
+        cardPool.setRelicDeck(shuffledCopy(game.getAllRelics()));
         cardPool.setRelicFullDeckSize(game.getRelicFullDeckSize());
 
         // Agendas
-        cardPool.setAgendaDeck(new ArrayList<>(game.getAgendas()));
+        cardPool.setAgendaDeck(shuffledCopy(game.getAgendas()));
         cardPool.setAgendaDiscard(new ArrayList<>(game.getDiscardAgendas().keySet()));
         cardPool.setAgendaFullDeckSize(game.getAgendaFullDeckSize());
 
         return cardPool;
+    }
+
+    private static List<String> shuffledCopy(List<String> cards) {
+        List<String> shuffled = new ArrayList<>(cards);
+        Collections.shuffle(shuffled);
+        return shuffled;
     }
 }


### PR DESCRIPTION
## Summary
- shuffle exposed secret objective, explore, relic, and agenda deck lists before serializing web data
- keep game state untouched by only shuffling copied lists in the web payload builder
- leave the companion UI sorting update in `ti4_web_new` out of this backend PR as requested

## Verification
- mvn -q -DskipTests compile
- npm run type-check (in `ti4_web_new`)
- npm run build (in `ti4_web_new`)