### PR TITLE
Fix Franken PN add in FoW private channels

### DIFF
--- a/src/main/java/ti4/commands/CommandHelper.java
+++ b/src/main/java/ti4/commands/CommandHelper.java
@@ -111,7 +111,14 @@ public class CommandHelper {
         if (factionColorOption != null) {
             String factionColor =
                     AliasHandler.resolveColor(factionColorOption.getAsString().toLowerCase());
-            return getPlayerByFactionColor(factionColor, game);
+            Player player = getPlayerByFactionColor(factionColor, game);
+            if (player != null) {
+                return player;
+            }
+        }
+        Player player = getPlayerFromChannel(game, event);
+        if (player != null) {
+            return player;
         }
         return getPlayerFromGame(game, event.getMember(), event.getUser().getId());
     }
@@ -141,6 +148,17 @@ public class CommandHelper {
             if (Objects.equals(factionColor, player_.getFaction())
                     || Objects.equals(factionColor, player_.getColor())) {
                 return player_;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static Player getPlayerFromChannel(Game game, GenericCommandInteractionEvent event) {
+        String channelId = event.getChannel().getId();
+        for (Player player : game.getPlayers().values()) {
+            if (channelId.equals(player.getPrivateChannelID()) || channelId.equals(player.getCardsInfoThreadID())) {
+                return player;
             }
         }
         return null;


### PR DESCRIPTION
## Summary
- fall back to FoW private-channel and cards-info thread ownership when resolving the acting player for slash commands
- avoid aborting player resolution when `faction_or_color` is present but does not map to a player
- fix `/franken pn_add` failing with "Unable to determine player" in FoW private threads

## Test Plan
- `mvn -q -DskipTests compile`