### PR TITLE
Revert (temporarily) to old deploy style due to lack of perms

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,3 @@ target
 node_modules
 *.log
 .DS_Store
-src/main/resources/**
-!src/main/resources/config/
-!src/main/resources/config/application.yml
-!src/main/resources/logback.xml

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -3,11 +3,6 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 name: BuildAndDeploy
-permissions:
-  contents: read
-  packages: write
-env:
-  IMAGE_REPOSITORY: ghcr.io/asyncti4/ti4-map-generator-bot
 concurrency:
   group: deploy-to-production-master
   cancel-in-progress: true
@@ -15,40 +10,11 @@ jobs:
   saveGamesBeforeDeploy:
     uses: ./.github/workflows/force-backup-of-savefiles.yml
     secrets: inherit
-  buildImage:
-    needs: saveGamesBeforeDeploy
-    name: Build & Publish Bot Image
-    runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.image.outputs.image_tag }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Compute image tag
-        id: image
-        run: echo "image_tag=sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.image_tag }}
-            ${{ env.IMAGE_REPOSITORY }}:master
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
   build:
     concurrency:
       group: "Start Bot"
-    needs: [saveGamesBeforeDeploy, buildImage]
-    name: Pull & Deploy Bot
+    needs: saveGamesBeforeDeploy
+    name: Build, Test, & Deploy Bot
     runs-on: ubuntu-latest
     steps:
       - name: Execute remote ssh commands
@@ -79,15 +45,13 @@ jobs:
 
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`NEW DEPLOYMENT TRIGGERED\"}" $DISCORD_WEBHOOK_URL
-              echo "Pulling deployment config from GitHub..."
+              echo "Pulling changes from GitHub..."
               cd ${{ vars.HOST_TI4_REPO_DIR }}
               git pull --ff-only
               export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
               export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
               export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
               export COMPOSE_PROJECT_NAME="ti4-bot"
-              export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
-              export IMAGE_TAG="${{ needs.buildImage.outputs.image_tag }}"
               compose_file="docker-compose.production.yml"
               rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
 
@@ -99,10 +63,11 @@ jobs:
               fi
 
               timestamp=$(date "+%F %T.%3N")
-              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`PULLING DOCKER IMAGE ${IMAGE_TAG}\"}" $DISCORD_WEBHOOK_URL
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`BUILDING DOCKER IMAGE\"}" $DISCORD_WEBHOOK_URL
+              echo "Building docker image..."
               docker version
-              docker compose -f "$compose_file" pull tibot
-
+              docker compose -f "$compose_file" build tibot
+              
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ENSURING TRAEFIK PROXY IS RUNNING\"}" $DISCORD_WEBHOOK_URL
               docker compose -f "$compose_file" up -d traefik
@@ -121,8 +86,8 @@ jobs:
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`CLEANING UP DOCKER\"}" $DISCORD_WEBHOOK_URL
               echo "Cleaning up docker stuff..."
               
-              docker image prune --force --filter until=48h
-              docker builder prune --force --filter until=48h
+              docker image prune --force
+              docker builder prune --force
               
               echo "DONE!"
   saveGamesAfterDeploy:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -49,7 +49,6 @@ jobs:
               cd ${{ vars.HOST_TI4_REPO_DIR }}
               git pull --ff-only
               export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
-              export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
               export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
               export COMPOSE_PROJECT_NAME="ti4-bot"
               compose_file="docker-compose.production.yml"

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -34,7 +34,6 @@ jobs:
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
-          export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
           compose_file="docker-compose.production.yml"

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -1,7 +1,5 @@
 on: workflow_dispatch
 name: RestartBot
-env:
-  IMAGE_REPOSITORY: ghcr.io/asyncti4/ti4-map-generator-bot
 concurrency:
   group: "Start Bot"
 jobs:
@@ -35,14 +33,10 @@ jobs:
           set -eu
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
-          echo "Pulling deployment config from GitHub..."
-          git pull --ff-only
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
           export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
-          export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
-          export IMAGE_TAG="master"
           compose_file="docker-compose.production.yml"
           rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
 
@@ -53,9 +47,9 @@ jobs:
             docker rollout --help >/dev/null
           fi
           
-          echo "Pulling docker image..."
+          echo "Building docker image..."
           docker version
-          docker compose -f "$compose_file" pull tibot
+          docker compose -f "$compose_file" build tibot
           
           docker compose -f "$compose_file" up -d traefik
 
@@ -69,6 +63,6 @@ jobs:
           fi
           echo "Cleaning up docker stuff..."
           
-          docker image prune --force --filter until=48h
+          docker image prune --force
           
           echo "DONE!"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,11 +54,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21 for x64
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v3
         with:
           java-version: "21"
           distribution: "corretto"
           architecture: x64
-          cache: maven
       - name: Run the Maven verify phase
-        run: mvn --batch-mode --no-transfer-progress verify
+        run: mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -34,7 +34,6 @@ jobs:
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
-          export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
           compose_file="docker-compose.production.yml"

--- a/.github/workflows/start-bot.yml
+++ b/.github/workflows/start-bot.yml
@@ -1,7 +1,5 @@
 on: workflow_dispatch
 name: StartBot
-env:
-  IMAGE_REPOSITORY: ghcr.io/asyncti4/ti4-map-generator-bot
 concurrency:
   group: "Start Bot"
 jobs:
@@ -35,24 +33,20 @@ jobs:
           set -eu
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
-          echo "Pulling deployment config from GitHub..."
-          git pull --ff-only
           export HOST_TI4_SAVES_DIR="${{ vars.HOST_TI4_SAVES_DIR }}"
           export HOST_TI4_REPO_DIR="${{ vars.HOST_TI4_REPO_DIR }}"
           export GUILDID_LIST="${{ vars.GUILDID_LIST }}"
           export COMPOSE_PROJECT_NAME="ti4-bot"
-          export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
-          export IMAGE_TAG="master"
           compose_file="docker-compose.production.yml"
           
-          echo "Pulling docker image..."
+          echo "Building docker image..."
           docker version
-          docker compose -f "$compose_file" pull tibot
+          docker compose -f "$compose_file" build tibot
           
           echo "Starting Container..."
           docker compose -f "$compose_file" up -d traefik tibot
           echo "Cleaning up docker stuff..."
           
-          docker image prune --force --filter until=48h
+          docker image prune --force
           
           echo "DONE!"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,12 @@ RUN --mount=type=cache,target=/root/.m2 \
     mvn -B -ntp -DskipTests dependency:go-offline
 
 # add sources late for better layer reuse
-# Only package classpath config; runtime assets are mounted from the host repo.
-COPY src/main/resources/config/application.yml ./src/main/resources/config/application.yml
-COPY src/main/resources/logback.xml ./src/main/resources/logback.xml
+COPY src/test ./src/test
+COPY src/main/resources ./src/main/resources
 COPY src/main/java ./src/main/java
 
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -ntp -Dspotless.skip=true -Dmaven.test.skip=true clean package
+    mvn -B -ntp -DskipTests clean package
 
 # ---- Runtime stage ----
 FROM amazoncorretto:21-alpine
@@ -23,6 +22,7 @@ WORKDIR /app
 # needed to handle fonts
 RUN apk add --no-cache fontconfig ttf-dejavu
 
+COPY --from=build /opt/app/src/main/resources /opt/resources
 COPY --from=build /opt/app/target/TI4_map_generator_discord_bot-1.0-SNAPSHOT.jar tibot.jar
 
 ENV DB_PATH=/opt/STORAGE

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -19,7 +19,6 @@ services:
     mem_limit: 7g
     volumes:
       - ${HOST_TI4_SAVES_DIR}:/opt/STORAGE
-      - ${HOST_TI4_REPO_DIR}/src/main/resources:/opt/resources:ro
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_KEY}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -14,7 +14,7 @@ services:
       - ti4-rollout
 
   tibot:
-    image: ${IMAGE_REPOSITORY:-ghcr.io/asyncti4/ti4-map-generator-bot}:${IMAGE_TAG:-master}
+    build: .
     restart: unless-stopped
     mem_limit: 7g
     volumes:

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <webp-imageio.version>0.10.2</webp-imageio.version>
     <jemoji.version>1.7.6</jemoji.version>
     <spotless.version>3.4.0</spotless.version>
-    <spotless.skip>false</spotless.skip>
     <spotbugs.version>4.9.8</spotbugs.version>
     <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
     <findsecbugs.version>1.14.0</findsecbugs.version>
@@ -196,7 +195,6 @@
           </execution>
         </executions>
         <configuration>
-          <skip>${spotless.skip}</skip>
           <java>
             <cleanthat>
               <sourceJdk>${java.version}</sourceJdk>


### PR DESCRIPTION
## Summary
Temporarily revert the deploy flow back to building on the host instead of pulling a GHCR image.

## What this reverts
- 9cb66388631a17c7cc80d340dd61a4855a5b8062
- 092a5ee7c96661178f20155b4d257dbed8a72456
- dcb3a8b7e8356e64008732b26835e863f0a750b9
