### PR TITLE
Handle missing tile aliases during web data serialization

### DIFF
--- a/src/main/java/ti4/model/TileModel.java
+++ b/src/main/java/ti4/model/TileModel.java
@@ -75,6 +75,10 @@ public class TileModel implements ModelInterface, EmbeddableModel {
         return Optional.ofNullable(name).orElse("");
     }
 
+    public List<String> getAliases() {
+        return aliases == null ? List.of() : aliases;
+    }
+
     public String getNameRepresentation() {
         StringBuilder sb = new StringBuilder();
         TileEmojis emoji = TileEmojis.getTileEmojiFromTileID(id);


### PR DESCRIPTION
## Summary
- make `TileModel.getAliases()` return an empty list when aliases are missing
- prevent FoW adjacency and website web-data serialization from crashing on null tile aliases

## Verification
- mvn -q -DskipTests compile