### PR TITLE
Lower Lazax War Archives contest threshold

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -45,7 +45,7 @@ public class CombatContestService {
 
     private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives";
     private static final Duration CONTEST_COOLDOWN = Duration.ofMinutes(10);
-    private static final double MIN_FLEET_RESOURCES = 12.0;
+    private static final double MIN_FLEET_RESOURCES = 8.0;
     private static final double MIN_HP_RATIO = 0.7;
     private static final double ZERO_EPSILON = 0.0001;
     private static final boolean PREDICTION_LOCK_ENABLED = false;


### PR DESCRIPTION
## Summary
- lower the minimum fleet resource threshold for Lazax War Archives contests from 12 to 8 per side

## Testing
- mvn -q -DskipTests compile