### PR TITLE
fix: prevent sardakk agent slash exhaust crash

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperAgents.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAgents.java
@@ -1196,6 +1196,21 @@ public final class ButtonHelperAgents {
             String exhaustText = player.getRepresentation() + " has exhausted " + ssruuClever + "T'ro An, the N'orr"
                     + ssruuSlash + " agent.";
             MessageHelper.sendMessageToChannel(channel, exhaustText);
+            if (!rest.contains("_")) {
+                Tile activeSystem = game.getTileByPosition(game.getActiveSystem());
+                if (activeSystem == null || activeSystem.getPlanetUnitHolders().isEmpty()) {
+                    MessageHelper.sendMessageToChannel(
+                            channel,
+                            trueIdentity + ", choose the planet for " + ssruuClever + "T'ro An, the N'orr"
+                                    + ssruuSlash
+                                    + " agent from the tactical action buttons while an active system with planets is selected.");
+                    return;
+                }
+                message = trueIdentity + ", please choose the planet where you wish to place 2 infantry with "
+                        + ssruuClever + "T'ro An, the N'orr" + ssruuSlash + " agent.";
+                MessageHelper.sendMessageToChannelWithButtons(channel, message, getSardakkAgentButtons(game));
+                return;
+            }
             String posNPlanet = rest.replace("sardakkagent_", "");
             String pos = posNPlanet.split("_")[0];
             String planetName = posNPlanet.split("_")[1];


### PR DESCRIPTION
## Summary
- handle the `/leaders exhaust` Sardakk agent slash-command path when no button-encoded planet target is present
- route players back into the existing tactical-action button flow when an active system with planets is available
- avoid the `ArrayIndexOutOfBoundsException` reported in Rollbar item 19 (occurrence 458589330477)

## Test Plan
- `mvn spotless:apply`
- `DB_PATH=./src/test/resources RESOURCE_PATH=./src/main/resources mvn --batch-mode --update-snapshots --no-transfer-progress verify test-compile`