### PR TITLE
Handle stale players in public draft reprint

### DIFF
--- a/src/main/java/ti4/service/draft/PublicDraftInfoService.java
+++ b/src/main/java/ti4/service/draft/PublicDraftInfoService.java
@@ -141,6 +141,7 @@ public class PublicDraftInfoService {
         Game game = draftManager.getGame();
         List<Draftable> draftables = draftManager.getDraftables();
         int padding = String.format("%s", playerOrder.size()).length() + 1;
+        List<String> skippedPlayerIds = new ArrayList<>();
 
         Map<DraftableType, DraftChoice> defaultChoices = draftables.stream()
                 .collect(HashMap::new, (m, d) -> m.put(d.getType(), d.getNothingPickedChoice()), Map::putAll);
@@ -150,8 +151,10 @@ public class PublicDraftInfoService {
         for (String userId : playerOrder) {
             Player player = game.getPlayer(userId);
             PlayerDraftState picks = draftManager.getPlayerStates().get(userId);
-            if (player == null || picks == null)
-                throw new IllegalStateException("Player or picks missing for playerID " + userId);
+            if (player == null || picks == null) {
+                skippedPlayerIds.add(userId);
+                continue;
+            }
 
             sb.append("\n> `").append(Helper.leftpad(pickNum + ".", padding)).append("` ");
             StringBuilder bulletSummary = new StringBuilder();
@@ -194,6 +197,13 @@ public class PublicDraftInfoService {
             if (userId.equals(nextPlayer)) sb.append("*");
 
             pickNum++;
+        }
+
+        if (!skippedPlayerIds.isEmpty()) {
+            BotLogger.warning("Skipping stale public draft summary entries for game `"
+                    + game.getName()
+                    + "`: "
+                    + String.join(", ", skippedPlayerIds));
         }
         return sb.toString();
     }


### PR DESCRIPTION
## Summary
- stop public snake draft reprints from throwing when the saved draft order still contains a player who is no longer in the game or draft state map
- skip stale entries when rebuilding the public draft summary instead of crashing the button handler
- log the skipped player IDs so moderators can clean up the draft state if needed

## Verification
- 

## Notes
- no tests added, per request