### PR TITLE
Disable startup data migrations

### DIFF
--- a/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
@@ -49,10 +49,10 @@ public class DataMigrationManager {
 
     static {
         migrations = new HashMap<>();
-        migrations.put(
-                "renameGarboziaToBozgarbia_201025_withEnded",
-                DataMigrationManager::renameGarboziaToBozgarbia_201025_withEnded);
-        migrations.put("fixMisspelledAgendaIds_200226", DataMigrationManager::fixMisspelledAgendaIds_200226);
+        // migrations.put(
+        //         "renameGarboziaToBozgarbia_201025_withEnded",
+        //         DataMigrationManager::renameGarboziaToBozgarbia_201025_withEnded);
+        // migrations.put("fixMisspelledAgendaIds_200226", DataMigrationManager::fixMisspelledAgendaIds_200226);
         // migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
     }
 


### PR DESCRIPTION
## Summary
- comment out the two currently registered startup data migrations in `DataMigrationManager`
- leave the migration framework in place so startup can be tested without the existing migration pass

## Test Plan
- mvn -Dtest=GameLoadServiceTest test