### PR TITLE
Re-enable steady-state docker rollout

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -59,33 +59,19 @@ jobs:
               docker version
               docker compose -f "$compose_file" build tibot
               
-              # Real steady-state rollout path after the first Traefik migration:
-              # timestamp=$(date "+%F %T.%3N")
-              # curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ENSURING TRAEFIK PROXY IS RUNNING\"}" $DISCORD_WEBHOOK_URL
-              # docker compose -f "$compose_file" up -d traefik
-              #
-              # timestamp=$(date "+%F %T.%3N")
-              # existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
-              # if [ -n "$existing_bot_containers" ]; then
-              #   curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ROLLING OUT NEW TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
-              #   docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
-              # else
-              #   curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING INITIAL TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
-              #   docker compose -f "$compose_file" up -d tibot
-              # fi
-
-              # Temporary first-migration path from direct docker-run to Traefik + Compose.
               timestamp=$(date "+%F %T.%3N")
-              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STOPPING LEGACY DIRECT-RUN TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
-              legacy_bot_containers="$(docker ps -q --filter ancestor=tibot)"
-              if [ -n "$legacy_bot_containers" ]; then
-                docker stop $legacy_bot_containers --time 600
-                docker rm $legacy_bot_containers || true
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ENSURING TRAEFIK PROXY IS RUNNING\"}" $DISCORD_WEBHOOK_URL
+              docker compose -f "$compose_file" up -d traefik
+
+              timestamp=$(date "+%F %T.%3N")
+              existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
+              if [ -n "$existing_bot_containers" ]; then
+                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ROLLING OUT NEW TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+                docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
+              else
+                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING INITIAL TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+                docker compose -f "$compose_file" up -d tibot
               fi
-
-              timestamp=$(date "+%F %T.%3N")
-              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING TRAEFIK AND COMPOSE-MANAGED TIBOT\"}" $DISCORD_WEBHOOK_URL
-              docker compose -f "$compose_file" up -d traefik tibot
               
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`CLEANING UP DOCKER\"}" $DISCORD_WEBHOOK_URL


### PR DESCRIPTION
## Summary
- remove the one-time legacy-container migration block from `deploy-to-production.yml`
- restore the steady-state `docker rollout` path now that the Traefik cutover is complete

## Test Plan
- `python - <<'PY'
import yaml, pathlib
path = pathlib.Path('.github/workflows/deploy-to-production.yml')
with path.open() as f:
    yaml.safe_load(f)
print('ok')
PY`
