### PR TITLE
Handle stale Twilights Fall splice queue prompts

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -176,10 +176,26 @@ public final class ButtonHelperTwilightsFall {
         return msg.toString();
     }
 
+    private static List<Player> getQueueEligibleParticipants(Game game, Player player) {
+        List<Player> participants = getParticipantsList(game);
+        if (!participants.isEmpty() && participants.contains(player)) {
+            return participants;
+        }
+
+        MessageHelper.sendMessageToChannel(
+                player.getCardsInfoThread(), "That splice queue prompt is no longer active.");
+        return null;
+    }
+
     @ButtonHandler("queueSplicePick_")
     public static void queueSplicePick(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
         event.getMessage().delete().queue(Consumers.nop(), BotLogger::catchRestError);
-        if (getParticipantsList(game).getFirst() == player) {
+        List<Player> participants = getQueueEligibleParticipants(game, player);
+        if (participants == null) {
+            game.setStoredValue(player.getFaction() + "splicequeue", "");
+            return;
+        }
+        if (participants.getFirst() == player) {
             MessageHelper.sendMessageToChannel(
                     player.getCardsInfoThread(),
                     "You are currently up to pick a splice card, and should just do that instead of queueing.");
@@ -203,7 +219,7 @@ public final class ButtonHelperTwilightsFall {
             }
         }
         alreadyQueued = game.getStoredValue(player.getFaction() + "splicequeue");
-        int number = getParticipantsList(game).indexOf(player) + 1;
+        int number = participants.indexOf(player) + 1;
         int numQueued = alreadyQueued.split("_").length;
         if (alreadyQueued.isEmpty()) {
             numQueued = 0;
@@ -226,6 +242,10 @@ public final class ButtonHelperTwilightsFall {
     public static void restartSpliceQueue(ButtonInteractionEvent event, Game game, Player player) {
         event.getMessage().delete().queue(Consumers.nop(), BotLogger::catchRestError);
         game.setStoredValue(player.getFaction() + "splicequeue", "");
+        List<Player> participants = getQueueEligibleParticipants(game, player);
+        if (participants == null) {
+            return;
+        }
         List<Button> buttons = getQueueSplicePickButtons(game, player);
         String msg = getQueueSpliceMessage(game, player);
         msg += "You can use these buttons to queue your splice pick.";


### PR DESCRIPTION
## Summary
- guard Twilights Fall splice queue handlers against stale prompts with no active participants
- reuse a shared helper for participant validation instead of duplicating the check
- clear queued picks when a stale queue button is pressed so old state does not linger

## Verification
- mvn -q -DskipTests compile