### PR TITLE
Raise Lazax underdog payout cap

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -565,7 +565,7 @@ public class CombatContestService {
         totalPredictions = Math.max(1, totalPredictions);
         double winnerShare = winnerPredictions / (double) totalPredictions;
         double scaledPoints = 4.0 / Math.max(winnerShare, ZERO_EPSILON);
-        return (int) Math.round(Math.max(4.0, Math.min(12.0, scaledPoints)));
+        return (int) Math.round(Math.max(4.0, Math.min(100.0, scaledPoints)));
     }
 
     private void postPredictionPointsSummary(


### PR DESCRIPTION
## Summary
- let lazax contest payouts for against-the-crowd winners grow much higher
- raise the payout clamp from 12 points to 100 points so longshot picks can pay out appropriately

## Testing
- mvn -q -DskipTests compile
- mvn -q spotless:check