### PR TITLE
Cancel stale production deploy runs

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -3,6 +3,9 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 name: BuildAndDeploy
+concurrency:
+  group: deploy-to-production-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   saveGamesBeforeDeploy:
     uses: ./.github/workflows/force-backup-of-savefiles.yml

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 name: BuildAndDeploy
 concurrency:
-  group: deploy-to-production-${{ github.ref }}
+  group: deploy-to-production-master
   cancel-in-progress: true
 jobs:
   saveGamesBeforeDeploy:


### PR DESCRIPTION
## Summary
- add workflow-level concurrency to the production deploy workflow
- enable cancel-in-progress so a new push to master cancels the older deploy run
- scope the concurrency group to the current ref

## Testing
- not run (GitHub Actions workflow change only)