### PR TITLE
Fix concurrent ring count access during web serialization

### DIFF
--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -1236,7 +1236,8 @@ public class Game extends GameProperties {
         if (tileMap.isEmpty()) {
             return 0;
         }
-        String highestPosition = tileMap.keySet().stream()
+        List<String> tilePositions = new ArrayList<>(tileMap.keySet());
+        String highestPosition = tilePositions.stream()
                 .filter(Helper::isInteger)
                 .max(Comparator.comparingInt(Integer::parseInt))
                 .orElse(null);

--- a/src/main/java/ti4/helpers/PlayerStatsHelper.java
+++ b/src/main/java/ti4/helpers/PlayerStatsHelper.java
@@ -38,8 +38,9 @@ public final class PlayerStatsHelper {
         if (anchor == null) return null;
         if (randomizeLocation) anchor = "000"; // just stick them on 000
 
+        int maxStatTileRing = game.getRingCount() + 1;
         Set<String> validPositions = PositionMapper.getTilePositions().stream()
-                .filter(pos -> tileRing(pos) <= (game.getRingCount() + 1))
+                .filter(pos -> tileRing(pos) <= maxStatTileRing)
                 .filter(pos -> game.getTileByPosition(pos) == null)
                 .filter(pos -> taken == null || !taken.contains(pos))
                 .collect(Collectors.toSet());


### PR DESCRIPTION
## Summary
- snapshot tile positions before computing ring count to avoid iterating a mutating key set
- compute the max stat-tile ring once before filtering stat tile positions
- keep the website serialization path from tripping the reported ConcurrentModificationException

## Testing
- mvn -q -DskipTests compile