### PR TITLE
Fix tactical action refresh when move buttons overflow

### DIFF
--- a/src/main/java/ti4/service/tactical/TacticalActionOutputService.java
+++ b/src/main/java/ti4/service/tactical/TacticalActionOutputService.java
@@ -17,6 +17,7 @@ import ti4.game.Planet;
 import ti4.game.Player;
 import ti4.game.Tile;
 import ti4.game.UnitHolder;
+import ti4.helpers.ButtonHelper;
 import ti4.helpers.ButtonHelperTacticalAction;
 import ti4.helpers.CheckDistanceHelper;
 import ti4.helpers.Constants;
@@ -37,9 +38,19 @@ public class TacticalActionOutputService {
         List<Button> systemButtons = TacticalActionService.getTilesToMoveFrom(player, game, event);
         if (event == null) {
             MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), message, systemButtons);
+        } else if (requiresFreshMessageForChoosingTileRefresh(systemButtons)) {
+            MessageHelper.sendMessageToChannelWithButtonsAndNoUndo(event.getMessageChannel(), message, systemButtons);
+            ButtonHelper.deleteMessage(event);
         } else {
             MessageHelper.editMessageWithButtons(event, message, systemButtons);
         }
+    }
+
+    static boolean requiresFreshMessageForChoosingTileRefresh(List<Button> buttons) {
+        if (buttons == null || buttons.isEmpty()) {
+            return false;
+        }
+        return MessageHelper.getPartitionedButtonLists(new ArrayList<>(buttons)).size() > 1;
     }
 
     public void refreshButtonsAndMessageForTile(

--- a/src/test/java/ti4/service/tactical/TacticalActionOutputServiceTest.java
+++ b/src/test/java/ti4/service/tactical/TacticalActionOutputServiceTest.java
@@ -1,0 +1,31 @@
+package ti4.service.tactical;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import net.dv8tion.jda.api.components.buttons.Button;
+import org.junit.jupiter.api.Test;
+
+class TacticalActionOutputServiceTest {
+
+    @Test
+    void requiresFreshMessageWhenButtonsExceedSingleMessageComponentLimit() {
+        List<Button> buttons = IntStream.range(0, 26)
+                .mapToObj(i -> Button.primary("button" + i, "Button " + i))
+                .toList();
+
+        assertThat(TacticalActionOutputService.requiresFreshMessageForChoosingTileRefresh(buttons))
+                .isTrue();
+    }
+
+    @Test
+    void keepsEditingExistingMessageWhenButtonsFitWithinSingleMessageLimit() {
+        List<Button> buttons = IntStream.range(0, 25)
+                .mapToObj(i -> Button.primary("button" + i, "Button " + i))
+                .toList();
+
+        assertThat(TacticalActionOutputService.requiresFreshMessageForChoosingTileRefresh(buttons))
+                .isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- fix Rollbar item 58 / occurrence 458591545162 by avoiding `editOriginal` when the tactical move-from button set spans more than one Discord message
- send a fresh message with the full button set and delete the old interaction message instead
- add regression coverage for the 25-button threshold used by the tactical refresh logic

## Root cause
The `doneWithOneSystem_` handler refreshed the choose-a-system UI via `MessageHelper.editMessageWithButtons(...)`. In large movement states, `TacticalActionService.getTilesToMoveFrom(...)` can produce more than 25 buttons, which turns into 6 action rows and JDA rejects the edit with `Cannot build message with over 5 top-level components, provided 6`.

## Validation
- `mvn -q -Dtest=TacticalActionOutputServiceTest test`
- `mvn spotless:apply`
- `DB_PATH=./src/test/resources RESOURCE_PATH=./src/main/resources mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile`