### PR TITLE
Refactor cold-start managed game warmup

### DIFF
--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -273,11 +273,12 @@ public class JdaService {
         initializeWhitelistedRoles();
         TIGLHelper.validateTIGLness();
 
-        jda.getPresence().setActivity(Activity.customStatus("STARTING UP: Loading Games"));
+        jda.getPresence().setActivity(Activity.customStatus("STARTING UP: Indexing Game Names"));
 
-        BotLogger.info("LOADING GAMES");
+        BotLogger.info("INDEXING GAME NAMES");
         GameManager.initialize();
-        BotLogger.info("FINISHED LOADING GAMES");
+        BotLogger.info("FINISHED INDEXING GAME NAMES");
+        BotLogger.info("STARTED BACKGROUND MANAGED GAME WARMUP");
 
         if (DataMigrationManager.runMigrations()) {
             BotLogger.info("FINISHED RUNNING MIGRATIONS");
@@ -305,7 +306,11 @@ public class JdaService {
         // BOT IS READY
         GlobalSettings.setSetting(ImplementedSettings.READY_TO_RECEIVE_COMMANDS, true);
         BotLogger.info("BOT IS READY TO RECEIVE COMMANDS");
-        updatePresence();
+        if (GameManager.isManagedGamesWarmupComplete()) {
+            updatePresence();
+        } else {
+            jda.getPresence().setPresence(OnlineStatus.ONLINE, Activity.customStatus("Warming game index"));
+        }
     }
 
     private static Guild tryToInitGuild(String guildID, boolean addToNewGameServerList) {

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -92,12 +92,30 @@ class GameLoadService {
                     .addKeyDeserializer(Units.UnitKey.class, new UnitKeyMapKeyDeserializer()))
             .build();
     private static final Pattern PATTERN = Pattern.compile("—");
+    private static final String GAME_FILE_EXTENSION = Constants.TXT;
+
+    /**
+     * Returns game names from filenames only, avoiding a full parse of every saved game during startup.
+     */
+    static List<String> loadManagedGameNames() {
+        try (Stream<Path> pathStream = Files.list(Storage.getGamesDirectory().toPath())) {
+            return pathStream
+                    .filter(path -> path.toString().toLowerCase().endsWith(GAME_FILE_EXTENSION))
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .map(GameLoadService::stripGameFileExtension)
+                    .toList();
+        } catch (IOException e) {
+            BotLogger.critical("Exception occurred while getting all game names.", e);
+        }
+        return Collections.emptyList();
+    }
 
     static List<ManagedGame> loadManagedGames() {
         try (Stream<Path> pathStream = Files.list(Storage.getGamesDirectory().toPath())) {
             return pathStream
                     .parallel()
-                    .filter(path -> path.toString().toLowerCase().endsWith(".txt"))
+                    .filter(path -> path.toString().toLowerCase().endsWith(GAME_FILE_EXTENSION))
                     .map(GameLoadService::loadManagedGame)
                     .filter(Objects::nonNull)
                     .toList();
@@ -126,12 +144,36 @@ class GameLoadService {
     @Nullable
     public static Game load(String gameName) {
         return GameFileLockManager.wrapWithReadLock(gameName, () -> {
-            File gameFile = Storage.getGameFile(gameName + Constants.TXT);
+            File gameFile = Storage.getGameFile(gameName + GAME_FILE_EXTENSION);
             if (!gameFile.exists()) {
                 return null;
             }
             return readGame(gameFile);
         });
+    }
+
+    /**
+     * Loads one game's lightweight managed metadata from disk for lazy or background warmup paths.
+     */
+    @Nullable
+    static ManagedGame loadManagedGame(String gameName) {
+        return loadManagedGame(gameName, ManagedGameLoadMode.WARMUP);
+    }
+
+    /**
+     * Loads one game's managed metadata using the requested retention mode for the parsed Game.
+     */
+    @Nullable
+    static ManagedGame loadManagedGame(String gameName, ManagedGameLoadMode loadMode) {
+        Game game = load(gameName);
+        if (game == null) {
+            return null;
+        }
+        return new ManagedGame(game, loadMode);
+    }
+
+    private static String stripGameFileExtension(String fileName) {
+        return fileName.substring(0, fileName.length() - GAME_FILE_EXTENSION.length());
     }
 
     @Nullable

--- a/src/main/java/ti4/game/persistence/GameManager.java
+++ b/src/main/java/ti4/game/persistence/GameManager.java
@@ -7,22 +7,38 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import lombok.experimental.UtilityClass;
 import ti4.discord.JdaService;
+import ti4.executors.ExecutorServiceManager;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.logging.BotLogger;
 
 @UtilityClass
 public class GameManager {
 
+    private static final Set<String> validGameNames = ConcurrentHashMap.newKeySet();
     private static final ConcurrentMap<String, ManagedGame> gameNameToManagedGame =
             new ConcurrentHashMap<>(); // TODO: We can evaluate dropping the managed objects entirely
     private static final ConcurrentMap<String, ManagedPlayer> userIdToManagedPlayer = new ConcurrentHashMap<>();
+    private static final AtomicBoolean managedGamesWarmupComplete = new AtomicBoolean(false);
 
+    /**
+     * Loads the authoritative game-name index synchronously, then warms managed-game metadata in the background.
+     */
     public static void initialize() {
-        GameLoadService.loadManagedGames()
-                .forEach(managedGame -> gameNameToManagedGame.put(managedGame.getName(), managedGame));
+        validGameNames.clear();
+        gameNameToManagedGame.clear();
+        userIdToManagedPlayer.clear();
+        managedGamesWarmupComplete.set(false);
+
+        validGameNames.addAll(GameLoadService.loadManagedGameNames());
+        if (JdaService.testingMode) {
+            return;
+        }
+        ExecutorServiceManager.runAsync("GameManager managed game warmup", GameManager::warmupManagedGames);
     }
 
     private static Game load(String gameName) {
@@ -46,6 +62,7 @@ public class GameManager {
         if (!isValid(gameName)) {
             return null;
         }
+        ensureManagedGameLoaded(gameName);
         Game game = load(gameName);
         if (game == null) {
             handleManagedGameRemoval(gameName);
@@ -54,6 +71,7 @@ public class GameManager {
     }
 
     private static void handleManagedGameRemoval(String gameName) {
+        validGameNames.remove(gameName);
         var managedGame = gameNameToManagedGame.remove(gameName);
         if (managedGame != null) {
             managedGame.getPlayers().forEach(player -> player.getGames().remove(managedGame));
@@ -61,10 +79,11 @@ public class GameManager {
     }
 
     public static boolean isValid(String gameName) {
-        return gameName != null && gameNameToManagedGame.containsKey(gameName);
+        return gameName != null && validGameNames.contains(gameName);
     }
 
     public static boolean save(Game game, String reason) {
+        validGameNames.add(game.getName());
         boolean wasActive = Optional.ofNullable(gameNameToManagedGame.get(game.getName()))
                 .map(ManagedGame::isActive)
                 .orElse(false);
@@ -123,30 +142,35 @@ public class GameManager {
     }
 
     public static List<String> getGameNames() {
-        return new ArrayList<>(gameNameToManagedGame.keySet());
+        return new ArrayList<>(validGameNames);
     }
 
     public static int getGameCount() {
-        return gameNameToManagedGame.size();
+        return validGameNames.size();
     }
 
     public static long getActiveGameCount() {
-        return getManagedGames().stream().filter(ManagedGame::isActive).count();
+        return gameNameToManagedGame.values().stream()
+                .filter(ManagedGame::isActive)
+                .count();
     }
 
     public static ManagedGame getManagedGame(String gameName) {
-        return gameNameToManagedGame.get(gameName);
+        return ensureManagedGameLoaded(gameName);
     }
 
     public static List<ManagedGame> getManagedGames() {
+        ensureAllManagedGamesLoaded();
         return new ArrayList<>(gameNameToManagedGame.values());
     }
 
     public static ManagedPlayer getManagedPlayer(String playerId) {
+        ensureAllManagedGamesLoaded();
         return userIdToManagedPlayer.get(playerId);
     }
 
     public static Set<ManagedPlayer> getManagedPlayers() {
+        ensureAllManagedGamesLoaded();
         return new HashSet<>(userIdToManagedPlayer.values());
     }
 
@@ -159,5 +183,65 @@ public class GameManager {
         }
         managedPlayer.addOrReplaceGame(game, player);
         return managedPlayer;
+    }
+
+    /**
+     * Returns whether the background pass that materializes all managed games has finished.
+     */
+    public static boolean isManagedGamesWarmupComplete() {
+        return managedGamesWarmupComplete.get();
+    }
+
+    /**
+     * Ensures a single valid game has a ManagedGame entry, loading it lazily on first access.
+     */
+    private static ManagedGame ensureManagedGameLoaded(String gameName) {
+        return ensureManagedGameLoaded(gameName, ManagedGameLoadMode.LAZY_REQUEST);
+    }
+
+    /**
+     * Materializes managed metadata for one game, choosing whether the parsed Game is retained for immediate reuse.
+     */
+    private static ManagedGame ensureManagedGameLoaded(String gameName, ManagedGameLoadMode loadMode) {
+        if (!isValid(gameName)) {
+            return null;
+        }
+        return gameNameToManagedGame.computeIfAbsent(gameName, key -> loadManagedGame(key, loadMode));
+    }
+
+    @Nullable
+    private static ManagedGame loadManagedGame(String gameName, ManagedGameLoadMode loadMode) {
+        ManagedGame managedGame = GameLoadService.loadManagedGame(gameName, loadMode);
+        if (managedGame == null) {
+            handleManagedGameRemoval(gameName);
+        }
+        return managedGame;
+    }
+
+    /**
+     * Blocks until every indexed game has managed metadata, for callers that require a complete global view.
+     */
+    private static void ensureAllManagedGamesLoaded() {
+        if (managedGamesWarmupComplete.get()) {
+            return;
+        }
+        validGameNames.forEach(gameName -> ensureManagedGameLoaded(gameName, ManagedGameLoadMode.WARMUP));
+        managedGamesWarmupComplete.compareAndSet(false, true);
+    }
+
+    /**
+     * Background task that hydrates ManagedGame entries and player indexes for every known game.
+     */
+    private static void warmupManagedGames() {
+        try {
+            validGameNames.forEach(gameName -> ensureManagedGameLoaded(gameName, ManagedGameLoadMode.WARMUP));
+        } catch (Exception e) {
+            BotLogger.critical("Failed during managed game warmup.", e);
+        } finally {
+            managedGamesWarmupComplete.set(true);
+            if (JdaService.jda != null) {
+                JdaService.updatePresence();
+            }
+        }
     }
 }

--- a/src/main/java/ti4/game/persistence/ManagedGame.java
+++ b/src/main/java/ti4/game/persistence/ManagedGame.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
@@ -46,7 +47,17 @@ public class ManagedGame {
     private final Map<ManagedPlayer, Boolean> playerToIsReal;
     private final boolean stale;
 
+    @Nullable
+    private final AtomicReference<Game> preloadedGame;
+
     public ManagedGame(Game game) {
+        this(game, ManagedGameLoadMode.WARMUP);
+    }
+
+    /**
+     * Builds lightweight metadata from a parsed game and optionally retains that parsed Game for one immediate read.
+     */
+    public ManagedGame(Game game, ManagedGameLoadMode loadMode) {
         name = game.getName();
         hasEnded = game.isHasEnded();
         hasWinner = game.hasWinner();
@@ -84,6 +95,7 @@ public class ManagedGame {
 
         final long sixtyDays = 1000L * 60 * 60 * 24 * 60;
         stale = (System.currentTimeMillis() - game.getLastModifiedDate()) > sixtyDays;
+        preloadedGame = loadMode == ManagedGameLoadMode.LAZY_REQUEST ? new AtomicReference<>(game) : null;
     }
 
     private static String sanitizeToNull(String str) {
@@ -121,7 +133,16 @@ public class ManagedGame {
         return name.equals(game.getName()) && lastModifiedDate == game.getLastModifiedDate();
     }
 
+    /**
+     * Reuses the one-shot preloaded Game when available, otherwise reloads the current game state from disk.
+     */
     public Game getGame() {
+        if (preloadedGame != null) {
+            Game game = preloadedGame.getAndSet(null);
+            if (game != null) {
+                return game;
+            }
+        }
         return GameManager.get(name);
     }
 

--- a/src/main/java/ti4/game/persistence/ManagedGameLoadMode.java
+++ b/src/main/java/ti4/game/persistence/ManagedGameLoadMode.java
@@ -1,0 +1,13 @@
+package ti4.game.persistence;
+
+/**
+ * Describes why managed-game metadata is being materialized, which determines whether the parsed Game should be
+ * retained for an immediate follow-up read.
+ */
+enum ManagedGameLoadMode {
+    /** Keeps the parsed Game for a single immediate getGame() call on the same request path. */
+    LAZY_REQUEST,
+
+    /** Discards the parsed Game after extracting lightweight metadata to minimize warmup memory usage. */
+    WARMUP
+}


### PR DESCRIPTION
## Summary
- load the game-name index synchronously at startup and warm managed-game metadata in the background
- allow per-game requests during warmup via lazy managed-game loading, while preserving full-load behavior for global queries
- reuse the first parsed Game on lazy request paths, document the load modes, and update startup logging/presence to match the new flow

## Test Plan
- mvn -Dtest=GameLoadServiceTest test