### PR TITLE
Fix duplicated Winnu combat dice

### DIFF
--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -807,8 +807,8 @@ public class CombatRollService {
                     unitHolder);
             int numRollsPerUnit = unitModel.getCombatDieCountForAbility(rollType, player);
             if (rollType == CombatRollType.combatround) {
-                CombatStatsService.CombatRoundProfile combatRoundProfile =
-                        CombatStatsService.getCombatRoundProfile(true, unitModel, player, activeSystem, opponent);
+                CombatStatsService.CombatRoundProfile combatRoundProfile = CombatStatsService.getCombatRoundProfile(
+                        true, unitModel, player, activeSystem, opponent, false);
                 modifierToHit += toHit - combatRoundProfile.hitsOn();
                 toHit = combatRoundProfile.hitsOn();
                 numRollsPerUnit = combatRoundProfile.diceCount();

--- a/src/main/java/ti4/service/combat/CombatStatsService.java
+++ b/src/main/java/ti4/service/combat/CombatStatsService.java
@@ -19,18 +19,33 @@ public class CombatStatsService {
 
     public static CombatRoundProfile getCombatRoundProfile(
             boolean participates, UnitModel unitModel, Player player, Tile activeSystem, @Nullable Player opponent) {
-        EffectiveCombatStats effectiveCombatStats = getEffectiveCombatStats(unitModel, player, activeSystem, opponent);
+        return getCombatRoundProfile(participates, unitModel, player, activeSystem, opponent, true);
+    }
+
+    public static CombatRoundProfile getCombatRoundProfile(
+            boolean participates,
+            UnitModel unitModel,
+            Player player,
+            Tile activeSystem,
+            @Nullable Player opponent,
+            boolean includeDisplayOnlyScaling) {
+        EffectiveCombatStats effectiveCombatStats =
+                getEffectiveCombatStats(unitModel, player, activeSystem, opponent, includeDisplayOnlyScaling);
         return new CombatRoundProfile(participates, effectiveCombatStats.diceCount(), effectiveCombatStats.hitsOn());
     }
 
     private static EffectiveCombatStats getEffectiveCombatStats(
-            UnitModel unitModel, Player player, Tile activeSystem, @Nullable Player opponent) {
+            UnitModel unitModel,
+            Player player,
+            Tile activeSystem,
+            @Nullable Player opponent,
+            boolean includeDisplayOnlyScaling) {
         int numRollsPerUnit = unitModel.getCombatDieCountForAbility(CombatRollType.combatround, player);
         int extraDice = 0;
         if (isEidolonLandwasterMech(unitModel, player)) extraDice++;
         if (isEchoOfAscensionFlagship(unitModel, player)) extraDice++;
         numRollsPerUnit += extraDice;
-        if (isWinnuFlagship(unitModel) && numRollsPerUnit <= 0) {
+        if (includeDisplayOnlyScaling && isBaseWinnuFlagship(unitModel) && numRollsPerUnit <= 0) {
             if (opponent != null) {
                 numRollsPerUnit = ButtonHelper.checkNumberNonFighterShips(opponent, activeSystem);
             }
@@ -56,8 +71,8 @@ public class CombatStatsService {
         return unitModel.getUnitType() == UnitType.Mech && player.ownsUnit("tf-eidolonterminus");
     }
 
-    private static boolean isWinnuFlagship(UnitModel unitModel) {
-        return unitModel.getId() != null && unitModel.getId().contains("winnu_flagship");
+    private static boolean isBaseWinnuFlagship(UnitModel unitModel) {
+        return "winnu_flagship".equals(unitModel.getId());
     }
 
     /**

--- a/src/test/java/ti4/service/combat/CombatStatsServiceTest.java
+++ b/src/test/java/ti4/service/combat/CombatStatsServiceTest.java
@@ -1,0 +1,126 @@
+package ti4.service.combat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Leader;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.helpers.CombatModHelper;
+import ti4.helpers.Constants;
+import ti4.helpers.Units;
+import ti4.helpers.Units.UnitType;
+import ti4.image.Mapper;
+import ti4.image.PositionMapper;
+import ti4.model.FactionModel;
+import ti4.model.NamedCombatModifierModel;
+import ti4.model.TileModel;
+import ti4.model.UnitModel;
+import ti4.service.player.PlayerColorService;
+import ti4.testUtils.BaseTi4Test;
+
+class CombatStatsServiceTest extends BaseTi4Test {
+
+    private static Game testGame;
+    private static Player neutral;
+    private static Player winnu;
+
+    @BeforeAll
+    static void setupTestGame() {
+        if (testGame != null) return;
+        testGame = new Game();
+        testGame.newGameSetup();
+        testGame.setName("Test Combat Stats");
+        testGame.setCcNPlasticLimit(false);
+
+        neutral = testGame.setupNeutralPlayer("gray");
+        winnu = setupPlayer("winnu");
+    }
+
+    @Test
+    void baseWinnuScalingIsDisplayOnlyForCombatProfiles() {
+        Tile tile = new Tile("112", getNextPosition());
+        testGame.setTile(tile);
+        tile.addUnit("space", Units.getUnitKey(UnitType.Flagship, winnu.getColorID()), 1);
+        tile.addUnit("space", Units.getUnitKey(UnitType.Carrier, neutral.getColorID()), 1);
+        tile.addUnit("space", Units.getUnitKey(UnitType.Destroyer, neutral.getColorID()), 2);
+
+        TileModel tileModel = tile.getTileModel();
+        Map<UnitModel, Integer> winnuUnits = CombatRollService.getUnitsInCombat(
+                tile, tile.getUnitHolders().get("space"), winnu, null, CombatRollType.combatround, testGame);
+        Map<UnitModel, Integer> neutralUnits = CombatRollService.getUnitsInCombat(
+                tile, tile.getUnitHolders().get("space"), neutral, null, CombatRollType.combatround, testGame);
+        UnitModel winnuFlagship = winnuUnits.keySet().stream()
+                .filter(unit -> "winnu_flagship".equals(unit.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        CombatStatsService.CombatRoundProfile displayProfile =
+                CombatStatsService.getCombatRoundProfile(true, winnuFlagship, winnu, tile, neutral, true);
+        CombatStatsService.CombatRoundProfile rollProfile =
+                CombatStatsService.getCombatRoundProfile(true, winnuFlagship, winnu, tile, neutral, false);
+
+        List<NamedCombatModifierModel> extraRolls = CombatModHelper.getModifiers(
+                winnu,
+                neutral,
+                winnuUnits,
+                neutralUnits,
+                tileModel,
+                testGame,
+                CombatRollType.combatround,
+                Constants.COMBAT_EXTRA_ROLLS);
+        int extraRollCount = CombatModHelper.getCombinedModifierForUnit(
+                winnuFlagship,
+                1,
+                extraRolls,
+                winnu,
+                neutral,
+                testGame,
+                new ArrayList<>(winnuUnits.keySet()),
+                CombatRollType.combatround,
+                tile,
+                tile.getUnitHolders().get("space"));
+
+        Assertions.assertEquals(3, displayProfile.diceCount());
+        Assertions.assertEquals(0, rollProfile.diceCount());
+        Assertions.assertEquals(3, extraRollCount);
+    }
+
+    private static Player setupPlayer(String faction) {
+        FactionModel model = Mapper.getFaction(faction);
+        var player = testGame.addPlayer(model.getAlias(), model.getFactionName());
+        player.setFaction(testGame, faction);
+        player.setFactionEmoji("<" + faction + ">");
+        player.setColor(PlayerColorService.getPreferredColor(player));
+        player.setUnitsOwned(new HashSet<>(model.getUnits()));
+        player.addBreakthrough(model.getBreakthrough());
+        player.setBreakthroughUnlocked(model.getBreakthrough(), true);
+        player.setCommoditiesBase(model.getCommodities());
+        player.setPlanets(model.getHomePlanets());
+        player.setFactionTechs(model.getFactionTech());
+
+        for (Leader leader : player.getLeaders()) {
+            leader.setLocked(false);
+        }
+
+        if (model.getStartingTech() != null) {
+            player.setTechs(model.getStartingTech());
+        }
+        for (String tech : player.getFactionTechs()) {
+            player.addTech(tech);
+        }
+        return player;
+    }
+
+    private static String getNextPosition() {
+        for (String pos : PositionMapper.getTilePositions()) {
+            if (testGame.getTileByPosition(pos) == null) return pos;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- keep base Winnu flagship's variable dice in the pre-combat summary only
- preserve combat-roll execution on the existing combat modifier path so Winnu dice are not counted twice
- add a regression test covering the base Winnu flagship profile and extra-roll modifier split

## Testing
- mvn -q -Dtest=CombatStatsServiceTest test
- mvn -q -Dtest=CombatModifierTest#testWinnuCombatMods test