### PR TITLE
Fix locate my game button resolution

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -474,9 +474,21 @@ public class ButtonHelper {
     }
 
     @ButtonHandler("pingGame")
-    public static void pingGame(Game game, ButtonInteractionEvent event, Player player, String buttonID) {
-        Helper.fixGameChannelPermissions(game.getActionsChannel().getGuild(), game);
-        MessageHelper.sendMessageToChannel(game.getBotMapUpdatesThread(), "Pinging game" + game.getPing() + ".");
+    public static void pingGame(Game inferredGame, ButtonInteractionEvent event, Player player, String buttonID) {
+        Game gameToPing = inferredGame;
+        // Prefer the game encoded in the button id here, because inferredGame only works when the button was pressed
+        // from that game's channel.
+        if (gameToPing == null && buttonID.startsWith("pingGame_")) {
+            gameToPing = GameManager.reload(buttonID.replace("pingGame_", ""));
+        }
+        if (gameToPing == null) {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Could not find that game.");
+            return;
+        }
+
+        Helper.fixGameChannelPermissions(gameToPing.getActionsChannel().getGuild(), gameToPing);
+        MessageHelper.sendMessageToChannel(
+                gameToPing.getBotMapUpdatesThread(), "Pinging game" + gameToPing.getPing() + ".");
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), "Attempted to ping the game.");
     }
 

--- a/src/main/java/ti4/service/game/CreateGameService.java
+++ b/src/main/java/ti4/service/game/CreateGameService.java
@@ -128,7 +128,7 @@ public class CreateGameService {
         }
 
         // CHECK IF GUILD HAS ALL PLAYERS LISTED
-        List<Member> missingMembers = inviteUsersToServer(guild, members, event.getMessageChannel());
+        List<Member> missingMembers = inviteUsersToServer(guild, members, event.getMessageChannel(), gameName);
 
         // CREATE ROLE
         Role role = guild.createRole().setName(gameName).setMentionable(true).complete();
@@ -428,6 +428,11 @@ public class CreateGameService {
      * @return the list of missing members
      */
     public static List<Member> inviteUsersToServer(Guild guild, List<Member> members, MessageChannel channel) {
+        return inviteUsersToServer(guild, members, channel, null);
+    }
+
+    public static List<Member> inviteUsersToServer(
+            Guild guild, List<Member> members, MessageChannel channel, String gameName) {
         List<String> guildMemberIDs =
                 guild.getMembers().stream().map(ISnowflake::getId).toList();
         List<Member> missingMembers = new ArrayList<>();
@@ -451,7 +456,8 @@ public class CreateGameService {
             MessageHelper.sendMessageToChannel(channel, sb.toString());
             String msg2 =
                     "If you have joined the server and cannot find your game, please click this button. If the invite has expired, please press this other button.";
-            Button findGameButton = Buttons.green("pingGame", "Locate My Game");
+            String findGameButtonId = gameName == null ? "pingGame" : "pingGame_" + gameName;
+            Button findGameButton = Buttons.green(findGameButtonId, "Locate My Game");
             Button resendInvite = Buttons.blue("resendInvite_" + guild.getId(), "Resend Server Invite");
             MessageHelper.sendMessageToChannelWithButtons(channel, msg2, List.of(findGameButton, resendInvite));
         }


### PR DESCRIPTION
## Summary
- encode the target game name into the Locate My Game button id during game creation
- resolve pingGame from the explicit button game id when channel-based context inference is unavailable
- keep the existing ping behavior while removing user/guild-based guesswork

## Testing
- mvn -q spotless:apply
- mvn -q -DskipTests compile