### PR TITLE
Fix Lazax contest resolution regressions

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -397,9 +397,14 @@ public class CombatContestService {
         TextChannel contestChannel = getContestPublicChannel(contest);
         if (contestChannel == null) return;
 
-        Message message =
-                contestChannel.retrieveMessageById(contest.getPublicMessageId()).complete();
-        capturePredictions(game, message, contest);
+        try {
+            Message message = contestChannel
+                    .retrieveMessageById(contest.getPublicMessageId())
+                    .complete();
+            capturePredictions(game, message, contest);
+        } catch (Exception e) {
+            BotLogger.error(new LogOrigin(game), "Failed to capture combat contest predictions at resolution.", e);
+        }
     }
 
     private void refreshParentMessageSummary(
@@ -812,9 +817,12 @@ public class CombatContestService {
                 .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS)
                 .queue(
                         thread -> {
-                            contest.setPublicThreadId(thread.getIdLong());
-                            repository.save(contest);
-                            postContestThreadIntro(game, contest, thread, threadSummaryText);
+                            CombatContestEntity latest =
+                                    repository.findById(contest.getId()).orElse(null);
+                            if (latest == null) return;
+                            latest.setPublicThreadId(thread.getIdLong());
+                            repository.save(latest);
+                            postContestThreadIntro(game, latest, thread, threadSummaryText);
                         },
                         error -> BotLogger.error(
                                 "Failed to create combat predictor thread for contest " + contest.getId(), error));


### PR DESCRIPTION
## Summary
- catch prediction-capture failures during contest resolution so contests still close instead of getting stuck in POSTED
- reload the latest contest entity before saving the async thread id so thread creation cannot overwrite a newer resolved or cancelled status
- prevent stale active contests from blocking later Lazax War Archives contest nominations for the same game and tile

## Test Plan
- mvn -q -DskipTests compile
- targeted CombatContest test run was not possible because no matching CombatContest* tests exist in the repo