### PR TITLE
Raise Lazax minigame resource threshold to 15

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -53,7 +53,7 @@ public class CombatContestService {
     public static final String LAZAX_MINIGAME_ROLE_NAME = "Lazax Minigame";
     private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives";
     private static final Duration CONTEST_COOLDOWN = Duration.ofMinutes(10);
-    private static final double MIN_FLEET_RESOURCES = 8.0;
+    private static final double MIN_FLEET_RESOURCES = 15.0;
     private static final double MIN_HP_RATIO = 0.7;
     private static final double ZERO_EPSILON = 0.0001;
     private static final boolean PREDICTION_LOCK_ENABLED = false;


### PR DESCRIPTION
## Summary
- raise the Lazax minigame fleet resource threshold from 8 to 15

## Testing
- not run (constant change only)