### PR TITLE
Increase backup workflow SSH timeout

### DIFF
--- a/.github/workflows/force-backup-of-savefiles.yml
+++ b/.github/workflows/force-backup-of-savefiles.yml
@@ -22,7 +22,7 @@ jobs:
           username: ${{ secrets.HOSTINGER_SSH_USER }}
           password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
           port: ${{ secrets.HOSTINGER_SSH_PORT }}
-          timeout: 15s
+          timeout: 60s
           envs: DISCORD_WEBHOOK_URL
           script: |
             set -eu
@@ -49,7 +49,7 @@ jobs:
           username: ${{ secrets.HOSTINGER_SSH_USER }}
           password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
           port: ${{ secrets.HOSTINGER_SSH_PORT }}
-          timeout: 15s
+          timeout: 60s
           envs: DISCORD_WEBHOOK_URL
           script: |
             set -eu


### PR DESCRIPTION
## Summary
- increase the SSH connect timeout in the save-file backup workflow from 15s to 60s
- apply the same timeout increase to the built-in retry step so transient remote reachability issues have more time to recover

## Test Plan
- review the workflow diff
- validate that only `.github/workflows/force-backup-of-savefiles.yml` is included in this PR