### PR TITLE
fix: handle stale secret discard buttons

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/objective/SecretObjectiveButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/objective/SecretObjectiveButtonHandler.java
@@ -16,6 +16,7 @@ import ti4.helpers.SecretObjectiveHelper;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.message.MessageHelper;
+import ti4.model.SecretObjectiveModel;
 import ti4.service.info.SecretObjectiveInfoService;
 import ti4.service.milty.MiltyDraftManager;
 import ti4.service.objectives.DiscardSecretService;
@@ -39,6 +40,12 @@ class SecretObjectiveButtonHandler {
 
         try {
             int soIndex = Integer.parseInt(soID);
+            SecretObjectiveModel secretObjective = player.getSecret(soIndex);
+            if (secretObjective == null) {
+                MessageHelper.sendMessageToPlayerCardsInfoThread(
+                        player, "No such secret objective ID found, please retry.");
+                return;
+            }
 
             String msg = player.getRepresentation() + " discarded a secret objective";
             if (game.getRound() == 1 && !game.isFowMode() && player.getSo() > 1) {
@@ -53,11 +60,13 @@ class SecretObjectiveButtonHandler {
                             + " still to discard)";
                 }
             }
+            if (!DiscardSecretService.discardSO(player, soIndex, game)) {
+                return;
+            }
             MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg + ".");
-            String oldSO = player.getSecret(soIndex).getAlias();
-            DiscardSecretService.discardSO(player, soIndex, game);
 
             if (drawReplacement) {
+                String oldSO = secretObjective.getAlias();
                 DrawSecretService.drawSO(event, game, player);
 
                 if (player.getSecrets().containsKey(oldSO)

--- a/src/main/java/ti4/service/objectives/DiscardSecretService.java
+++ b/src/main/java/ti4/service/objectives/DiscardSecretService.java
@@ -16,7 +16,7 @@ import ti4.service.info.SecretObjectiveInfoService;
 @UtilityClass
 public class DiscardSecretService {
 
-    public static void discardSO(Player player, int SOID, Game game) {
+    public static boolean discardSO(Player player, int SOID, Game game) {
         String soIDString = "";
         for (Map.Entry<String, Integer> so : player.getSecrets().entrySet()) {
             if (so.getValue().equals(SOID)) {
@@ -27,7 +27,7 @@ public class DiscardSecretService {
         if (!removed) {
             MessageHelper.sendMessageToPlayerCardsInfoThread(
                     player, "No such secret objective ID found, please retry.");
-            return;
+            return false;
         }
         MessageHelper.sendMessageToPlayerCardsInfoThread(player, "Secret objective discarded.");
 
@@ -45,6 +45,7 @@ public class DiscardSecretService {
         }
 
         handleSecretObjectiveDrawOrder(game, player);
+        return true;
     }
 
     private static void handleSecretObjectiveDrawOrder(Game game, Player player) {


### PR DESCRIPTION
## Summary
- guard the secret discard button flow when the clicked secret objective ID is no longer in the player's hand
- only post the public discard announcement after `DiscardSecretService` confirms the discard succeeded


## Test Plan
- `mvn spotless:apply`
- `DB_PATH=./src/test/resources RESOURCE_PATH=./src/main/resources mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile`