### PR TITLE
Fractured ranks support

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/game/WeirdGameSetup.java
+++ b/src/main/java/ti4/discord/interactions/commands/game/WeirdGameSetup.java
@@ -211,6 +211,11 @@ class WeirdGameSetup extends GameStateSubcommand {
             boolean discordantStarsMode,
             boolean isTIGLGame,
             boolean votcMode) {
+        if (isTIGLGame && (game.isAllianceMode() || game.isCommunityMode())) {
+            MessageHelper.sendMessageToChannel(
+                    event.getMessageChannel(), "TIGL Games cannot be mixed with Alliance or Community mode.");
+            return false;
+        }
         if (isTIGLGame
                 && !TIGLHelper.isFracturedTIGLGame(game)
                 && (baseGameMode
@@ -218,11 +223,9 @@ class WeirdGameSetup extends GameStateSubcommand {
                         || discordantStarsMode
                         || game.isHomebrewSCMode()
                         || game.isFowMode()
-                        || game.isAllianceMode()
-                        || game.isCommunityMode()
                         || votcMode)) {
             MessageHelper.sendMessageToChannel(
-                    event.getMessageChannel(), "TIGL Games cannot be mixed with other game modes.");
+                    event.getMessageChannel(), "TIGL Games in standard ladder cannot be mixed with other game modes.");
             return false;
         } else if (isTIGLGame) {
             TIGLHelper.initializeTIGLGame(game);

--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -800,14 +800,41 @@ public class Game extends GameProperties {
 
     @Override
     public void setCompetitiveTIGLGame(boolean competitiveTIGLGame) {
-        if (isAbsolMode()
-                || isMiltyModMode()
-                || isDiscordantStarsMode()
-                || isHomebrewSCMode()
-                || isFowMode()
-                || isAllianceMode()
-                || isCommunityMode()) competitiveTIGLGame = false;
+        boolean isFracturedTIGL = TIGLHelper.isFracturedTIGLGame(this);
+        boolean hasAlwaysIncompatibleMode = isAllianceMode() || isCommunityMode();
+        boolean hasStandardOnlyIncompatibleMode =
+                isAbsolMode() || isMiltyModMode() || isDiscordantStarsMode() || isHomebrewSCMode() || isFowMode();
+        if (hasAlwaysIncompatibleMode || (!isFracturedTIGL && hasStandardOnlyIncompatibleMode)) {
+            competitiveTIGLGame = false;
+        }
         super.setCompetitiveTIGLGame(competitiveTIGLGame);
+        if (!competitiveTIGLGame) {
+            clearTIGLSetupState();
+        }
+    }
+
+    @Override
+    public void setAllianceMode(boolean allianceMode) {
+        super.setAllianceMode(allianceMode);
+        if (allianceMode) {
+            setCompetitiveTIGLGame(false);
+        }
+    }
+
+    @Override
+    public void setCommunityMode(boolean communityMode) {
+        super.setCommunityMode(communityMode);
+        if (communityMode) {
+            setCompetitiveTIGLGame(false);
+        }
+    }
+
+    private void clearTIGLSetupState() {
+        TIGLHelper.removeFracturedTag(this);
+        setMinimumTIGLRankAtGameStart(null);
+        for (Player player : getPlayers().values()) {
+            player.setPlayerTIGLRankAtGameStart(null);
+        }
     }
 
     @Override

--- a/src/main/java/ti4/helpers/TIGLHelper.java
+++ b/src/main/java/ti4/helpers/TIGLHelper.java
@@ -3,12 +3,15 @@ package ti4.helpers;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import lombok.Getter;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
@@ -27,6 +30,11 @@ import ti4.service.emoji.MiscEmojis;
 
 public final class TIGLHelper {
 
+    private enum TIGLLadder {
+        STANDARD,
+        FRACTURED
+    }
+
     public enum TIGLRank {
         UNRANKED("TIGL - Unranked", 0), // <- because current formatter settings will oneline this list
         MINISTER("TIGL - Minister", 1), //
@@ -36,6 +44,13 @@ public final class TIGLHelper {
         EMPEROR(
                 "TIGL - Galactic Emperor",
                 99), // this is only obtainable once per TIGL season, not per HERO rankup game
+        THRALL("TIGL - Thrall", 1, TIGLLadder.FRACTURED),
+        ACOLYTE("TIGL - Acolyte", 2, TIGLLadder.FRACTURED),
+        LEGIONNAIRE("TIGL - Legionnaire", 3, TIGLLadder.FRACTURED),
+        STARLANCER("TIGL - Starlancer", 4, TIGLLadder.FRACTURED),
+        GENESORCERER("TIGL - Gene-Sorcerer", 5, TIGLLadder.FRACTURED),
+        IXTHLORD("TIGL - Ixth-Lord", 6, TIGLLadder.FRACTURED),
+        ARCHON("TIGL - Archon", 7, TIGLLadder.FRACTURED),
         HERO_ARBOREC("TIGL - Letani Miasmiala", -1), //
         HERO_ARGENT("TIGL - Mirik Aun Sissiri", -1), //
         HERO_CABAL("TIGL - It Feeds on Carrion", -1), //
@@ -68,10 +83,20 @@ public final class TIGLHelper {
         private final String name;
 
         private final Integer index;
+        private final Set<TIGLLadder> ladders;
 
         TIGLRank(String name, int index) {
+            this(name, index, Set.of(TIGLLadder.STANDARD));
+        }
+
+        TIGLRank(String name, int index, TIGLLadder ladder) {
+            this(name, index, Set.of(ladder));
+        }
+
+        TIGLRank(String name, int index, Set<TIGLLadder> ladders) {
             this.name = name;
             this.index = index;
+            this.ladders = ladders;
         }
 
         public String getShortName() {
@@ -84,7 +109,7 @@ public final class TIGLHelper {
 
         @Override
         public String toString() {
-            return super.toString().toLowerCase();
+            return super.toString().toLowerCase(Locale.ROOT);
         }
 
         public Role getRole() {
@@ -93,6 +118,11 @@ public final class TIGLHelper {
                 return null;
             }
             return roles.getFirst();
+        }
+
+        boolean belongsToLadder(boolean isFractured) {
+            TIGLLadder ladder = isFractured ? TIGLLadder.FRACTURED : TIGLLadder.STANDARD;
+            return ladders.contains(ladder);
         }
 
         TIGLRank getNextRank() {
@@ -107,26 +137,31 @@ public final class TIGLHelper {
         }
 
         public static List<TIGLRank> getSortedRanks() {
-            return Stream.of(values())
+            return Arrays.stream(values())
                     .filter(rank -> rank.index >= 0)
                     .sorted(Comparator.comparing(TIGLRank::getIndex))
                     .toList();
         }
 
         /**
-         * Converts a string identifier to the corresponding SimpleStatistics enum value.
+         * Converts a string identifier to the corresponding TIGL rank.
          *
          * @param id the string identifier
-         * @return the SimpleStatistics enum value, or null if not found
+         * @return the TIGL rank, or null if not found
          */
         public static TIGLRank fromString(String id) {
             if (isBlank(id)) return null;
+            String normalizedInput = normalizeRankId(id);
             for (TIGLRank rank : values()) {
-                if (id.equals(rank.toString())) {
+                if (id.equals(rank.toString()) || normalizedInput.equals(normalizeRankId(rank.toString()))) {
                     return rank;
                 }
             }
             return null;
+        }
+
+        private static String normalizeRankId(String id) {
+            return id.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
         }
     }
 
@@ -163,13 +198,17 @@ public final class TIGLHelper {
     }
 
     public static void initializeTIGLGame(Game game, boolean isFractured) {
-        game.setCompetitiveTIGLGame(true);
         if (isFractured) {
             addFracturedTag(game);
         } else {
             removeFracturedTag(game);
         }
+        game.setCompetitiveTIGLGame(true);
         sendTIGLSetupText(game);
+        setTIGLRankSnapshotAtSetup(game, isFractured);
+    }
+
+    private static void setTIGLRankSnapshotAtSetup(Game game, boolean isFractured) {
         List<User> users =
                 game.getPlayers().values().stream().map(Player::getUser).toList();
         if (!allUsersAreMembersOfHubServer(users)) {
@@ -178,10 +217,10 @@ public final class TIGLHelper {
             MessageHelper.sendMessageToChannel(game.getActionsChannel(), message);
             return;
         }
-        TIGLRank lowestRank = getLowestCommonRankBetweenPlayers(users);
+        TIGLRank lowestRank = getLowestCommonRankBetweenPlayers(users, isFractured);
         game.setMinimumTIGLRankAtGameStart(lowestRank);
         for (Player player : game.getPlayers().values()) {
-            player.setPlayerTIGLRankAtGameStart(getUsersHighestTIGLRank(player.getUser()));
+            player.setPlayerTIGLRankAtGameStart(getUsersHighestTIGLRank(player.getUser(), isFractured));
         }
     }
 
@@ -192,14 +231,6 @@ public final class TIGLHelper {
                 + "By continuing forward with this game, it is assumed you have accepted and are subject to the TIGL Code of Conduct.\n\n"
                 + "For more information, please see this channel: https://discord.com/channels/943410040369479690/1003741148017336360\n and the [Rules Document](https://docs.google.com/document/d/1WoFPiluIz5cw80x1-WxUeckADIdYszNFZFTb6d648tk/edit?tab=t.0)";
         MessageHelper.sendMessageToChannel(game.getActionsChannel(), message);
-    }
-
-    private static List<Role> getAllTIGLRoles() {
-        List<Role> roles = new ArrayList<>();
-        for (TIGLRank rank : TIGLRank.values()) {
-            roles.add(rank.getRole());
-        }
-        return roles;
     }
 
     private static List<TIGLRank> getAllTIGLRanks() {
@@ -213,22 +244,21 @@ public final class TIGLHelper {
                 .toList();
     }
 
-    private static TIGLRank getTIGLRankFromRole(@Nullable Role role) {
-        if (role == null) {
-            return null;
-        }
+    private static Map<Long, TIGLRank> getTIGLRoleIdToRankMap() {
+        Map<Long, TIGLRank> roleIdToRank = new HashMap<>();
         for (TIGLRank rank : getAllTIGLRanks()) {
-            if (role.equals(rank.getRole())) {
-                return rank;
+            Role role = rank.getRole();
+            if (role != null) {
+                roleIdToRank.put(role.getIdLong(), rank);
             }
         }
-        return null;
+        return roleIdToRank;
     }
 
-    private static TIGLRank getLowestCommonRankBetweenPlayers(List<User> users) {
-        TIGLRank lowestRank = TIGLRank.HERO;
+    private static TIGLRank getLowestCommonRankBetweenPlayers(List<User> users, boolean isFractured) {
+        TIGLRank lowestRank = isFractured ? TIGLRank.ARCHON : TIGLRank.HERO;
         for (User user : users) {
-            TIGLRank rank = getUsersHighestTIGLRank(user);
+            TIGLRank rank = getUsersHighestTIGLRank(user, isFractured);
             if (lowestRank.getIndex() > rank.getIndex()) {
                 lowestRank = rank;
             }
@@ -236,21 +266,26 @@ public final class TIGLHelper {
         return lowestRank;
     }
 
-    private static List<TIGLRank> getUsersTIGLRanks(User user) {
+    private static List<TIGLRank> getUsersTIGLRanks(User user, boolean isFractured) {
         Member hubMember = JdaService.guildPrimary.getMemberById(user.getId());
         if (hubMember == null) {
             return new ArrayList<>();
         }
+        Map<Long, TIGLRank> roleIdToRank = getTIGLRoleIdToRankMap();
         return hubMember.getRoles().stream()
-                .filter(r -> getAllTIGLRoles().contains(r))
-                .map(TIGLHelper::getTIGLRankFromRole)
+                .map(r -> roleIdToRank.get(r.getIdLong()))
                 .filter(Objects::nonNull)
+                .filter(r -> r.belongsToLadder(isFractured))
                 .sorted(Comparator.comparing(TIGLRank::getIndex))
                 .toList();
     }
 
     private static TIGLRank getUsersHighestTIGLRank(User user) {
-        List<TIGLRank> ranks = getUsersTIGLRanks(user);
+        return getUsersHighestTIGLRank(user, false);
+    }
+
+    private static TIGLRank getUsersHighestTIGLRank(User user, boolean isFractured) {
+        List<TIGLRank> ranks = getUsersTIGLRanks(user, isFractured);
         if (ranks.isEmpty()) {
             return TIGLRank.UNRANKED;
         }
@@ -311,6 +346,10 @@ public final class TIGLHelper {
         // do stuff
     }
 
+    /**
+     * @deprecated Obsolete legacy TIGL rank-up flow. No active code paths call this method.
+     */
+    @Deprecated(forRemoval = true, since = "2026-04")
     public static void checkIfTIGLRankUpOnGameEnd(Game game) {
         TIGLRank gameRank = game.getMinimumTIGLRankAtGameStart();
         Player winner = game.getWinner().orElse(null);
@@ -320,6 +359,9 @@ public final class TIGLHelper {
         User user = winner.getUser();
         TIGLRank userCurrentRank = getUsersHighestTIGLRank(user);
         TIGLRank nextRank = gameRank.getNextRank();
+        if (nextRank == null) {
+            return;
+        }
         if (nextRank.getIndex() - userCurrentRank.getIndex() == 1) {
             promoteUser(user, nextRank);
         }

--- a/src/main/java/ti4/helpers/settingsFramework/menus/GameSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/GameSettings.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.game.Game;
 import ti4.helpers.MapTemplateHelper;
+import ti4.helpers.TIGLHelper;
 import ti4.helpers.settingsFramework.menus.MiltySettings.DraftingMode;
 import ti4.helpers.settingsFramework.settings.BooleanSetting;
 import ti4.helpers.settingsFramework.settings.BooleanSettingWithCustomAction;
@@ -67,10 +68,14 @@ public class GameSettings extends SettingsMenu {
         stage2s = new IntegerSetting("Stage2s", "number of Stage 2 public objectives", 5, 1, 20, 1);
         secrets = new IntegerSetting("Secrets", "Max number of secret objectives", 3, 1, 10, 1);
         boolean defaultTigl = game.isCompetitiveTIGLGame();
+        boolean defaultTiglFractured = defaultTigl && TIGLHelper.isFracturedTIGLGame(game);
         tigl = new BooleanSettingWithCustomAction(
-                "TIGL", "TIGL Game", defaultTigl, (value) -> ensureTIGLConsistency(true, false));
+                "TIGL", "TIGL Game", defaultTigl, (value) -> ensureFracturedDisabledWhenTiglOff());
         tiglFractured = new BooleanSettingWithCustomAction(
-                "TIGL Fractured", "TIGL Fractured Game", false, (value) -> ensureTIGLConsistency(false, true));
+                "TIGL Fractured",
+                "TIGL Fractured Game",
+                defaultTiglFractured,
+                (value) -> ensureTiglEnabledWhenFracturedOn());
         alliance = new BooleanSetting("Alliance", "Alliance Mode", false);
         mapTemplate = new ChoiceSetting<>("Template", "Map Template", "6pStandard");
 
@@ -190,18 +195,15 @@ public class GameSettings extends SettingsMenu {
     // ---------------------------------------------------------------------------------------------------------------------------------
     // Specific Implementation
     // ---------------------------------------------------------------------------------------------------------------------------------
-    private void ensureTIGLConsistency(boolean userToggleTIGL, boolean userToggleTIGLFractured) {
-        if (userToggleTIGL) {
-            boolean tiglStatus = tigl.isVal();
-            if (!tiglStatus) {
-                tiglFractured.setVal(false); // keep fractured off if TIGL is turned off
-            }
+    private void ensureFracturedDisabledWhenTiglOff() {
+        if (!tigl.isVal()) {
+            tiglFractured.setVal(false);
         }
-        if (userToggleTIGLFractured) {
-            boolean fracturedStatus = tiglFractured.isVal();
-            if (fracturedStatus) {
-                tigl.setVal(true); // keep TIGL on if fractured is on
-            }
+    }
+
+    private void ensureTiglEnabledWhenFracturedOn() {
+        if (tiglFractured.isVal()) {
+            tigl.setVal(true);
         }
     }
 

--- a/src/main/java/ti4/helpers/settingsFramework/menus/GameSetupSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/GameSetupSettings.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.helpers.TIGLHelper;
 import ti4.helpers.settingsFramework.settings.BooleanSetting;
 import ti4.helpers.settingsFramework.settings.BooleanSettingWithCustomAction;
 import ti4.helpers.settingsFramework.settings.IntegerSetting;
@@ -61,10 +62,14 @@ public class GameSetupSettings extends SettingsMenu {
         stage2s = new IntegerSetting("Stage2s", "number of Stage 2 public objectives", 5, 1, 20, 1);
         secrets = new IntegerSetting("Secrets", "Max number of secret objectives", 3, 1, 10, 1);
         boolean defaultTigl = game.isCompetitiveTIGLGame();
+        boolean defaultTiglFractured = defaultTigl && TIGLHelper.isFracturedTIGLGame(game);
         tigl = new BooleanSettingWithCustomAction(
                 "TIGL", "TIGL Game", defaultTigl, (value) -> ensureTIGLConsistency(true, false));
         tiglFractured = new BooleanSettingWithCustomAction(
-                "TIGL Fractured", "TIGL Fractured Game", false, (value) -> ensureTIGLConsistency(false, true));
+                "TIGL Fractured",
+                "TIGL Fractured Game",
+                defaultTiglFractured,
+                (value) -> ensureTIGLConsistency(false, true));
         alliance = new BooleanSetting("Alliance", "Alliance Mode", false);
 
         // Initialize values & keys for gamePlayers

--- a/src/main/java/ti4/spring/service/persistence/GameEntity.java
+++ b/src/main/java/ti4/spring/service/persistence/GameEntity.java
@@ -67,6 +67,9 @@ public class GameEntity {
     @Column(name = "is_twilight_imperium_global_league")
     private boolean twilightImperiumGlobalLeague;
 
+    @Column(name = "is_twilight_imperium_global_league_fractured")
+    private boolean twilightImperiumGlobalLeagueFractured;
+
     @Column(name = "twilight_imperium_global_league_rank")
     private String twilightImperiumGlobalLeagueRank;
 

--- a/src/main/java/ti4/spring/service/persistence/PersistAllEntitiesService.java
+++ b/src/main/java/ti4/spring/service/persistence/PersistAllEntitiesService.java
@@ -12,6 +12,7 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.persistence.GameManager;
 import ti4.game.persistence.ManagedGame;
+import ti4.helpers.TIGLHelper;
 import ti4.logging.BotLogger;
 import ti4.service.map.FractureService;
 
@@ -83,6 +84,8 @@ public class PersistAllEntitiesService {
         gameEntity.setFrankenMode(game.isFrankenGame());
         gameEntity.setAllianceMode(game.isAllianceMode());
         gameEntity.setTwilightImperiumGlobalLeague(game.isCompetitiveTIGLGame());
+        gameEntity.setTwilightImperiumGlobalLeagueFractured(
+                game.isCompetitiveTIGLGame() && TIGLHelper.isFracturedTIGLGame(game));
         gameEntity.setTwilightImperiumGlobalLeagueRank(
                 game.getMinimumTIGLRankAtGameStart() == null
                         ? null

--- a/src/main/java/ti4/spring/service/tigl/TiglGamesInfoService.java
+++ b/src/main/java/ti4/spring/service/tigl/TiglGamesInfoService.java
@@ -15,44 +15,88 @@ import ti4.spring.service.persistence.GameEntityRepository;
 @RequiredArgsConstructor
 public class TiglGamesInfoService {
 
+    private record ParsedTiglGame(String gameName, TIGLRank rank, boolean fractured) {}
+
     private final GameEntityRepository gameEntityRepository;
+    private static final List<TIGLRank> BASE_TIGL_GAMES_DISPLAY_ORDER =
+            List.of(TIGLRank.MINISTER, TIGLRank.AGENT, TIGLRank.COMMANDER, TIGLRank.HERO);
+    private static final List<TIGLRank> FRACTURED_TIGL_GAMES_DISPLAY_ORDER = List.of(
+            TIGLRank.THRALL,
+            TIGLRank.ACOLYTE,
+            TIGLRank.LEGIONNAIRE,
+            TIGLRank.STARLANCER,
+            TIGLRank.GENESORCERER,
+            TIGLRank.IXTHLORD,
+            TIGLRank.ARCHON);
 
     @Transactional(readOnly = true)
     public String getOngoingGamesByRankMessage(boolean showGameIds) {
         List<GameEntity> ongoingTiglGames =
                 gameEntityRepository.findByTwilightImperiumGlobalLeagueTrueAndEndedEpochMillisecondsIsNull();
 
-        Map<TIGLRank, List<String>> rankToGames = ongoingTiglGames.stream()
+        List<ParsedTiglGame> parsedGames = ongoingTiglGames.stream()
+                .map(game -> {
+                    TIGLRank rank = TIGLRank.fromString(game.getTwilightImperiumGlobalLeagueRank());
+                    if (rank == null) {
+                        rank = TIGLRank.UNRANKED;
+                    }
+                    return new ParsedTiglGame(game.getGameName(), rank, game.isTwilightImperiumGlobalLeagueFractured());
+                })
+                .toList();
+
+        Map<TIGLRank, List<String>> baseRankToGames = parsedGames.stream()
+                .filter(game -> !game.fractured())
                 .collect(Collectors.groupingBy(
-                        game -> {
-                            TIGLRank rank = TIGLRank.fromString(game.getTwilightImperiumGlobalLeagueRank());
-                            return rank == null ? TIGLRank.UNRANKED : rank;
-                        },
-                        Collectors.mapping(GameEntity::getGameName, Collectors.toList())));
+                        ParsedTiglGame::rank, Collectors.mapping(ParsedTiglGame::gameName, Collectors.toList())));
+
+        Map<TIGLRank, List<String>> fracturedRankToGames = parsedGames.stream()
+                .filter(ParsedTiglGame::fractured)
+                .collect(Collectors.groupingBy(
+                        ParsedTiglGame::rank, Collectors.mapping(ParsedTiglGame::gameName, Collectors.toList())));
+
+        List<String> unrankedBaseGames = parsedGames.stream()
+                .filter(game -> game.rank() == TIGLRank.UNRANKED)
+                .filter(game -> !game.fractured())
+                .map(ParsedTiglGame::gameName)
+                .toList();
+
+        List<String> unrankedFracturedGames = parsedGames.stream()
+                .filter(game -> game.rank() == TIGLRank.UNRANKED)
+                .filter(ParsedTiglGame::fractured)
+                .map(ParsedTiglGame::gameName)
+                .toList();
 
         StringBuilder sb = new StringBuilder("## Ongoing TIGL games by rank\n");
         sb.append("Total ongoing TIGL games: `").append(ongoingTiglGames.size()).append("`\n");
 
-        for (TIGLRank rank : TIGLRank.getSortedRanks()) {
-            if (rank == TIGLRank.EMPEROR) {
-                continue;
-            }
-            List<String> gamesForRank = rankToGames.getOrDefault(rank, List.of());
-            sb.append("- **")
-                    .append(rank.getShortName())
-                    .append("**: `")
-                    .append(gamesForRank.size())
-                    .append("` game");
-            if (gamesForRank.size() != 1) {
-                sb.append("s");
-            }
-            if (showGameIds && !gamesForRank.isEmpty()) {
-                sb.append(" → ").append(String.join(", ", gamesForRank));
-            }
-            sb.append('\n');
+        appendRankLine(sb, "Unranked (Base)", unrankedBaseGames, showGameIds);
+        for (TIGLRank rank : BASE_TIGL_GAMES_DISPLAY_ORDER) {
+            List<String> gamesForRank = baseRankToGames.getOrDefault(rank, List.of());
+            appendRankLine(sb, rank.getShortName(), gamesForRank, showGameIds);
+        }
+
+        appendRankLine(sb, "Unranked (Fractured)", unrankedFracturedGames, showGameIds);
+        for (TIGLRank rank : FRACTURED_TIGL_GAMES_DISPLAY_ORDER) {
+            List<String> gamesForRank = fracturedRankToGames.getOrDefault(rank, List.of());
+            appendRankLine(sb, rank.getShortName(), gamesForRank, showGameIds);
         }
 
         return sb.toString();
+    }
+
+    private static void appendRankLine(StringBuilder sb, String label, List<String> gamesForRank, boolean showGameIds) {
+        sb.append("- **")
+                .append(label)
+                .append("**: `")
+                .append(gamesForRank.size())
+                .append("` game");
+        if (gamesForRank.size() != 1) {
+            sb.append("s");
+        }
+        if (showGameIds && !gamesForRank.isEmpty()) {
+            sb.append(" → ").append(String.join(", ", gamesForRank));
+        }
+        sb.append('\n');
     }
 
     public static TiglGamesInfoService getBean() {


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of TIGL (Twilight Imperium Global League) game modes, especially around the new "Fractured" ladder, mode compatibility, and rank management. The changes ensure that TIGL and TIGL Fractured are treated as distinct ladders with their own ranks, enforce stricter game mode combinations, and enhance persistence and reporting for these modes.

**TIGL Ladder and Rank System Enhancements:**

- Introduced a new `TIGLLadder` enum to distinguish between STANDARD and FRACTURED ladders, and updated the `TIGLRank` enum to support ladder-specific ranks (e.g., Thrall, Acolyte, etc., for FRACTURED). Ranks now track which ladder(s) they belong to, and rank comparison and assignment functions have been updated to respect the ladder context. [[1]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fR31-R35) [[2]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fR45-R51) [[3]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fR84-R97) [[4]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fR121-R125) [[5]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fR152-R163) [[6]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fL228-R276) [[7]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fR285-R295)

- The TIGL game initialization process now snapshots player ranks and the minimum rank at game start, taking the ladder type into account. This ensures correct rank assignment and tracking for both ladders. [[1]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fL166-R209) [[2]](diffhunk://#diff-a0b1b865b66622e7397166d0cc3ac2264e72bcd567be2327003b2cd16735cf5fL181-R221)

**Game Mode Compatibility and Enforcement:**

- Added stricter checks to prevent mixing TIGL (both STANDARD and FRACTURED) with Alliance or Community modes, and clarified error messages when incompatible modes are selected.

- Updated the `setCompetitiveTIGLGame`, `setAllianceMode`, and `setCommunityMode` methods in `Game` to enforce mode exclusivity and automatically disable TIGL when incompatible modes are enabled.

**Persistence and Settings Updates:**

- Extended the `GameEntity` persistence model to store whether a game is a TIGL Fractured game, and updated the persistence service to save this information. [[1]](diffhunk://#diff-f93395923db3a09c7bb44376871579f725dfd09f497c3ed103d5d112fef6ca01R70-R72) [[2]](diffhunk://#diff-542b6083638f1764e4c27bb78051b836680c44425b470655bc413d9e6ecdd387R87)

- Updated game settings menus (`GameSettings`, `GameSetupSettings`) to properly reflect and initialize the TIGL Fractured setting based on the current game state. [[1]](diffhunk://#diff-6ef91423d59d9854ad0f2efa503114bd4827cc7696fd607d625f0e40de220354R71-R78) [[2]](diffhunk://#diff-2f4c598a4faf5b6a4fcdbc85dc46cbb023d43a86a613110ddda2d029fb9d0721R65-R72)

**Reporting and Display Improvements:**

- Enhanced the TIGL games info service to display ongoing games grouped and ordered by ladder and rank, including unranked games for both ladders, with separate display orders for STANDARD and FRACTURED ladders. [[1]](diffhunk://#diff-5c156ff37b281f40024876a843869cda42ea04d6983fc018fb894f16b923e468R19-R28) [[2]](diffhunk://#diff-5c156ff37b281f40024876a843869cda42ea04d6983fc018fb894f16b923e468L27-R78)

**Additional Improvements:**

- Improved normalization and matching in TIGL rank parsing to handle various string formats and ensure robust rank identification.

These changes collectively provide robust support for the new TIGL Fractured ladder, ensure game mode integrity, and improve the user experience for both players and administrators.