### PR TITLE
Show combat stats in the pre-combat system summary

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -108,6 +108,8 @@ import ti4.service.breakthrough.ValefarZService;
 import ti4.service.button.ReactionService;
 import ti4.service.combat.CombatRollService;
 import ti4.service.combat.CombatRollType;
+import ti4.service.combat.CombatStatsService;
+import ti4.service.combat.CombatUnitSelectionHelper;
 import ti4.service.decks.ShowActionCardsService;
 import ti4.service.draft.PlayerSetupService;
 import ti4.service.draft.PlayerSetupState;
@@ -3286,6 +3288,33 @@ public class ButtonHelper {
 
     public static String getTileSummaryMessage(
             Game game, boolean justUnits, Tile tile, Player ogPlayer, GenericInteractionCreateEvent event) {
+        return getTileSummaryMessage(game, justUnits, tile, ogPlayer, event, null);
+    }
+
+    public static String getCombatTileSummaryMessage(
+            Game game,
+            Tile tile,
+            Player ogPlayer,
+            GenericInteractionCreateEvent event,
+            String combatType,
+            @Nullable String combatHolderName,
+            List<Player> combatPlayers) {
+        return getTileSummaryMessage(
+                game,
+                true,
+                tile,
+                ogPlayer,
+                event,
+                new CombatSummaryContext(combatType, combatHolderName, combatPlayers));
+    }
+
+    private static String getTileSummaryMessage(
+            Game game,
+            boolean justUnits,
+            Tile tile,
+            Player ogPlayer,
+            GenericInteractionCreateEvent event,
+            @Nullable CombatSummaryContext combatSummaryContext) {
         String tileName = tile.getTilePath();
         tileName = tileName.substring(tileName.indexOf('_') + 1);
         tileName = tileName.substring(0, tileName.indexOf(".png"));
@@ -3375,7 +3404,9 @@ public class ButtonHelper {
                     sb.append(" `").append(unitEntry.getValue()).append("x` ");
                     if (unitModel != null) {
                         sb.append(unitModel.getUnitEmoji()).append(' ');
-                        sb.append(privateGame ? unitModel.getBaseType() : unitModel.getName())
+                        sb.append(privateGame ? unitModel.getBaseType() : unitModel.getName());
+                        sb.append(getCombatProfileForTileSummary(
+                                        tile, unitHolder, unitModel, player, combatSummaryContext))
                                 .append('\n');
                     } else {
                         sb.append(unitKey).append('\n');
@@ -3386,6 +3417,59 @@ public class ButtonHelper {
             sb.append("----------\n");
         }
         return sb.toString();
+    }
+
+    private static String getCombatProfileForTileSummary(
+            Tile tile,
+            UnitHolder unitHolder,
+            UnitModel unitModel,
+            Player player,
+            @Nullable CombatSummaryContext combatSummaryContext) {
+        if (combatSummaryContext == null
+                || !combatSummaryContext.combatPlayers().contains(player)) {
+            return "";
+        }
+        boolean participates = CombatUnitSelectionHelper.collectCombatRoundUnits(
+                        tile, combatSummaryContext.getCombatUnitHolder(tile, unitHolder), player)
+                .containsKey(unitModel);
+        CombatStatsService.CombatRoundProfile combatRoundProfile = CombatStatsService.getCombatRoundProfile(
+                participates, unitModel, player, tile, combatSummaryContext.opponentFor(player));
+        if (!combatRoundProfile.participates()) {
+            return "";
+        }
+
+        if (combatRoundProfile.diceCount() == 1) {
+            return " `[Combat " + combatRoundProfile.hitsOn() + "+]`";
+        }
+        return " `[Combat " + combatRoundProfile.diceCount() + "x" + combatRoundProfile.hitsOn() + "+]`";
+    }
+
+    /**
+     * Encapsulates the combat metadata needed to annotate a generic tile summary with
+     * combat-specific unit information, without threading nullable combat arguments
+     * through the public tile-summary API.
+     */
+    private record CombatSummaryContext(
+            String combatType, @Nullable String combatHolderName, List<Player> combatPlayers) {
+
+        private boolean isGroundCombat() {
+            return "ground".equalsIgnoreCase(combatType);
+        }
+
+        private boolean isSpaceCombat() {
+            return "space".equalsIgnoreCase(combatType);
+        }
+
+        private @Nullable Player opponentFor(Player player) {
+            return combatPlayers.stream().filter(p -> p != player).findFirst().orElse(null);
+        }
+
+        private UnitHolder getCombatUnitHolder(Tile tile, UnitHolder currentUnitHolder) {
+            if (isGroundCombat()) {
+                return currentUnitHolder;
+            }
+            return tile.getUnitHolders().get(Constants.SPACE);
+        }
     }
 
     public static int checkNetGain(Player player, String ccs) {

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -795,6 +795,13 @@ public class CombatRollService {
                     activeSystem,
                     unitHolder);
             int numRollsPerUnit = unitModel.getCombatDieCountForAbility(rollType, player);
+            if (rollType == CombatRollType.combatround) {
+                CombatStatsService.CombatRoundProfile combatRoundProfile =
+                        CombatStatsService.getCombatRoundProfile(true, unitModel, player, activeSystem, opponent);
+                modifierToHit += toHit - combatRoundProfile.hitsOn();
+                toHit = combatRoundProfile.hitsOn();
+                numRollsPerUnit = combatRoundProfile.diceCount();
+            }
             boolean extraRollsCount = false;
             if ((numRollsPerUnit > 1 || extraRollsForUnit > 0)
                     && "true".equalsIgnoreCase(game.getStoredValue("thalnosPlusOne"))) {
@@ -823,19 +830,6 @@ public class CombatRollService {
                     continue;
                 }
             }
-            if (rollType == CombatRollType.combatround) {
-                if (unitModel.getUnitType() == UnitType.Mech && player.ownsUnit("tf-eidolonlandwaster")) {
-                    numRollsPerUnit++;
-                }
-                if (unitModel.getUnitType() == UnitType.Mech && player.ownsUnit("tf-eidolonterminus")) {
-                    modifierToHit++;
-                }
-                if (unitModel.getUnitType() == UnitType.Flagship && player.ownsUnit("tf-echoofascension")) {
-                    modifierToHit++;
-                    numRollsPerUnit++;
-                }
-            }
-
             List<String> singleUnitUse = new ArrayList<>(List.of("no"));
             if (rollType == CombatRollType.combatround
                     && !"true".equalsIgnoreCase(game.getStoredValue("thalnosPlusOne"))
@@ -1372,7 +1366,7 @@ public class CombatRollService {
             unitHolderPlanet = (Planet) unitHolder;
         }
         return switch (roleType) {
-            case combatround -> getUnitsInCombatRound(unitHolder, player, event, tile);
+            case combatround -> getCombatRoundUnits(tile, unitHolder, player, event);
             case AFB -> getUnitsInAFB(tile, player, event);
             case bombardment -> getUnitsInBombardment(tile, player, event);
             case SpaceCannonOffence -> getUnitsInSpaceCannonOffense(tile, player, event, game);
@@ -1380,102 +1374,12 @@ public class CombatRollService {
         };
     }
 
-    private static Map<UnitModel, Integer> getUnitsInCombatRound(
-            UnitHolder unitHolder, Player player, GenericInteractionCreateEvent event, Tile tile) {
+    public static Map<UnitModel, Integer> getCombatRoundUnits(
+            Tile tile, UnitHolder unitHolder, Player player, GenericInteractionCreateEvent event) {
         String colorID = Mapper.getColorID(player.getColor());
         Map<String, Integer> unitsByAsyncId = unitHolder.getUnitAsyncIdsOnHolder(colorID);
-        Map<UnitModel, Integer> unitsInCombat = unitsByAsyncId.entrySet().stream()
-                .map(entry -> new ImmutablePair<>(
-                        player.getPriorityUnitByAsyncID(entry.getKey(), unitHolder), entry.getValue()))
-                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
-        HashMap<UnitModel, Integer> output;
-        if (Constants.SPACE.equals(unitHolder.getName())) {
-            if (unitsByAsyncId.containsKey("fs")
-                    && (player.hasUnit("nekro_flagship") || player.hasUnit("sigma_nekro_flagship_2"))) {
-                output = new HashMap<>(unitsInCombat.entrySet().stream()
-                        .filter(entry -> entry.getKey() != null
-                                && (entry.getKey().getIsGroundForce()
-                                        || entry.getKey().getIsShip()))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                for (UnitHolder u2 : tile.getUnitHolders().values()) {
-                    if (u2 == unitHolder) {
-                        continue;
-                    }
-                    Map<String, Integer> unitsByAsyncId2 = u2.getUnitAsyncIdsOnHolder(colorID);
-                    Map<UnitModel, Integer> unitsInCombat2 = unitsByAsyncId2.entrySet().stream()
-                            .map(entry -> new ImmutablePair<>(
-                                    player.getPriorityUnitByAsyncID(entry.getKey(), unitHolder), entry.getValue()))
-                            .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
-                    Map<UnitModel, Integer> output2;
-                    output2 = new HashMap<>(unitsInCombat2.entrySet().stream()
-                            .filter(entry -> entry.getKey() != null
-                                    && (entry.getKey().getIsGroundForce()
-                                            || entry.getKey().getIsShip()))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                    for (Map.Entry<UnitModel, Integer> entry : output2.entrySet()) {
-                        UnitModel unit = entry.getKey();
-                        if (output.containsKey(unit)) {
-                            output.put(unit, output.get(unit) + entry.getValue());
-                        } else {
-                            output.put(unit, entry.getValue());
-                        }
-                    }
-                }
-            } else {
-
-                if (player.hasUnit("purpletf_mech") || player.hasUnit("naaz_voltron")) {
-                    output = new HashMap<>(unitsInCombat.entrySet().stream()
-                            .filter(entry -> entry.getKey() != null
-                                    && (entry.getKey().getUnitType() == UnitType.Mech
-                                            || entry.getKey().getIsShip()))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                    for (UnitHolder u2 : tile.getUnitHolders().values()) {
-                        if (u2 == unitHolder) {
-                            continue;
-                        }
-                        Map<String, Integer> unitsByAsyncId2 = u2.getUnitAsyncIdsOnHolder(colorID);
-                        Map<UnitModel, Integer> unitsInCombat2 = unitsByAsyncId2.entrySet().stream()
-                                .map(entry -> new ImmutablePair<>(
-                                        player.getPriorityUnitByAsyncID(entry.getKey(), unitHolder), entry.getValue()))
-                                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
-                        Map<UnitModel, Integer> output2;
-                        output2 = new HashMap<>(unitsInCombat2.entrySet().stream()
-                                .filter(entry -> entry.getKey() != null
-                                        && (entry.getKey().getUnitType() == UnitType.Mech
-                                                || entry.getKey().getIsShip()))
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                        for (Map.Entry<UnitModel, Integer> entry : output2.entrySet()) {
-                            UnitModel unit = entry.getKey();
-                            if (output.containsKey(unit)) {
-                                output.put(unit, output.get(unit) + entry.getValue());
-                            } else {
-                                output.put(unit, entry.getValue());
-                            }
-                        }
-                    }
-                } else {
-                    output = new HashMap<>(unitsInCombat.entrySet().stream()
-                            .filter(entry ->
-                                    entry.getKey() != null && entry.getKey().getIsShip())
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                }
-            }
-            if (player.getGame().isCosmicPhenomenaeMode() && tile.isAsteroidField() && !player.hasFF2Tech()) {
-                output = new HashMap<>(unitsInCombat.entrySet().stream()
-                        .filter(entry -> entry.getKey() != null
-                                && entry.getKey().getIsShip()
-                                && entry.getKey().getUnitType() != UnitType.Fighter)
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-            }
-        } else {
-            output = new HashMap<>(unitsInCombat.entrySet().stream()
-                    .filter(entry -> entry.getKey() != null
-                            && (entry.getKey().getIsGroundForce()
-                                    || entry.getKey().getIsShip()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-        }
+        Map<UnitModel, Integer> output = CombatUnitSelectionHelper.collectCombatRoundUnits(tile, unitHolder, player);
         checkBadUnits(player, event, unitsByAsyncId, output);
-
         return output;
     }
 

--- a/src/main/java/ti4/service/combat/CombatStatsService.java
+++ b/src/main/java/ti4/service/combat/CombatStatsService.java
@@ -1,0 +1,71 @@
+package ti4.service.combat;
+
+import javax.annotation.Nullable;
+import lombok.experimental.UtilityClass;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.Units.UnitType;
+import ti4.model.UnitModel;
+
+/**
+ * Computes effective combat-round stats for units that are already known to be in a combat context.
+ * This owns combat stat adjustments and profile construction, while
+ * {@link CombatUnitSelectionHelper} decides which units participate and
+ * {@link CombatRollService} handles validated roll execution.
+ */
+@UtilityClass
+public class CombatStatsService {
+
+    public static CombatRoundProfile getCombatRoundProfile(
+            boolean participates, UnitModel unitModel, Player player, Tile activeSystem, @Nullable Player opponent) {
+        EffectiveCombatStats effectiveCombatStats = getEffectiveCombatStats(unitModel, player, activeSystem, opponent);
+        return new CombatRoundProfile(participates, effectiveCombatStats.diceCount(), effectiveCombatStats.hitsOn());
+    }
+
+    private static EffectiveCombatStats getEffectiveCombatStats(
+            UnitModel unitModel, Player player, Tile activeSystem, @Nullable Player opponent) {
+        int numRollsPerUnit = unitModel.getCombatDieCountForAbility(CombatRollType.combatround, player);
+        int extraDice = 0;
+        if (isEidolonLandwasterMech(unitModel, player)) extraDice++;
+        if (isEchoOfAscensionFlagship(unitModel, player)) extraDice++;
+        numRollsPerUnit += extraDice;
+        if (isWinnuFlagship(unitModel) && numRollsPerUnit <= 0) {
+            if (opponent != null) {
+                numRollsPerUnit = ButtonHelper.checkNumberNonFighterShips(opponent, activeSystem);
+            }
+        }
+
+        int toHit = unitModel.getCombatDieHitsOnForAbility(CombatRollType.combatround, player);
+        int hitBonus = 0;
+        if (isEidolonTerminusMech(unitModel, player)) hitBonus++;
+        if (isEchoOfAscensionFlagship(unitModel, player)) hitBonus++;
+        toHit = Math.max(1, toHit - hitBonus);
+        return new EffectiveCombatStats(numRollsPerUnit, toHit);
+    }
+
+    private static boolean isEchoOfAscensionFlagship(UnitModel unitModel, Player player) {
+        return unitModel.getUnitType() == UnitType.Flagship && player.ownsUnit("tf-echoofascension");
+    }
+
+    private static boolean isEidolonLandwasterMech(UnitModel unitModel, Player player) {
+        return unitModel.getUnitType() == UnitType.Mech && player.ownsUnit("tf-eidolonlandwaster");
+    }
+
+    private static boolean isEidolonTerminusMech(UnitModel unitModel, Player player) {
+        return unitModel.getUnitType() == UnitType.Mech && player.ownsUnit("tf-eidolonterminus");
+    }
+
+    private static boolean isWinnuFlagship(UnitModel unitModel) {
+        return unitModel.getId() != null && unitModel.getId().contains("winnu_flagship");
+    }
+
+    /**
+     * Effective combat-round state for a specific unit in a specific combat context.
+     * This bundles the three values callers otherwise have to orchestrate separately:
+     * whether the unit participates, how many dice it rolls, and what value it hits on.
+     */
+    public record CombatRoundProfile(boolean participates, int diceCount, int hitsOn) {}
+
+    private record EffectiveCombatStats(int diceCount, int hitsOn) {}
+}

--- a/src/main/java/ti4/service/combat/CombatUnitSelectionHelper.java
+++ b/src/main/java/ti4/service/combat/CombatUnitSelectionHelper.java
@@ -1,0 +1,148 @@
+package ti4.service.combat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.internal.utils.tuple.ImmutablePair;
+import net.dv8tion.jda.internal.utils.tuple.Pair;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.game.UnitHolder;
+import ti4.helpers.Constants;
+import ti4.helpers.Units.UnitType;
+import ti4.image.Mapper;
+import ti4.model.UnitModel;
+
+/**
+ * Selects which units participate in a combat round for a given tile, holder, and player.
+ * This owns combat-round participant collection and eligibility rules, while
+ * {@link CombatStatsService} computes the effective combat stats for those units and
+ * {@link CombatRollService} handles validated roll execution.
+ */
+@UtilityClass
+public class CombatUnitSelectionHelper {
+
+    public static Map<UnitModel, Integer> collectCombatRoundUnits(Tile tile, UnitHolder unitHolder, Player player) {
+        CombatSelectionContext context = CombatSelectionContext.forCombatHolder(tile, unitHolder, player);
+        if (context.isSpaceCombat()) {
+            return selectSpaceUnits(context);
+        }
+        return selectGroundUnits(context.unitsOnCombatHolder());
+    }
+
+    private static Map<UnitModel, Integer> selectSpaceUnits(CombatSelectionContext context) {
+        Map<UnitModel, Integer> selectedUnits = selectStandardSpaceUnits(context.unitsOnCombatHolder());
+        // Nekro flagship lets its owner's ground forces join the space combat from elsewhere in the system.
+        if (hasNekroFlagship(context)) {
+            selectedUnits = includeGroundForcesFromSystem(context);
+            // Purple TF mechs / Naaz Voltron let those mechs join the space combat from planets in the system.
+        } else if (hasPurpleTFMech(context.player())) {
+            selectedUnits = includeMechsFromPlanets(context);
+        }
+        return applySpaceRestrictions(context, selectedUnits);
+    }
+
+    private static Map<UnitModel, Integer> applySpaceRestrictions(
+            CombatSelectionContext context, Map<UnitModel, Integer> selectedUnits) {
+        // In Cosmic Phenomena, asteroid fields keep fighters out of space combat unless the player has FF2.
+        if (context.player().getGame().isCosmicPhenomenaeMode()
+                && context.tile().isAsteroidField()
+                && !context.player().hasFF2Tech()) {
+            return filterUnits(selectedUnits, unit -> unit.getUnitType() != UnitType.Fighter);
+        }
+        return selectedUnits;
+    }
+
+    private static boolean hasNekroFlagship(CombatSelectionContext context) {
+        return context.unitsByAsyncIdOnCombatHolder().containsKey("fs")
+                && (context.player().hasUnit("nekro_flagship")
+                        || context.player().hasUnit("sigma_nekro_flagship_2"));
+    }
+
+    private static Map<UnitModel, Integer> includeGroundForcesFromSystem(CombatSelectionContext context) {
+        return collectEligibleUnitsFromSystem(
+                context.tile(), context.player(), unit -> unit.getIsGroundForce() || unit.getIsShip());
+    }
+
+    private static boolean hasPurpleTFMech(Player player) {
+        return player.hasUnit("purpletf_mech") || player.hasUnit("naaz_voltron");
+    }
+
+    private static Map<UnitModel, Integer> includeMechsFromPlanets(CombatSelectionContext context) {
+        return collectEligibleUnitsFromSystem(
+                context.tile(), context.player(), unit -> unit.getUnitType() == UnitType.Mech || unit.getIsShip());
+    }
+
+    private static Map<UnitModel, Integer> selectStandardSpaceUnits(Map<UnitModel, Integer> unitsOnCombatHolder) {
+        return filterUnits(unitsOnCombatHolder, UnitModel::getIsShip);
+    }
+
+    private static Map<UnitModel, Integer> selectGroundUnits(Map<UnitModel, Integer> unitsOnCombatHolder) {
+        return filterUnits(unitsOnCombatHolder, unit -> unit.getIsGroundForce() || unit.getIsShip());
+    }
+
+    private static Map<UnitModel, Integer> collectEligibleUnitsFromSystem(
+            Tile tile, Player player, Predicate<UnitModel> eligibilityCheck) {
+        Map<UnitModel, Integer> mergedUnits = new HashMap<>();
+        for (UnitHolder unitHolder : tile.getUnitHolders().values()) {
+            addEligibleUnitsOnHolder(mergedUnits, unitHolder, player, eligibilityCheck);
+        }
+        return mergedUnits;
+    }
+
+    private static void addEligibleUnitsOnHolder(
+            Map<UnitModel, Integer> mergedUnits,
+            UnitHolder unitHolder,
+            Player player,
+            Predicate<UnitModel> eligibilityCheck) {
+        Map<UnitModel, Integer> unitsOnHolder = collectUnitsOnHolder(unitHolder, player);
+        for (Map.Entry<UnitModel, Integer> entry : unitsOnHolder.entrySet()) {
+            UnitModel unit = entry.getKey();
+            if (unit == null || !eligibilityCheck.test(unit)) continue;
+            mergedUnits.merge(unit, entry.getValue(), Integer::sum);
+        }
+    }
+
+    private static Map<UnitModel, Integer> collectUnitsOnHolder(UnitHolder unitHolder, Player player) {
+        String colorID = Mapper.getColorID(player.getColor());
+        Map<String, Integer> unitsByAsyncId = unitHolder.getUnitAsyncIdsOnHolder(colorID);
+        return unitsByAsyncId.entrySet().stream()
+                .map(entry -> new ImmutablePair<>(
+                        player.getPriorityUnitByAsyncID(entry.getKey(), unitHolder), entry.getValue()))
+                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+    }
+
+    private static Map<UnitModel, Integer> filterUnits(
+            Map<UnitModel, Integer> unitsInCombat, Predicate<UnitModel> eligibilityCheck) {
+        return new HashMap<>(unitsInCombat.entrySet().stream()
+                .filter(entry -> entry.getKey() != null && eligibilityCheck.test(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    /**
+     * Carries the precomputed unit data needed to apply combat participation rules for one player on one holder.
+     */
+    private record CombatSelectionContext(
+            Tile tile,
+            UnitHolder unitHolder,
+            Player player,
+            Map<String, Integer> unitsByAsyncIdOnCombatHolder,
+            Map<UnitModel, Integer> unitsOnCombatHolder) {
+
+        private static CombatSelectionContext forCombatHolder(Tile tile, UnitHolder unitHolder, Player player) {
+            String colorID = Mapper.getColorID(player.getColor());
+            Map<String, Integer> unitsByAsyncId = unitHolder.getUnitAsyncIdsOnHolder(colorID);
+            Map<UnitModel, Integer> unitsOnCombatHolder = unitsByAsyncId.entrySet().stream()
+                    .map(entry -> new ImmutablePair<>(
+                            player.getPriorityUnitByAsyncID(entry.getKey(), unitHolder), entry.getValue()))
+                    .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+            return new CombatSelectionContext(tile, unitHolder, player, unitsByAsyncId, unitsOnCombatHolder);
+        }
+
+        private boolean isSpaceCombat() {
+            return Constants.SPACE.equals(unitHolder.getName());
+        }
+    }
+}

--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -353,7 +353,9 @@ public class StartCombatService {
         }
         if (amount > 2 || tile.getNumberOfUnitsInSystem() > 2) {
             MessageHelper.sendMessageToChannel(
-                    threadChannel, ButtonHelper.getTileSummaryMessage(game, true, tile, player1, event));
+                    threadChannel,
+                    ButtonHelper.getCombatTileSummaryMessage(
+                            game, tile, player1, event, spaceOrGround, unitHolderName, List.of(player1, player2)));
         }
 
         // Space Cannon Offense


### PR DESCRIPTION
## Summary
- add combat stat tags to the existing pre-combat tile summary so players can see current dice and hit values before rolling
- pass the active combat context into the tile summary builder so only units participating in the shown combat are annotated
- account for situational combat profile changes such as Winnu flagship dice scaling and relevant Twilight Falls unit upgrades

## Test Plan
- run `mvn -q spotless:apply`
- run `mvn -q -DskipTests compile`