### PR TITLE
Increase Lazax contest cooldown to four hours

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -17,7 +17,7 @@ public class CombatContestSelectionService {
     private static final String MODE_DYNAMIC = "DYNAMIC";
     private static final int LOOKBACK_MINUTES = 60;
     private static final int MINIMUM_SAMPLE_COUNT = 24;
-    private static final int COOLDOWN_MINUTES = 60;
+    private static final int COOLDOWN_MINUTES = 240;
     private static final double TARGET_POSTS_PER_HOUR = 1.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
     private static final double MAX_TARGET_SELECTION_FRACTION = 0.50;


### PR DESCRIPTION
## Summary
- increase the default lazax contest cooldown from 60 minutes to 240 minutes
- leave the rest of the dynamic selection logic unchanged

## Testing
- mvn -q -DskipTests compile
- mvn -q spotless:check