### PR TITLE
chore: speed up production image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,7 @@ target
 node_modules
 *.log
 .DS_Store
+src/main/resources/**
+!src/main/resources/config/
+!src/main/resources/config/application.yml
+!src/main/resources/logback.xml

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -83,6 +83,7 @@ jobs:
               cd ${{ vars.HOST_TI4_REPO_DIR }}
               git pull --ff-only
               export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
+              export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
               export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
               export COMPOSE_PROJECT_NAME="ti4-bot"
               export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -38,6 +38,7 @@ jobs:
           echo "Pulling deployment config from GitHub..."
           git pull --ff-only
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
+          export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
           export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -38,6 +38,7 @@ jobs:
           echo "Pulling deployment config from GitHub..."
           git pull --ff-only
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
+          export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
           export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@ RUN --mount=type=cache,target=/root/.m2 \
     mvn -B -ntp -DskipTests dependency:go-offline
 
 # add sources late for better layer reuse
-COPY src/test ./src/test
-COPY src/main/resources ./src/main/resources
+# Only package classpath config; runtime assets are mounted from the host repo.
+COPY src/main/resources/config/application.yml ./src/main/resources/config/application.yml
+COPY src/main/resources/logback.xml ./src/main/resources/logback.xml
 COPY src/main/java ./src/main/java
 
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -ntp -Dmaven.test.skip=true clean package
+    mvn -B -ntp -Dspotless.skip=true -Dmaven.test.skip=true clean package
 
 # ---- Runtime stage ----
 FROM amazoncorretto:21-alpine
@@ -22,7 +23,6 @@ WORKDIR /app
 # needed to handle fonts
 RUN apk add --no-cache fontconfig ttf-dejavu
 
-COPY --from=build /opt/app/src/main/resources /opt/resources
 COPY --from=build /opt/app/target/TI4_map_generator_discord_bot-1.0-SNAPSHOT.jar tibot.jar
 
 ENV DB_PATH=/opt/STORAGE

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -19,6 +19,7 @@ services:
     mem_limit: 7g
     volumes:
       - ${HOST_TI4_SAVES_DIR}:/opt/STORAGE
+      - ${HOST_TI4_REPO_DIR}/src/main/resources:/opt/resources:ro
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_KEY}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <webp-imageio.version>0.10.2</webp-imageio.version>
     <jemoji.version>1.7.6</jemoji.version>
     <spotless.version>3.4.0</spotless.version>
+    <spotless.skip>false</spotless.skip>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
     <findsecbugs.version>1.14.0</findsecbugs.version>
@@ -195,6 +196,7 @@
           </execution>
         </executions>
         <configuration>
+          <skip>${spotless.skip}</skip>
           <java>
             <cleanthat>
               <sourceJdk>${java.version}</sourceJdk>


### PR DESCRIPTION
## Summary
- skip Spotless in the Docker packaging path to avoid repeating formatting checks during production image builds
- stop baking runtime resources into the image and mount `src/main/resources` from the Hostinger repo checkout instead
- export `HOST_TI4_REPO_DIR` in the deploy/start/restart workflows so Compose can resolve the resource bind mount

## Test Plan
- `mvn -B -ntp -Dspotless.skip=true -Dmaven.test.skip=true clean package`
- `HOST_TI4_SAVES_DIR=/tmp HOST_TI4_REPO_DIR=/Users/jstrong/webapps/asyncti/TI4_map_generator_bot IMAGE_REPOSITORY=test IMAGE_TAG=test docker compose -f docker-compose.production.yml config`
- built a simulated Docker-context-only package in `/tmp/ti4-minbuild`; repackaged jar size was `120M` versus `929M` with full resources present
- compressed Docker context approximation dropped to `4.8M`

