### PR TITLE
Add docker-rollout deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -59,19 +59,33 @@ jobs:
               docker version
               docker compose -f "$compose_file" build tibot
               
+              # Real steady-state rollout path after the first Traefik migration:
+              # timestamp=$(date "+%F %T.%3N")
+              # curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ENSURING TRAEFIK PROXY IS RUNNING\"}" $DISCORD_WEBHOOK_URL
+              # docker compose -f "$compose_file" up -d traefik
+              #
+              # timestamp=$(date "+%F %T.%3N")
+              # existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
+              # if [ -n "$existing_bot_containers" ]; then
+              #   curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ROLLING OUT NEW TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+              #   docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
+              # else
+              #   curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING INITIAL TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+              #   docker compose -f "$compose_file" up -d tibot
+              # fi
+
+              # Temporary first-migration path from direct docker-run to Traefik + Compose.
               timestamp=$(date "+%F %T.%3N")
-              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ENSURING TRAEFIK PROXY IS RUNNING\"}" $DISCORD_WEBHOOK_URL
-              docker compose -f "$compose_file" up -d traefik
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STOPPING LEGACY DIRECT-RUN TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+              legacy_bot_containers="$(docker ps -q --filter ancestor=tibot)"
+              if [ -n "$legacy_bot_containers" ]; then
+                docker stop $legacy_bot_containers --time 600
+                docker rm $legacy_bot_containers || true
+              fi
 
               timestamp=$(date "+%F %T.%3N")
-              existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
-              if [ -n "$existing_bot_containers" ]; then
-                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ROLLING OUT NEW TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
-                docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
-              else
-                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING INITIAL TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
-                docker compose -f "$compose_file" up -d tibot
-              fi
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING TRAEFIK AND COMPOSE-MANAGED TIBOT\"}" $DISCORD_WEBHOOK_URL
+              docker compose -f "$compose_file" up -d traefik tibot
               
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`CLEANING UP DOCKER\"}" $DISCORD_WEBHOOK_URL

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -48,29 +48,36 @@ jobs:
               echo "Pulling changes from GitHub..."
               cd ${{ vars.HOST_TI4_REPO_DIR }}
               git pull --ff-only
+              export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
+              export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
+              export COMPOSE_PROJECT_NAME="ti4-bot"
+              compose_file="docker-compose.production.yml"
 
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`BUILDING DOCKER IMAGE\"}" $DISCORD_WEBHOOK_URL
               echo "Building docker image..."
               docker version
-              docker build -t tibot .
+              docker compose -f "$compose_file" build tibot
               
               timestamp=$(date "+%F %T.%3N")
-              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STOPPING DOCKER CONTAINER (MAX 10 MINUTES)\"}" $DISCORD_WEBHOOK_URL
-              echo "Restarting TIBot... giving 600 seconds to shutdown"
-              docker stop $(docker ps -q) --time 600
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ENSURING TRAEFIK PROXY IS RUNNING\"}" $DISCORD_WEBHOOK_URL
+              docker compose -f "$compose_file" up -d traefik
 
               timestamp=$(date "+%F %T.%3N")
-              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING DOCKER CONTAINER\"}" $DISCORD_WEBHOOK_URL
-              echo "Starting Container..."
-              docker run -v ${{ vars.HOST_TI4_SAVES_DIR }}:/opt/STORAGE -p 8081:8081 -d --restart unless-stopped -m 7g -e TI4_ULTIMATE_STATISTICS_API_KEY=$TI4_ULTIMATE_STATISTICS_API_KEY -e MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY=$MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY -e REPO_DISPATCH_TOKEN=$REPO_DISPATCH_TOKEN -e AWS_ACCESS_KEY_ID=$AWS_KEY -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET -e DISCORD_REDIRECT_URI=$DISCORD_REDIRECT_URI -e DISCORD_CLIENT_ID=$DISCORD_CLIENT_ID -e DISCORD_CLIENT_SECRET=$DISCORD_CLIENT_SECRET -e ROLLBAR_ACCESS_TOKEN=$ROLLBAR_ACCESS_TOKEN -e ROLLBAR_ENVIRONMENT=$ROLLBAR_ENVIRONMENT -e ROLLBAR_CODE_VERSION=$ROLLBAR_CODE_VERSION tibot $DISCORD_BOT_TOKEN $DISCORD_BOT_USERID ${{ vars.GUILDID_LIST }}
+              existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
+              if [ -n "$existing_bot_containers" ]; then
+                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ROLLING OUT NEW TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+                docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
+              else
+                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING INITIAL TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+                docker compose -f "$compose_file" up -d tibot
+              fi
               
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`CLEANING UP DOCKER\"}" $DISCORD_WEBHOOK_URL
               echo "Cleaning up docker stuff..."
               
-              docker rm $(docker ps --filter status=exited -q) || true
-              docker rmi -f $(docker images --filter "dangling=true" -q) || true
+              docker image prune --force
               docker builder prune --force
               
               echo "DONE!"

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -33,19 +33,27 @@ jobs:
           set -eu
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
+          export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
+          export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
+          export COMPOSE_PROJECT_NAME="ti4-bot"
+          compose_file="docker-compose.production.yml"
           
           echo "Building docker image..."
           docker version
-          docker build -t tibot .
+          docker compose -f "$compose_file" build tibot
           
-          echo "Restarting TIBot... giving 600 seconds to shutdown"
-          docker stop $(docker ps -q) --time 600
-          
-          echo "Starting Container..."
-          docker run -v ${{ vars.HOST_TI4_SAVES_DIR }}:/opt/STORAGE -p 8081:8081 -d --restart unless-stopped -m 7g -e TI4_ULTIMATE_STATISTICS_API_KEY=$TI4_ULTIMATE_STATISTICS_API_KEY -e MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY=$MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY -e REPO_DISPATCH_TOKEN=$REPO_DISPATCH_TOKEN -e AWS_ACCESS_KEY_ID=$AWS_KEY -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET -e DISCORD_REDIRECT_URI=$DISCORD_REDIRECT_URI -e DISCORD_CLIENT_ID=$DISCORD_CLIENT_ID -e DISCORD_CLIENT_SECRET=$DISCORD_CLIENT_SECRET -e ROLLBAR_ACCESS_TOKEN=$ROLLBAR_ACCESS_TOKEN -e ROLLBAR_ENVIRONMENT=$ROLLBAR_ENVIRONMENT -e ROLLBAR_CODE_VERSION=$ROLLBAR_CODE_VERSION tibot $DISCORD_BOT_TOKEN $DISCORD_BOT_USERID ${{ vars.GUILDID_LIST }}
+          docker compose -f "$compose_file" up -d traefik
+
+          existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
+          if [ -n "$existing_bot_containers" ]; then
+            echo "Rolling out TIBot..."
+            docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
+          else
+            echo "Starting initial container..."
+            docker compose -f "$compose_file" up -d tibot
+          fi
           echo "Cleaning up docker stuff..."
           
-          docker rm $(docker ps --filter status=exited -q) || true
-          docker rmi -f $(docker images --filter "dangling=true" -q) || true
+          docker image prune --force
           
           echo "DONE!"

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -33,16 +33,19 @@ jobs:
           set -eu
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
+          export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
+          export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
+          export COMPOSE_PROJECT_NAME="ti4-bot"
+          compose_file="docker-compose.production.yml"
           
           echo "Building docker image..."
           docker version
-          docker build -t tibot .
+          docker compose -f "$compose_file" build tibot
           
           echo "Starting Container..."
-          docker run -v ${{ vars.HOST_TI4_SAVES_DIR }}:/opt/STORAGE -p 8081:8081 -d --restart unless-stopped -m 7g -e TI4_ULTIMATE_STATISTICS_API_KEY=$TI4_ULTIMATE_STATISTICS_API_KEY -e MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY=$MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY -e REPO_DISPATCH_TOKEN=$REPO_DISPATCH_TOKEN -e AWS_ACCESS_KEY_ID=$AWS_KEY -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET -e DISCORD_REDIRECT_URI=$DISCORD_REDIRECT_URI -e DISCORD_CLIENT_ID=$DISCORD_CLIENT_ID -e DISCORD_CLIENT_SECRET=$DISCORD_CLIENT_SECRET -e ROLLBAR_ACCESS_TOKEN=$ROLLBAR_ACCESS_TOKEN -e ROLLBAR_ENVIRONMENT=$ROLLBAR_ENVIRONMENT -e ROLLBAR_CODE_VERSION=$ROLLBAR_CODE_VERSION tibot $DISCORD_BOT_TOKEN $DISCORD_BOT_USERID ${{ vars.GUILDID_LIST }}
+          docker compose -f "$compose_file" up -d traefik tibot
           echo "Cleaning up docker stuff..."
           
-          docker rm $(docker ps --filter status=exited -q) || true
-          docker rmi -f $(docker images --filter "dangling=true" -q) || true
+          docker image prune --force
           
           echo "DONE!"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,58 @@
+services:
+  traefik:
+    image: traefik:v3.3
+    restart: unless-stopped
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:8081
+    ports:
+      - "8081:8081"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - ti4-rollout
+
+  tibot:
+    build: .
+    restart: unless-stopped
+    mem_limit: 7g
+    volumes:
+      - ${HOST_TI4_SAVES_DIR}:/opt/STORAGE
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_KEY}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET}
+      DB_PATH: /opt/STORAGE
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN}
+      DISCORD_BOT_USERID: ${DISCORD_BOT_USERID}
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
+      DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
+      DISCORD_REDIRECT_URI: ${DISCORD_REDIRECT_URI}
+      GUILDID_LIST: ${GUILDID_LIST}
+      MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY: ${MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY}
+      REPO_DISPATCH_TOKEN: ${REPO_DISPATCH_TOKEN}
+      RESOURCE_PATH: /opt/resources
+      ROLLBAR_ACCESS_TOKEN: ${ROLLBAR_ACCESS_TOKEN}
+      ROLLBAR_CODE_VERSION: ${ROLLBAR_CODE_VERSION}
+      ROLLBAR_ENVIRONMENT: ${ROLLBAR_ENVIRONMENT}
+      TI4_ULTIMATE_STATISTICS_API_KEY: ${TI4_ULTIMATE_STATISTICS_API_KEY}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8081/api/public/ping >/dev/null 2>&1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 10s
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: ti4-rollout
+      traefik.http.routers.tibot.entrypoints: web
+      traefik.http.routers.tibot.rule: PathPrefix(`/`)
+      traefik.http.services.tibot.loadbalancer.healthcheck.interval: 2s
+      traefik.http.services.tibot.loadbalancer.healthcheck.path: /api/public/ready
+      traefik.http.services.tibot.loadbalancer.server.port: "8081"
+    networks:
+      - ti4-rollout
+
+networks:
+  ti4-rollout:
+    name: ti4-rollout

--- a/src/main/java/ti4/spring/api/publicstatus/DeployController.java
+++ b/src/main/java/ti4/spring/api/publicstatus/DeployController.java
@@ -1,0 +1,40 @@
+package ti4.spring.api.publicstatus;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ti4.spring.service.deploy.ActiveLeaseService;
+
+@RestController
+@RequestMapping("/api/public/deploy")
+public class DeployController {
+
+    private final ActiveLeaseService activeLeaseService;
+
+    public DeployController(ActiveLeaseService activeLeaseService) {
+        this.activeLeaseService = activeLeaseService;
+    }
+
+    @PostMapping("/drain")
+    public ResponseEntity<Map<String, Object>> drain(HttpServletRequest request) {
+        if (!isLoopback(request.getRemoteAddr())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("accepted", false, "reason", "drain endpoint is loopback-only"));
+        }
+
+        if (!activeLeaseService.requestDrain()) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("accepted", false, "reason", "process is not active or is already draining"));
+        }
+
+        return ResponseEntity.accepted().body(Map.of("accepted", true));
+    }
+
+    private boolean isLoopback(String remoteAddr) {
+        return "127.0.0.1".equals(remoteAddr) || "0:0:0:0:0:0:0:1".equals(remoteAddr) || "::1".equals(remoteAddr);
+    }
+}

--- a/src/main/java/ti4/spring/resilience/CircuitBreakerFilter.java
+++ b/src/main/java/ti4/spring/resilience/CircuitBreakerFilter.java
@@ -22,6 +22,8 @@ public class CircuitBreakerFilter extends OncePerRequestFilter {
 
     private static final String SERVICE_UNAVAILABLE_MESSAGE = "Service temporarily unavailable: ";
     private static final String READY_PATH = "/api/public/ready";
+    private static final String PING_PATH = "/api/public/ping";
+    private static final String DEPLOY_DRAIN_PATH = "/api/public/deploy/drain";
 
     @Override
     protected void doFilterInternal(
@@ -29,7 +31,9 @@ public class CircuitBreakerFilter extends OncePerRequestFilter {
             @NotNull HttpServletResponse response,
             @NotNull FilterChain filterChain)
             throws ServletException, IOException {
-        if (READY_PATH.equals(request.getRequestURI())) {
+        if (READY_PATH.equals(request.getRequestURI())
+                || PING_PATH.equals(request.getRequestURI())
+                || DEPLOY_DRAIN_PATH.equals(request.getRequestURI())) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/ti4/spring/service/jda/JdaLifecycleService.java
+++ b/src/main/java/ti4/spring/service/jda/JdaLifecycleService.java
@@ -2,6 +2,9 @@ package ti4.spring.service.jda;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.stereotype.Service;
@@ -15,11 +18,37 @@ class JdaLifecycleService {
 
     @PostConstruct
     private void init() {
-        JdaService.initialize(applicationArguments.getSourceArgs());
+        JdaService.initialize(resolveSourceArgs());
     }
 
     @PreDestroy
     private void shutdown() {
         JdaService.shutdown();
+    }
+
+    private String[] resolveSourceArgs() {
+        String[] sourceArgs = applicationArguments.getSourceArgs();
+        if (sourceArgs.length >= 3) {
+            return sourceArgs;
+        }
+
+        // Compatibility bridge: the legacy startup path passes Discord config as positional args,
+        // while the Compose/docker-rollout deployment path provides the same values via env vars.
+        String botToken = System.getenv("DISCORD_BOT_TOKEN");
+        String botUserId = System.getenv("DISCORD_BOT_USERID");
+        String guildIdList = System.getenv("GUILDID_LIST");
+        if (isBlank(botToken) || isBlank(botUserId) || isBlank(guildIdList)) {
+            return sourceArgs;
+        }
+
+        List<String> resolvedArgs = new ArrayList<>();
+        resolvedArgs.add(botToken);
+        resolvedArgs.add(botUserId);
+        resolvedArgs.addAll(Arrays.asList(guildIdList.trim().split("\\s+")));
+        return resolvedArgs.toArray(String[]::new);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }


### PR DESCRIPTION
## Summary
- switch production bot deployment workflows from direct `docker run` to Compose-managed services
- add a `docker-compose.production.yml` with Traefik in front of the bot so start-first rollout can overlap old and new containers on the same host port
- add a localhost-only deploy drain endpoint and small startup compatibility bridge so `docker rollout` can trigger the existing lease-aware shutdown handoff cleanly

## Why
This is the Phase 5 rollout PR: the plumbing for lease-aware zero or near-zero downtime deploys is already on `master`, and this PR is the deployment-side wiring that actually uses it.

The important behavior is:
- the new container can boot behind Traefik without binding host `8081` directly
- container health uses `/api/public/ping` so rollout can wait for boot completion without deadlocking on lease ownership
- Traefik routes only to instances whose `/api/public/ready` endpoint reports active lease ownership
- `docker rollout` calls the local drain endpoint on the old instance before stopping it, which reuses the existing shutdown path and only releases the lease when shutdown completes

## Verification
- `mvn -q spotless:apply`
- `mvn -q -DskipTests compile`
- `docker compose -f docker-compose.production.yml config` with dummy env vars

## Follow-up
This PR only adds the deployment mechanism. The next step is to exercise it in production and verify the actual handoff behavior.
