### PR TITLE
Simplify combat contest dynamic scaling

### DIFF
--- a/src/main/java/ti4/cron/CombatContestSelectionCron.java
+++ b/src/main/java/ti4/cron/CombatContestSelectionCron.java
@@ -1,0 +1,32 @@
+package ti4.cron;
+
+import java.util.concurrent.TimeUnit;
+import lombok.experimental.UtilityClass;
+import ti4.logging.BotLogger;
+import ti4.spring.context.SpringContext;
+import ti4.spring.service.contest.CombatContestSelectionService;
+import ti4.spring.service.deploy.ActiveLeaseService;
+
+@UtilityClass
+public class CombatContestSelectionCron {
+
+    public static void register() {
+        CronManager.schedulePeriodically(
+                CombatContestSelectionCron.class,
+                CombatContestSelectionCron::refreshSelectionSettings,
+                30,
+                600,
+                TimeUnit.SECONDS);
+    }
+
+    private static void refreshSelectionSettings() {
+        if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        BotLogger.logCron("Running CombatContestSelectionCron.");
+        try {
+            SpringContext.getBean(CombatContestSelectionService.class).recomputeAndPersistSettings();
+        } catch (Exception e) {
+            BotLogger.error("**CombatContestSelectionCron failed.**", e);
+        }
+        BotLogger.logCron("Finished CombatContestSelectionCron.");
+    }
+}

--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -26,6 +26,7 @@ import ti4.cron.AutoPingCron;
 import ti4.cron.CategoryCleanupCron;
 import ti4.cron.CloseLaunchThreadsCron;
 import ti4.cron.CombatContestLeaderboardCron;
+import ti4.cron.CombatContestSelectionCron;
 import ti4.cron.CronManager;
 import ti4.cron.EndOldGamesCron;
 import ti4.cron.FastScFollowCron;
@@ -305,6 +306,7 @@ public class JdaService {
         SabotageAutoReactCron.register();
         FastScFollowCron.register();
         CloseLaunchThreadsCron.register();
+        CombatContestSelectionCron.register();
         CombatContestLeaderboardCron.register();
         InteractionLogCron.register();
         LongExecutionHistoryCron.register();

--- a/src/main/java/ti4/spring/api/publicstatus/CombatContestSelectionController.java
+++ b/src/main/java/ti4/spring/api/publicstatus/CombatContestSelectionController.java
@@ -1,0 +1,20 @@
+package ti4.spring.api.publicstatus;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ti4.spring.service.contest.CombatContestSelectionService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/public/contest")
+public class CombatContestSelectionController {
+
+    private final CombatContestSelectionService combatContestSelectionService;
+
+    @GetMapping("/selection")
+    public CombatContestSelectionService.Snapshot getSelection() {
+        return combatContestSelectionService.getSelectionSnapshot();
+    }
+}

--- a/src/main/java/ti4/spring/service/contest/CombatContestSampleEntity.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSampleEntity.java
@@ -1,0 +1,79 @@
+package ti4.spring.service.contest;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "combat_predictor_sample",
+        indexes = {
+            @Index(name = "idx_combat_sample_started_at", columnList = "started_at"),
+            @Index(name = "idx_combat_sample_game_tile", columnList = "game_name, tile_position, started_at")
+        })
+public class CombatContestSampleEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "game_name", nullable = false)
+    private String gameName;
+
+    @Column(name = "tile_position", nullable = false)
+    private String tilePosition;
+
+    @Column(name = "attacker_strength", nullable = false)
+    private Double attackerStrength;
+
+    @Column(name = "defender_strength", nullable = false)
+    private Double defenderStrength;
+
+    @Column(name = "attacker_hp", nullable = false)
+    private Double attackerHp;
+
+    @Column(name = "defender_hp", nullable = false)
+    private Double defenderHp;
+
+    @Column(name = "weaker_strength", nullable = false)
+    private Double weakerStrength;
+
+    @Column(name = "stronger_strength", nullable = false)
+    private Double strongerStrength;
+
+    @Column(name = "weaker_hp", nullable = false)
+    private Double weakerHp;
+
+    @Column(name = "stronger_hp", nullable = false)
+    private Double strongerHp;
+
+    @Column(name = "fairness_ratio", nullable = false)
+    private Double fairnessRatio;
+
+    @Column(name = "contest_score", nullable = false)
+    private Double contestScore;
+
+    @Column(name = "score_cutoff_at_start", nullable = false)
+    private Double scoreCutoffAtStart;
+
+    @Column(name = "selection_mode_at_start", nullable = false)
+    private String selectionModeAtStart;
+
+    @Column(name = "eligible_under_current_thresholds", nullable = false)
+    private Boolean eligibleUnderCurrentThresholds;
+
+    @Column(name = "contest_posted", nullable = false)
+    private Boolean contestPosted;
+}

--- a/src/main/java/ti4/spring/service/contest/CombatContestSampleRepository.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSampleRepository.java
@@ -1,0 +1,10 @@
+package ti4.spring.service.contest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CombatContestSampleRepository extends JpaRepository<CombatContestSampleEntity, Long> {
+
+    List<CombatContestSampleEntity> findByStartedAtGreaterThanEqualOrderByStartedAtAsc(LocalDateTime startedAt);
+}

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionConfigEntity.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionConfigEntity.java
@@ -1,0 +1,65 @@
+package ti4.spring.service.contest;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "combat_predictor_selection_config")
+public class CombatContestSelectionConfigEntity {
+
+    @Id
+    @Column(nullable = false)
+    private Integer id;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "selection_mode", nullable = false)
+    private String selectionMode;
+
+    @Column(name = "lookback_minutes", nullable = false)
+    private Integer lookbackMinutes;
+
+    @Column(name = "window_sample_count", nullable = false)
+    private Integer windowSampleCount;
+
+    @Column(name = "target_posts_per_hour", nullable = false)
+    private Double targetPostsPerHour;
+
+    @Column(name = "target_selection_fraction", nullable = false)
+    private Double targetSelectionFraction;
+
+    @Column(name = "score_cutoff", nullable = false)
+    private Double scoreCutoff;
+
+    @Column(name = "strength_scale", nullable = false)
+    private Double strengthScale;
+
+    @Column(name = "hp_scale", nullable = false)
+    private Double hpScale;
+
+    @Column(name = "weaker_strength_weight", nullable = false)
+    private Double weakerStrengthWeight;
+
+    @Column(name = "weaker_hp_weight", nullable = false)
+    private Double weakerHpWeight;
+
+    @Column(name = "fairness_weight", nullable = false)
+    private Double fairnessWeight;
+
+    @Column(name = "cooldown_minutes", nullable = false)
+    private Integer cooldownMinutes;
+
+    @Column(name = "minimum_weaker_strength", nullable = false)
+    private Double minimumWeakerStrength;
+
+    @Column(name = "minimum_sample_count", nullable = false)
+    private Integer minimumSampleCount;
+}

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionConfigRepository.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionConfigRepository.java
@@ -1,0 +1,6 @@
+package ti4.spring.service.contest;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CombatContestSelectionConfigRepository
+        extends JpaRepository<CombatContestSelectionConfigEntity, Integer> {}

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -1,0 +1,291 @@
+package ti4.spring.service.contest;
+
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CombatContestSelectionService {
+
+    private static final int CONFIG_ID = 1;
+    private static final String MODE_WARMUP = "WARMUP";
+    private static final String MODE_DYNAMIC = "DYNAMIC";
+    private static final int LOOKBACK_MINUTES = 60;
+    private static final int MINIMUM_SAMPLE_COUNT = 24;
+    private static final int COOLDOWN_MINUTES = 60;
+    private static final double TARGET_POSTS_PER_HOUR = 1.0;
+    private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
+    private static final double MAX_TARGET_SELECTION_FRACTION = 0.50;
+    private static final double DEFAULT_STRENGTH_SCALE = 28.0;
+    private static final double DEFAULT_HP_SCALE = 10.0;
+    private static final double DEFAULT_SCORE_CUTOFF = 0.78;
+    private static final double MINIMUM_WEAKER_STRENGTH = 8.0;
+    private static final double WEAKER_STRENGTH_WEIGHT = 0.30;
+    private static final double WEAKER_HP_WEIGHT = 0.20;
+    private static final double FAIRNESS_WEIGHT = 0.50;
+    private static final double SCALE_PERCENTILE = 0.90;
+
+    private final CombatContestSampleRepository sampleRepository;
+    private final CombatContestSelectionConfigRepository configRepository;
+
+    private volatile Settings currentSettings = defaultSettings(LocalDateTime.now());
+
+    @PostConstruct
+    void initialize() {
+        loadPersistedSettings();
+    }
+
+    public Evaluation evaluate(double attackerStrength, double defenderStrength, double attackerHp, double defenderHp) {
+        return evaluate(attackerStrength, defenderStrength, attackerHp, defenderHp, currentSettings);
+    }
+
+    public Settings getCurrentSettings() {
+        return currentSettings;
+    }
+
+    public Snapshot getSelectionSnapshot() {
+        Settings settings = currentSettings;
+        int sampleCountLastHour = sampleRepository
+                .findByStartedAtGreaterThanEqualOrderByStartedAtAsc(
+                        LocalDateTime.now().minusMinutes(LOOKBACK_MINUTES))
+                .size();
+        double observedCombatsPerHour = sampleCountLastHour * 60.0 / LOOKBACK_MINUTES;
+        return new Snapshot(settings, sampleCountLastHour, observedCombatsPerHour, LocalDateTime.now());
+    }
+
+    public void loadPersistedSettings() {
+        configRepository.findById(CONFIG_ID).ifPresent(config -> currentSettings = fromEntity(config));
+    }
+
+    public Settings recomputeAndPersistSettings() {
+        LocalDateTime now = LocalDateTime.now();
+        List<CombatContestSampleEntity> samples =
+                sampleRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(now.minusMinutes(LOOKBACK_MINUTES));
+        Settings recomputed = recomputeSettings(samples, now);
+        CombatContestSelectionConfigEntity entity = toEntity(recomputed);
+        configRepository.save(entity);
+        currentSettings = recomputed;
+        return recomputed;
+    }
+
+    private Settings recomputeSettings(List<CombatContestSampleEntity> samples, LocalDateTime now) {
+        if (samples.size() < MINIMUM_SAMPLE_COUNT) {
+            Settings defaults = defaultSettings(now);
+            return new Settings(
+                    defaults.updatedAt(),
+                    MODE_WARMUP,
+                    defaults.lookbackMinutes(),
+                    samples.size(),
+                    defaults.targetPostsPerHour(),
+                    defaults.targetSelectionFraction(),
+                    defaults.scoreCutoff(),
+                    defaults.strengthScale(),
+                    defaults.hpScale(),
+                    defaults.weakerStrengthWeight(),
+                    defaults.weakerHpWeight(),
+                    defaults.fairnessWeight(),
+                    defaults.cooldownMinutes(),
+                    defaults.minimumWeakerStrength(),
+                    defaults.minimumSampleCount());
+        }
+
+        double strengthScale = Math.max(
+                DEFAULT_STRENGTH_SCALE,
+                percentile(
+                        samples.stream()
+                                .map(CombatContestSampleEntity::getWeakerStrength)
+                                .toList(),
+                        SCALE_PERCENTILE));
+        double hpScale = Math.max(
+                DEFAULT_HP_SCALE,
+                percentile(
+                        samples.stream()
+                                .map(CombatContestSampleEntity::getWeakerHp)
+                                .toList(),
+                        SCALE_PERCENTILE));
+
+        List<Double> scores = new ArrayList<>(samples.size());
+        for (CombatContestSampleEntity sample : samples) {
+            scores.add(computeScore(
+                    sample.getWeakerStrength(),
+                    sample.getWeakerHp(),
+                    sample.getFairnessRatio(),
+                    strengthScale,
+                    hpScale,
+                    WEAKER_STRENGTH_WEIGHT,
+                    WEAKER_HP_WEIGHT,
+                    FAIRNESS_WEIGHT));
+        }
+
+        double observedCombatsPerHour = samples.size() * 60.0 / LOOKBACK_MINUTES;
+        double targetSelectionFraction = clamp(
+                TARGET_POSTS_PER_HOUR / Math.max(observedCombatsPerHour, 1.0),
+                MIN_TARGET_SELECTION_FRACTION,
+                MAX_TARGET_SELECTION_FRACTION);
+        double scoreCutoff = percentile(scores, 1.0 - targetSelectionFraction);
+
+        return new Settings(
+                now,
+                MODE_DYNAMIC,
+                LOOKBACK_MINUTES,
+                samples.size(),
+                TARGET_POSTS_PER_HOUR,
+                targetSelectionFraction,
+                scoreCutoff,
+                strengthScale,
+                hpScale,
+                WEAKER_STRENGTH_WEIGHT,
+                WEAKER_HP_WEIGHT,
+                FAIRNESS_WEIGHT,
+                COOLDOWN_MINUTES,
+                MINIMUM_WEAKER_STRENGTH,
+                MINIMUM_SAMPLE_COUNT);
+    }
+
+    private CombatContestSelectionConfigEntity toEntity(Settings settings) {
+        CombatContestSelectionConfigEntity entity = new CombatContestSelectionConfigEntity();
+        entity.setId(CONFIG_ID);
+        entity.setUpdatedAt(settings.updatedAt());
+        entity.setSelectionMode(settings.selectionMode());
+        entity.setLookbackMinutes(settings.lookbackMinutes());
+        entity.setWindowSampleCount(settings.windowSampleCount());
+        entity.setTargetPostsPerHour(settings.targetPostsPerHour());
+        entity.setTargetSelectionFraction(settings.targetSelectionFraction());
+        entity.setScoreCutoff(settings.scoreCutoff());
+        entity.setStrengthScale(settings.strengthScale());
+        entity.setHpScale(settings.hpScale());
+        entity.setWeakerStrengthWeight(settings.weakerStrengthWeight());
+        entity.setWeakerHpWeight(settings.weakerHpWeight());
+        entity.setFairnessWeight(settings.fairnessWeight());
+        entity.setCooldownMinutes(settings.cooldownMinutes());
+        entity.setMinimumWeakerStrength(settings.minimumWeakerStrength());
+        entity.setMinimumSampleCount(settings.minimumSampleCount());
+        return entity;
+    }
+
+    private Settings fromEntity(CombatContestSelectionConfigEntity entity) {
+        return new Settings(
+                entity.getUpdatedAt(),
+                entity.getSelectionMode(),
+                entity.getLookbackMinutes(),
+                entity.getWindowSampleCount(),
+                entity.getTargetPostsPerHour(),
+                entity.getTargetSelectionFraction(),
+                entity.getScoreCutoff(),
+                entity.getStrengthScale(),
+                entity.getHpScale(),
+                entity.getWeakerStrengthWeight(),
+                entity.getWeakerHpWeight(),
+                entity.getFairnessWeight(),
+                entity.getCooldownMinutes(),
+                entity.getMinimumWeakerStrength(),
+                entity.getMinimumSampleCount());
+    }
+
+    private Settings defaultSettings(LocalDateTime now) {
+        return new Settings(
+                now,
+                MODE_WARMUP,
+                LOOKBACK_MINUTES,
+                0,
+                TARGET_POSTS_PER_HOUR,
+                0.15,
+                DEFAULT_SCORE_CUTOFF,
+                DEFAULT_STRENGTH_SCALE,
+                DEFAULT_HP_SCALE,
+                WEAKER_STRENGTH_WEIGHT,
+                WEAKER_HP_WEIGHT,
+                FAIRNESS_WEIGHT,
+                COOLDOWN_MINUTES,
+                MINIMUM_WEAKER_STRENGTH,
+                MINIMUM_SAMPLE_COUNT);
+    }
+
+    private Evaluation evaluate(
+            double attackerStrength, double defenderStrength, double attackerHp, double defenderHp, Settings settings) {
+        double weakerStrength = Math.min(attackerStrength, defenderStrength);
+        double strongerStrength = Math.max(attackerStrength, defenderStrength);
+        double weakerHp = Math.min(attackerHp, defenderHp);
+        double strongerHp = Math.max(attackerHp, defenderHp);
+        double fairnessRatio = strongerHp <= 0 ? 0.0 : weakerHp / strongerHp;
+        double contestScore = computeScore(
+                weakerStrength,
+                weakerHp,
+                fairnessRatio,
+                settings.strengthScale(),
+                settings.hpScale(),
+                settings.weakerStrengthWeight(),
+                settings.weakerHpWeight(),
+                settings.fairnessWeight());
+        boolean eligible = weakerStrength >= settings.minimumWeakerStrength()
+                && attackerHp > 0
+                && defenderHp > 0
+                && contestScore >= settings.scoreCutoff();
+        return new Evaluation(
+                weakerStrength, strongerStrength, weakerHp, strongerHp, fairnessRatio, contestScore, eligible);
+    }
+
+    private double computeScore(
+            double weakerStrength,
+            double weakerHp,
+            double fairnessRatio,
+            double strengthScale,
+            double hpScale,
+            double weakerStrengthWeight,
+            double weakerHpWeight,
+            double fairnessWeight) {
+        return weakerStrengthWeight * normalize(weakerStrength, strengthScale)
+                + weakerHpWeight * normalize(weakerHp, hpScale)
+                + fairnessWeight * clamp(fairnessRatio, 0.0, 1.0);
+    }
+
+    private double normalize(double value, double scale) {
+        if (scale <= 0) return 0.0;
+        return clamp(value / scale, 0.0, 1.0);
+    }
+
+    private double percentile(List<Double> values, double percentile) {
+        if (values.isEmpty()) return 0.0;
+        List<Double> sorted = values.stream().sorted(Comparator.naturalOrder()).toList();
+        int index = (int) Math.ceil(clamp(percentile, 0.0, 1.0) * (sorted.size() - 1));
+        return sorted.get(index);
+    }
+
+    private double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    public record Snapshot(
+            Settings settings, int sampleCountLastHour, double observedCombatsPerHour, LocalDateTime generatedAt) {}
+
+    public record Evaluation(
+            double weakerStrength,
+            double strongerStrength,
+            double weakerHp,
+            double strongerHp,
+            double fairnessRatio,
+            double contestScore,
+            boolean eligibleUnderCurrentThresholds) {}
+
+    public record Settings(
+            LocalDateTime updatedAt,
+            String selectionMode,
+            int lookbackMinutes,
+            int windowSampleCount,
+            double targetPostsPerHour,
+            double targetSelectionFraction,
+            double scoreCutoff,
+            double strengthScale,
+            double hpScale,
+            double weakerStrengthWeight,
+            double weakerHpWeight,
+            double fairnessWeight,
+            int cooldownMinutes,
+            double minimumWeakerStrength,
+            int minimumSampleCount) {}
+}

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -2,8 +2,6 @@ package ti4.spring.service.contest;
 
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,7 +26,6 @@ public class CombatContestSelectionService {
     private static final double WEAKER_STRENGTH_WEIGHT = 0.30;
     private static final double WEAKER_HP_WEIGHT = 0.20;
     private static final double FAIRNESS_WEIGHT = 0.50;
-    private static final double SCALE_PERCENTILE = 0.90;
 
     private final CombatContestSampleRepository sampleRepository;
     private final CombatContestSelectionConfigRepository configRepository;
@@ -94,33 +91,19 @@ public class CombatContestSelectionService {
                     defaults.minimumSampleCount());
         }
 
-        double strengthScale = Math.max(
-                DEFAULT_STRENGTH_SCALE,
-                percentile(
-                        samples.stream()
-                                .map(CombatContestSampleEntity::getWeakerStrength)
-                                .toList(),
-                        SCALE_PERCENTILE));
-        double hpScale = Math.max(
-                DEFAULT_HP_SCALE,
-                percentile(
-                        samples.stream()
-                                .map(CombatContestSampleEntity::getWeakerHp)
-                                .toList(),
-                        SCALE_PERCENTILE));
-
-        List<Double> scores = new ArrayList<>(samples.size());
-        for (CombatContestSampleEntity sample : samples) {
-            scores.add(computeScore(
-                    sample.getWeakerStrength(),
-                    sample.getWeakerHp(),
-                    sample.getFairnessRatio(),
-                    strengthScale,
-                    hpScale,
-                    WEAKER_STRENGTH_WEIGHT,
-                    WEAKER_HP_WEIGHT,
-                    FAIRNESS_WEIGHT));
-        }
+        double strengthScale = DEFAULT_STRENGTH_SCALE;
+        double hpScale = DEFAULT_HP_SCALE;
+        List<Double> scores = samples.stream()
+                .map(sample -> computeScore(
+                        sample.getWeakerStrength(),
+                        sample.getWeakerHp(),
+                        sample.getFairnessRatio(),
+                        strengthScale,
+                        hpScale,
+                        WEAKER_STRENGTH_WEIGHT,
+                        WEAKER_HP_WEIGHT,
+                        FAIRNESS_WEIGHT))
+                .toList();
 
         double observedCombatsPerHour = samples.size() * 60.0 / LOOKBACK_MINUTES;
         double targetSelectionFraction = clamp(
@@ -251,7 +234,7 @@ public class CombatContestSelectionService {
 
     private double percentile(List<Double> values, double percentile) {
         if (values.isEmpty()) return 0.0;
-        List<Double> sorted = values.stream().sorted(Comparator.naturalOrder()).toList();
+        List<Double> sorted = values.stream().sorted().toList();
         int index = (int) Math.ceil(clamp(percentile, 0.0, 1.0) * (sorted.size() - 1));
         return sorted.get(index);
     }

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -55,13 +55,10 @@ public class CombatContestService {
     public static final String LAZAX_MINIGAME_SUBSCRIPTION_MARKER = "-# Lazax Minigame Subscription";
     public static final String LAZAX_MINIGAME_ROLE_NAME = "Lazax Minigame";
     private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives";
-    private static final Duration CONTEST_COOLDOWN = Duration.ofMinutes(10);
-    private static final double MIN_FLEET_RESOURCES = 18.0;
     private static final String THREAD_SUMMARY_HEADER = "## Combat Units\n";
     private static final Set<String> COMBAT_SUMMARY_TECH_ALIASES = Set.of("da", "asc", "x89", "x89c4");
     private static final Set<String> COMBAT_SUMMARY_RELIC_ALIASES = Set.of(
             "metalivoidarmaments", "metalivoidshielding", "lightrailordnance", "baldrick_crownofthalnos", "pi_thalnos");
-    private static final double MIN_HP_RATIO = 0.8;
     private static final double ZERO_EPSILON = 0.0001;
     private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
     private static final String UNSUBSCRIBE_EMOJI = "\uD83D\uDD34";
@@ -73,26 +70,41 @@ public class CombatContestService {
 
     private final CombatContestRepository repository;
     private final CombatContestPredictionRepository predictionRepository;
+    private final CombatContestSampleRepository sampleRepository;
+    private final CombatContestSelectionService selectionService;
 
     // ==================== Public Entry Points ====================
 
     public void onSpaceCombatStarted(Game game, Player attacker, Player defender, Tile tile) {
         try {
             if (!isEligibleGame(game) || !isEligibleCombat(game, attacker, defender, tile)) return;
+
+            SpaceCombatSnapshot snapshot = buildSnapshot(game, attacker, defender, tile);
+            if (snapshot == null) return;
+
+            CombatContestSelectionService.Evaluation evaluation = selectionService.evaluate(
+                    snapshot.attackerStrength(),
+                    snapshot.defenderStrength(),
+                    snapshot.attackerHp(),
+                    snapshot.defenderHp());
+            CombatContestSelectionService.Settings settings = selectionService.getCurrentSettings();
+            CombatContestSampleEntity sample =
+                    sampleRepository.save(buildSampleEntity(game, tile, snapshot, evaluation, settings));
+
             if (repository
                     .findFirstByGameNameAndTilePositionAndCombatTypeAndStatusInOrderByPostedAtDesc(
                             game.getName(), tile.getPosition(), CombatContestType.SPACE, ACTIVE_STATUSES)
                     .isPresent()) {
                 return;
             }
-
-            SpaceCombatSnapshot snapshot = buildSnapshot(game, attacker, defender, tile);
-            if (snapshot == null || !snapshot.isMeaningful()) return;
+            if (!evaluation.eligibleUnderCurrentThresholds() || !cooldownElapsed()) return;
 
             TextChannel contestChannel = getContestChannel();
             if (contestChannel == null) return;
 
             CombatContestEntity contest = repository.save(buildContestEntity(game, attacker, defender, tile, snapshot));
+            sample.setContestPosted(true);
+            sampleRepository.save(sample);
             postContestMessage(game, attacker, defender, tile, contestChannel, contest, snapshot);
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Combat contest nomination failed.", e);
@@ -170,10 +182,12 @@ public class CombatContestService {
     }
 
     private boolean cooldownElapsed() {
+        Duration cooldown =
+                Duration.ofMinutes(selectionService.getCurrentSettings().cooldownMinutes());
         return repository
                 .findFirstByOrderByPostedAtDesc()
                 .map(contest -> Duration.between(contest.getPostedAt(), LocalDateTime.now())
-                                .compareTo(CONTEST_COOLDOWN)
+                                .compareTo(cooldown)
                         >= 0)
                 .orElse(true);
     }
@@ -211,6 +225,33 @@ public class CombatContestService {
         return contest;
     }
 
+    private CombatContestSampleEntity buildSampleEntity(
+            Game game,
+            Tile tile,
+            SpaceCombatSnapshot snapshot,
+            CombatContestSelectionService.Evaluation evaluation,
+            CombatContestSelectionService.Settings settings) {
+        CombatContestSampleEntity sample = new CombatContestSampleEntity();
+        sample.setStartedAt(LocalDateTime.now());
+        sample.setGameName(game.getName());
+        sample.setTilePosition(tile.getPosition());
+        sample.setAttackerStrength(snapshot.attackerStrength());
+        sample.setDefenderStrength(snapshot.defenderStrength());
+        sample.setAttackerHp(snapshot.attackerHp());
+        sample.setDefenderHp(snapshot.defenderHp());
+        sample.setWeakerStrength(evaluation.weakerStrength());
+        sample.setStrongerStrength(evaluation.strongerStrength());
+        sample.setWeakerHp(evaluation.weakerHp());
+        sample.setStrongerHp(evaluation.strongerHp());
+        sample.setFairnessRatio(evaluation.fairnessRatio());
+        sample.setContestScore(evaluation.contestScore());
+        sample.setScoreCutoffAtStart(settings.scoreCutoff());
+        sample.setSelectionModeAtStart(settings.selectionMode());
+        sample.setEligibleUnderCurrentThresholds(evaluation.eligibleUnderCurrentThresholds());
+        sample.setContestPosted(false);
+        return sample;
+    }
+
     // ==================== Combat Snapshot & Strength ====================
 
     private SpaceCombatSnapshot buildSnapshot(Game game, Player attacker, Player defender, Tile tile) {
@@ -219,7 +260,6 @@ public class CombatContestService {
 
         FleetStrength attackerStrength = calculateFleetStrength(game, attacker, space);
         FleetStrength defenderStrength = calculateFleetStrength(game, defender, space);
-        if (!attackerStrength.hasNonFighterShip() || !defenderStrength.hasNonFighterShip()) return null;
 
         double stronger = Math.max(attackerStrength.hp(), defenderStrength.hp());
         double weaker = Math.min(attackerStrength.hp(), defenderStrength.hp());
@@ -249,7 +289,6 @@ public class CombatContestService {
     private FleetStrength calculateFleetStrength(Game game, Player player, UnitHolder space) {
         double total = 0;
         double hp = 0;
-        boolean hasNonFighterShip = false;
         for (UnitKey unitKey : space.getUnitKeys()) {
             if (!unitKey.getColorID().equalsIgnoreCase(player.getColorID())) {
                 continue;
@@ -270,11 +309,8 @@ public class CombatContestService {
                     hp += undamagedUnits;
                 }
             }
-            if (!"fighter".equalsIgnoreCase(unitModel.getBaseType())) {
-                hasNonFighterShip = true;
-            }
         }
-        return new FleetStrength(total, hp, hasNonFighterShip);
+        return new FleetStrength(total, hp);
     }
 
     private String extractSpaceOnlySummary(String summary) {
@@ -972,7 +1008,7 @@ public class CombatContestService {
 
     // ==================== Records ====================
 
-    private record FleetStrength(double value, double hp, boolean hasNonFighterShip) {}
+    private record FleetStrength(double value, double hp) {}
 
     private record SpaceCombatSnapshot(
             String parentPostText,
@@ -982,15 +1018,5 @@ public class CombatContestService {
             double defenderStrength,
             double attackerHp,
             double defenderHp,
-            double strengthRatio) {
-        private boolean isMeaningful() {
-            double strongerResources = Math.max(attackerStrength, defenderStrength);
-            double weakerResources = Math.min(attackerStrength, defenderStrength);
-            return strongerResources >= MIN_FLEET_RESOURCES
-                    && weakerResources >= MIN_FLEET_RESOURCES
-                    && attackerHp > 0
-                    && defenderHp > 0
-                    && strengthRatio >= MIN_HP_RATIO;
-        }
-    }
+            double strengthRatio) {}
 }


### PR DESCRIPTION
## Summary
- keep the lazax contest score formula and hard floor intact
- stop dynamically recomputing strength and hp normalization scales
- only move the score cutoff dynamically based on the recent score distribution

## Testing
- mvn -q -DskipTests compile
- mvn -q spotless:check