### PR TITLE
Gracefully reject invalid game subcommands

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/ParentCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/ParentCommand.java
@@ -14,16 +14,13 @@ public interface ParentCommand extends Command<SlashCommandInteractionEvent> {
     default boolean accept(SlashCommandInteractionEvent event) {
         if (!Command.super.accept(event)) return false;
 
-        String subcommandGroupName = event.getInteraction().getSubcommandGroup();
-        if (subcommandGroupName == null) {
-            String subcommandName = event.getInteraction().getSubcommandName();
-            Subcommand subcommand = getSubcommands().get(subcommandName);
-            return subcommand == null
-                    || getSubcommands().containsKey(event.getInteraction().getSubcommandName());
+        Command<SlashCommandInteractionEvent> subcommand = getSubcommand(event);
+        if (subcommand != null) {
+            return subcommand.accept(event);
         }
 
-        SubcommandGroup subcommandGroup = getSubcommandGroups().get(subcommandGroupName);
-        return subcommandGroup == null || getSubcommandGroups().containsKey(subcommandGroupName);
+        return event.getInteraction().getSubcommandName() == null
+                && event.getInteraction().getSubcommandGroup() == null;
     }
 
     default void preExecute(SlashCommandInteractionEvent event) {

--- a/src/main/java/ti4/discord/interactions/commands/SubcommandGroup.java
+++ b/src/main/java/ti4/discord/interactions/commands/SubcommandGroup.java
@@ -20,7 +20,8 @@ public abstract class SubcommandGroup extends SubcommandGroupData implements Com
     public boolean accept(SlashCommandInteractionEvent event) {
         if (!getName().equals(event.getInteraction().getSubcommandGroup())) return false;
 
-        return getGroupSubcommands().containsKey(event.getInteraction().getSubcommandName());
+        Subcommand subcommand = getGroupSubcommands().get(event.getInteraction().getSubcommandName());
+        return subcommand != null && subcommand.accept(event);
     }
 
     public void execute(SlashCommandInteractionEvent event) {


### PR DESCRIPTION
## Summary
- `ParentCommand.accept(...)` now calls `accept(...)` on the actual selected subcommand, including grouped subcommands.
- Before this, parent commands only checked that the subcommand name existed, so subcommand-level game/player guards never ran during acceptance.
- That let commands like `/player change_color` reach `preExecute(...)` in an invalid context and throw. Now they fail during `accept(...)` and return the normal user-facing rejection instead.

## Validation
- `mvn spotless:apply`
- `DB_PATH=./src/test/resources RESOURCE_PATH=./src/main/resources mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile`
