### PR TITLE
Pin original cards info messages in cards threads

### DIFF
--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -74,9 +74,8 @@ public class ActionCardHelper {
 
     public static void sendActionCardInfo(Game game, Player player) {
         // AC INFO
-        MessageHelper.sendMessageToPlayerCardsInfoThread(player, getActionCardInfo(game, player));
-        MessageHelper.replacePinnedMessageInPlayerCardsInfoThread(
-                player, PINNED_AC_INFO_MESSAGE_ID, getPinnedActionCardInfo(game, player));
+        MessageHelper.sendMessageToPlayerCardsInfoThreadAndPin(
+                game, player, PINNED_AC_INFO_MESSAGE_ID, getActionCardInfo(game, player));
         Map<String, Integer> actionCards = player.getActionCards();
         if (actionCards != null && !actionCards.isEmpty()) {
             MessageHelper.sendMessageToChannelWithButtons(
@@ -357,42 +356,6 @@ public class ActionCardHelper {
                 }
             }
         }
-        return sb.toString();
-    }
-
-    private static String getPinnedActionCardInfo(Game game, Player player) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("## Latest Action Cards (")
-                .append(player.getAcCount())
-                .append('/')
-                .append(ButtonHelper.getACLimit(game, player))
-                .append(")\n");
-
-        Map<String, Integer> actionCards = player.getActionCards();
-        if (actionCards == null || actionCards.isEmpty()) {
-            sb.append("> None");
-            return sb.toString();
-        }
-
-        int index = 1;
-        for (Map.Entry<String, Integer> ac : actionCards.entrySet()) {
-            ActionCardModel actionCard = Mapper.getActionCard(ac.getKey());
-            sb.append(index).append("\\. ");
-            if (actionCard == null) {
-                sb.append("Unknown card `(").append(ac.getValue()).append(")`");
-            } else {
-                sb.append(CardEmojis.getACEmoji(game))
-                        .append(actionCard.isWild(game) ? CardEmojis.Event : "")
-                        .append(" _")
-                        .append(actionCard.getName())
-                        .append("_ `(")
-                        .append(Helper.leftpad("" + ac.getValue(), 3))
-                        .append(")`");
-            }
-            sb.append('\n');
-            index++;
-        }
-
         return sb.toString();
     }
 

--- a/src/main/java/ti4/helpers/PromissoryNoteHelper.java
+++ b/src/main/java/ti4/helpers/PromissoryNoteHelper.java
@@ -33,9 +33,13 @@ import ti4.service.unit.AddUnitService;
 @UtilityClass
 public class PromissoryNoteHelper {
 
+    private static final String PINNED_PN_INFO_MESSAGE_ID = "pinned_pn_info_message_id";
+
     public static void sendPromissoryNoteInfo(Game game, Player player, boolean longFormat) {
-        MessageHelper.sendMessageToChannelWithButtons(
-                player.getCardsInfoThread(),
+        MessageHelper.sendMessageToPlayerCardsInfoThreadWithButtonsAndPin(
+                game,
+                player,
+                PINNED_PN_INFO_MESSAGE_ID,
                 getPromissoryNoteCardInfo(game, player, longFormat, false),
                 getPNButtons(game, player));
     }

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -861,8 +861,8 @@ public class MessageHelper {
         sendMessageToChannel(threadChannel, messageText);
     }
 
-    public static void replacePinnedMessageInPlayerCardsInfoThread(
-            @NotNull Player player, @NotNull String storedValueKey, String messageText) {
+    public static void sendMessageToPlayerCardsInfoThreadAndPin(
+            @NotNull Game game, @NotNull Player player, @NotNull String storedValueKeyPrefix, String messageText) {
         if (messageText == null || messageText.isEmpty()) {
             return;
         }
@@ -872,30 +872,58 @@ public class MessageHelper {
             return;
         }
 
-        splitAndSentWithAction(messageText, threadChannel, msg -> {
-            String previousMessageId = player.getStoredValue(storedValueKey);
-            Runnable pinAndTrack =
-                    () -> msg.pin().queue(success -> player.addStoredValue(storedValueKey, msg.getId()), error -> {
-                        player.addStoredValue(storedValueKey, msg.getId());
-                        String err = getRestActionFailureMessage(
-                                threadChannel, "Failed to pin cards info snapshot", null, error);
-                        BotLogger.error(err, error);
-                    });
+        splitAndSentWithAction(
+                messageText,
+                threadChannel,
+                msg -> rotatePinnedCardsInfoMessage(game, threadChannel, storedValueKeyPrefix, msg));
+    }
 
-            if (StringUtils.isBlank(previousMessageId) || previousMessageId.equals(msg.getId())) {
-                pinAndTrack.run();
-                return;
-            }
+    public static void sendMessageToPlayerCardsInfoThreadWithButtonsAndPin(
+            @NotNull Game game,
+            @NotNull Player player,
+            @NotNull String storedValueKeyPrefix,
+            String messageText,
+            List<Button> buttons) {
+        if (messageText == null || messageText.isEmpty()) {
+            return;
+        }
 
-            threadChannel.deleteMessageById(previousMessageId).queue(success -> pinAndTrack.run(), error -> {
-                if (!isUnknownMessageError(error)) {
-                    String err = getRestActionFailureMessage(
-                            threadChannel, "Failed to delete previous pinned cards info snapshot", null, error);
-                    BotLogger.error(err, error);
-                }
-                pinAndTrack.run();
-            });
-        });
+        ThreadChannel threadChannel = player.getCardsInfoThread();
+        if (threadChannel == null) {
+            return;
+        }
+
+        splitAndSentWithAction(
+                messageText,
+                threadChannel,
+                msg -> rotatePinnedCardsInfoMessage(game, threadChannel, storedValueKeyPrefix, msg),
+                null,
+                buttons);
+    }
+
+    private static void rotatePinnedCardsInfoMessage(
+            @NotNull Game game,
+            @NotNull ThreadChannel threadChannel,
+            @NotNull String storedValueKeyPrefix,
+            @NotNull Message msg) {
+        String storedValueKey = storedValueKeyPrefix + "_" + threadChannel.getId();
+        String previousMessageId = game.getStoredValue(storedValueKey);
+
+        if (StringUtils.isNotBlank(previousMessageId) && !previousMessageId.equals(msg.getId())) {
+            threadChannel
+                    .retrieveMessageById(previousMessageId)
+                    .queue(
+                            previousMessage ->
+                                    previousMessage.unpin().queue(Consumers.nop(), BotLogger::catchRestError),
+                            BotLogger::catchRestError);
+        }
+
+        pinCardsInfoMessage(game, storedValueKey, msg);
+    }
+
+    private static void pinCardsInfoMessage(@NotNull Game game, @NotNull String storedValueKey, @NotNull Message msg) {
+        game.setStoredValue(storedValueKey, msg.getId());
+        msg.pin().queue(Consumers.nop(), BotLogger::catchRestError);
     }
 
     /**

--- a/src/main/java/ti4/service/info/SecretObjectiveInfoService.java
+++ b/src/main/java/ti4/service/info/SecretObjectiveInfoService.java
@@ -66,9 +66,8 @@ public class SecretObjectiveInfoService {
     public static void sendSecretObjectiveInfo(
             Game game, Player player, boolean autoDiscardButtons, boolean autoScoreButtons) {
         // SO INFO
-        MessageHelper.sendMessageToPlayerCardsInfoThread(player, getSecretObjectiveCardInfo(game, player));
-        MessageHelper.replacePinnedMessageInPlayerCardsInfoThread(
-                player, PINNED_SO_INFO_MESSAGE_ID, getPinnedSecretObjectiveCardInfo(game, player));
+        MessageHelper.sendMessageToPlayerCardsInfoThreadAndPin(
+                game, player, PINNED_SO_INFO_MESSAGE_ID, getSecretObjectiveCardInfo(game, player));
 
         if (player.getSecretsUnscored().isEmpty()) return;
 
@@ -166,63 +165,6 @@ public class SecretObjectiveInfoService {
                 }
             }
         }
-        return sb.toString();
-    }
-
-    private static String getPinnedSecretObjectiveCardInfo(Game game, Player player) {
-        Map<String, Integer> secretObjective = player.getSecrets();
-        Map<String, Integer> scoredSecretObjective = new LinkedHashMap<>(player.getSecretsScored());
-        for (String id : game.getSoToPoList()) {
-            scoredSecretObjective.remove(id);
-        }
-
-        StringBuilder sb = new StringBuilder();
-        sb.append("## Latest Secret Objectives (")
-                .append(player.getSoScored())
-                .append('/')
-                .append(player.getMaxSOCount())
-                .append(")\n");
-
-        sb.append("**Scored:**\n");
-        if (scoredSecretObjective.isEmpty()) {
-            sb.append("> None\n");
-        } else {
-            int index = 1;
-            for (Map.Entry<String, Integer> so : scoredSecretObjective.entrySet()) {
-                SecretObjectiveModel soModel = Mapper.getSecretObjective(so.getKey());
-                sb.append(index)
-                        .append("\\. ")
-                        .append(CardEmojis.SecretObjectiveAlt)
-                        .append(" _")
-                        .append(soModel.getName())
-                        .append("_ `(")
-                        .append(so.getValue())
-                        .append(")`\n");
-                index++;
-            }
-        }
-
-        sb.append("**Unscored:**\n");
-        if (secretObjective == null || secretObjective.isEmpty()) {
-            sb.append("> None");
-        } else {
-            int index = 1;
-            for (Map.Entry<String, Integer> so : secretObjective.entrySet()) {
-                SecretObjectiveModel soModel = Mapper.getSecretObjective(so.getKey());
-                sb.append(index)
-                        .append("\\. ")
-                        .append(CardEmojis.SecretObjectiveAlt)
-                        .append(" _")
-                        .append(soModel.getName())
-                        .append("_ - ")
-                        .append(soModel.getPhase())
-                        .append(" `(")
-                        .append(Helper.leftpad("" + so.getValue(), 3))
-                        .append(")`\n");
-                index++;
-            }
-        }
-
         return sb.toString();
     }
 


### PR DESCRIPTION
## Summary
- pin the original action card and secret objective info messages instead of posting duplicate snapshot messages
- extend the same behavior to promissory note info messages
- track the last pinned cards-info message in game state by card type and thread id, then unpin the prior message before pinning the new one

## Testing
- mvn -q spotless:apply
- mvn -q -DskipTests compile