### PR TITLE
Speed up CI and production deploys

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -125,8 +125,8 @@ jobs:
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`CLEANING UP DOCKER\"}" $DISCORD_WEBHOOK_URL
               echo "Cleaning up docker stuff..."
               
-              docker image prune --force --filter until=168h
-              docker builder prune --force --filter until=168h
+              docker image prune --force --filter until=48h
+              docker builder prune --force --filter until=48h
               
               echo "DONE!"
   saveGamesAfterDeploy:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -3,6 +3,11 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 name: BuildAndDeploy
+permissions:
+  contents: read
+  packages: write
+env:
+  IMAGE_REPOSITORY: ghcr.io/asyncti/ti4-map-generator-bot
 concurrency:
   group: deploy-to-production-master
   cancel-in-progress: true
@@ -10,11 +15,40 @@ jobs:
   saveGamesBeforeDeploy:
     uses: ./.github/workflows/force-backup-of-savefiles.yml
     secrets: inherit
+  buildImage:
+    needs: saveGamesBeforeDeploy
+    name: Build & Publish Bot Image
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.image.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute image tag
+        id: image
+        run: echo "image_tag=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.image_tag }}
+            ${{ env.IMAGE_REPOSITORY }}:master
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build:
     concurrency:
       group: "Start Bot"
-    needs: saveGamesBeforeDeploy
-    name: Build, Test, & Deploy Bot
+    needs: [saveGamesBeforeDeploy, buildImage]
+    name: Pull & Deploy Bot
     runs-on: ubuntu-latest
     steps:
       - name: Execute remote ssh commands
@@ -34,23 +68,27 @@ jobs:
             ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
             ROLLBAR_ENVIRONMENT: production
             ROLLBAR_CODE_VERSION: ${{ github.sha }}
+            GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+            GHCR_READ_PACKAGES_TOKEN: ${{ secrets.GHCR_READ_PACKAGES_TOKEN }}
         with:
             host: ${{ secrets.HOSTINGER_SSH_HOST }}
             username: ${{ secrets.HOSTINGER_SSH_USER }}
             password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
             port: ${{ secrets.HOSTINGER_SSH_PORT }}
-            envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_WEBHOOK_URL, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
+            envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_WEBHOOK_URL, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION, GHCR_USERNAME, GHCR_READ_PACKAGES_TOKEN
             script: |
               set -eu
 
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`NEW DEPLOYMENT TRIGGERED\"}" $DISCORD_WEBHOOK_URL
-              echo "Pulling changes from GitHub..."
+              echo "Pulling deployment config from GitHub..."
               cd ${{ vars.HOST_TI4_REPO_DIR }}
               git pull --ff-only
               export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
               export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
               export COMPOSE_PROJECT_NAME="ti4-bot"
+              export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
+              export IMAGE_TAG="${{ needs.buildImage.outputs.image_tag }}"
               compose_file="docker-compose.production.yml"
               rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
 
@@ -62,11 +100,13 @@ jobs:
               fi
 
               timestamp=$(date "+%F %T.%3N")
-              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`BUILDING DOCKER IMAGE\"}" $DISCORD_WEBHOOK_URL
-              echo "Building docker image..."
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`PULLING DOCKER IMAGE ${IMAGE_TAG}\"}" $DISCORD_WEBHOOK_URL
               docker version
-              docker compose -f "$compose_file" build tibot
-              
+              if [ -n "${GHCR_READ_PACKAGES_TOKEN:-}" ]; then
+                echo "$GHCR_READ_PACKAGES_TOKEN" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+              fi
+              docker compose -f "$compose_file" pull tibot
+
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ENSURING TRAEFIK PROXY IS RUNNING\"}" $DISCORD_WEBHOOK_URL
               docker compose -f "$compose_file" up -d traefik
@@ -85,8 +125,8 @@ jobs:
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`CLEANING UP DOCKER\"}" $DISCORD_WEBHOOK_URL
               echo "Cleaning up docker stuff..."
               
-              docker image prune --force
-              docker builder prune --force
+              docker image prune --force --filter until=168h
+              docker builder prune --force --filter until=168h
               
               echo "DONE!"
   saveGamesAfterDeploy:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -68,14 +68,12 @@ jobs:
             ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
             ROLLBAR_ENVIRONMENT: production
             ROLLBAR_CODE_VERSION: ${{ github.sha }}
-            GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
-            GHCR_READ_PACKAGES_TOKEN: ${{ secrets.GHCR_READ_PACKAGES_TOKEN }}
         with:
             host: ${{ secrets.HOSTINGER_SSH_HOST }}
             username: ${{ secrets.HOSTINGER_SSH_USER }}
             password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
             port: ${{ secrets.HOSTINGER_SSH_PORT }}
-            envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_WEBHOOK_URL, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION, GHCR_USERNAME, GHCR_READ_PACKAGES_TOKEN
+            envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_WEBHOOK_URL, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
             script: |
               set -eu
 
@@ -102,9 +100,6 @@ jobs:
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`PULLING DOCKER IMAGE ${IMAGE_TAG}\"}" $DISCORD_WEBHOOK_URL
               docker version
-              if [ -n "${GHCR_READ_PACKAGES_TOKEN:-}" ]; then
-                echo "$GHCR_READ_PACKAGES_TOKEN" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
-              fi
               docker compose -f "$compose_file" pull tibot
 
               timestamp=$(date "+%F %T.%3N")

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -73,6 +73,6 @@ jobs:
           fi
           echo "Cleaning up docker stuff..."
           
-          docker image prune --force --filter until=168h
+          docker image prune --force --filter until=48h
           
           echo "DONE!"

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -25,14 +25,12 @@ jobs:
         ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
         ROLLBAR_ENVIRONMENT: production
         ROLLBAR_CODE_VERSION: ${{ github.sha }}
-        GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
-        GHCR_READ_PACKAGES_TOKEN: ${{ secrets.GHCR_READ_PACKAGES_TOKEN }}
       with:
         host: ${{ secrets.HOSTINGER_SSH_HOST }}
         username: ${{ secrets.HOSTINGER_SSH_USER }}
         password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
         port: ${{ secrets.HOSTINGER_SSH_PORT }}
-        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION, GHCR_USERNAME, GHCR_READ_PACKAGES_TOKEN
+        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
         script: |
           set -eu
           
@@ -56,9 +54,6 @@ jobs:
           
           echo "Pulling docker image..."
           docker version
-          if [ -n "${GHCR_READ_PACKAGES_TOKEN:-}" ]; then
-            echo "$GHCR_READ_PACKAGES_TOKEN" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
-          fi
           docker compose -f "$compose_file" pull tibot
           
           docker compose -f "$compose_file" up -d traefik

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -1,5 +1,7 @@
 on: workflow_dispatch
 name: RestartBot
+env:
+  IMAGE_REPOSITORY: ghcr.io/asyncti/ti4-map-generator-bot
 concurrency:
   group: "Start Bot"
 jobs:
@@ -23,19 +25,25 @@ jobs:
         ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
         ROLLBAR_ENVIRONMENT: production
         ROLLBAR_CODE_VERSION: ${{ github.sha }}
+        GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+        GHCR_READ_PACKAGES_TOKEN: ${{ secrets.GHCR_READ_PACKAGES_TOKEN }}
       with:
         host: ${{ secrets.HOSTINGER_SSH_HOST }}
         username: ${{ secrets.HOSTINGER_SSH_USER }}
         password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
         port: ${{ secrets.HOSTINGER_SSH_PORT }}
-        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
+        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION, GHCR_USERNAME, GHCR_READ_PACKAGES_TOKEN
         script: |
           set -eu
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
+          echo "Pulling deployment config from GitHub..."
+          git pull --ff-only
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
+          export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
+          export IMAGE_TAG="master"
           compose_file="docker-compose.production.yml"
           rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
 
@@ -46,9 +54,12 @@ jobs:
             docker rollout --help >/dev/null
           fi
           
-          echo "Building docker image..."
+          echo "Pulling docker image..."
           docker version
-          docker compose -f "$compose_file" build tibot
+          if [ -n "${GHCR_READ_PACKAGES_TOKEN:-}" ]; then
+            echo "$GHCR_READ_PACKAGES_TOKEN" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+          fi
+          docker compose -f "$compose_file" pull tibot
           
           docker compose -f "$compose_file" up -d traefik
 
@@ -62,6 +73,6 @@ jobs:
           fi
           echo "Cleaning up docker stuff..."
           
-          docker image prune --force
+          docker image prune --force --filter until=168h
           
           echo "DONE!"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,10 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21 for x64
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "corretto"
           architecture: x64
+          cache: maven
       - name: Run the Maven verify phase
-        run: mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile
+        run: mvn --batch-mode --no-transfer-progress verify

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -1,5 +1,7 @@
 on: workflow_dispatch
 name: StartBot
+env:
+  IMAGE_REPOSITORY: ghcr.io/asyncti/ti4-map-generator-bot
 concurrency:
   group: "Start Bot"
 jobs:
@@ -23,29 +25,38 @@ jobs:
         ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
         ROLLBAR_ENVIRONMENT: production
         ROLLBAR_CODE_VERSION: ${{ github.sha }}
+        GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+        GHCR_READ_PACKAGES_TOKEN: ${{ secrets.GHCR_READ_PACKAGES_TOKEN }}
       with:
         host: ${{ secrets.HOSTINGER_SSH_HOST }}
         username: ${{ secrets.HOSTINGER_SSH_USER }}
         password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
         port: ${{ secrets.HOSTINGER_SSH_PORT }}
-        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
+        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION, GHCR_USERNAME, GHCR_READ_PACKAGES_TOKEN
         script: |
           set -eu
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
+          echo "Pulling deployment config from GitHub..."
+          git pull --ff-only
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
+          export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
+          export IMAGE_TAG="master"
           compose_file="docker-compose.production.yml"
           
-          echo "Building docker image..."
+          echo "Pulling docker image..."
           docker version
-          docker compose -f "$compose_file" build tibot
+          if [ -n "${GHCR_READ_PACKAGES_TOKEN:-}" ]; then
+            echo "$GHCR_READ_PACKAGES_TOKEN" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+          fi
+          docker compose -f "$compose_file" pull tibot
           
           echo "Starting Container..."
           docker compose -f "$compose_file" up -d traefik tibot
           echo "Cleaning up docker stuff..."
           
-          docker image prune --force
+          docker image prune --force --filter until=168h
           
           echo "DONE!"

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -25,14 +25,12 @@ jobs:
         ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
         ROLLBAR_ENVIRONMENT: production
         ROLLBAR_CODE_VERSION: ${{ github.sha }}
-        GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
-        GHCR_READ_PACKAGES_TOKEN: ${{ secrets.GHCR_READ_PACKAGES_TOKEN }}
       with:
         host: ${{ secrets.HOSTINGER_SSH_HOST }}
         username: ${{ secrets.HOSTINGER_SSH_USER }}
         password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
         port: ${{ secrets.HOSTINGER_SSH_PORT }}
-        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION, GHCR_USERNAME, GHCR_READ_PACKAGES_TOKEN
+        envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
         script: |
           set -eu
           
@@ -48,9 +46,6 @@ jobs:
           
           echo "Pulling docker image..."
           docker version
-          if [ -n "${GHCR_READ_PACKAGES_TOKEN:-}" ]; then
-            echo "$GHCR_READ_PACKAGES_TOKEN" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
-          fi
           docker compose -f "$compose_file" pull tibot
           
           echo "Starting Container..."

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -57,6 +57,6 @@ jobs:
           docker compose -f "$compose_file" up -d traefik tibot
           echo "Cleaning up docker stuff..."
           
-          docker image prune --force --filter until=168h
+          docker image prune --force --filter until=48h
           
           echo "DONE!"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -14,7 +14,7 @@ services:
       - ti4-rollout
 
   tibot:
-    build: .
+    image: ${IMAGE_REPOSITORY:-ghcr.io/asyncti/ti4-map-generator-bot}:${IMAGE_TAG:-master}
     restart: unless-stopped
     mem_limit: 7g
     volumes:


### PR DESCRIPTION
## Summary
- build and publish the production image in GitHub Actions, then have Hostinger pull immutable GHCR tags instead of compiling on the VPS
- keep Docker caches warm by pruning only cache older than 7 days, and update manual start/restart workflows to use the pulled image path too
- speed up PR CI by enabling Maven dependency caching, removing `--update-snapshots`, and dropping the redundant `test-compile` goal
- note: production deploys now expect `GHCR_USERNAME` and `GHCR_READ_PACKAGES_TOKEN` secrets so the VPS can pull private GHCR images

## Test Plan
- parsed the updated workflow and compose YAML files with Ruby `YAML.load_file`
- ran `git diff --check`
- ran `docker compose -f docker-compose.production.yml config` with representative env vars to verify the production compose renders correctly