### PR TITLE
Add fuzzy /find component search

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/SlashCommandManager.java
+++ b/src/main/java/ti4/discord/interactions/commands/SlashCommandManager.java
@@ -35,6 +35,7 @@ import ti4.discord.interactions.commands.planet.PlanetCommand;
 import ti4.discord.interactions.commands.player.PlayerCommand;
 import ti4.discord.interactions.commands.relic.RelicCommand;
 import ti4.discord.interactions.commands.rules.RulesCommand;
+import ti4.discord.interactions.commands.search.FindCommand;
 import ti4.discord.interactions.commands.search.SearchCommand;
 import ti4.discord.interactions.commands.search.SearchCommand2;
 import ti4.discord.interactions.commands.special.Special2Command;
@@ -84,6 +85,7 @@ public class SlashCommandManager {
                     new RemoveCCCommand(),
                     new RemoveAllCC(),
                     new SearchCommand2(),
+                    new FindCommand(),
                     new AddFrontierTokensCommand(),
                     new MoveUnits(),
                     new ModifyUnitsButtons(),

--- a/src/main/java/ti4/discord/interactions/commands/search/FindCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/search/FindCommand.java
@@ -1,0 +1,42 @@
+package ti4.discord.interactions.commands.search;
+
+import java.util.List;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.ParentCommand;
+import ti4.helpers.Constants;
+
+public class FindCommand implements ParentCommand {
+
+    private final List<OptionData> options = List.of(
+            new OptionData(OptionType.STRING, Constants.SEARCH_TYPE, "What kind of component to search")
+                    .setRequired(true)
+                    .setAutoComplete(true),
+            new OptionData(OptionType.STRING, Constants.SEARCH, "Free text or exact id").setRequired(true),
+            new OptionData(
+                            OptionType.STRING,
+                            Constants.SOURCE,
+                            "Optional source filter. Defaults to base, pok, and thunders_edge")
+                    .setAutoComplete(true));
+
+    @Override
+    public String getName() {
+        return Constants.FIND;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Fuzzy text search across one or many component types";
+    }
+
+    @Override
+    public List<OptionData> getOptions() {
+        return options;
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        FindService.execute(event);
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/search/FindRegistry.java
+++ b/src/main/java/ti4/discord/interactions/commands/search/FindRegistry.java
@@ -1,0 +1,257 @@
+package ti4.discord.interactions.commands.search;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.apache.commons.lang3.StringUtils;
+import ti4.helpers.Constants;
+import ti4.image.Mapper;
+import ti4.image.TileHelper;
+import ti4.model.ActionCardModel;
+import ti4.model.AgendaModel;
+import ti4.model.EmbeddableModel;
+import ti4.model.ModelInterface;
+import ti4.model.Source.ComponentSource;
+
+@UtilityClass
+class FindRegistry {
+
+    private static final Map<String, FindSpec> TYPES = Stream.of(
+                    spec(
+                            Constants.SEARCH_ABILITIES,
+                            "Abilities",
+                            () -> Mapper.getAbilities().values(),
+                            model -> model.getRepresentationEmbed(),
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_ACTION_CARDS,
+                            "Action Cards",
+                            () -> Mapper.getActionCards().values(),
+                            FindRegistry::actionCardSearchText,
+                            model -> model.getRepresentationEmbed(true, true),
+                            model -> model.getRepresentationEmbed(true, true)),
+                    spec(
+                            Constants.SEARCH_AGENDAS,
+                            "Agendas",
+                            () -> Mapper.getAgendas().values(),
+                            FindRegistry::agendaSearchText,
+                            model -> model.getRepresentationEmbed(true),
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_ATTACHMENTS,
+                            "Attachments",
+                            () -> Mapper.getAttachments().values(),
+                            EmbeddableModel::getRepresentationEmbed,
+                            EmbeddableModel::getRepresentationEmbed),
+                    spec(
+                            Constants.SEARCH_BREAKTHROUGHS,
+                            "Breakthroughs",
+                            () -> Mapper.getBreakthroughs().values(),
+                            model -> model.getRepresentationEmbed(true),
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_DECKS,
+                            "Decks",
+                            () -> Mapper.getDecks().values(),
+                            EmbeddableModel::getRepresentationEmbed,
+                            EmbeddableModel::getRepresentationEmbed),
+                    spec(
+                            Constants.SEARCH_EVENTS,
+                            "Events",
+                            () -> Mapper.getEvents().values(),
+                            EmbeddableModel::getRepresentationEmbed,
+                            EmbeddableModel::getRepresentationEmbed),
+                    spec(
+                            Constants.SEARCH_EXPLORES,
+                            "Explores",
+                            () -> Mapper.getExplores().values(),
+                            model -> model.getRepresentationEmbed(true, true),
+                            model -> model.getRepresentationEmbed(true, true)),
+                    spec(
+                            Constants.SEARCH_FACTIONS,
+                            "Factions",
+                            Mapper::getFactionsValues,
+                            model -> model.getRepresentationEmbed(true, false),
+                            model -> model.getRepresentationEmbed(true, false)),
+                    spec(
+                            Constants.SEARCH_GALACTIC_EVENTS,
+                            "Galactic Events",
+                            () -> Mapper.getGalacticEvents().values(),
+                            model -> model.getRepresentationEmbed(true),
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_LEADERS,
+                            "Leaders",
+                            () -> Mapper.getLeaders().values(),
+                            model -> model.getRepresentationEmbed(true, true, true, true),
+                            model -> model.getRepresentationEmbed(true, true, true, true)),
+                    spec(
+                            Constants.SEARCH_GENOMES,
+                            "Genomes",
+                            () -> Mapper.getDeck(Constants.TF_GENOME).getNewDeck().stream()
+                                    .map(Mapper::getLeader)
+                                    .toList(),
+                            model -> model.getRepresentationEmbed(true, true, false, true, true),
+                            model -> model.getRepresentationEmbed(true, true, false, true, true)),
+                    spec(
+                            Constants.SEARCH_PARADIGMS,
+                            "Paradigms",
+                            () -> Mapper.getDeck(Constants.TF_PARADIGM).getNewDeck().stream()
+                                    .map(Mapper::getLeader)
+                                    .toList(),
+                            model -> model.getRepresentationEmbed(true, true, false, true, true),
+                            model -> model.getRepresentationEmbed(true, true, false, true, true)),
+                    spec(
+                            Constants.SEARCH_PLANETS,
+                            "Planets",
+                            TileHelper::getAllPlanetModels,
+                            EmbeddableModel::getRepresentationEmbed,
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_PLOTS,
+                            "Plots",
+                            () -> Mapper.getPlots().values(),
+                            EmbeddableModel::getRepresentationEmbed,
+                            EmbeddableModel::getRepresentationEmbed),
+                    spec(
+                            Constants.SEARCH_PROMISSORY_NOTES,
+                            "Promissory Notes",
+                            () -> Mapper.getPromissoryNotes().values(),
+                            model -> model.getRepresentationEmbed(false, true, true),
+                            model -> model.getRepresentationEmbed(false, true, true)),
+                    spec(
+                            Constants.SEARCH_PUBLIC_OBJECTIVES,
+                            "Public Objectives",
+                            () -> Mapper.getPublicObjectives().values(),
+                            model -> model.getRepresentationEmbed(true),
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_RELICS,
+                            "Relics",
+                            () -> Mapper.getRelics().values(),
+                            model -> model.getRepresentationEmbed(true, true),
+                            model -> model.getRepresentationEmbed(true, true)),
+                    spec(
+                            Constants.SEARCH_RULES,
+                            "Rules",
+                            () -> Mapper.getRules().values(),
+                            EmbeddableModel::getRepresentationEmbed,
+                            EmbeddableModel::getRepresentationEmbed),
+                    spec(
+                            Constants.SEARCH_SECRET_OBJECTIVES,
+                            "Secret Objectives",
+                            () -> Mapper.getSecretObjectives().values(),
+                            model -> model.getRepresentationEmbed(true),
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_STRATEGY_CARDS,
+                            "Strategy Cards",
+                            () -> Mapper.getStrategyCards().values(),
+                            model -> model.getRepresentationEmbed(true),
+                            model -> model.getRepresentationEmbed(true)),
+                    spec(
+                            Constants.SEARCH_TECHS,
+                            "Techs",
+                            () -> Mapper.getTechs().values(),
+                            model -> model.getRepresentationEmbed(true, true),
+                            model -> model.getRepresentationEmbed(true, true)),
+                    spec(
+                            Constants.SEARCH_TILES,
+                            "Tiles",
+                            TileHelper::getAllTileModels,
+                            EmbeddableModel::getRepresentationEmbed,
+                            EmbeddableModel::getRepresentationEmbed),
+                    spec(
+                            Constants.SEARCH_TOKENS,
+                            "Tokens",
+                            () -> Mapper.getTokens().values(),
+                            EmbeddableModel::getRepresentationEmbed,
+                            EmbeddableModel::getRepresentationEmbed),
+                    spec(
+                            Constants.SEARCH_UNITS,
+                            "Units",
+                            () -> Mapper.getUnits().values(),
+                            EmbeddableModel::getRepresentationEmbed,
+                            model -> model.getRepresentationEmbed(true)))
+            .collect(
+                    Collectors.toMap(FindSpec::key, Function.identity(), (first, second) -> first, LinkedHashMap::new));
+
+    List<FindSpec> getTypes() {
+        return List.copyOf(TYPES.values());
+    }
+
+    FindSpec getType(String key) {
+        return TYPES.get(key);
+    }
+
+    private static <T extends ModelInterface & EmbeddableModel> FindSpec spec(
+            String key,
+            String displayName,
+            Supplier<Collection<T>> models,
+            Function<T, String> textSearch,
+            Function<T, MessageEmbed> exactEmbed,
+            Function<T, MessageEmbed> listEmbed) {
+        return new FindSpec(key, displayName, () -> models.get().stream()
+                .map(model -> new FindItem(
+                        model.getAlias(),
+                        model.getSource(),
+                        model.getAutoCompleteName(),
+                        model.getNameRepresentation(),
+                        textSearch.apply(model),
+                        model::search,
+                        () -> exactEmbed.apply(model),
+                        () -> listEmbed.apply(model)))
+                .toList());
+    }
+
+    private static <T extends ModelInterface & EmbeddableModel> FindSpec spec(
+            String key,
+            String displayName,
+            Supplier<Collection<T>> models,
+            Function<T, MessageEmbed> exactEmbed,
+            Function<T, MessageEmbed> listEmbed) {
+        return spec(key, displayName, models, model -> "", exactEmbed, listEmbed);
+    }
+
+    record FindSpec(String key, String displayName, Supplier<List<FindItem>> items) {}
+
+    record FindItem(
+            String alias,
+            ComponentSource source,
+            String autoCompleteName,
+            String nameRepresentation,
+            String textSearchBlob,
+            Predicate<String> searchMatcher,
+            Supplier<MessageEmbed> exactEmbed,
+            Supplier<MessageEmbed> listEmbed) {
+
+        boolean matches(String query) {
+            return searchMatcher.test(query);
+        }
+
+        boolean hasTextSearch() {
+            return StringUtils.isNotBlank(textSearchBlob);
+        }
+    }
+
+    private static String actionCardSearchText(ActionCardModel model) {
+        return String.join(
+                " ",
+                model.getWindow(),
+                model.getText(),
+                model.getNotes() == null ? "" : model.getNotes(),
+                model.getFlavorText().orElse(""));
+    }
+
+    private static String agendaSearchText(AgendaModel model) {
+        return String.join(" ", model.getType(), model.getTarget(), model.getText1(), model.getText2());
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/search/FindService.java
+++ b/src/main/java/ti4/discord/interactions/commands/search/FindService.java
@@ -1,0 +1,188 @@
+package ti4.discord.interactions.commands.search;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import org.apache.commons.lang3.StringUtils;
+import ti4.discord.interactions.commands.search.FindRegistry.FindItem;
+import ti4.discord.interactions.commands.search.FindRegistry.FindSpec;
+import ti4.helpers.Constants;
+import ti4.model.Source.ComponentSource;
+
+@UtilityClass
+public class FindService {
+
+    private static final String ALL = "all";
+    private static final Set<ComponentSource> DEFAULT_SOURCES =
+            Set.of(ComponentSource.base, ComponentSource.pok, ComponentSource.thunders_edge);
+
+    public static void execute(SlashCommandInteractionEvent event) {
+        String typeKey = event.getOption(Constants.SEARCH_TYPE, null, OptionMapping::getAsString);
+        if (StringUtils.isBlank(typeKey)) {
+            SearchHelper.sendSearchEmbedsToEventChannel(event, List.of());
+            return;
+        }
+
+        String query = event.getOption(Constants.SEARCH, "", OptionMapping::getAsString);
+        boolean allTypes = isAllKeyword(typeKey);
+        boolean allQuery = isAllKeyword(query);
+        if (allTypes && allQuery) {
+            SearchHelper.sendSearchMessageToEventChannel(
+                    event, "> `type:ALL search:ALL` would return too many results.");
+            return;
+        }
+
+        ComponentSource source =
+                ComponentSource.fromString(event.getOption(Constants.SOURCE, null, OptionMapping::getAsString));
+
+        List<FindItem> items = filteredItems(typeKey, query, source);
+        if (!allQuery) {
+            FindItem exactMatch = findExactMatch(items, query);
+            if (exactMatch == null) {
+                exactMatch = findExactMatch(getItems(typeKey, source), query);
+            }
+            if (exactMatch != null) {
+                SearchHelper.sendSearchEmbedsToEventChannel(
+                        event, List.of(exactMatch.exactEmbed().get()));
+                return;
+            }
+        }
+
+        List<MessageEmbed> embeds =
+                items.stream().limit(10).map(item -> item.listEmbed().get()).toList();
+        SearchHelper.sendSearchEmbedsToEventChannel(event, embeds);
+    }
+
+    public static List<Command.Choice> autoCompleteType(CommandAutoCompleteInteractionEvent event) {
+        String enteredValue = normalize(event.getFocusedOption().getValue());
+        Stream<Command.Choice> allChoice = Stream.of(new Command.Choice("ALL", ALL));
+        Stream<Command.Choice> typeChoices = FindRegistry.getTypes().stream()
+                .filter(type -> contains(type.key(), enteredValue) || contains(type.displayName(), enteredValue))
+                .map(type -> new Command.Choice(type.displayName(), type.key()));
+        return Stream.concat(allChoice, typeChoices)
+                .filter(choice -> contains(choice.getName(), enteredValue))
+                .limit(25)
+                .toList();
+    }
+
+    public static List<Command.Choice> autoCompleteSource(CommandAutoCompleteInteractionEvent event) {
+        String enteredValue = normalize(event.getFocusedOption().getValue());
+        String typeKey = event.getOption(Constants.SEARCH_TYPE, null, OptionMapping::getAsString);
+        return availableSources(typeKey).stream()
+                .filter(source ->
+                        contains(source.toString(), enteredValue) || contains(source.prettyName(), enteredValue))
+                .limit(25)
+                .map(source -> new Command.Choice(source.prettyName(), source.toString()))
+                .toList();
+    }
+
+    private static List<ComponentSource> availableSources(String typeKey) {
+        return getAllItems(typeKey).stream()
+                .map(FindItem::source)
+                .distinct()
+                .filter(source -> !source.isHiddenFromSearch())
+                .sorted(sourceComparator())
+                .toList();
+    }
+
+    private static Comparator<ComponentSource> sourceComparator() {
+        return Comparator.comparingInt((ComponentSource source) -> DEFAULT_SOURCES.contains(source) ? 0 : 1)
+                .thenComparing(ComponentSource::prettyName);
+    }
+
+    private static List<FindItem> filteredItems(String typeKey, String query, ComponentSource selectedSource) {
+        List<FindItem> items = getItems(typeKey, selectedSource);
+        if (isAllKeyword(query)) {
+            return items.stream()
+                    .sorted(Comparator.comparing(FindItem::autoCompleteName))
+                    .toList();
+        }
+
+        String normalizedQuery = normalize(query);
+        return items.stream()
+                .map(item -> new RankedItem(item, score(item, normalizedQuery)))
+                .filter(item -> item.score() > 0)
+                .sorted(Comparator.comparingInt(RankedItem::score).reversed().thenComparing(item -> item.item()
+                        .autoCompleteName()))
+                .map(RankedItem::item)
+                .toList();
+    }
+
+    private static List<FindItem> getItems(String typeKey, ComponentSource selectedSource) {
+        return getAllItems(typeKey).stream()
+                .filter(item -> matchesSource(item, selectedSource))
+                .toList();
+    }
+
+    private static List<FindItem> getAllItems(String typeKey) {
+        FindSpec type = getType(typeKey);
+        if (!isAllKeyword(typeKey) && type == null) return List.of();
+
+        Stream<FindItem> items = isAllKeyword(typeKey)
+                ? FindRegistry.getTypes().stream().flatMap(spec -> spec.items().get().stream())
+                : type.items().get().stream();
+        return items.toList();
+    }
+
+    private static FindSpec getType(String typeKey) {
+        if (StringUtils.isBlank(typeKey) || isAllKeyword(typeKey)) return null;
+        return FindRegistry.getType(typeKey);
+    }
+
+    private static FindItem findExactMatch(List<FindItem> items, String query) {
+        String normalizedQuery = normalize(query);
+        return items.stream()
+                .filter(item -> normalize(item.alias()).equals(normalizedQuery))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean matchesSource(FindItem item, ComponentSource selectedSource) {
+        if (selectedSource != null) return item.source() == selectedSource;
+        return DEFAULT_SOURCES.contains(item.source());
+    }
+
+    private static boolean isAllKeyword(String value) {
+        return ALL.equals(normalize(value));
+    }
+
+    private static int score(FindItem item, String query) {
+        if (StringUtils.isBlank(query)) return 0;
+
+        int score = 0;
+        score = Math.max(score, scoreText(query, item.alias(), 1000, 850));
+        score = Math.max(score, scoreText(query, item.autoCompleteName(), 950, 800));
+        score = Math.max(score, scoreText(query, item.nameRepresentation(), 900, 750));
+        if (item.hasTextSearch()) {
+            score = Math.max(score, scoreText(query, item.textSearchBlob(), 650, 500));
+        }
+        if (item.matches(query)) score += 100;
+        return score;
+    }
+
+    private static int scoreText(String query, String text, int exactScore, int containsScore) {
+        String normalizedText = normalize(text);
+        if (normalizedText.equals(query)) return exactScore;
+        if (normalizedText.startsWith(query)) return containsScore + 50 - normalizedText.length();
+        if (normalizedText.contains(query)) return containsScore - normalizedText.indexOf(query);
+        return 0;
+    }
+
+    private static boolean contains(String value, String search) {
+        return normalize(value).contains(search);
+    }
+
+    private static String normalize(String value) {
+        if (value == null) return "";
+        return value.toLowerCase().replaceAll("[^a-z0-9]+", "");
+    }
+
+    private record RankedItem(FindItem item, int score) {}
+}

--- a/src/main/java/ti4/discord/interactions/commands/search/SearchHelper.java
+++ b/src/main/java/ti4/discord/interactions/commands/search/SearchHelper.java
@@ -11,6 +11,10 @@ import ti4.message.MessageHelper;
 @UtilityClass
 class SearchHelper {
 
+    public static void sendSearchMessageToEventChannel(SlashCommandInteractionEvent event, String message) {
+        event.getChannel().sendMessage(message).queue(Consumers.nop(), BotLogger::catchRestError);
+    }
+
     public static void sendSearchEmbedsToEventChannel(
             SlashCommandInteractionEvent event, List<MessageEmbed> messageEmbeds) {
         if (messageEmbeds.size() > 3) {

--- a/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
+++ b/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import ti4.cron.CronManager;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.commands.CommandHelper;
+import ti4.discord.interactions.commands.search.FindService;
 import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
 import ti4.discord.interactions.commands.uncategorized.ServerPromoteCommand;
 import ti4.game.Game;
@@ -101,6 +102,11 @@ class AutoCompleteProvider {
         String commandName = event.getName();
         String subCommandName = event.getSubcommandName();
         String optionName = event.getFocusedOption().getName();
+
+        if (Constants.FIND.equals(commandName)) {
+            resolveFindAutoComplete(event, optionName);
+            if (event.isAcknowledged()) return;
+        }
 
         if (subCommandName != null) {
             switch (commandName) {
@@ -1434,6 +1440,17 @@ class AutoCompleteProvider {
         }
         event.replyChoices(Objects.requireNonNullElse(options, Collections.emptyList()))
                 .queue(Consumers.nop(), BotLogger::catchRestError);
+    }
+
+    private static void resolveFindAutoComplete(
+            @NotNull CommandAutoCompleteInteractionEvent event, @NotNull String optionName) {
+        List<Command.Choice> options =
+                switch (optionName) {
+                    case Constants.SEARCH_TYPE -> FindService.autoCompleteType(event);
+                    case Constants.SOURCE -> FindService.autoCompleteSource(event);
+                    default -> Collections.emptyList();
+                };
+        event.replyChoices(options).queue(Consumers.nop(), BotLogger::catchRestError);
     }
 
     private static void resolveFrankenAutoComplete(

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -233,6 +233,7 @@ public final class Constants {
 
     /* From \data\ */
     public static final String SEARCH_ABILITIES = "abilities";
+    public static final String SEARCH_PLOTS = "plots";
     public static final String SEARCH_BREAKTHROUGHS = "breakthroughs";
     public static final String SEARCH_GALACTIC_EVENTS = "galactic_events";
     public static final String SEARCH_ACTION_CARDS = "action_cards";
@@ -1282,6 +1283,8 @@ public final class Constants {
     public static final String NORMAL_GAME = "normal_game";
     public static final String INCLUDE_ALIASES = "include_aliases";
     public static final String SEARCH = "search";
+    public static final String FIND = "find";
+    public static final String SEARCH_TYPE = "type";
     public static final String BENTOR_HAS_FOUND_CFRAG = "has_found_cfrag";
     public static final String BENTOR_HAS_FOUND_HFRAG = "has_found_hfrag";
     public static final String BENTOR_HAS_FOUND_IFRAG = "has_found_ifrag";


### PR DESCRIPTION
## Summary
- add a new `/find` slash command for fuzzy component search
- support fuzzy matching across component types with dedicated autocomplete
- include text-body matching for agendas and action cards and expose all non-hidden sources in source autocomplete

## Testing
- mvn -q -DskipTests compile