### PR TITLE
Improve Docker build caching + fix image repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git
-.worktrees
 .idea
 target
 **/*.iml
@@ -7,5 +6,3 @@ target
 node_modules
 *.log
 .DS_Store
-docs
-scripts

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+.worktrees
 .idea
 target
 **/*.iml
@@ -6,3 +7,5 @@ target
 node_modules
 *.log
 .DS_Store
+docs
+scripts

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
   packages: write
 env:
-  IMAGE_REPOSITORY: ghcr.io/asyncti/ti4-map-generator-bot
+  IMAGE_REPOSITORY: ghcr.io/asyncti4/ti4-map-generator-bot
 concurrency:
   group: deploy-to-production-master
   cancel-in-progress: true

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -1,7 +1,7 @@
 on: workflow_dispatch
 name: RestartBot
 env:
-  IMAGE_REPOSITORY: ghcr.io/asyncti/ti4-map-generator-bot
+  IMAGE_REPOSITORY: ghcr.io/asyncti4/ti4-map-generator-bot
 concurrency:
   group: "Start Bot"
 jobs:

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -1,7 +1,7 @@
 on: workflow_dispatch
 name: StartBot
 env:
-  IMAGE_REPOSITORY: ghcr.io/asyncti/ti4-map-generator-bot
+  IMAGE_REPOSITORY: ghcr.io/asyncti4/ti4-map-generator-bot
 concurrency:
   group: "Start Bot"
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN --mount=type=cache,target=/root/.m2 \
     mvn -B -ntp -DskipTests dependency:go-offline
 
 # add sources late for better layer reuse
+COPY src/test ./src/test
 COPY src/main/resources ./src/main/resources
 COPY src/main/java ./src/main/java
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,11 @@ RUN --mount=type=cache,target=/root/.m2 \
     mvn -B -ntp -DskipTests dependency:go-offline
 
 # add sources late for better layer reuse
-COPY src/test ./src/test
 COPY src/main/resources ./src/main/resources
 COPY src/main/java ./src/main/java
 
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -ntp -DskipTests clean package
+    mvn -B -ntp -Dmaven.test.skip=true clean package
 
 # ---- Runtime stage ----
 FROM amazoncorretto:21-alpine

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -14,7 +14,7 @@ services:
       - ti4-rollout
 
   tibot:
-    image: ${IMAGE_REPOSITORY:-ghcr.io/asyncti/ti4-map-generator-bot}:${IMAGE_TAG:-master}
+    image: ${IMAGE_REPOSITORY:-ghcr.io/asyncti4/ti4-map-generator-bot}:${IMAGE_TAG:-master}
     restart: unless-stopped
     mem_limit: 7g
     volumes:


### PR DESCRIPTION
## Summary
- stop copying `src/test` into the production image build context so test-only changes do not invalidate the package layer
- switch the production image package step to `-Dmaven.test.skip=true` so the container build no longer expects test sources at all
- expand `.dockerignore` to exclude local worktree metadata, docs, and scripts from the Docker build context

## Test Plan
- ran `git diff --check`
- ran `mvn --batch-mode --no-transfer-progress -Dmaven.test.skip=true clean package`