### PR TITLE
Install docker-rollout plugin in deploy workflows

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -52,6 +52,14 @@ jobs:
               export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
               export COMPOSE_PROJECT_NAME="ti4-bot"
               compose_file="docker-compose.production.yml"
+              rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
+
+              if ! docker rollout --help >/dev/null 2>&1; then
+                mkdir -p "$(dirname "$rollout_plugin_path")"
+                curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/v0.13/docker-rollout -o "$rollout_plugin_path"
+                chmod +x "$rollout_plugin_path"
+                docker rollout --help >/dev/null
+              fi
 
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`BUILDING DOCKER IMAGE\"}" $DISCORD_WEBHOOK_URL

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -37,6 +37,14 @@ jobs:
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
           compose_file="docker-compose.production.yml"
+          rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
+
+          if ! docker rollout --help >/dev/null 2>&1; then
+            mkdir -p "$(dirname "$rollout_plugin_path")"
+            curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/v0.13/docker-rollout -o "$rollout_plugin_path"
+            chmod +x "$rollout_plugin_path"
+            docker rollout --help >/dev/null
+          fi
           
           echo "Building docker image..."
           docker version


### PR DESCRIPTION
## Summary
- install the `docker-rollout` CLI plugin on the remote host when it is missing
- pin the plugin download to `v0.13` so deploy behavior is stable across runs
- apply the same plugin bootstrap to the restart workflow so manual rollouts work too

## Test Plan
- `python - <<'PY'
import yaml, pathlib
for path_str in [
    '.github/workflows/deploy-to-production.yml',
    '.github/workflows/restart-bot.yml',
]:
    path = pathlib.Path(path_str)
    with path.open() as f:
        yaml.safe_load(f)
print('ok')
PY`
- inspected failed run `24539327672` / job `71741565616` and confirmed the remote host error was `unknown shorthand flag: 'f' in -f` at `docker rollout -f ...`
