### PR TITLE
Hide franken speaker order announcement in FoW

### DIFF
--- a/src/main/java/ti4/service/game/SetOrderService.java
+++ b/src/main/java/ti4/service/game/SetOrderService.java
@@ -11,6 +11,7 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.message.MessageHelper;
 import ti4.service.emoji.MiscEmojis;
+import ti4.service.fow.GMService;
 
 @UtilityClass
 public class SetOrderService {
@@ -37,8 +38,21 @@ public class SetOrderService {
                 sb.append(MiscEmojis.SpeakerToken);
             }
         }
-        MessageChannel channel = event == null ? game.getActionsChannel() : event.getMessageChannel();
-        MessageHelper.sendMessageToChannel(channel, sb.toString());
+        MessageChannel channel = getAnnouncementChannel(event, game);
+        if (channel != null) {
+            MessageHelper.sendMessageToChannel(channel, sb.toString());
+        }
+    }
+
+    private static MessageChannel getAnnouncementChannel(GenericInteractionCreateEvent event, Game game) {
+        if (game.isFowMode()) {
+            MessageChannel gmChannel = GMService.getGMChannel(game);
+            if (gmChannel != null && !gmChannel.equals(game.getMainGameChannel())) {
+                return gmChannel;
+            }
+            return null;
+        }
+        return event == null ? game.getActionsChannel() : event.getMessageChannel();
     }
 
     private static void setPlayerOrder(Map<String, Player> newPlayerOrder, Map<String, Player> players, User user) {


### PR DESCRIPTION
## Summary
- route automatic player order announcements to the GM channel in FoW games
- suppress the announcement entirely if FoW has no separate GM room, instead of leaking order into a public channel
- preserve the existing public announcement behavior outside FoW

## Testing
- not run successfully in this worktree; existing unrelated compile and spotless/index issues blocked focused verification in the original checkout