### PR TITLE
Remove Lazax contest outlook labeling

### DIFF
--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -825,7 +825,13 @@ public class ActionCardHelper {
                 MessageHelper.sendMessageToChannelWithEmbed(bEvent.getChannel(), message, acEmbed);
             }
         }
-        SpringContext.getBean(CombatContestService.class).mirrorCombatActionCard(game, player, actionCard);
+        SpringContext.getBean(CombatContestService.class)
+                .mirrorCombatEvent(
+                        game,
+                        player,
+                        "Action Card",
+                        "played _" + actionCard.getName() + "_.",
+                        actionCard.getRepresentationEmbed(false, true, game));
         if (actionCardIsSabotageOrShatter) {
             MessageHelper.sendMessageToChannelWithEmbed(mainGameChannel, message, acEmbed);
             if (game.isWildWildGalaxyMode()) {

--- a/src/main/java/ti4/helpers/ButtonHelperAgents.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAgents.java
@@ -606,7 +606,13 @@ public final class ButtonHelperAgents {
         ExhaustLeaderService.exhaustLeader(game, player, playerLeader);
         LeaderModel agentModel = playerLeader.getLeaderModel().orElse(null);
         if (agentModel != null) {
-            SpringContext.getBean(CombatContestService.class).mirrorCombatAgent(game, player, agentModel);
+            SpringContext.getBean(CombatContestService.class)
+                    .mirrorCombatEvent(
+                            game,
+                            player,
+                            "Agent",
+                            "used _" + agentModel.getName() + "_.",
+                            agentModel.getRepresentationEmbed());
         }
 
         MessageChannel channel = player.getCorrectChannel();

--- a/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
@@ -102,10 +102,6 @@ public class CombatContestEntity {
     @Column(name = "initial_hp_defender")
     private Double initialHpDefender;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "upset_index")
-    private CombatContestUpsetIndex upsetIndex;
-
     @Column(name = "prediction_locked_at")
     private LocalDateTime predictionLockedAt;
 

--- a/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
@@ -105,15 +105,6 @@ public class CombatContestEntity {
     @Column(name = "initial_hp_defender")
     private Double initialHpDefender;
 
-    @Column(name = "prediction_locked_at")
-    private LocalDateTime predictionLockedAt;
-
-    @Column(name = "locked_attacker_predictions")
-    private Integer lockedAttackerPredictions;
-
-    @Column(name = "locked_defender_predictions")
-    private Integer lockedDefenderPredictions;
-
     @Column(name = "attacker_hit_assigned_round")
     private Integer attackerHitAssignedRound;
 

--- a/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
@@ -90,6 +90,9 @@ public class CombatContestEntity {
     @Column(name = "initial_summary_text", nullable = false, columnDefinition = "TEXT")
     private String initialSummaryText;
 
+    @Column(name = "active_player_summary", columnDefinition = "TEXT")
+    private String activePlayerSummary;
+
     @Column(name = "initial_strength_attacker", nullable = false)
     private Double initialStrengthAttacker;
 

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -11,8 +12,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
@@ -38,8 +43,6 @@ import ti4.image.TileGenerator;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.message.MessageHelper;
-import ti4.model.ActionCardModel;
-import ti4.model.LeaderModel;
 import ti4.model.RelicModel;
 import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
@@ -60,10 +63,13 @@ public class CombatContestService {
             "metalivoidarmaments", "metalivoidshielding", "lightrailordnance", "baldrick_crownofthalnos", "pi_thalnos");
     private static final double MIN_HP_RATIO = 0.9;
     private static final double ZERO_EPSILON = 0.0001;
-    private static final boolean PREDICTION_LOCK_ENABLED = false;
     private static final String SUBSCRIBE_EMOJI = "🟢";
     private static final String UNSUBSCRIBE_EMOJI = "🔴";
     private static final Set<CombatContestStatus> ACTIVE_STATUSES = Set.of(CombatContestStatus.POSTED);
+    private static final Comparator<TechnologyModel> TECH_COMPARATOR = Comparator.comparingInt(
+                    CombatContestService::getTechTypeOrder)
+            .thenComparingInt(tech -> tech.getRequirements().orElse("").length())
+            .thenComparing(TechnologyModel::getName, String.CASE_INSENSITIVE_ORDER);
 
     private final CombatContestRepository repository;
     private final CombatContestPredictionRepository predictionRepository;
@@ -85,33 +91,8 @@ public class CombatContestService {
             TextChannel contestChannel = getContestChannel();
             if (contestChannel == null) return;
 
-            CombatContestEntity contest = new CombatContestEntity();
-            contest.setStatus(CombatContestStatus.POSTED);
-            contest.setCombatType(CombatContestType.SPACE);
-            contest.setGameName(game.getName());
-            contest.setTilePosition(tile.getPosition());
-            contest.setTileRepresentation(tile.getRepresentationForButtons());
-            contest.setAttackerFaction(attacker.getFaction());
-            contest.setDefenderFaction(defender.getFaction());
-            contest.setAttackerColor(attacker.getColor());
-            contest.setDefenderColor(defender.getColor());
-            contest.setPostedAt(LocalDateTime.now());
-            contest.setInitialSummaryText(snapshot.parentPostText());
-            contest.setActivePlayerSummary(snapshot.activePlayerSummary());
-            contest.setInitialStrengthAttacker(snapshot.attackerStrength());
-            contest.setInitialStrengthDefender(snapshot.defenderStrength());
-            contest.setInitialHpAttacker(snapshot.attackerHp());
-            contest.setInitialHpDefender(snapshot.defenderHp());
-            long contestId = repository.save(contest).getId();
-            postContestMessage(
-                    game,
-                    attacker,
-                    defender,
-                    tile,
-                    contestChannel,
-                    contestId,
-                    snapshot.parentPostText(),
-                    snapshot.threadSummaryText());
+            CombatContestEntity contest = repository.save(buildContestEntity(game, attacker, defender, tile, snapshot));
+            postContestMessage(game, attacker, defender, tile, contestChannel, contest, snapshot);
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Combat contest nomination failed.", e);
         }
@@ -142,57 +123,28 @@ public class CombatContestService {
 
             MessageChannel threadOrChannel = getContestThreadOrChannel(contest);
             if (threadOrChannel == null) return;
-            if (PREDICTION_LOCK_ENABLED) {
-                lockPredictions(game, contest, threadOrChannel);
-            }
             MessageHelper.splitAndSentWithAction("## Roll Update\n" + message, threadOrChannel, null);
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Combat contest roll mirror failed.", e);
         }
     }
 
-    public void mirrorCombatActionCard(Game game, Player player, ActionCardModel actionCard) {
+    public void mirrorCombatEvent(Game game, Player player, String header, String name, MessageEmbed embed) {
         try {
-            if (game == null || player == null || actionCard == null) return;
+            if (game == null || player == null || name == null) return;
             List<CombatContestEntity> activeContests =
                     repository.findByGameNameAndStatusIn(game.getName(), ACTIVE_STATUSES);
             if (activeContests.isEmpty()) return;
 
+            String message = "## " + header + "\n" + player.getRepresentation() + " " + name;
             for (CombatContestEntity contest : activeContests) {
                 if (!matchesParticipant(contest, player)) continue;
-
                 MessageChannel threadOrChannel = getContestThreadOrChannel(contest);
                 if (threadOrChannel == null) continue;
-
-                String message =
-                        "## Action Card\n" + player.getRepresentation() + " played _" + actionCard.getName() + "_.";
-                MessageHelper.sendMessageToChannelWithEmbed(
-                        threadOrChannel, message, actionCard.getRepresentationEmbed(false, true, game));
+                MessageHelper.sendMessageToChannelWithEmbed(threadOrChannel, message, embed);
             }
         } catch (Exception e) {
-            BotLogger.error(new LogOrigin(game), "Combat contest action card relay failed.", e);
-        }
-    }
-
-    public void mirrorCombatAgent(Game game, Player player, LeaderModel agent) {
-        try {
-            if (game == null || player == null || agent == null) return;
-            List<CombatContestEntity> activeContests =
-                    repository.findByGameNameAndStatusIn(game.getName(), ACTIVE_STATUSES);
-            if (activeContests.isEmpty()) return;
-
-            for (CombatContestEntity contest : activeContests) {
-                if (!matchesParticipant(contest, player)) continue;
-
-                MessageChannel threadOrChannel = getContestThreadOrChannel(contest);
-                if (threadOrChannel == null) continue;
-
-                String message = "## Agent\n" + player.getRepresentation() + " used _" + agent.getName() + "_.";
-
-                MessageHelper.sendMessageToChannelWithEmbed(threadOrChannel, message, agent.getRepresentationEmbed());
-            }
-        } catch (Exception e) {
-            BotLogger.error(new LogOrigin(game), "Combat contest agent relay failed.", e);
+            BotLogger.error(new LogOrigin(game), "Combat contest " + header.toLowerCase() + " relay failed.", e);
         }
     }
 
@@ -224,6 +176,28 @@ public class CombatContestService {
                 .filter(player -> !player.isDummy())
                 .toList();
         return shipPlayers.size() == 2;
+    }
+
+    private CombatContestEntity buildContestEntity(
+            Game game, Player attacker, Player defender, Tile tile, SpaceCombatSnapshot snapshot) {
+        CombatContestEntity contest = new CombatContestEntity();
+        contest.setStatus(CombatContestStatus.POSTED);
+        contest.setCombatType(CombatContestType.SPACE);
+        contest.setGameName(game.getName());
+        contest.setTilePosition(tile.getPosition());
+        contest.setTileRepresentation(tile.getRepresentationForButtons());
+        contest.setAttackerFaction(attacker.getFaction());
+        contest.setDefenderFaction(defender.getFaction());
+        contest.setAttackerColor(attacker.getColor());
+        contest.setDefenderColor(defender.getColor());
+        contest.setPostedAt(LocalDateTime.now());
+        contest.setInitialSummaryText(snapshot.parentPostText());
+        contest.setActivePlayerSummary(snapshot.activePlayerSummary());
+        contest.setInitialStrengthAttacker(snapshot.attackerStrength());
+        contest.setInitialStrengthDefender(snapshot.defenderStrength());
+        contest.setInitialHpAttacker(snapshot.attackerHp());
+        contest.setInitialHpDefender(snapshot.defenderHp());
+        return contest;
     }
 
     private SpaceCombatSnapshot buildSnapshot(Game game, Player attacker, Player defender, Tile tile) {
@@ -276,8 +250,7 @@ public class CombatContestService {
             int undamagedUnits = Math.max(0, totalUnits - damagedUnits);
 
             total += unitModel.getCost() * totalUnits;
-            hp += damagedUnits;
-            hp += undamagedUnits;
+            hp += totalUnits;
             if (unitModel.getSustainDamage(player, space)) {
                 hp += undamagedUnits;
                 if (player.hasTech("nes")) {
@@ -336,30 +309,27 @@ public class CombatContestService {
             Player defender,
             Tile tile,
             TextChannel contestChannel,
-            long contestId,
-            String parentPostText,
-            String threadSummaryText) {
+            CombatContestEntity contest,
+            SpaceCombatSnapshot snapshot) {
+        Consumer<Message> onMessage = message -> {
+            persistMessageAndThread(game, contest, contestChannel, message, snapshot.threadSummaryText());
+            addPredictionReactions(game, attacker, defender, message);
+        };
         try {
             FileUpload fileUpload =
                     new TileGenerator(game, null, null, 0, tile.getPosition(), attacker).createFileUpload();
             contestChannel
                     .sendMessage(new MessageCreateBuilder()
-                            .addContent(parentPostText)
+                            .addContent(snapshot.parentPostText())
                             .addFiles(fileUpload)
                             .build())
                     .queue(
-                            message -> {
-                                persistMessageAndThread(game, contestId, contestChannel, message, threadSummaryText);
-                                addPredictionReactions(game, attacker, defender, message);
-                            },
+                            onMessage,
                             error -> BotLogger.error(
                                     new LogOrigin(game), "Failed to post combat contest opener.", error));
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Failed to create combat contest opener image.", e);
-            MessageHelper.splitAndSentWithAction(parentPostText, contestChannel, message -> {
-                persistMessageAndThread(game, contestId, contestChannel, message, threadSummaryText);
-                addPredictionReactions(game, attacker, defender, message);
-            });
+            MessageHelper.splitAndSentWithAction(snapshot.parentPostText(), contestChannel, onMessage);
         }
     }
 
@@ -407,31 +377,7 @@ public class CombatContestService {
         return userName.replace("@", "@\u200B");
     }
 
-    private void lockPredictions(Game game, CombatContestEntity contest, MessageChannel threadOrChannel) {
-        if (contest.getPredictionLockedAt() != null
-                || contest.getPublicChannelId() == null
-                || contest.getPublicMessageId() == null) return;
-
-        TextChannel contestChannel = JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
-        if (contestChannel == null) return;
-
-        try {
-            Message message = contestChannel
-                    .retrieveMessageById(contest.getPublicMessageId())
-                    .complete();
-            PredictionSnapshot snapshot = capturePredictions(game, message, contest);
-            contest.setPredictionLockedAt(LocalDateTime.now());
-            contest.setLockedAttackerPredictions(snapshot.attackerPredictions());
-            contest.setLockedDefenderPredictions(snapshot.defenderPredictions());
-            repository.save(contest);
-            refreshParentMessageSummary(game, contest, null, null);
-            MessageHelper.sendMessageToChannel(threadOrChannel, formatLockAnnouncement(game, contest, snapshot));
-        } catch (Exception e) {
-            BotLogger.error(new LogOrigin(game), "Failed to lock combat contest predictions.", e);
-        }
-    }
-
-    private PredictionSnapshot capturePredictions(Game game, Message message, CombatContestEntity contest) {
+    private void capturePredictions(Game game, Message message, CombatContestEntity contest) {
         Map<String, Set<String>> factionsByUser = new HashMap<>();
         Map<String, String> namesByUser = new HashMap<>();
         Map<String, String> factionToEmoji = Map.of(
@@ -459,12 +405,8 @@ public class CombatContestService {
         }
 
         List<CombatContestPredictionEntity> predictions = new ArrayList<>();
-        int attackerPredictions = 0;
-        int defenderPredictions = 0;
-        int invalidPredictions = 0;
         for (Map.Entry<String, Set<String>> entry : factionsByUser.entrySet()) {
             if (entry.getValue().size() != 1) {
-                invalidPredictions++;
                 continue;
             }
 
@@ -476,12 +418,8 @@ public class CombatContestService {
             prediction.setPredictedFaction(predictedFaction);
             prediction.setLockedAt(LocalDateTime.now());
             predictions.add(prediction);
-
-            if (predictedFaction.equalsIgnoreCase(contest.getAttackerFaction())) attackerPredictions++;
-            if (predictedFaction.equalsIgnoreCase(contest.getDefenderFaction())) defenderPredictions++;
         }
         predictionRepository.saveAll(predictions);
-        return new PredictionSnapshot(attackerPredictions, defenderPredictions, predictions.size(), invalidPredictions);
     }
 
     private String getFactionEmoji(Game game, String faction) {
@@ -489,24 +427,12 @@ public class CombatContestService {
         return player == null ? "" : player.getFactionEmoji();
     }
 
-    private String formatLockAnnouncement(Game game, CombatContestEntity contest, PredictionSnapshot snapshot) {
-        return "## Votes Locked In\n"
-                + getFactionEmoji(game, contest.getAttackerFaction()) + " `"
-                + snapshot.attackerPredictions() + "`\n"
-                + getFactionEmoji(game, contest.getDefenderFaction()) + " `"
-                + snapshot.defenderPredictions() + "`\n"
-                + (snapshot.invalidPredictions() > 0
-                        ? "-# `" + snapshot.invalidPredictions()
-                                + "` multi-outcome vote" + (snapshot.invalidPredictions() == 1 ? " was" : "s were")
-                                + " excluded.\n"
-                        : "")
-                + "*May fortune favor the bold.*";
-    }
-
     private void persistMessageAndThread(
-            Game game, Long contestId, TextChannel contestChannel, Message message, String threadSummaryText) {
-        CombatContestEntity contest = repository.findById(contestId).orElse(null);
-        if (contest == null) return;
+            Game game,
+            CombatContestEntity contest,
+            TextChannel contestChannel,
+            Message message,
+            String threadSummaryText) {
         contest.setPublicChannelId(contestChannel.getIdLong());
         contest.setPublicMessageId(message.getIdLong());
         repository.save(contest);
@@ -515,43 +441,29 @@ public class CombatContestService {
                 .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS)
                 .queue(
                         thread -> {
-                            CombatContestEntity latest =
-                                    repository.findById(contestId).orElse(null);
-                            if (latest == null) return;
-                            latest.setPublicThreadId(thread.getIdLong());
-                            repository.save(latest);
-                            postContestThreadIntro(game, latest, thread, threadSummaryText);
+                            contest.setPublicThreadId(thread.getIdLong());
+                            repository.save(contest);
+                            postContestThreadIntro(game, contest, thread, threadSummaryText);
                         },
                         error -> BotLogger.error(
-                                "Failed to create combat predictor thread for contest " + contestId, error));
+                                "Failed to create combat predictor thread for contest " + contest.getId(), error));
     }
 
     private String buildLeaderboardMessage() {
         List<CombatContestLeaderboardRow> topEntries = predictionRepository.findLeaderboardRows(PageRequest.of(0, 10));
         if (topEntries.isEmpty()) return null;
 
-        StringBuilder message = new StringBuilder("## Lazax War Archives Leaderboard\n");
-        int rank = 1;
-        for (CombatContestLeaderboardRow entry : topEntries) {
-            long predictions = entry.getPredictionCount() == null ? 0 : entry.getPredictionCount();
-            long correctPredictions = entry.getCorrectPredictions() == null ? 0 : entry.getCorrectPredictions();
-            int accuracy = predictions == 0 ? 0 : Math.round((100f * correctPredictions) / predictions);
-            message.append('`')
-                    .append(rank++)
-                    .append(".` ")
-                    .append(getSafeLeaderboardName(entry.getDiscordUserName()))
-                    .append(" - **")
-                    .append(entry.getTotalPoints())
-                    .append("** points")
-                    .append(" (`")
-                    .append(correctPredictions)
-                    .append('/')
-                    .append(predictions)
-                    .append("` correct, ")
-                    .append(accuracy)
-                    .append("%)\n");
-        }
-        return message.toString().trim();
+        final int[] rank = {1};
+        return buildLineSection(
+                "## Lazax War Archives Leaderboard", topEntries.stream().map(entry -> {
+                    long predictions = entry.getPredictionCount() == null ? 0 : entry.getPredictionCount();
+                    long correctPredictions = entry.getCorrectPredictions() == null ? 0 : entry.getCorrectPredictions();
+                    int accuracy = predictions == 0 ? 0 : Math.round((100f * correctPredictions) / predictions);
+                    return '`' + Integer.toString(rank[0]++) + ".` "
+                            + getSafeLeaderboardName(entry.getDiscordUserName())
+                            + " - **" + entry.getTotalPoints() + "** points (`" + correctPredictions + "/" + predictions
+                            + "` correct, " + accuracy + "%)";
+                }));
     }
 
     private void postLeaderboardMessage(String message) {
@@ -566,9 +478,13 @@ public class CombatContestService {
         repository.saveAll(pendingBatch);
     }
 
+    private String buildLineSection(String header, Stream<String> lines) {
+        return lines.collect(Collectors.joining("\n", header + "\n", ""));
+    }
+
     private void postContestThreadIntro(
             Game game, CombatContestEntity contest, ThreadChannel thread, String threadSummaryText) {
-        postThreadSummaryThen(game, contest, thread, threadSummaryText, () -> {
+        postThreadSummaryThen(thread, threadSummaryText, () -> {
             String intro =
                     "Use this thread for combat follow-up. The bot will post the result here when the space combat resolves.";
             MessageHelper.splitAndSentWithAction(
@@ -576,8 +492,7 @@ public class CombatContestService {
         });
     }
 
-    private void postThreadSummaryThen(
-            Game game, CombatContestEntity contest, ThreadChannel thread, String threadSummaryText, Runnable nextStep) {
+    private void postThreadSummaryThen(ThreadChannel thread, String threadSummaryText, Runnable nextStep) {
         if (threadSummaryText == null) {
             nextStep.run();
             return;
@@ -609,15 +524,7 @@ public class CombatContestService {
                 .filter(tech -> tech.isFactionTech()
                         || tech.isUnitUpgrade()
                         || COMBAT_SUMMARY_TECH_ALIASES.contains(tech.getAlias()))
-                .sorted((left, right) -> {
-                    int typeComparison = Integer.compare(getTechTypeOrder(left), getTechTypeOrder(right));
-                    if (typeComparison != 0) return typeComparison;
-                    int tierComparison = Integer.compare(
-                            left.getRequirements().orElse("").length(),
-                            right.getRequirements().orElse("").length());
-                    if (tierComparison != 0) return tierComparison;
-                    return left.getName().compareToIgnoreCase(right.getName());
-                })
+                .sorted(TECH_COMPARATOR)
                 .map(tech -> tech.getCondensedReqsEmojis(false) + " " + tech.getName())
                 .reduce((left, right) -> left + ", " + right)
                 .orElse("No technologies");
@@ -661,7 +568,7 @@ public class CombatContestService {
         return "- " + player.getFactionEmoji() + " " + factionName + " " + player.getUserName() + ": " + summary;
     }
 
-    private int getTechTypeOrder(TechnologyModel tech) {
+    private static int getTechTypeOrder(TechnologyModel tech) {
         TechnologyModel.TechnologyType type = tech.getFirstType();
         return switch (type) {
             case PROPULSION -> 0;
@@ -739,12 +646,8 @@ public class CombatContestService {
             Player winner,
             String loserFaction) {
         capturePredictionsAtResolution(game, contest);
-        contest.setStatus(CombatContestStatus.RESOLVED);
-        contest.setResolvedAt(LocalDateTime.now());
-        contest.setWinnerFaction(winner.getFaction());
-        contest.setLoserFaction(loserFaction);
-        awardPredictionPoints(contest);
-        repository.save(contest);
+        closeContest(contest, CombatContestStatus.RESOLVED, winner.getFaction(), loserFaction);
+        List<CombatContestPredictionEntity> predictions = awardPredictionPoints(contest);
 
         MessageChannel threadOrChannel = getContestThreadOrChannel(contest);
         String resultMessage = "## Contest Result\n"
@@ -758,7 +661,7 @@ public class CombatContestService {
                 BotLogger.error(new LogOrigin(game), "Failed to create combat contest result image.", e);
                 MessageHelper.sendMessageToChannel(threadOrChannel, resultMessage);
             }
-            postPredictionPointsSummary(threadOrChannel, contest, () -> {
+            postPredictionPointsSummary(threadOrChannel, predictions, () -> {
                 postParticipantFollowup(game, contest, threadOrChannel);
                 postSubscriptionPrompt(threadOrChannel);
             });
@@ -766,15 +669,13 @@ public class CombatContestService {
         refreshParentMessageSummary(
                 game,
                 contest,
-                buildResultStamp(contest, tile, winner),
+                buildResultStamp(predictions, tile, winner, contest),
                 buildLossSummary(game, tile, contest, winner, loserFaction));
         maybePostLeaderboardAfterResolvedContest();
     }
 
     private void cancelContest(Game game, CombatContestEntity contest, String reason) {
-        contest.setStatus(CombatContestStatus.CANCELLED);
-        contest.setResolvedAt(LocalDateTime.now());
-        repository.save(contest);
+        closeContest(contest, CombatContestStatus.CANCELLED, null, null);
 
         MessageChannel threadOrChannel = getContestThreadOrChannel(contest);
         if (threadOrChannel != null)
@@ -782,12 +683,18 @@ public class CombatContestService {
         refreshParentMessageSummary(game, contest, "Cancelled", reason);
     }
 
-    private void capturePredictionsAtResolution(Game game, CombatContestEntity contest) {
-        if (PREDICTION_LOCK_ENABLED) return;
-        if (!predictionRepository.findByContestId(contest.getId()).isEmpty()) return;
-        if (contest.getPublicChannelId() == null || contest.getPublicMessageId() == null) return;
+    private void closeContest(
+            CombatContestEntity contest, CombatContestStatus status, String winnerFaction, String loserFaction) {
+        contest.setStatus(status);
+        contest.setResolvedAt(LocalDateTime.now());
+        contest.setWinnerFaction(winnerFaction);
+        contest.setLoserFaction(loserFaction);
+        repository.save(contest);
+    }
 
-        TextChannel contestChannel = JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
+    private void capturePredictionsAtResolution(Game game, CombatContestEntity contest) {
+        if (!predictionRepository.findByContestId(contest.getId()).isEmpty()) return;
+        TextChannel contestChannel = getContestPublicChannel(contest);
         if (contestChannel == null) return;
 
         try {
@@ -802,17 +709,9 @@ public class CombatContestService {
 
     private void refreshParentMessageSummary(
             Game game, CombatContestEntity contest, String resultStamp, String detailStamp) {
-        if (contest.getPublicChannelId() == null || contest.getPublicMessageId() == null) return;
-        TextChannel contestChannel = JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
+        TextChannel contestChannel = getContestPublicChannel(contest);
         if (contestChannel == null) return;
         StringBuilder updated = new StringBuilder(contest.getInitialSummaryText());
-        if (contest.getPredictionLockedAt() != null) {
-            int totalPredictions =
-                    safeInt(contest.getLockedAttackerPredictions()) + safeInt(contest.getLockedDefenderPredictions());
-            updated.append("\n-# Contest lock: Predictions locked at first dice roll (")
-                    .append(totalPredictions)
-                    .append(" captured).");
-        }
         if (resultStamp != null) updated.append("\n-# Contest result: ").append(resultStamp);
         if (detailStamp != null) updated.append("\n-# Contest details: ").append(detailStamp);
         contestChannel
@@ -822,33 +721,40 @@ public class CombatContestService {
                         BotLogger::catchRestError);
     }
 
+    private TextChannel getContestPublicChannel(CombatContestEntity contest) {
+        if (contest.getPublicChannelId() == null
+                || contest.getPublicMessageId() == null
+                || JdaService.guildPrimary == null) return null;
+        return JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
+    }
+
     private int safeInt(Integer value) {
         return value == null ? 0 : value;
     }
 
-    private void awardPredictionPoints(CombatContestEntity contest) {
+    private List<CombatContestPredictionEntity> awardPredictionPoints(CombatContestEntity contest) {
         List<CombatContestPredictionEntity> predictions = predictionRepository.findByContestId(contest.getId());
-        if (predictions.isEmpty()) return;
+        if (predictions.isEmpty()) return predictions;
 
         int attackerPredictions = (int) predictions.stream()
                 .filter(prediction -> prediction.getPredictedFaction().equalsIgnoreCase(contest.getAttackerFaction()))
                 .count();
         int defenderPredictions = predictions.size() - attackerPredictions;
+        int winnerPredictions = contest.getWinnerFaction().equalsIgnoreCase(contest.getAttackerFaction())
+                ? attackerPredictions
+                : defenderPredictions;
+        int totalPredictions = attackerPredictions + defenderPredictions;
         for (CombatContestPredictionEntity prediction : predictions) {
             boolean correct = prediction.getPredictedFaction().equalsIgnoreCase(contest.getWinnerFaction());
             prediction.setCorrect(correct);
-            int winnerPredictions = contest.getWinnerFaction().equalsIgnoreCase(contest.getAttackerFaction())
-                    ? attackerPredictions
-                    : defenderPredictions;
-            int totalPredictions = attackerPredictions + defenderPredictions;
             prediction.setPointsAwarded(correct ? calculatePredictionPoints(winnerPredictions, totalPredictions) : 0);
         }
         predictionRepository.saveAll(predictions);
+        return predictions;
     }
 
     private void postPredictionPointsSummary(
-            MessageChannel threadOrChannel, CombatContestEntity contest, Runnable afterPost) {
-        List<CombatContestPredictionEntity> predictions = predictionRepository.findByContestId(contest.getId());
+            MessageChannel threadOrChannel, List<CombatContestPredictionEntity> predictions, Runnable afterPost) {
         if (predictions.isEmpty()) {
             if (afterPost != null) afterPost.run();
             return;
@@ -867,30 +773,26 @@ public class CombatContestService {
                         .map(CombatContestPredictionEntity::getDiscordUserId)
                         .toList())
                 .stream()
-                .collect(java.util.stream.Collectors.toMap(
+                .collect(Collectors.toMap(
                         CombatContestUserPointsRow::getDiscordUserId, row -> safeInt(row.getTotalPoints())));
 
-        StringBuilder message = new StringBuilder("## Prediction Points\n");
-        winningPredictions.stream()
-                .sorted((left, right) -> {
-                    int pointsComparison =
-                            Integer.compare(safeInt(right.getPointsAwarded()), safeInt(left.getPointsAwarded()));
-                    if (pointsComparison != 0) return pointsComparison;
-                    return left.getDiscordUserName().compareToIgnoreCase(right.getDiscordUserName());
-                })
-                .forEach(prediction -> {
-                    int pointsAwarded = safeInt(prediction.getPointsAwarded());
-                    int totalPoints = totalsByUser.getOrDefault(prediction.getDiscordUserId(), 0);
-                    message.append("<@")
-                            .append(prediction.getDiscordUserId())
-                            .append("> - ")
-                            .append(totalPoints)
-                            .append(" points (+")
-                            .append(pointsAwarded)
-                            .append(")\n");
-                });
+        String message = buildLineSection(
+                "## Prediction Points",
+                winningPredictions.stream()
+                        .sorted((left, right) -> {
+                            int pointsComparison = Integer.compare(
+                                    safeInt(right.getPointsAwarded()), safeInt(left.getPointsAwarded()));
+                            if (pointsComparison != 0) return pointsComparison;
+                            return left.getDiscordUserName().compareToIgnoreCase(right.getDiscordUserName());
+                        })
+                        .map(prediction -> {
+                            int pointsAwarded = safeInt(prediction.getPointsAwarded());
+                            int totalPoints = totalsByUser.getOrDefault(prediction.getDiscordUserId(), 0);
+                            return "<@" + prediction.getDiscordUserId() + "> - " + totalPoints + " points (+"
+                                    + pointsAwarded + ")";
+                        }));
 
-        MessageHelper.splitAndSentWithAction(message.toString().trim(), threadOrChannel, postedMessage -> {
+        MessageHelper.splitAndSentWithAction(message, threadOrChannel, postedMessage -> {
             if (afterPost != null) afterPost.run();
         });
     }
@@ -925,17 +827,14 @@ public class CombatContestService {
         return (int) Math.round(Math.max(4.0, Math.min(12.0, scaledPoints)));
     }
 
-    private String buildResultStamp(CombatContestEntity contest, Tile tile, Player winner) {
-        List<CombatContestPredictionEntity> predictions = predictionRepository.findByContestId(contest.getId());
-        int totalPredictions = predictions.size();
+    private String buildResultStamp(
+            List<CombatContestPredictionEntity> predictions, Tile tile, Player winner, CombatContestEntity contest) {
         long correctPredictions = predictions.stream()
                 .filter(prediction -> prediction.getPredictedFaction().equalsIgnoreCase(winner.getFaction()))
                 .count();
-        String loserFaction = winner.getFaction().equalsIgnoreCase(contest.getAttackerFaction())
-                ? contest.getDefenderFaction()
-                : contest.getAttackerFaction();
-        return winner.getFactionEmoji() + " defeated `" + loserFaction + "` in " + tile.getRepresentationForButtons()
-                + " (" + correctPredictions + "/" + totalPredictions + " called it)";
+        return winner.getFactionEmoji() + " defeated `" + contest.getLoserFaction() + "` in "
+                + tile.getRepresentationForButtons()
+                + " (" + correctPredictions + "/" + predictions.size() + " called it)";
     }
 
     private String buildLossSummary(
@@ -1071,9 +970,6 @@ public class CombatContestService {
             MessageHelper.sendMessageToChannel(threadOrChannel, message);
         }
     }
-
-    private record PredictionSnapshot(
-            int attackerPredictions, int defenderPredictions, int totalPredictions, int invalidPredictions) {}
 
     private record FleetStrength(double value, double hp, boolean hasNonFighterShip) {}
 

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -514,7 +514,6 @@ public class CombatContestService {
         if (topEntries.isEmpty()) return null;
 
         StringBuilder message = new StringBuilder("## Lazax War Archives Leaderboard\n");
-        message.append("-# Posted daily at 15:00 UTC (9:00 CST).\n");
         int rank = 1;
         for (CombatContestLeaderboardRow entry : topEntries) {
             long predictions = entry.getPredictionCount() == null ? 0 : entry.getPredictionCount();

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -63,8 +63,8 @@ public class CombatContestService {
             "metalivoidarmaments", "metalivoidshielding", "lightrailordnance", "baldrick_crownofthalnos", "pi_thalnos");
     private static final double MIN_HP_RATIO = 0.9;
     private static final double ZERO_EPSILON = 0.0001;
-    private static final String SUBSCRIBE_EMOJI = "🟢";
-    private static final String UNSUBSCRIBE_EMOJI = "🔴";
+    private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
+    private static final String UNSUBSCRIBE_EMOJI = "\uD83D\uDD34";
     private static final Set<CombatContestStatus> ACTIVE_STATUSES = Set.of(CombatContestStatus.POSTED);
     private static final Comparator<TechnologyModel> TECH_COMPARATOR = Comparator.comparingInt(
                     CombatContestService::getTechTypeOrder)
@@ -74,10 +74,11 @@ public class CombatContestService {
     private final CombatContestRepository repository;
     private final CombatContestPredictionRepository predictionRepository;
 
+    // ==================== Public Entry Points ====================
+
     public void onSpaceCombatStarted(Game game, Player attacker, Player defender, Tile tile) {
         try {
             if (!isEligibleGame(game) || !isEligibleCombat(game, attacker, defender, tile)) return;
-            // if (!cooldownElapsed()) return;
             if (repository
                     .findFirstByGameNameAndTilePositionAndCombatTypeAndStatusInOrderByPostedAtDesc(
                             game.getName(), tile.getPosition(), CombatContestType.SPACE, ACTIVE_STATUSES)
@@ -114,7 +115,6 @@ public class CombatContestService {
 
     public void mirrorCombatRoll(Game game, Player player, Player opponent, Tile tile, String message) {
         try {
-            if (game == null || player == null || opponent == null || tile == null) return;
             CombatContestEntity contest = repository
                     .findFirstByGameNameAndTilePositionAndCombatTypeAndStatusInOrderByPostedAtDesc(
                             game.getName(), tile.getPosition(), CombatContestType.SPACE, ACTIVE_STATUSES)
@@ -131,7 +131,6 @@ public class CombatContestService {
 
     public void mirrorCombatEvent(Game game, Player player, String header, String name, MessageEmbed embed) {
         try {
-            if (game == null || player == null || name == null) return;
             List<CombatContestEntity> activeContests =
                     repository.findByGameNameAndStatusIn(game.getName(), ACTIVE_STATUSES);
             if (activeContests.isEmpty()) return;
@@ -147,6 +146,18 @@ public class CombatContestService {
             BotLogger.error(new LogOrigin(game), "Combat contest " + header.toLowerCase() + " relay failed.", e);
         }
     }
+
+    public boolean postLeaderboard() {
+        String message = buildLeaderboardMessage();
+        if (message == null) return false;
+
+        TextChannel contestChannel = getContestChannel();
+        if (contestChannel == null) return false;
+        MessageHelper.sendMessageToChannel(contestChannel, message);
+        return true;
+    }
+
+    // ==================== Contest Creation & Eligibility ====================
 
     private boolean isEligibleGame(Game game) {
         return game != null
@@ -199,6 +210,8 @@ public class CombatContestService {
         contest.setInitialHpDefender(snapshot.defenderHp());
         return contest;
     }
+
+    // ==================== Combat Snapshot & Strength ====================
 
     private SpaceCombatSnapshot buildSnapshot(Game game, Player attacker, Player defender, Tile tile) {
         UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
@@ -264,75 +277,6 @@ public class CombatContestService {
         return new FleetStrength(total, hp, hasNonFighterShip);
     }
 
-    private String formatContestPostHeader(
-            Game game, Tile tile, Player attacker, Player defender, String activePlayerSummary) {
-        String attackerLegend = ColorEmojis.getColorEmoji(attacker.getColor()) + " " + attacker.getFactionEmoji()
-                + " = " + attacker.getUserName();
-        String defenderLegend = ColorEmojis.getColorEmoji(defender.getColor()) + " " + defender.getFactionEmoji()
-                + " = " + defender.getUserName();
-        return "## A New Combat Contest Has Emerged!\n"
-                + getLazaxMinigameRoleMention()
-                + "\n"
-                + "**Game:** `" + game.getName() + "`\n"
-                + "**Game Link:** [Open Game](https://asyncti4.com/game/" + game.getName() + ")\n"
-                + activePlayerSummary
-                + "**System:** " + tile.getRepresentationForButtons() + "\n"
-                + "**Combat:** Space Combat\n"
-                + "**Predict the winner by reacting below.**\n"
-                + "- " + attackerLegend + "\n"
-                + "- " + defenderLegend;
-    }
-
-    private String formatActivePlayerSummary(Game game) {
-        Player activePlayer = game.getActivePlayer();
-        if (activePlayer == null) {
-            return "**Active Player:** None\n";
-        }
-        String factionName = activePlayer.getFactionModel() == null
-                ? activePlayer.getFaction()
-                : activePlayer.getFactionModel().getFactionName();
-        return "**Active Player:** " + activePlayer.getFactionEmoji() + " " + factionName + " "
-                + activePlayer.getUserName() + "\n";
-    }
-
-    private String getLazaxMinigameRoleMention() {
-        if (JdaService.guildPrimary == null) return "";
-        Role role = JdaService.guildPrimary.getRolesByName(LAZAX_MINIGAME_ROLE_NAME, true).stream()
-                .findFirst()
-                .orElse(null);
-        return role == null ? "" : role.getAsMention();
-    }
-
-    private void postContestMessage(
-            Game game,
-            Player attacker,
-            Player defender,
-            Tile tile,
-            TextChannel contestChannel,
-            CombatContestEntity contest,
-            SpaceCombatSnapshot snapshot) {
-        Consumer<Message> onMessage = message -> {
-            persistMessageAndThread(game, contest, contestChannel, message, snapshot.threadSummaryText());
-            addPredictionReactions(game, attacker, defender, message);
-        };
-        try {
-            FileUpload fileUpload =
-                    new TileGenerator(game, null, null, 0, tile.getPosition(), attacker).createFileUpload();
-            contestChannel
-                    .sendMessage(new MessageCreateBuilder()
-                            .addContent(snapshot.parentPostText())
-                            .addFiles(fileUpload)
-                            .build())
-                    .queue(
-                            onMessage,
-                            error -> BotLogger.error(
-                                    new LogOrigin(game), "Failed to post combat contest opener.", error));
-        } catch (Exception e) {
-            BotLogger.error(new LogOrigin(game), "Failed to create combat contest opener image.", e);
-            MessageHelper.splitAndSentWithAction(snapshot.parentPostText(), contestChannel, onMessage);
-        }
-    }
-
     private String extractSpaceOnlySummary(String summary) {
         String[] lines = summary.split("\n");
         StringBuilder trimmed = new StringBuilder();
@@ -354,251 +298,7 @@ public class CombatContestService {
         return trimmed.toString().trim();
     }
 
-    public boolean postLeaderboard() {
-        String message = buildLeaderboardMessage();
-        if (message == null) return false;
-
-        postLeaderboardMessage(message);
-        return true;
-    }
-
-    private void maybePostLeaderboardAfterResolvedContest() {
-        List<CombatContestEntity> pendingBatch =
-                repository.findTop5ByStatusAndResolvedAtIsNotNullAndLeaderboardPostedAtIsNullOrderByResolvedAtAsc(
-                        CombatContestStatus.RESOLVED);
-        if (pendingBatch.size() < 5) return;
-        if (!postLeaderboard()) return;
-
-        markLeaderboardBatchPosted(pendingBatch);
-    }
-
-    private String getSafeLeaderboardName(String userName) {
-        if (userName == null || userName.isBlank()) return "Unknown User";
-        return userName.replace("@", "@\u200B");
-    }
-
-    private void capturePredictions(Game game, Message message, CombatContestEntity contest) {
-        Map<String, Set<String>> factionsByUser = new HashMap<>();
-        Map<String, String> namesByUser = new HashMap<>();
-        Map<String, String> factionToEmoji = Map.of(
-                contest.getAttackerFaction(), getFactionEmoji(game, contest.getAttackerFaction()),
-                contest.getDefenderFaction(), getFactionEmoji(game, contest.getDefenderFaction()));
-
-        for (MessageReaction reaction : message.getReactions()) {
-            String predictedFaction = null;
-            for (Map.Entry<String, String> entry : factionToEmoji.entrySet()) {
-                if (reaction.getEmoji().getFormatted().equals(entry.getValue())) {
-                    predictedFaction = entry.getKey();
-                    break;
-                }
-            }
-            if (predictedFaction == null) continue;
-
-            List<User> users = reaction.retrieveUsers().complete();
-            for (User user : users) {
-                if (user.isBot()) continue;
-                factionsByUser
-                        .computeIfAbsent(user.getId(), key -> new HashSet<>())
-                        .add(predictedFaction);
-                namesByUser.put(user.getId(), user.getName());
-            }
-        }
-
-        List<CombatContestPredictionEntity> predictions = new ArrayList<>();
-        for (Map.Entry<String, Set<String>> entry : factionsByUser.entrySet()) {
-            if (entry.getValue().size() != 1) {
-                continue;
-            }
-
-            String predictedFaction = entry.getValue().iterator().next();
-            CombatContestPredictionEntity prediction = new CombatContestPredictionEntity();
-            prediction.setContestId(contest.getId());
-            prediction.setDiscordUserId(entry.getKey());
-            prediction.setDiscordUserName(namesByUser.getOrDefault(entry.getKey(), "Unknown User"));
-            prediction.setPredictedFaction(predictedFaction);
-            prediction.setLockedAt(LocalDateTime.now());
-            predictions.add(prediction);
-        }
-        predictionRepository.saveAll(predictions);
-    }
-
-    private String getFactionEmoji(Game game, String faction) {
-        Player player = game.getPlayerFromColorOrFaction(faction);
-        return player == null ? "" : player.getFactionEmoji();
-    }
-
-    private void persistMessageAndThread(
-            Game game,
-            CombatContestEntity contest,
-            TextChannel contestChannel,
-            Message message,
-            String threadSummaryText) {
-        contest.setPublicChannelId(contestChannel.getIdLong());
-        contest.setPublicMessageId(message.getIdLong());
-        repository.save(contest);
-
-        message.createThreadChannel("combat-predictor-" + contest.getGameName() + "-" + contest.getTilePosition())
-                .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS)
-                .queue(
-                        thread -> {
-                            contest.setPublicThreadId(thread.getIdLong());
-                            repository.save(contest);
-                            postContestThreadIntro(game, contest, thread, threadSummaryText);
-                        },
-                        error -> BotLogger.error(
-                                "Failed to create combat predictor thread for contest " + contest.getId(), error));
-    }
-
-    private String buildLeaderboardMessage() {
-        List<CombatContestLeaderboardRow> topEntries = predictionRepository.findLeaderboardRows(PageRequest.of(0, 10));
-        if (topEntries.isEmpty()) return null;
-
-        final int[] rank = {1};
-        return buildLineSection(
-                "## Lazax War Archives Leaderboard", topEntries.stream().map(entry -> {
-                    long predictions = entry.getPredictionCount() == null ? 0 : entry.getPredictionCount();
-                    long correctPredictions = entry.getCorrectPredictions() == null ? 0 : entry.getCorrectPredictions();
-                    int accuracy = predictions == 0 ? 0 : Math.round((100f * correctPredictions) / predictions);
-                    return '`' + Integer.toString(rank[0]++) + ".` "
-                            + getSafeLeaderboardName(entry.getDiscordUserName())
-                            + " - **" + entry.getTotalPoints() + "** points (`" + correctPredictions + "/" + predictions
-                            + "` correct, " + accuracy + "%)";
-                }));
-    }
-
-    private void postLeaderboardMessage(String message) {
-        TextChannel contestChannel = getContestChannel();
-        if (contestChannel == null) return;
-        MessageHelper.sendMessageToChannel(contestChannel, message);
-    }
-
-    private void markLeaderboardBatchPosted(List<CombatContestEntity> pendingBatch) {
-        LocalDateTime postedAt = LocalDateTime.now();
-        pendingBatch.forEach(contest -> contest.setLeaderboardPostedAt(postedAt));
-        repository.saveAll(pendingBatch);
-    }
-
-    private String buildLineSection(String header, Stream<String> lines) {
-        return lines.collect(Collectors.joining("\n", header + "\n", ""));
-    }
-
-    private void postContestThreadIntro(
-            Game game, CombatContestEntity contest, ThreadChannel thread, String threadSummaryText) {
-        postThreadSummaryThen(thread, threadSummaryText, () -> {
-            String intro =
-                    "Use this thread for combat follow-up. The bot will post the result here when the space combat resolves.";
-            MessageHelper.splitAndSentWithAction(
-                    intro, thread, ignored -> postCombatTechSummary(game, contest, thread));
-        });
-    }
-
-    private void postThreadSummaryThen(ThreadChannel thread, String threadSummaryText, Runnable nextStep) {
-        if (threadSummaryText == null) {
-            nextStep.run();
-            return;
-        }
-        MessageHelper.splitAndSentWithAction(threadSummaryText, thread, ignored -> nextStep.run());
-    }
-
-    private void postCombatTechSummary(Game game, CombatContestEntity contest, MessageChannel threadOrChannel) {
-        Player attacker = game.getPlayerFromColorOrFaction(contest.getAttackerFaction());
-        Player defender = game.getPlayerFromColorOrFaction(contest.getDefenderFaction());
-        if (attacker == null || defender == null) return;
-
-        StringBuilder message = new StringBuilder("## Combat Technologies\n")
-                .append(formatCombatTechLine(attacker))
-                .append("\n")
-                .append(formatCombatTechLine(defender));
-        String relicSection = formatCombatRelicSection(attacker, defender);
-        if (relicSection != null) {
-            message.append("\n\n").append(relicSection);
-        }
-        MessageHelper.sendMessageToChannel(threadOrChannel, message.toString());
-    }
-
-    private String formatCombatTechLine(Player player) {
-        String techSummary = player.getTechs().stream()
-                .map(Mapper::getTech)
-                .filter(Objects::nonNull)
-                .filter(tech -> !player.getPurgedTechs().contains(tech.getAlias()))
-                .filter(tech -> tech.isFactionTech()
-                        || tech.isUnitUpgrade()
-                        || COMBAT_SUMMARY_TECH_ALIASES.contains(tech.getAlias()))
-                .sorted(TECH_COMPARATOR)
-                .map(tech -> tech.getCondensedReqsEmojis(false) + " " + tech.getName())
-                .reduce((left, right) -> left + ", " + right)
-                .orElse("No technologies");
-        return formatPlayerSummaryLine(player, techSummary);
-    }
-
-    private String formatCombatRelicSection(Player attacker, Player defender) {
-        String attackerRelics = formatCombatRelicLine(attacker);
-        String defenderRelics = formatCombatRelicLine(defender);
-        if (attackerRelics == null && defenderRelics == null) return null;
-
-        StringBuilder section = new StringBuilder("## Relics");
-        if (attackerRelics != null) {
-            section.append("\n").append(attackerRelics);
-        }
-        if (defenderRelics != null) {
-            section.append("\n").append(defenderRelics);
-        }
-        return section.toString();
-    }
-
-    private String formatCombatRelicLine(Player player) {
-        String relicSummary = player.getRelics().stream()
-                .distinct()
-                .filter(COMBAT_SUMMARY_RELIC_ALIASES::contains)
-                .map(Mapper::getRelic)
-                .filter(Objects::nonNull)
-                .map(RelicModel::getName)
-                .sorted(String::compareToIgnoreCase)
-                .reduce((left, right) -> left + ", " + right)
-                .orElse(null);
-        if (relicSummary == null) return null;
-
-        return formatPlayerSummaryLine(player, relicSummary);
-    }
-
-    private String formatPlayerSummaryLine(Player player, String summary) {
-        String factionName = player.getFactionModel() == null
-                ? player.getFaction()
-                : player.getFactionModel().getFactionName();
-        return "- " + player.getFactionEmoji() + " " + factionName + " " + player.getUserName() + ": " + summary;
-    }
-
-    private static int getTechTypeOrder(TechnologyModel tech) {
-        TechnologyModel.TechnologyType type = tech.getFirstType();
-        return switch (type) {
-            case PROPULSION -> 0;
-            case BIOTIC -> 1;
-            case CYBERNETIC -> 2;
-            case WARFARE -> 3;
-            case UNITUPGRADE -> 4;
-            case GENERICTF -> 5;
-            case NONE -> 6;
-        };
-    }
-
-    private void addPredictionReactions(Game game, Player attacker, Player defender, Message message) {
-        addReaction(game, attacker, message);
-        addReaction(game, defender, message);
-    }
-
-    private void addReaction(Game game, Player player, Message message) {
-        try {
-            message.addReaction(Emoji.fromFormatted(player.getFactionEmoji()))
-                    .queue(
-                            null,
-                            error -> BotLogger.error(
-                                    new LogOrigin(game),
-                                    "Failed to add combat predictor reaction for " + player.getFaction(),
-                                    error));
-        } catch (Exception e) {
-            BotLogger.error(new LogOrigin(game), "Failed to parse combat predictor reaction emoji.", e);
-        }
-    }
+    // ==================== Contest Resolution ====================
 
     private boolean evaluateContestCompletion(Game game, ButtonInteractionEvent event, CombatContestEntity contest) {
         Tile tile = game.getTileByPosition(contest.getTilePosition());
@@ -697,14 +397,9 @@ public class CombatContestService {
         TextChannel contestChannel = getContestPublicChannel(contest);
         if (contestChannel == null) return;
 
-        try {
-            Message message = contestChannel
-                    .retrieveMessageById(contest.getPublicMessageId())
-                    .complete();
-            capturePredictions(game, message, contest);
-        } catch (Exception e) {
-            BotLogger.error(new LogOrigin(game), "Failed to capture combat contest predictions at resolution.", e);
-        }
+        Message message =
+                contestChannel.retrieveMessageById(contest.getPublicMessageId()).complete();
+        capturePredictions(game, message, contest);
     }
 
     private void refreshParentMessageSummary(
@@ -719,112 +414,6 @@ public class CombatContestService {
                 .queue(
                         message -> message.editMessage(updated.toString()).queueAfter(100, TimeUnit.MILLISECONDS),
                         BotLogger::catchRestError);
-    }
-
-    private TextChannel getContestPublicChannel(CombatContestEntity contest) {
-        if (contest.getPublicChannelId() == null
-                || contest.getPublicMessageId() == null
-                || JdaService.guildPrimary == null) return null;
-        return JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
-    }
-
-    private int safeInt(Integer value) {
-        return value == null ? 0 : value;
-    }
-
-    private List<CombatContestPredictionEntity> awardPredictionPoints(CombatContestEntity contest) {
-        List<CombatContestPredictionEntity> predictions = predictionRepository.findByContestId(contest.getId());
-        if (predictions.isEmpty()) return predictions;
-
-        int attackerPredictions = (int) predictions.stream()
-                .filter(prediction -> prediction.getPredictedFaction().equalsIgnoreCase(contest.getAttackerFaction()))
-                .count();
-        int defenderPredictions = predictions.size() - attackerPredictions;
-        int winnerPredictions = contest.getWinnerFaction().equalsIgnoreCase(contest.getAttackerFaction())
-                ? attackerPredictions
-                : defenderPredictions;
-        int totalPredictions = attackerPredictions + defenderPredictions;
-        for (CombatContestPredictionEntity prediction : predictions) {
-            boolean correct = prediction.getPredictedFaction().equalsIgnoreCase(contest.getWinnerFaction());
-            prediction.setCorrect(correct);
-            prediction.setPointsAwarded(correct ? calculatePredictionPoints(winnerPredictions, totalPredictions) : 0);
-        }
-        predictionRepository.saveAll(predictions);
-        return predictions;
-    }
-
-    private void postPredictionPointsSummary(
-            MessageChannel threadOrChannel, List<CombatContestPredictionEntity> predictions, Runnable afterPost) {
-        if (predictions.isEmpty()) {
-            if (afterPost != null) afterPost.run();
-            return;
-        }
-
-        List<CombatContestPredictionEntity> winningPredictions = predictions.stream()
-                .filter(prediction -> safeInt(prediction.getPointsAwarded()) > 0)
-                .toList();
-        if (winningPredictions.isEmpty()) {
-            if (afterPost != null) afterPost.run();
-            return;
-        }
-
-        Map<String, Integer> totalsByUser = predictionRepository
-                .findPointTotalsByDiscordUserIdIn(winningPredictions.stream()
-                        .map(CombatContestPredictionEntity::getDiscordUserId)
-                        .toList())
-                .stream()
-                .collect(Collectors.toMap(
-                        CombatContestUserPointsRow::getDiscordUserId, row -> safeInt(row.getTotalPoints())));
-
-        String message = buildLineSection(
-                "## Prediction Points",
-                winningPredictions.stream()
-                        .sorted((left, right) -> {
-                            int pointsComparison = Integer.compare(
-                                    safeInt(right.getPointsAwarded()), safeInt(left.getPointsAwarded()));
-                            if (pointsComparison != 0) return pointsComparison;
-                            return left.getDiscordUserName().compareToIgnoreCase(right.getDiscordUserName());
-                        })
-                        .map(prediction -> {
-                            int pointsAwarded = safeInt(prediction.getPointsAwarded());
-                            int totalPoints = totalsByUser.getOrDefault(prediction.getDiscordUserId(), 0);
-                            return "<@" + prediction.getDiscordUserId() + "> - " + totalPoints + " points (+"
-                                    + pointsAwarded + ")";
-                        }));
-
-        MessageHelper.splitAndSentWithAction(message, threadOrChannel, postedMessage -> {
-            if (afterPost != null) afterPost.run();
-        });
-    }
-
-    private void postSubscriptionPrompt(MessageChannel threadOrChannel) {
-        String message = "Did you like this? React " + SUBSCRIBE_EMOJI
-                + " to subscribe to more, " + UNSUBSCRIBE_EMOJI
-                + " to opt out if already subscribed.\n"
-                + LAZAX_MINIGAME_SUBSCRIPTION_MARKER;
-        MessageHelper.splitAndSentWithAction(message, threadOrChannel, postedMessage -> {
-            postedMessage.addReaction(Emoji.fromUnicode(SUBSCRIBE_EMOJI)).queue(null, BotLogger::catchRestError);
-            postedMessage.addReaction(Emoji.fromUnicode(UNSUBSCRIBE_EMOJI)).queue(null, BotLogger::catchRestError);
-        });
-    }
-
-    private void postParticipantFollowup(Game game, CombatContestEntity contest, MessageChannel threadOrChannel) {
-        Player attacker = game.getPlayerFromColorOrFaction(contest.getAttackerFaction());
-        Player defender = game.getPlayerFromColorOrFaction(contest.getDefenderFaction());
-        if (attacker == null || defender == null) return;
-
-        String message = "## Summons From The Archives\n"
-                + "<@" + attacker.getUserID() + "> <@" + defender.getUserID() + ">\n"
-                + "By decree of the Lazax War Game, your fleets have been judged worthy of remembrance. "
-                + "If it pleases the honored claimants, tarry a moment and read the commentaries, acclaim, and quiet condemnation recorded above concerning your struggle.";
-        MessageHelper.sendMessageToChannel(threadOrChannel, message);
-    }
-
-    private int calculatePredictionPoints(int winnerPredictions, int totalPredictions) {
-        totalPredictions = Math.max(1, totalPredictions);
-        double winnerShare = winnerPredictions / (double) totalPredictions;
-        double scaledPoints = 4.0 / Math.max(winnerShare, ZERO_EPSILON);
-        return (int) Math.round(Math.max(4.0, Math.min(12.0, scaledPoints)));
     }
 
     private String buildResultStamp(
@@ -857,31 +446,161 @@ public class CombatContestService {
 
     private String describeLosses(double initialStrength, double remainingStrength) {
         if (initialStrength <= 0) return "unknown losses";
-        double inflictedDamage = Math.max(0, initialStrength - remainingStrength);
-        if (inflictedDamage <= ZERO_EPSILON) return "no losses";
-        double losses = inflictedDamage / initialStrength;
-        if (losses < 0.2) return "light losses";
-        if (losses < 0.5) return "moderate losses";
-        if (losses < 0.85) return "heavy losses";
+        double lossRatio = Math.max(0, initialStrength - remainingStrength) / initialStrength;
+        if (lossRatio <= ZERO_EPSILON) return "no losses";
+        if (lossRatio < 0.2) return "light losses";
+        if (lossRatio < 0.5) return "moderate losses";
+        if (lossRatio < 0.85) return "heavy losses";
         return "catastrophic losses";
     }
 
-    private MessageChannel getContestThreadOrChannel(CombatContestEntity contest) {
-        if (contest.getPublicThreadId() != null) {
-            ThreadChannel thread = JdaService.guildPrimary.getThreadChannelById(contest.getPublicThreadId());
-            if (thread != null) return thread;
+    // ==================== Predictions ====================
+
+    private void capturePredictions(Game game, Message message, CombatContestEntity contest) {
+        Map<String, Set<String>> factionsByUser = new HashMap<>();
+        Map<String, String> namesByUser = new HashMap<>();
+        Map<String, String> factionToEmoji = Map.of(
+                contest.getAttackerFaction(), getFactionEmoji(game, contest.getAttackerFaction()),
+                contest.getDefenderFaction(), getFactionEmoji(game, contest.getDefenderFaction()));
+
+        for (MessageReaction reaction : message.getReactions()) {
+            String predictedFaction = null;
+            for (Map.Entry<String, String> entry : factionToEmoji.entrySet()) {
+                if (reaction.getEmoji().getFormatted().equals(entry.getValue())) {
+                    predictedFaction = entry.getKey();
+                    break;
+                }
+            }
+            if (predictedFaction == null) continue;
+
+            List<User> users = reaction.retrieveUsers().complete();
+            for (User user : users) {
+                if (user.isBot()) continue;
+                factionsByUser
+                        .computeIfAbsent(user.getId(), key -> new HashSet<>())
+                        .add(predictedFaction);
+                namesByUser.put(user.getId(), user.getName());
+            }
         }
-        if (contest.getPublicChannelId() != null)
-            return JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
-        return null;
+
+        List<CombatContestPredictionEntity> predictions = new ArrayList<>();
+        for (Map.Entry<String, Set<String>> entry : factionsByUser.entrySet()) {
+            if (entry.getValue().size() != 1) continue;
+
+            String predictedFaction = entry.getValue().iterator().next();
+            CombatContestPredictionEntity prediction = new CombatContestPredictionEntity();
+            prediction.setContestId(contest.getId());
+            prediction.setDiscordUserId(entry.getKey());
+            prediction.setDiscordUserName(namesByUser.getOrDefault(entry.getKey(), "Unknown User"));
+            prediction.setPredictedFaction(predictedFaction);
+            prediction.setLockedAt(LocalDateTime.now());
+            predictions.add(prediction);
+        }
+        predictionRepository.saveAll(predictions);
     }
 
-    private TextChannel getContestChannel() {
-        if (JdaService.guildPrimary == null) return null;
-        return JdaService.guildPrimary.getTextChannelsByName(CONTEST_CHANNEL_NAME, true).stream()
-                .findFirst()
-                .orElse(null);
+    private List<CombatContestPredictionEntity> awardPredictionPoints(CombatContestEntity contest) {
+        List<CombatContestPredictionEntity> predictions = predictionRepository.findByContestId(contest.getId());
+        if (predictions.isEmpty()) return predictions;
+
+        int attackerPredictions = (int) predictions.stream()
+                .filter(prediction -> prediction.getPredictedFaction().equalsIgnoreCase(contest.getAttackerFaction()))
+                .count();
+        int defenderPredictions = predictions.size() - attackerPredictions;
+        int winnerPredictions = contest.getWinnerFaction().equalsIgnoreCase(contest.getAttackerFaction())
+                ? attackerPredictions
+                : defenderPredictions;
+        int totalPredictions = attackerPredictions + defenderPredictions;
+        for (CombatContestPredictionEntity prediction : predictions) {
+            boolean correct = prediction.getPredictedFaction().equalsIgnoreCase(contest.getWinnerFaction());
+            prediction.setCorrect(correct);
+            prediction.setPointsAwarded(correct ? calculatePredictionPoints(winnerPredictions, totalPredictions) : 0);
+        }
+        predictionRepository.saveAll(predictions);
+        return predictions;
     }
+
+    private int calculatePredictionPoints(int winnerPredictions, int totalPredictions) {
+        totalPredictions = Math.max(1, totalPredictions);
+        double winnerShare = winnerPredictions / (double) totalPredictions;
+        double scaledPoints = 4.0 / Math.max(winnerShare, ZERO_EPSILON);
+        return (int) Math.round(Math.max(4.0, Math.min(12.0, scaledPoints)));
+    }
+
+    private void postPredictionPointsSummary(
+            MessageChannel threadOrChannel, List<CombatContestPredictionEntity> predictions, Runnable afterPost) {
+        List<CombatContestPredictionEntity> winningPredictions = predictions.stream()
+                .filter(prediction -> safeInt(prediction.getPointsAwarded()) > 0)
+                .toList();
+        if (winningPredictions.isEmpty()) {
+            afterPost.run();
+            return;
+        }
+
+        Map<String, Integer> totalsByUser = predictionRepository
+                .findPointTotalsByDiscordUserIdIn(winningPredictions.stream()
+                        .map(CombatContestPredictionEntity::getDiscordUserId)
+                        .toList())
+                .stream()
+                .collect(Collectors.toMap(
+                        CombatContestUserPointsRow::getDiscordUserId, row -> safeInt(row.getTotalPoints())));
+
+        String message = buildLineSection(
+                "## Prediction Points",
+                winningPredictions.stream()
+                        .sorted((left, right) -> {
+                            int pointsComparison = Integer.compare(
+                                    safeInt(right.getPointsAwarded()), safeInt(left.getPointsAwarded()));
+                            if (pointsComparison != 0) return pointsComparison;
+                            return left.getDiscordUserName().compareToIgnoreCase(right.getDiscordUserName());
+                        })
+                        .map(prediction -> {
+                            int pointsAwarded = safeInt(prediction.getPointsAwarded());
+                            int totalPoints = totalsByUser.getOrDefault(prediction.getDiscordUserId(), 0);
+                            return "<@" + prediction.getDiscordUserId() + "> - " + totalPoints + " points (+"
+                                    + pointsAwarded + ")";
+                        }));
+
+        MessageHelper.splitAndSentWithAction(message, threadOrChannel, postedMessage -> afterPost.run());
+    }
+
+    // ==================== Leaderboard ====================
+
+    private void maybePostLeaderboardAfterResolvedContest() {
+        List<CombatContestEntity> pendingBatch =
+                repository.findTop5ByStatusAndResolvedAtIsNotNullAndLeaderboardPostedAtIsNullOrderByResolvedAtAsc(
+                        CombatContestStatus.RESOLVED);
+        if (pendingBatch.size() < 5) return;
+        if (!postLeaderboard()) return;
+
+        LocalDateTime postedAt = LocalDateTime.now();
+        pendingBatch.forEach(contest -> contest.setLeaderboardPostedAt(postedAt));
+        repository.saveAll(pendingBatch);
+    }
+
+    private String buildLeaderboardMessage() {
+        List<CombatContestLeaderboardRow> topEntries = predictionRepository.findLeaderboardRows(PageRequest.of(0, 10));
+        if (topEntries.isEmpty()) return null;
+
+        final int[] rank = {1};
+        return buildLineSection(
+                "## Lazax War Archives Leaderboard", topEntries.stream().map(entry -> {
+                    long predictions = entry.getPredictionCount() == null ? 0 : entry.getPredictionCount();
+                    long correctPredictions = entry.getCorrectPredictions() == null ? 0 : entry.getCorrectPredictions();
+                    int accuracy = predictions == 0 ? 0 : Math.round((100f * correctPredictions) / predictions);
+                    return '`' + Integer.toString(rank[0]++) + ".` "
+                            + getSafeLeaderboardName(entry.getDiscordUserName())
+                            + " - **" + entry.getTotalPoints() + "** points (`" + correctPredictions + "/" + predictions
+                            + "` correct, " + accuracy + "%)";
+                }));
+    }
+
+    private String getSafeLeaderboardName(String userName) {
+        if (userName == null || userName.isBlank()) return "Unknown User";
+        return userName.replace("@", "@\u200B");
+    }
+
+    // ==================== Hit Tracking ====================
 
     private void trackHitAssignments(
             Game game, Player player, ButtonInteractionEvent event, CombatContestEntity contest) {
@@ -918,19 +637,6 @@ public class CombatContestService {
         return "spacecombat".equals(assignHitsType) || "pds".equals(assignHitsType);
     }
 
-    private String getTilePosition(String buttonId) {
-        String sanitized = stripFactionChecker(buttonId).replace("deleteThis", "");
-        String[] parts = sanitized.split("_");
-        return parts.length > 1 ? parts[1] : "";
-    }
-
-    private String stripFactionChecker(String buttonId) {
-        if (!buttonId.startsWith("FFCC_")) return buttonId;
-        int secondUnderscore = buttonId.indexOf('_', 5);
-        if (secondUnderscore < 0) return buttonId;
-        return buttonId.substring(secondUnderscore + 1);
-    }
-
     private int getCurrentRound(Game game, CombatContestEntity contest) {
         return Math.max(
                 getCurrentRound(game, contest.getAttackerFaction(), contest.getTilePosition()),
@@ -940,15 +646,6 @@ public class CombatContestService {
     private int getCurrentRound(Game game, String faction, String tilePosition) {
         String tracker = game.getStoredValue("combatRoundTracker" + faction + tilePosition + Constants.SPACE);
         return tracker.isBlank() ? 0 : Integer.parseInt(tracker);
-    }
-
-    private boolean matchesParticipants(CombatContestEntity contest, Player player, Player opponent) {
-        return matchesParticipant(contest, player) && matchesParticipant(contest, opponent);
-    }
-
-    private boolean matchesParticipant(CombatContestEntity contest, Player player) {
-        return player.getFaction().equalsIgnoreCase(contest.getAttackerFaction())
-                || player.getFaction().equalsIgnoreCase(contest.getDefenderFaction());
     }
 
     private void postAssignedHitsImage(
@@ -970,6 +667,302 @@ public class CombatContestService {
             MessageHelper.sendMessageToChannel(threadOrChannel, message);
         }
     }
+
+    // ==================== Message Formatting ====================
+
+    private String formatContestPostHeader(
+            Game game, Tile tile, Player attacker, Player defender, String activePlayerSummary) {
+        String attackerLegend = ColorEmojis.getColorEmoji(attacker.getColor()) + " " + attacker.getFactionEmoji()
+                + " = " + attacker.getUserName();
+        String defenderLegend = ColorEmojis.getColorEmoji(defender.getColor()) + " " + defender.getFactionEmoji()
+                + " = " + defender.getUserName();
+        return "## A New Combat Contest Has Emerged!\n"
+                + getLazaxMinigameRoleMention()
+                + "\n"
+                + "**Game:** `" + game.getName() + "`\n"
+                + "**Game Link:** [Open Game](https://asyncti4.com/game/" + game.getName() + ")\n"
+                + activePlayerSummary
+                + "**System:** " + tile.getRepresentationForButtons() + "\n"
+                + "**Combat:** Space Combat\n"
+                + "**Predict the winner by reacting below.**\n"
+                + "- " + attackerLegend + "\n"
+                + "- " + defenderLegend;
+    }
+
+    private String formatActivePlayerSummary(Game game) {
+        Player activePlayer = game.getActivePlayer();
+        if (activePlayer == null) {
+            return "**Active Player:** None\n";
+        }
+        String factionName = activePlayer.getFactionModel() == null
+                ? activePlayer.getFaction()
+                : activePlayer.getFactionModel().getFactionName();
+        return "**Active Player:** " + activePlayer.getFactionEmoji() + " " + factionName + " "
+                + activePlayer.getUserName() + "\n";
+    }
+
+    private String formatCombatTechLine(Player player) {
+        String techSummary = player.getTechs().stream()
+                .map(Mapper::getTech)
+                .filter(Objects::nonNull)
+                .filter(tech -> !player.getPurgedTechs().contains(tech.getAlias()))
+                .filter(tech -> tech.isFactionTech()
+                        || tech.isUnitUpgrade()
+                        || COMBAT_SUMMARY_TECH_ALIASES.contains(tech.getAlias()))
+                .sorted(TECH_COMPARATOR)
+                .map(tech -> tech.getCondensedReqsEmojis(false) + " " + tech.getName())
+                .reduce((left, right) -> left + ", " + right)
+                .orElse("No technologies");
+        return formatPlayerSummaryLine(player, techSummary);
+    }
+
+    private String formatCombatRelicSection(Player attacker, Player defender) {
+        String attackerRelics = formatCombatRelicLine(attacker);
+        String defenderRelics = formatCombatRelicLine(defender);
+        if (attackerRelics == null && defenderRelics == null) return null;
+
+        StringBuilder section = new StringBuilder("## Relics");
+        if (attackerRelics != null) {
+            section.append("\n").append(attackerRelics);
+        }
+        if (defenderRelics != null) {
+            section.append("\n").append(defenderRelics);
+        }
+        return section.toString();
+    }
+
+    private String formatCombatRelicLine(Player player) {
+        String relicSummary = player.getRelics().stream()
+                .distinct()
+                .filter(COMBAT_SUMMARY_RELIC_ALIASES::contains)
+                .map(Mapper::getRelic)
+                .filter(Objects::nonNull)
+                .map(RelicModel::getName)
+                .sorted(String::compareToIgnoreCase)
+                .reduce((left, right) -> left + ", " + right)
+                .orElse(null);
+        if (relicSummary == null) return null;
+
+        return formatPlayerSummaryLine(player, relicSummary);
+    }
+
+    private String formatPlayerSummaryLine(Player player, String summary) {
+        String factionName = player.getFactionModel() == null
+                ? player.getFaction()
+                : player.getFactionModel().getFactionName();
+        return "- " + player.getFactionEmoji() + " " + factionName + " " + player.getUserName() + ": " + summary;
+    }
+
+    private static int getTechTypeOrder(TechnologyModel tech) {
+        TechnologyModel.TechnologyType type = tech.getFirstType();
+        return switch (type) {
+            case PROPULSION -> 0;
+            case BIOTIC -> 1;
+            case CYBERNETIC -> 2;
+            case WARFARE -> 3;
+            case UNITUPGRADE -> 4;
+            case GENERICTF -> 5;
+            case NONE -> 6;
+        };
+    }
+
+    // ==================== Message Posting & Discord ====================
+
+    private void postContestMessage(
+            Game game,
+            Player attacker,
+            Player defender,
+            Tile tile,
+            TextChannel contestChannel,
+            CombatContestEntity contest,
+            SpaceCombatSnapshot snapshot) {
+        Consumer<Message> onMessage = message -> {
+            persistMessageAndThread(game, contest, contestChannel, message, snapshot.threadSummaryText());
+            addPredictionReactions(game, attacker, defender, message);
+        };
+        try {
+            FileUpload fileUpload =
+                    new TileGenerator(game, null, null, 0, tile.getPosition(), attacker).createFileUpload();
+            contestChannel
+                    .sendMessage(new MessageCreateBuilder()
+                            .addContent(snapshot.parentPostText())
+                            .addFiles(fileUpload)
+                            .build())
+                    .queue(
+                            onMessage,
+                            error -> BotLogger.error(
+                                    new LogOrigin(game), "Failed to post combat contest opener.", error));
+        } catch (Exception e) {
+            BotLogger.error(new LogOrigin(game), "Failed to create combat contest opener image.", e);
+            MessageHelper.splitAndSentWithAction(snapshot.parentPostText(), contestChannel, onMessage);
+        }
+    }
+
+    private void persistMessageAndThread(
+            Game game,
+            CombatContestEntity contest,
+            TextChannel contestChannel,
+            Message message,
+            String threadSummaryText) {
+        contest.setPublicChannelId(contestChannel.getIdLong());
+        contest.setPublicMessageId(message.getIdLong());
+        repository.save(contest);
+
+        message.createThreadChannel("combat-predictor-" + contest.getGameName() + "-" + contest.getTilePosition())
+                .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS)
+                .queue(
+                        thread -> {
+                            contest.setPublicThreadId(thread.getIdLong());
+                            repository.save(contest);
+                            postContestThreadIntro(game, contest, thread, threadSummaryText);
+                        },
+                        error -> BotLogger.error(
+                                "Failed to create combat predictor thread for contest " + contest.getId(), error));
+    }
+
+    private void postContestThreadIntro(
+            Game game, CombatContestEntity contest, ThreadChannel thread, String threadSummaryText) {
+        Runnable postIntro = () -> {
+            String intro =
+                    "Use this thread for combat follow-up. The bot will post the result here when the space combat resolves.";
+            MessageHelper.splitAndSentWithAction(
+                    intro, thread, ignored -> postCombatTechSummary(game, contest, thread));
+        };
+        if (threadSummaryText == null) {
+            postIntro.run();
+        } else {
+            MessageHelper.splitAndSentWithAction(threadSummaryText, thread, ignored -> postIntro.run());
+        }
+    }
+
+    private void postCombatTechSummary(Game game, CombatContestEntity contest, MessageChannel threadOrChannel) {
+        Player attacker = game.getPlayerFromColorOrFaction(contest.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(contest.getDefenderFaction());
+        if (attacker == null || defender == null) return;
+
+        StringBuilder message = new StringBuilder("## Combat Technologies\n")
+                .append(formatCombatTechLine(attacker))
+                .append("\n")
+                .append(formatCombatTechLine(defender));
+        String relicSection = formatCombatRelicSection(attacker, defender);
+        if (relicSection != null) {
+            message.append("\n\n").append(relicSection);
+        }
+        MessageHelper.sendMessageToChannel(threadOrChannel, message.toString());
+    }
+
+    private void addPredictionReactions(Game game, Player attacker, Player defender, Message message) {
+        addReaction(game, attacker, message);
+        addReaction(game, defender, message);
+    }
+
+    private void addReaction(Game game, Player player, Message message) {
+        try {
+            message.addReaction(Emoji.fromFormatted(player.getFactionEmoji()))
+                    .queue(
+                            null,
+                            error -> BotLogger.error(
+                                    new LogOrigin(game),
+                                    "Failed to add combat predictor reaction for " + player.getFaction(),
+                                    error));
+        } catch (Exception e) {
+            BotLogger.error(new LogOrigin(game), "Failed to parse combat predictor reaction emoji.", e);
+        }
+    }
+
+    private void postParticipantFollowup(Game game, CombatContestEntity contest, MessageChannel threadOrChannel) {
+        Player attacker = game.getPlayerFromColorOrFaction(contest.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(contest.getDefenderFaction());
+        if (attacker == null || defender == null) return;
+
+        String message = "## Summons From The Archives\n"
+                + "<@" + attacker.getUserID() + "> <@" + defender.getUserID() + ">\n"
+                + "By decree of the Lazax War Game, your fleets have been judged worthy of remembrance. "
+                + "If it pleases the honored claimants, tarry a moment and read the commentaries, acclaim, and quiet condemnation recorded above concerning your struggle.";
+        MessageHelper.sendMessageToChannel(threadOrChannel, message);
+    }
+
+    private void postSubscriptionPrompt(MessageChannel threadOrChannel) {
+        String message = "Did you like this? React " + SUBSCRIBE_EMOJI
+                + " to subscribe to more, " + UNSUBSCRIBE_EMOJI
+                + " to opt out if already subscribed.\n"
+                + LAZAX_MINIGAME_SUBSCRIPTION_MARKER;
+        MessageHelper.splitAndSentWithAction(message, threadOrChannel, postedMessage -> {
+            postedMessage.addReaction(Emoji.fromUnicode(SUBSCRIBE_EMOJI)).queue(null, BotLogger::catchRestError);
+            postedMessage.addReaction(Emoji.fromUnicode(UNSUBSCRIBE_EMOJI)).queue(null, BotLogger::catchRestError);
+        });
+    }
+
+    // ==================== Utilities ====================
+
+    private TextChannel getContestChannel() {
+        if (JdaService.guildPrimary == null) return null;
+        return JdaService.guildPrimary.getTextChannelsByName(CONTEST_CHANNEL_NAME, true).stream()
+                .findFirst()
+                .orElse(null);
+    }
+
+    private TextChannel getContestPublicChannel(CombatContestEntity contest) {
+        if (contest.getPublicChannelId() == null
+                || contest.getPublicMessageId() == null
+                || JdaService.guildPrimary == null) return null;
+        return JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
+    }
+
+    private MessageChannel getContestThreadOrChannel(CombatContestEntity contest) {
+        if (contest.getPublicThreadId() != null) {
+            ThreadChannel thread = JdaService.guildPrimary.getThreadChannelById(contest.getPublicThreadId());
+            if (thread != null) return thread;
+        }
+        if (contest.getPublicChannelId() != null)
+            return JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
+        return null;
+    }
+
+    private String getLazaxMinigameRoleMention() {
+        if (JdaService.guildPrimary == null) return "";
+        Role role = JdaService.guildPrimary.getRolesByName(LAZAX_MINIGAME_ROLE_NAME, true).stream()
+                .findFirst()
+                .orElse(null);
+        return role == null ? "" : role.getAsMention();
+    }
+
+    private boolean matchesParticipants(CombatContestEntity contest, Player player, Player opponent) {
+        return matchesParticipant(contest, player) && matchesParticipant(contest, opponent);
+    }
+
+    private boolean matchesParticipant(CombatContestEntity contest, Player player) {
+        return player.getFaction().equalsIgnoreCase(contest.getAttackerFaction())
+                || player.getFaction().equalsIgnoreCase(contest.getDefenderFaction());
+    }
+
+    private String getFactionEmoji(Game game, String faction) {
+        Player player = game.getPlayerFromColorOrFaction(faction);
+        return player == null ? "" : player.getFactionEmoji();
+    }
+
+    private int safeInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private String buildLineSection(String header, Stream<String> lines) {
+        return lines.collect(Collectors.joining("\n", header + "\n", ""));
+    }
+
+    private String getTilePosition(String buttonId) {
+        String sanitized = stripFactionChecker(buttonId).replace("deleteThis", "");
+        String[] parts = sanitized.split("_");
+        return parts.length > 1 ? parts[1] : "";
+    }
+
+    private String stripFactionChecker(String buttonId) {
+        if (!buttonId.startsWith("FFCC_")) return buttonId;
+        int secondUnderscore = buttonId.indexOf('_', 5);
+        if (secondUnderscore < 0) return buttonId;
+        return buttonId.substring(secondUnderscore + 1);
+    }
+
+    // ==================== Records ====================
 
     private record FleetStrength(double value, double hp, boolean hasNonFighterShip) {}
 

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -97,6 +97,7 @@ public class CombatContestService {
             contest.setDefenderColor(defender.getColor());
             contest.setPostedAt(LocalDateTime.now());
             contest.setInitialSummaryText(snapshot.parentPostText());
+            contest.setActivePlayerSummary(snapshot.activePlayerSummary());
             contest.setInitialStrengthAttacker(snapshot.attackerStrength());
             contest.setInitialStrengthDefender(snapshot.defenderStrength());
             contest.setInitialHpAttacker(snapshot.attackerHp());
@@ -239,7 +240,8 @@ public class CombatContestService {
         String summary = extractSpaceOnlySummary(ButtonHelper.getCombatTileSummaryMessage(
                 game, tile, attacker, null, "space", Constants.SPACE, List.of(attacker, defender)));
 
-        String openerText = formatContestPostHeader(game, tile, attacker, defender);
+        String activePlayerSummary = formatActivePlayerSummary(game);
+        String openerText = formatContestPostHeader(game, tile, attacker, defender, activePlayerSummary);
         String threadSummaryText = null;
         String parentPostText = openerText + "\n\n" + summary;
         if (parentPostText.length() > Message.MAX_CONTENT_LENGTH) {
@@ -249,6 +251,7 @@ public class CombatContestService {
         return new SpaceCombatSnapshot(
                 parentPostText,
                 threadSummaryText,
+                activePlayerSummary,
                 attackerStrength.value(),
                 defenderStrength.value(),
                 attackerStrength.hp(),
@@ -288,7 +291,8 @@ public class CombatContestService {
         return new FleetStrength(total, hp, hasNonFighterShip);
     }
 
-    private String formatContestPostHeader(Game game, Tile tile, Player attacker, Player defender) {
+    private String formatContestPostHeader(
+            Game game, Tile tile, Player attacker, Player defender, String activePlayerSummary) {
         String attackerLegend = ColorEmojis.getColorEmoji(attacker.getColor()) + " " + attacker.getFactionEmoji()
                 + " = " + attacker.getUserName();
         String defenderLegend = ColorEmojis.getColorEmoji(defender.getColor()) + " " + defender.getFactionEmoji()
@@ -298,11 +302,24 @@ public class CombatContestService {
                 + "\n"
                 + "**Game:** `" + game.getName() + "`\n"
                 + "**Game Link:** [Open Game](https://asyncti4.com/game/" + game.getName() + ")\n"
+                + activePlayerSummary
                 + "**System:** " + tile.getRepresentationForButtons() + "\n"
                 + "**Combat:** Space Combat\n"
                 + "**Predict the winner by reacting below.**\n"
                 + "- " + attackerLegend + "\n"
                 + "- " + defenderLegend;
+    }
+
+    private String formatActivePlayerSummary(Game game) {
+        Player activePlayer = game.getActivePlayer();
+        if (activePlayer == null) {
+            return "**Active Player:** None\n";
+        }
+        String factionName = activePlayer.getFactionModel() == null
+                ? activePlayer.getFaction()
+                : activePlayer.getFactionModel().getFactionName();
+        return "**Active Player:** " + activePlayer.getFactionEmoji() + " " + factionName + " "
+                + activePlayer.getUserName() + "\n";
     }
 
     private String getLazaxMinigameRoleMention() {
@@ -1063,6 +1080,7 @@ public class CombatContestService {
     private record SpaceCombatSnapshot(
             String parentPostText,
             String threadSummaryText,
+            String activePlayerSummary,
             double attackerStrength,
             double defenderStrength,
             double attackerHp,

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -101,7 +101,6 @@ public class CombatContestService {
             contest.setInitialStrengthDefender(snapshot.defenderStrength());
             contest.setInitialHpAttacker(snapshot.attackerHp());
             contest.setInitialHpDefender(snapshot.defenderHp());
-            contest.setUpsetIndex(snapshot.upsetIndex());
             long contestId = repository.save(contest).getId();
             postContestMessage(
                     game,
@@ -237,12 +236,10 @@ public class CombatContestService {
         double stronger = Math.max(attackerStrength.hp(), defenderStrength.hp());
         double weaker = Math.min(attackerStrength.hp(), defenderStrength.hp());
         double ratio = stronger == 0 ? 0 : weaker / stronger;
-        CombatContestUpsetIndex upsetIndex = getUpsetIndex(ratio);
         String summary = extractSpaceOnlySummary(ButtonHelper.getCombatTileSummaryMessage(
                 game, tile, attacker, null, "space", Constants.SPACE, List.of(attacker, defender)));
 
-        String openerText =
-                formatContestPostHeader(game, tile, attacker, defender, upsetIndex, attackerStrength, defenderStrength);
+        String openerText = formatContestPostHeader(game, tile, attacker, defender);
         String threadSummaryText = null;
         String parentPostText = openerText + "\n\n" + summary;
         if (parentPostText.length() > Message.MAX_CONTENT_LENGTH) {
@@ -256,8 +253,7 @@ public class CombatContestService {
                 defenderStrength.value(),
                 attackerStrength.hp(),
                 defenderStrength.hp(),
-                ratio,
-                upsetIndex);
+                ratio);
     }
 
     private FleetStrength calculateFleetStrength(Game game, Player player, UnitHolder space) {
@@ -292,14 +288,7 @@ public class CombatContestService {
         return new FleetStrength(total, hp, hasNonFighterShip);
     }
 
-    private String formatContestPostHeader(
-            Game game,
-            Tile tile,
-            Player attacker,
-            Player defender,
-            CombatContestUpsetIndex upsetIndex,
-            FleetStrength attackerStrength,
-            FleetStrength defenderStrength) {
+    private String formatContestPostHeader(Game game, Tile tile, Player attacker, Player defender) {
         String attackerLegend = ColorEmojis.getColorEmoji(attacker.getColor()) + " " + attacker.getFactionEmoji()
                 + " = " + attacker.getUserName();
         String defenderLegend = ColorEmojis.getColorEmoji(defender.getColor()) + " " + defender.getFactionEmoji()
@@ -311,8 +300,6 @@ public class CombatContestService {
                 + "**Game Link:** [Open Game](https://asyncti4.com/game/" + game.getName() + ")\n"
                 + "**System:** " + tile.getRepresentationForButtons() + "\n"
                 + "**Combat:** Space Combat\n"
-                + "**Outlook:** "
-                + formatUpsetIndex(upsetIndex, attacker, defender, attackerStrength.hp(), defenderStrength.hp()) + "\n"
                 + "**Predict the winner by reacting below.**\n"
                 + "- " + attackerLegend + "\n"
                 + "- " + defenderLegend;
@@ -378,46 +365,6 @@ public class CombatContestService {
             if ("----------".equals(line.trim())) break;
         }
         return trimmed.toString().trim();
-    }
-
-    private CombatContestUpsetIndex getUpsetIndex(double ratio) {
-        if (ratio >= 0.9) return CombatContestUpsetIndex.EVEN_FIGHT;
-        if (ratio >= 0.78) return CombatContestUpsetIndex.FAVORED;
-        return CombatContestUpsetIndex.LONG_SHOT;
-    }
-
-    private String formatUpsetIndex(
-            CombatContestUpsetIndex upsetIndex,
-            Player attacker,
-            Player defender,
-            double attackerHp,
-            double defenderHp) {
-        return switch (upsetIndex) {
-            case EVEN_FIGHT -> "Even Fight";
-            case FAVORED, LONG_SHOT -> {
-                Player favoredPlayer = attackerHp >= defenderHp ? attacker : defender;
-                String label = upsetIndex == CombatContestUpsetIndex.FAVORED ? "Favored" : "Long Shot";
-                yield favoredPlayer.getFactionEmoji() + " " + label;
-            }
-        };
-    }
-
-    private String formatUpsetIndex(Game game, CombatContestEntity contest) {
-        Player attacker = game.getPlayerFromColorOrFaction(contest.getAttackerFaction());
-        Player defender = game.getPlayerFromColorOrFaction(contest.getDefenderFaction());
-        if (attacker == null || defender == null) {
-            return switch (contest.getUpsetIndex()) {
-                case EVEN_FIGHT -> "Even Fight";
-                case FAVORED -> "Favored";
-                case LONG_SHOT -> "Long Shot";
-            };
-        }
-        return formatUpsetIndex(
-                contest.getUpsetIndex(),
-                attacker,
-                defender,
-                safeDouble(contest.getInitialHpAttacker()),
-                safeDouble(contest.getInitialHpDefender()));
     }
 
     public boolean postLeaderboard() {
@@ -843,7 +790,6 @@ public class CombatContestService {
         TextChannel contestChannel = JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
         if (contestChannel == null) return;
         StringBuilder updated = new StringBuilder(contest.getInitialSummaryText());
-        updated.append("\n\n-# Contest outlook: ").append(formatUpsetIndex(game, contest));
         if (contest.getPredictionLockedAt() != null) {
             int totalPredictions =
                     safeInt(contest.getLockedAttackerPredictions()) + safeInt(contest.getLockedDefenderPredictions());
@@ -861,10 +807,6 @@ public class CombatContestService {
     }
 
     private int safeInt(Integer value) {
-        return value == null ? 0 : value;
-    }
-
-    private double safeDouble(Double value) {
         return value == null ? 0 : value;
     }
 
@@ -1126,8 +1068,7 @@ public class CombatContestService {
             double defenderStrength,
             double attackerHp,
             double defenderHp,
-            double strengthRatio,
-            CombatContestUpsetIndex upsetIndex) {
+            double strengthRatio) {
         private boolean isMeaningful() {
             double strongerResources = Math.max(attackerStrength, defenderStrength);
             double weakerResources = Math.min(attackerStrength, defenderStrength);

--- a/src/main/java/ti4/spring/service/contest/CombatContestUpsetIndex.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestUpsetIndex.java
@@ -1,7 +1,0 @@
-package ti4.spring.service.contest;
-
-public enum CombatContestUpsetIndex {
-    EVEN_FIGHT,
-    FAVORED,
-    LONG_SHOT
-}


### PR DESCRIPTION
## Summary
- remove the Lazax contest outlook line from the opener and parent summary
- delete the upset-index calculation and enum since they are no longer used
- keep the existing HP-ratio eligibility gate intact

## Testing
- mvn -q -DskipTests compile