### PR TITLE
Fix FoW hidden combat and trade notification routing

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/cardspn/SendPN.java
+++ b/src/main/java/ti4/discord/interactions/commands/cardspn/SendPN.java
@@ -133,7 +133,8 @@ class SendPN extends GameStateSubcommand {
         String message = player.getRepresentation() + " sent " + CardEmojis.PN + conditionalPNName + preposition
                 + targetPlayer.getRepresentation() + ".";
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
+            MessageHelper.sendMessageToChannel(
+                    TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
             MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(player, game), message);
         } else {
             MessageHelper.sendMessageToChannel(player.getCorrectChannel(), message);

--- a/src/main/java/ti4/discord/interactions/commands/cardspn/SendPN.java
+++ b/src/main/java/ti4/discord/interactions/commands/cardspn/SendPN.java
@@ -12,6 +12,7 @@ import ti4.helpers.ButtonHelperAbilities;
 import ti4.helpers.Constants;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.PromissoryNoteHelper;
+import ti4.helpers.TransactionHelper;
 import ti4.image.Mapper;
 import ti4.message.MessageHelper;
 import ti4.model.PromissoryNoteModel;
@@ -132,8 +133,8 @@ class SendPN extends GameStateSubcommand {
         String message = player.getRepresentation() + " sent " + CardEmojis.PN + conditionalPNName + preposition
                 + targetPlayer.getRepresentation() + ".";
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(targetPlayer.getPrivateChannel(), message);
-            MessageHelper.sendMessageToChannel(player.getCorrectChannel(), "Promissory note sent.");
+            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
+            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(player, game), message);
         } else {
             MessageHelper.sendMessageToChannel(player.getCorrectChannel(), message);
         }

--- a/src/main/java/ti4/discord/interactions/commands/player/SendCommodities.java
+++ b/src/main/java/ti4/discord/interactions/commands/player/SendCommodities.java
@@ -87,7 +87,8 @@ class SendCommodities extends GameStateSubcommand {
         }
 
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
+            MessageHelper.sendMessageToChannel(
+                    TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
 
             // Add extra message for transaction visibility
             FoWHelper.pingPlayersTransaction(game, event, player, targetPlayer, commString, null);

--- a/src/main/java/ti4/discord/interactions/commands/player/SendCommodities.java
+++ b/src/main/java/ti4/discord/interactions/commands/player/SendCommodities.java
@@ -72,7 +72,7 @@ class SendCommodities extends GameStateSubcommand {
         String p2 = targetPlayer.getRepresentation();
         String commString = sendCommodities + " commodit" + (sendCommodities == 1 ? "y" : "ies");
         String message = p1 + " sent " + commString + " to " + p2 + ".";
-        MessageHelper.sendMessageToChannel(player.getCorrectChannel(), message);
+        MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(player, game), message);
         ButtonHelperFactionSpecific.resolveDarkPactCheck(game, player, targetPlayer, sendCommodities);
         ButtonHelperAbilities.pillageCheck(targetPlayer, game);
         ButtonHelperAbilities.pillageCheck(player, game);
@@ -87,7 +87,7 @@ class SendCommodities extends GameStateSubcommand {
         }
 
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(targetPlayer.getPrivateChannel(), message);
+            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
 
             // Add extra message for transaction visibility
             FoWHelper.pingPlayersTransaction(game, event, player, targetPlayer, commString, null);

--- a/src/main/java/ti4/discord/interactions/commands/player/SendDebt.java
+++ b/src/main/java/ti4/discord/interactions/commands/player/SendDebt.java
@@ -9,6 +9,7 @@ import ti4.discord.interactions.commands.GameStateSubcommand;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.Constants;
+import ti4.helpers.TransactionHelper;
 import ti4.message.MessageHelper;
 import ti4.service.leader.CommanderUnlockCheckService;
 import ti4.service.transaction.SendDebtService;
@@ -52,9 +53,10 @@ class SendDebt extends GameStateSubcommand {
         String debtMsg = sendingPlayer.getRepresentation() + " sent " + debtCountToSend + " debt token"
                 + (debtCountToSend == 1 ? "" : "s") + " to " + receivingPlayer.getRepresentation() + ", for their \""
                 + pool + "\" pool.";
-        MessageHelper.sendMessageToChannel(sendingPlayer.getCorrectChannel(), debtMsg);
+        MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(sendingPlayer, game), debtMsg);
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(receivingPlayer.getPrivateChannel(), debtMsg);
+            MessageHelper.sendMessageToChannel(
+                    TransactionHelper.getTradeNotificationChannel(receivingPlayer, game), debtMsg);
         }
     }
 }

--- a/src/main/java/ti4/discord/interactions/commands/player/SendTG.java
+++ b/src/main/java/ti4/discord/interactions/commands/player/SendTG.java
@@ -75,7 +75,7 @@ class SendTG extends GameStateSubcommand {
         }
 
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(targetPlayer.getPrivateChannel(), message);
+            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
 
             // Add extra message for transaction visibility
             FoWHelper.pingPlayersTransaction(game, event, player, targetPlayer, tgString, null);

--- a/src/main/java/ti4/discord/interactions/commands/player/SendTG.java
+++ b/src/main/java/ti4/discord/interactions/commands/player/SendTG.java
@@ -75,7 +75,8 @@ class SendTG extends GameStateSubcommand {
         }
 
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
+            MessageHelper.sendMessageToChannel(
+                    TransactionHelper.getTradeNotificationChannel(targetPlayer, game), message);
 
             // Add extra message for transaction visibility
             FoWHelper.pingPlayersTransaction(game, event, player, targetPlayer, tgString, null);

--- a/src/main/java/ti4/helpers/ButtonHelperAbilities.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAbilities.java
@@ -2536,6 +2536,7 @@ public final class ButtonHelperAbilities {
         AddUnitService.addUnits(event, tile, game, player.getColor(), "1 " + unit + " " + planet);
         String opponent = "their opponent's";
         String colour = "";
+        Player indoctrinatedPlayer = null;
         for (Player p2 : game.getPlayers().values()) {
             if (p2.getColor() == null
                     || p2 == player
@@ -2548,6 +2549,7 @@ public final class ButtonHelperAbilities {
                 ButtonHelper.resolveInfantryRemoval(p2, 1, tile);
                 opponent = p2.getRepresentationNoPing();
                 colour = p2.getColor();
+                indoctrinatedPlayer = p2;
                 break;
             }
         }
@@ -2610,6 +2612,13 @@ public final class ButtonHelperAbilities {
                     event.getMessageChannel(),
                     player.getRepresentationNoPing() + " replaced 1 of " + opponent + " infantry with 1 " + unit
                             + " on " + Helper.getPlanetRepresentation(planet, game) + " using **Indoctrination**.");
+        }
+        if (game.isFowMode() && indoctrinatedPlayer != null) {
+            MessageHelper.sendPrivateMessageToPlayer(
+                    indoctrinatedPlayer,
+                    game,
+                    player.getFactionEmoji() + " replaced 1 of your infantry with 1 " + unit + " on "
+                            + Helper.getPlanetRepresentation(planet, game) + " using **Indoctrination**.");
         }
         options.add(Buttons.red("deleteButtons", "Done Exhausting Planets"));
         MessageHelper.sendMessageToChannelWithButtons(

--- a/src/main/java/ti4/helpers/ButtonHelperCommanders.java
+++ b/src/main/java/ti4/helpers/ButtonHelperCommanders.java
@@ -869,11 +869,23 @@ public class ButtonHelperCommanders {
         String planet = buttonID.split("_")[1];
         ButtonHelper.deleteButtonAndDeleteMessageIfEmpty(event);
         Tile tile = game.getTileFromPlanet(planet);
+        List<Player> playersToNotify = game.isFowMode()
+                ? game.getRealPlayersExcludingThis(player).stream()
+                        .filter(p2 -> FoWHelper.playerHasUnitsOnPlanet(p2, tile, planet))
+                        .toList()
+                : List.of();
         AddUnitService.addUnits(event, tile, game, player.getColor(), "1 inf " + planet);
         MessageHelper.sendMessageToChannel(
                 event.getMessageChannel(),
                 player.getFactionEmoji() + " placed 1 infantry on " + Helper.getPlanetRepresentation(planet, game)
                         + " using Claire Gibson, the Sol Commander.");
+        for (Player p2 : playersToNotify) {
+            MessageHelper.sendPrivateMessageToPlayer(
+                    p2,
+                    game,
+                    player.getFactionEmoji() + " placed 1 infantry on " + Helper.getPlanetRepresentation(planet, game)
+                            + " using Claire Gibson, the Sol Commander.");
+        }
     }
 
     @ButtonHandler("utilizeMykoBT_")
@@ -901,6 +913,7 @@ public class ButtonHelperCommanders {
             Player player, Game game, String buttonID, ButtonInteractionEvent event) {
         String planet = buttonID.split("_")[1];
         Tile tile = game.getTileFromPlanet(planet);
+        Player destroyedPlayer = null;
         for (Player p2 : game.getPlayers().values()) {
             if (p2.getColor() == null
                     || p2 == player
@@ -910,6 +923,7 @@ public class ButtonHelperCommanders {
             if (FoWHelper.playerHasInfantryOnPlanet(p2, tile, planet)
                     && !player.getAllianceMembers().contains(p2.getFaction())) {
                 DestroyUnitService.destroyUnits(event, tile, game, p2.getColor(), "1 infantry " + planet, true);
+                destroyedPlayer = p2;
                 break;
             }
         }
@@ -917,6 +931,14 @@ public class ButtonHelperCommanders {
                 event.getMessageChannel(),
                 player.getFactionEmoji() + " destroyed 1 opposing infantry on "
                         + Helper.getPlanetRepresentation(planet, game) + " using the Avhkan, the Pharad’n commander.");
+        if (game.isFowMode() && destroyedPlayer != null) {
+            MessageHelper.sendPrivateMessageToPlayer(
+                    destroyedPlayer,
+                    game,
+                    player.getFactionEmoji() + " destroyed 1 of your infantry on "
+                            + Helper.getPlanetRepresentation(planet, game)
+                            + " using the Avhkan, the Pharad’n commander.");
+        }
     }
 
     @ButtonHandler("yssarilcommander_")

--- a/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
+++ b/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
@@ -3044,6 +3044,11 @@ public final class ButtonHelperFactionSpecific {
         String planet = buttonID.split("_")[1];
         String unit = buttonID.split("_")[2];
         Tile tile = game.getTileFromPlanet(planet);
+        List<Player> playersToNotify = game.isFowMode()
+                ? game.getRealPlayersExcludingThis(player).stream()
+                        .filter(p2 -> FoWHelper.playerHasUnitsOnPlanet(p2, tile, planet))
+                        .toList()
+                : List.of();
         AddUnitService.addUnits(event, tile, game, player.getColor(), "1 " + unit + " " + planet);
         RemoveUnitService.removeUnits(event, tile, game, player.getColor(), "1 infantry " + planet);
         List<Button> options = ButtonHelper.getExhaustButtonsWithTG(game, player, "res");
@@ -3051,6 +3056,13 @@ public final class ButtonHelperFactionSpecific {
                 event.getMessageChannel(),
                 player.getRepresentationNoPing() + " replaced 1 of their infantry with 1 " + unit + " on "
                         + Helper.getPlanetRepresentation(planet, game) + " using the mech's DEPLOY ability.");
+        for (Player p2 : playersToNotify) {
+            MessageHelper.sendPrivateMessageToPlayer(
+                    p2,
+                    game,
+                    player.getFactionEmoji() + " replaced 1 infantry with 1 " + unit + " on "
+                            + Helper.getPlanetRepresentation(planet, game) + " using the mech's DEPLOY ability.");
+        }
         options.add(Buttons.red("deleteButtons", "Done Exhausting Planets"));
         MessageHelper.sendMessageToChannelWithButtons(
                 event.getMessageChannel(),
@@ -3699,6 +3711,7 @@ public final class ButtonHelperFactionSpecific {
         Tile tile = game.getTileFromPlanet(planet);
         AddUnitService.addUnits(event, tile, game, player.getColor(), "1 " + unit + " " + planet);
         String opponent = "their opponent's";
+        Player greyfireTarget = null;
         for (Player p2 : game.getRealPlayersNNeutral()) {
             if (p2 == player) {
                 continue;
@@ -3706,6 +3719,7 @@ public final class ButtonHelperFactionSpecific {
             if (FoWHelper.playerHasInfantryOnPlanet(p2, tile, planet)) {
                 RemoveUnitService.removeUnits(event, tile, game, p2.getColor(), "1 infantry " + planet);
                 opponent = p2.getRepresentationNoPing();
+                greyfireTarget = p2;
                 break;
             }
         }
@@ -3719,6 +3733,13 @@ public final class ButtonHelperFactionSpecific {
                     event.getMessageChannel(),
                     player.getRepresentationNoPing() + " replaced 1 of " + opponent + " infantry with 1 " + unit
                             + " on " + Helper.getPlanetRepresentation(planet, game) + " using _Greyfire Mutagen_.");
+        }
+        if (game.isFowMode() && greyfireTarget != null) {
+            MessageHelper.sendPrivateMessageToPlayer(
+                    greyfireTarget,
+                    game,
+                    player.getFactionEmoji() + " replaced 1 of your infantry with 1 " + unit + " on "
+                            + Helper.getPlanetRepresentation(planet, game) + " using _Greyfire Mutagen_.");
         }
         event.getMessage().delete().queue(Consumers.nop(), BotLogger::catchRestError);
     }

--- a/src/main/java/ti4/helpers/TransactionHelper.java
+++ b/src/main/java/ti4/helpers/TransactionHelper.java
@@ -50,6 +50,16 @@ import ti4.settings.users.UserSettingsManager;
 
 public final class TransactionHelper {
 
+    public static MessageChannel getTradeNotificationChannel(Player player, Game game) {
+        if (game.isFowMode()) {
+            MessageChannel cardsInfoThread = player.getCardsInfoThread();
+            if (cardsInfoThread != null) {
+                return cardsInfoThread;
+            }
+        }
+        return player.getCorrectChannel();
+    }
+
     private static void acceptTransactionOffer(Player p1, Player p2, Game game, ButtonInteractionEvent event) {
         List<String> transactionItems = p1.getTransactionItemsWithPlayer(p2);
         List<Player> players = new ArrayList<>();
@@ -1680,8 +1690,10 @@ public final class TransactionHelper {
                 String msg = p1.getRepresentation() + " sent "
                         + (RandomHelper.isOneInX(20) ? "||a secret objective||" : "a secret objective") + " to "
                         + p2.getRepresentation() + ".";
-                MessageHelper.sendMessageToChannel(p1.getCorrectChannel(), msg);
-                if (game.isFowMode()) MessageHelper.sendMessageToChannel(p2.getCorrectChannel(), msg);
+                MessageHelper.sendMessageToChannel(getTradeNotificationChannel(p1, game), msg);
+                if (game.isFowMode()) {
+                    MessageHelper.sendMessageToChannel(getTradeNotificationChannel(p2, game), msg);
+                }
             }
             case "Frags" -> {
                 String fragType = amountToTrans.substring(0, 3).toUpperCase();
@@ -1700,7 +1712,7 @@ public final class TransactionHelper {
             case "Technology" -> {
                 p2.addTech(amountToTrans);
                 MessageHelper.sendMessageToChannel(
-                        p2.getCorrectChannel(),
+                        getTradeNotificationChannel(p2, game),
                         p2.getRepresentation() + ", you have received the technology _" + Mapper.getTech(amountToTrans)
                                 + "_ from a transaction.");
             }
@@ -1715,7 +1727,8 @@ public final class TransactionHelper {
         if (game.isFowMode()) {
             if (!message2.isEmpty()) {
                 MessageHelper.sendMessageToChannel(p1.getCardsInfoThread(), message2);
-                MessageHelper.sendMessageToChannel(p2.getPrivateChannel(), "**🤝 Transaction:** " + message2);
+                MessageHelper.sendMessageToChannel(
+                        getTradeNotificationChannel(p2, game), "**🤝 Transaction:** " + message2);
             }
         } else {
             TextChannel channel = game.getMainGameChannel();
@@ -1977,9 +1990,9 @@ public final class TransactionHelper {
             String message2 = p1.getRepresentation() + " returned _"
                     + Mapper.getPromissoryNote(id).getName() + "_ from their play area to " + p2.getRepresentation()
                     + ".";
-            MessageHelper.sendMessageToChannel(p2.getCorrectChannel(), message2);
+            MessageHelper.sendMessageToChannel(getTradeNotificationChannel(p2, game), message2);
             if (game.isFowMode()) {
-                MessageHelper.sendMessageToChannel(p1.getCorrectChannel(), message2);
+                MessageHelper.sendMessageToChannel(getTradeNotificationChannel(p1, game), message2);
             }
         }
         ButtonHelper.deleteMessage(event);

--- a/src/main/java/ti4/service/transaction/SendPromissoryService.java
+++ b/src/main/java/ti4/service/transaction/SendPromissoryService.java
@@ -7,6 +7,7 @@ import ti4.game.Player;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
 import ti4.helpers.PromissoryNoteHelper;
+import ti4.helpers.TransactionHelper;
 import ti4.image.Mapper;
 import ti4.message.MessageHelper;
 import ti4.model.PromissoryNoteModel;
@@ -101,10 +102,10 @@ public class SendPromissoryService {
         } else {
             reportMsg = String.format(reportMsgFmt, "a promissory note to the hand");
         }
-        MessageHelper.sendMessageToChannel(receiver.getCorrectChannel(), reportMsg);
+        MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(receiver, game), reportMsg);
         if (game.isFowMode()) {
             MessageHelper.sendMessageToChannel(
-                    sender.getCorrectChannel(),
+                    TransactionHelper.getTradeNotificationChannel(sender, game),
                     reportMsg.replace(receiver.getRepresentation(), receiver.getColorIfCanSeeStats(sender)));
             String extra = null;
             if (model.getAlias().endsWith("_sftt")) extra = "Scores changed.";
@@ -142,9 +143,9 @@ public class SendPromissoryService {
     private static void reportReturnedProm(Game game, Player sender, Player receiver, PromissoryNoteModel model) {
         String reportMsg = sender.getRepresentation() + " returned " + model.getNameRepresentation() + " to "
                 + receiver.getRepresentation() + ".";
-        MessageHelper.sendMessageToChannel(receiver.getCorrectChannel(), reportMsg);
+        MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(receiver, game), reportMsg);
         if (game.isFowMode()) {
-            MessageHelper.sendMessageToChannel(sender.getCorrectChannel(), reportMsg);
+            MessageHelper.sendMessageToChannel(TransactionHelper.getTradeNotificationChannel(sender, game), reportMsg);
             String extra = null;
             if (model.getAlias().endsWith("_sftt")) extra = "Scores changed.";
             FoWHelper.pingPlayersTransaction(game, null, sender, receiver, CardEmojis.PN + model.getName(), extra);


### PR DESCRIPTION
## Summary
- send explicit FoW notifications for hidden combat unit changes such as Yin indoctrination, Greyfire Mutagen, Sol commander/Letnev mech ground-force changes, and Pharad'n commander infantry destruction
- route fog-game trade notifications to a single destination by preferring each player's cards-info thread over splitting messages between the FoW private channel and the cards-info thread
- apply that trade-routing behavior across transaction offers and resolutions plus direct TG, commodities, debt, and promissory-note sends so incoming and outgoing trade history stays in one place

## Test Plan
-  *(fails due unrelated pre-existing Spotless issues in the dirty workspace outside this PR)*
-  *(fails due unrelated pre-existing compilation issues in local untracked files outside this PR)*