### PR TITLE
fix: guard exhausted stage 2 objective reveal

### DIFF
--- a/src/main/java/ti4/service/objectives/RevealPublicObjectiveService.java
+++ b/src/main/java/ti4/service/objectives/RevealPublicObjectiveService.java
@@ -39,6 +39,11 @@ public class RevealPublicObjectiveService {
         } else {
             objective = game.revealStage2();
         }
+        if (objective == null) {
+            MessageHelper.sendMessageToChannel(
+                    game.getActionsChannel(), "No unrevealed stage 2 public objectives remain.");
+            return;
+        }
 
         PublicObjectiveModel po = Mapper.getPublicObjective(objective.getKey());
         NeuraloopService.offerInitialNeuraloopChoice(game, objective.getKey());


### PR DESCRIPTION
## Summary
- guard `RevealPublicObjectiveService.revealS2` when no unrevealed stage 2 objectives remain
- send a user-facing message to the actions channel instead of throwing a null-pointer exception during agenda resolution

## Test Plan
- `mvn -q -DskipTests compile`