### PR TITLE
Handle empty relic deck in Artifice edict

### DIFF
--- a/src/main/java/ti4/buttons/handlers/agenda/EdictPhaseHandler.java
+++ b/src/main/java/ti4/buttons/handlers/agenda/EdictPhaseHandler.java
@@ -290,19 +290,29 @@ public class EdictPhaseHandler {
                                     + ", so they were not able to draw any additional relics or paradigms.");
                 } else {
                     ButtonHelperTwilightsFall.drawParadigm(game, player, event, false, true);
-                    String relic = game.getAllRelics().getFirst();
-                    RelicModel mod = Mapper.getRelic(relic);
-                    MessageHelper.sendMessageToChannelWithEmbed(
-                            player.getCorrectChannel(),
-                            player.getRepresentationNoPing() + " will draw the following relic:",
-                            mod.getRepresentationEmbed());
+                    List<String> relicDeck = game.getAllRelics();
+                    if (relicDeck.isEmpty()) {
+                        MessageHelper.sendMessageToChannel(
+                                player.getCorrectChannel(),
+                                "The relic deck is empty, so "
+                                        + player.getRepresentationNoPing()
+                                        + " may only draw additional paradigms.");
+                    } else {
+                        String relic = relicDeck.getFirst();
+                        RelicModel mod = Mapper.getRelic(relic);
+                        MessageHelper.sendMessageToChannelWithEmbed(
+                                player.getCorrectChannel(),
+                                player.getRepresentationNoPing() + " will draw the following relic:",
+                                mod.getRepresentationEmbed());
+                    }
                     String plural = (vpDifference == 1 ? "" : "s");
                     MessageHelper.sendMessageToChannel(
                             player.getCorrectChannel(),
                             player.getRepresentationNoPing() + " is " + vpDifference + " point" + plural
                                     + " behind the player with the most victory points, so they may draw "
                                     + vpDifference + " additional card" + plural + " from either deck.");
-                    for (int x = 0; x < vpDifference + 1; x++) {
+                    int maxExtraRelics = relicDeck.isEmpty() ? 0 : vpDifference;
+                    for (int x = 0; x < maxExtraRelics + 1; x++) {
                         buttons.add(Buttons.green(
                                 player.getFinsFactionCheckerPrefix() + "artificeStep2_" + (x) + "_"
                                         + (vpDifference - x),


### PR DESCRIPTION
## Summary
- guard the Artifice edict relic preview against an empty relic deck
- only offer extra relic draw splits when relics are actually available
- keep the existing paradigm flow intact when the relic deck is exhausted

## Verification
- mvn -q -DskipTests compile