### PR TITLE
Handle decorated undo autocomplete selections

### DIFF
--- a/src/main/java/ti4/commands/game/Undo.java
+++ b/src/main/java/ti4/commands/game/Undo.java
@@ -10,6 +10,7 @@ import ti4.game.persistence.GameManager;
 import ti4.helpers.Constants;
 import ti4.helpers.FoWHelper;
 import ti4.message.MessageHelper;
+import ti4.service.game.GameUndoNameService;
 
 class Undo extends GameStateSubcommand {
 
@@ -51,13 +52,12 @@ class Undo extends GameStateSubcommand {
             return;
         }
 
-        if (!gameToUndoBackTo.contains(gameName)) {
+        Integer targetUndoIndex = GameUndoNameService.getUndoNumberFromSelection(gameName, gameToUndoBackTo);
+        if (targetUndoIndex == null) {
             MessageHelper.replyToMessage(event, "Undo failed - Parameter doesn't look right: " + gameToUndoBackTo);
             return;
         }
 
-        String targetUndoIndexStr = gameToUndoBackTo.replace(gameName + "_", "").replace(".txt", "");
-        int targetUndoIndex = Integer.parseInt(targetUndoIndexStr);
         GameManager.undo(game, targetUndoIndex);
     }
 }

--- a/src/main/java/ti4/service/game/GameUndoNameService.java
+++ b/src/main/java/ti4/service/game/GameUndoNameService.java
@@ -27,6 +27,7 @@ public class GameUndoNameService {
 
     private static final Pattern lastestCommandPattern = Pattern.compile("^(?>latest_command ).*$");
     private static final Pattern lastModifiedPattern = Pattern.compile("^(?>last_modified_date ).*$");
+    private static final Pattern undoFileNamePattern = Pattern.compile("([A-Za-z0-9_-]+_\\d+\\.txt)");
     private static final Comparator<File> fileComparator =
             Comparator.comparingInt(file -> getUndoNumberFromFileName(file.getName()));
 
@@ -77,6 +78,23 @@ public class GameUndoNameService {
         String number = StringUtils.substringAfterLast(name, "_");
         number = StringUtils.substringBefore(number, ".txt");
         return StringUtils.isEmpty(number) ? 0 : Integer.parseInt(number);
+    }
+
+    public static Integer getUndoNumberFromSelection(String gameName, String selection) {
+        if (StringUtils.isBlank(selection)) {
+            return null;
+        }
+
+        // Accept either the raw filename or the human-readable autocomplete label.
+        var matcher = undoFileNamePattern.matcher(selection);
+        while (matcher.find()) {
+            String fileName = matcher.group(1);
+            if (StringUtils.startsWith(fileName, gameName + "_")) {
+                return getUndoNumberFromFileName(fileName);
+            }
+        }
+
+        return null;
     }
 
     public static List<Integer> getSortedUndoNumbers(String gameName) {

--- a/src/test/java/ti4/service/game/GameUndoNameServiceTest.java
+++ b/src/test/java/ti4/service/game/GameUndoNameServiceTest.java
@@ -17,4 +17,24 @@ class GameUndoNameServiceTest {
         int undoNumber = GameUndoNameService.getUndoNumberFromFileName("pbd14_321.txt");
         assertThat(undoNumber).isEqualTo(321);
     }
+
+    @Test
+    void shouldParseUndoNumberFromRawSelection() {
+        Integer undoNumber = GameUndoNameService.getUndoNumberFromSelection("pbd21740", "pbd21740_1668.txt");
+        assertThat(undoNumber).isEqualTo(1668);
+    }
+
+    @Test
+    void shouldParseUndoNumberFromDecoratedSelection() {
+        Integer undoNumber = GameUndoNameService.getUndoNumberFromSelection(
+                "pbd21740",
+                "pbd21740_1668.txt (00h:20m:38s ago):  gabs2482 pressed button: argentHeroStep4_310_311_space_fighter");
+        assertThat(undoNumber).isEqualTo(1668);
+    }
+
+    @Test
+    void shouldRejectSelectionForAnotherGame() {
+        Integer undoNumber = GameUndoNameService.getUndoNumberFromSelection("pbd21740", "pbd21741_1668.txt");
+        assertThat(undoNumber).isNull();
+    }
 }


### PR DESCRIPTION
## Summary
- parse undo selections from either the raw filename or the human-readable autocomplete label
- reject selections that do not belong to the current game instead of throwing a NumberFormatException
- add coverage for raw, decorated, and wrong-game undo selections

## Testing
- mvn -Dtest=GameUndoNameServiceTest test