### PR TITLE
Pin latest action card and secret objective snapshots in cards threads

### DIFF
--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -53,6 +53,8 @@ import ti4.service.unit.AddUnitService;
 @UtilityClass
 public class ActionCardHelper {
 
+    private static final String PINNED_AC_INFO_MESSAGE_ID = "pinned_ac_info_message_id";
+
     private static final Set<String> WAR_MACHINE_IDS = Set.of(
             "war_machine1",
             "war_machine2",
@@ -73,6 +75,8 @@ public class ActionCardHelper {
     public static void sendActionCardInfo(Game game, Player player) {
         // AC INFO
         MessageHelper.sendMessageToPlayerCardsInfoThread(player, getActionCardInfo(game, player));
+        MessageHelper.replacePinnedMessageInPlayerCardsInfoThread(
+                player, PINNED_AC_INFO_MESSAGE_ID, getPinnedActionCardInfo(game, player));
         Map<String, Integer> actionCards = player.getActionCards();
         if (actionCards != null && !actionCards.isEmpty()) {
             MessageHelper.sendMessageToChannelWithButtons(
@@ -353,6 +357,42 @@ public class ActionCardHelper {
                 }
             }
         }
+        return sb.toString();
+    }
+
+    private static String getPinnedActionCardInfo(Game game, Player player) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("## Latest Action Cards (")
+                .append(player.getAcCount())
+                .append('/')
+                .append(ButtonHelper.getACLimit(game, player))
+                .append(")\n");
+
+        Map<String, Integer> actionCards = player.getActionCards();
+        if (actionCards == null || actionCards.isEmpty()) {
+            sb.append("> None");
+            return sb.toString();
+        }
+
+        int index = 1;
+        for (Map.Entry<String, Integer> ac : actionCards.entrySet()) {
+            ActionCardModel actionCard = Mapper.getActionCard(ac.getKey());
+            sb.append(index).append("\\. ");
+            if (actionCard == null) {
+                sb.append("Unknown card `(").append(ac.getValue()).append(")`");
+            } else {
+                sb.append(CardEmojis.getACEmoji(game))
+                        .append(actionCard.isWild(game) ? CardEmojis.Event : "")
+                        .append(" _")
+                        .append(actionCard.getName())
+                        .append("_ `(")
+                        .append(Helper.leftpad("" + ac.getValue(), 3))
+                        .append(")`");
+            }
+            sb.append('\n');
+            index++;
+        }
+
         return sb.toString();
     }
 

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -861,6 +861,43 @@ public class MessageHelper {
         sendMessageToChannel(threadChannel, messageText);
     }
 
+    public static void replacePinnedMessageInPlayerCardsInfoThread(
+            @NotNull Player player, @NotNull String storedValueKey, String messageText) {
+        if (messageText == null || messageText.isEmpty()) {
+            return;
+        }
+
+        ThreadChannel threadChannel = player.getCardsInfoThread();
+        if (threadChannel == null) {
+            return;
+        }
+
+        splitAndSentWithAction(messageText, threadChannel, msg -> {
+            String previousMessageId = player.getStoredValue(storedValueKey);
+            Runnable pinAndTrack =
+                    () -> msg.pin().queue(success -> player.addStoredValue(storedValueKey, msg.getId()), error -> {
+                        player.addStoredValue(storedValueKey, msg.getId());
+                        String err = getRestActionFailureMessage(
+                                threadChannel, "Failed to pin cards info snapshot", null, error);
+                        BotLogger.error(err, error);
+                    });
+
+            if (StringUtils.isBlank(previousMessageId) || previousMessageId.equals(msg.getId())) {
+                pinAndTrack.run();
+                return;
+            }
+
+            threadChannel.deleteMessageById(previousMessageId).queue(success -> pinAndTrack.run(), error -> {
+                if (!isUnknownMessageError(error)) {
+                    String err = getRestActionFailureMessage(
+                            threadChannel, "Failed to delete previous pinned cards info snapshot", null, error);
+                    BotLogger.error(err, error);
+                }
+                pinAndTrack.run();
+            });
+        });
+    }
+
     /**
      * Given a text string and a maximum length, will return a List<String> split by
      * either the max length or the last newline "\n"

--- a/src/main/java/ti4/service/info/SecretObjectiveInfoService.java
+++ b/src/main/java/ti4/service/info/SecretObjectiveInfoService.java
@@ -22,6 +22,8 @@ import ti4.service.emoji.CardEmojis;
 @UtilityClass
 public class SecretObjectiveInfoService {
 
+    private static final String PINNED_SO_INFO_MESSAGE_ID = "pinned_so_info_message_id";
+
     public static void sendSecretObjectiveInfo(Game game, Player player, ButtonInteractionEvent event) {
         sendSecretObjectiveInfo(game, player, event, false, false);
     }
@@ -65,6 +67,8 @@ public class SecretObjectiveInfoService {
             Game game, Player player, boolean autoDiscardButtons, boolean autoScoreButtons) {
         // SO INFO
         MessageHelper.sendMessageToPlayerCardsInfoThread(player, getSecretObjectiveCardInfo(game, player));
+        MessageHelper.replacePinnedMessageInPlayerCardsInfoThread(
+                player, PINNED_SO_INFO_MESSAGE_ID, getPinnedSecretObjectiveCardInfo(game, player));
 
         if (player.getSecretsUnscored().isEmpty()) return;
 
@@ -162,6 +166,63 @@ public class SecretObjectiveInfoService {
                 }
             }
         }
+        return sb.toString();
+    }
+
+    private static String getPinnedSecretObjectiveCardInfo(Game game, Player player) {
+        Map<String, Integer> secretObjective = player.getSecrets();
+        Map<String, Integer> scoredSecretObjective = new LinkedHashMap<>(player.getSecretsScored());
+        for (String id : game.getSoToPoList()) {
+            scoredSecretObjective.remove(id);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("## Latest Secret Objectives (")
+                .append(player.getSoScored())
+                .append('/')
+                .append(player.getMaxSOCount())
+                .append(")\n");
+
+        sb.append("**Scored:**\n");
+        if (scoredSecretObjective.isEmpty()) {
+            sb.append("> None\n");
+        } else {
+            int index = 1;
+            for (Map.Entry<String, Integer> so : scoredSecretObjective.entrySet()) {
+                SecretObjectiveModel soModel = Mapper.getSecretObjective(so.getKey());
+                sb.append(index)
+                        .append("\\. ")
+                        .append(CardEmojis.SecretObjectiveAlt)
+                        .append(" _")
+                        .append(soModel.getName())
+                        .append("_ `(")
+                        .append(so.getValue())
+                        .append(")`\n");
+                index++;
+            }
+        }
+
+        sb.append("**Unscored:**\n");
+        if (secretObjective == null || secretObjective.isEmpty()) {
+            sb.append("> None");
+        } else {
+            int index = 1;
+            for (Map.Entry<String, Integer> so : secretObjective.entrySet()) {
+                SecretObjectiveModel soModel = Mapper.getSecretObjective(so.getKey());
+                sb.append(index)
+                        .append("\\. ")
+                        .append(CardEmojis.SecretObjectiveAlt)
+                        .append(" _")
+                        .append(soModel.getName())
+                        .append("_ - ")
+                        .append(soModel.getPhase())
+                        .append(" `(")
+                        .append(Helper.leftpad("" + so.getValue(), 3))
+                        .append(")`\n");
+                index++;
+            }
+        }
+
         return sb.toString();
     }
 


### PR DESCRIPTION
## Summary
- keep a pinned action card snapshot in each player's `#cards-info` thread
- keep a pinned secret objective snapshot in each player's `#cards-info` thread
- replace the previous pinned snapshot on refresh without changing other pinning flows

## Test Plan
- run `mvn -q spotless:apply`
- run `mvn -q -DskipTests compile`