### PR TITLE
Harden startup lease handoff

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -1,5 +1,8 @@
 package ti4;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -25,10 +28,10 @@ public class AsyncTI4DiscordBot {
         BotLogger.info("\n# __BOT IS STARTING UP__");
 
         ConfigurableApplicationContext applicationContext = SpringApplication.run(AsyncTI4DiscordBot.class, args);
-        JdaLifecycleService jdaLifecycleService = applicationContext.getBean(JdaLifecycleService.class);
+        applicationContext.getBean(JdaLifecycleService.class);
         ActiveLeaseService activeLeaseService = applicationContext.getBean(ActiveLeaseService.class);
 
-        String[] resolvedArgs = jdaLifecycleService.resolveSourceArgs();
+        String[] resolvedArgs = resolveSourceArgs(args);
         JdaService.startJdaAndRegisterListeners(resolvedArgs);
         if (!JdaService.waitForJdaReadyAndInitializeGuilds(resolvedArgs)) {
             applicationContext.close();
@@ -51,5 +54,30 @@ public class AsyncTI4DiscordBot {
         } else {
             BotLogger.info("DEFERRED BACKGROUND MANAGED GAME WARMUP UNTIL THIS PROCESS BECOMES ACTIVE");
         }
+    }
+
+    private static String[] resolveSourceArgs(String[] sourceArgs) {
+        if (sourceArgs.length >= 3) {
+            return sourceArgs;
+        }
+
+        // Compatibility bridge: the legacy startup path passes Discord config as positional args,
+        // while the Compose/docker-rollout deployment path provides the same values via env vars.
+        String botToken = System.getenv("DISCORD_BOT_TOKEN");
+        String botUserId = System.getenv("DISCORD_BOT_USERID");
+        String guildIdList = System.getenv("GUILDID_LIST");
+        if (isBlank(botToken) || isBlank(botUserId) || isBlank(guildIdList)) {
+            return sourceArgs;
+        }
+
+        List<String> resolvedArgs = new ArrayList<>();
+        resolvedArgs.add(botToken);
+        resolvedArgs.add(botUserId);
+        resolvedArgs.addAll(Arrays.asList(guildIdList.trim().split("\\s+")));
+        return resolvedArgs.toArray(String[]::new);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -2,10 +2,16 @@ package ti4;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import ti4.discord.JdaService;
+import ti4.game.persistence.GameManager;
+import ti4.game.persistence.migration.DataMigrationManager;
 import ti4.logging.BotLogger;
 import ti4.logging.RollbarManager;
 import ti4.settings.GlobalSettings;
+import ti4.spring.service.deploy.ActiveLeaseService;
+import ti4.spring.service.jda.JdaLifecycleService;
 
 @EnableScheduling
 @SpringBootApplication
@@ -18,6 +24,32 @@ public class AsyncTI4DiscordBot {
         RollbarManager.init();
         BotLogger.info("\n# __BOT IS STARTING UP__");
 
-        SpringApplication.run(AsyncTI4DiscordBot.class, args);
+        ConfigurableApplicationContext applicationContext = SpringApplication.run(AsyncTI4DiscordBot.class, args);
+        JdaLifecycleService jdaLifecycleService = applicationContext.getBean(JdaLifecycleService.class);
+        ActiveLeaseService activeLeaseService = applicationContext.getBean(ActiveLeaseService.class);
+
+        String[] resolvedArgs = jdaLifecycleService.resolveSourceArgs();
+        JdaService.startJdaAndRegisterListeners(resolvedArgs);
+        if (!JdaService.waitForJdaReadyAndInitializeGuilds(resolvedArgs)) {
+            applicationContext.close();
+            throw new IllegalStateException("Failed to initialize JDA and guilds");
+        }
+        JdaService.loadStaticDataAndResources();
+        JdaService.indexGameNames();
+        activeLeaseService.beginLeaseParticipation(AsyncTI4DiscordBot::runLeaseOwnedStartupWork);
+        JdaService.registerAndStartCronJobs();
+        JdaService.markProcessReady();
+    }
+
+    static void runLeaseOwnedStartupWork() {
+        if (DataMigrationManager.runMigrations()) {
+            BotLogger.info("FINISHED RUNNING MIGRATIONS");
+        }
+
+        if (GameManager.startManagedGamesWarmupIfNeeded()) {
+            BotLogger.info("STARTED BACKGROUND MANAGED GAME WARMUP");
+        } else {
+            BotLogger.info("DEFERRED BACKGROUND MANAGED GAME WARMUP UNTIL THIS PROCESS BECOMES ACTIVE");
+        }
     }
 }

--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -48,7 +48,6 @@ import ti4.discord.interactions.listeners.ListenerManager;
 import ti4.discord.interactions.selections.SelectionManager;
 import ti4.executors.ExecutorServiceManager;
 import ti4.game.persistence.GameManager;
-import ti4.game.persistence.migration.DataMigrationManager;
 import ti4.helpers.AliasHandler;
 import ti4.helpers.Constants;
 import ti4.helpers.Storage;
@@ -102,7 +101,7 @@ public class JdaService {
     public static final List<Guild> serversToCreateNewGamesOn = new ArrayList<>();
     public static final List<Guild> fowServers = new ArrayList<>();
 
-    public static void initialize(String[] args) {
+    public static void startJdaAndRegisterListeners(String[] args) {
         BotLogger.info("STARTING JDA");
         jda = JDABuilder.createDefault(args[0])
                 // This is a privileged gateway intent that is used to update user information and join/leaves
@@ -124,13 +123,15 @@ public class JdaService {
 
         BotLogger.info("INITIALIZING LISTENERS");
         ListenerManager.registerListeners(jda);
+    }
 
+    public static boolean waitForJdaReadyAndInitializeGuilds(String[] args) {
         BotLogger.info("AWAITING JDA READY");
         try {
             jda.awaitReady();
         } catch (Throwable t) {
             BotLogger.critical("Error waiting for bot to get ready", t);
-            return;
+            return false;
         }
 
         jda.getPresence()
@@ -144,7 +145,7 @@ public class JdaService {
 
         if (guildPrimary == null) {
             BotLogger.critical("Failed to start the bot on the primary guild. Aborting.");
-            return;
+            return false;
         }
 
         // Community Plays TI
@@ -256,8 +257,10 @@ public class JdaService {
                     "BOT-LOG WEBHOOK NOT FOUND for Primary GuildID:" + guildPrimaryID
                             + "\nPlease set a valid bot-log Webhook URL using `/developer setting setting_name:bot_log_webhook_url setting_type:string setting_value:<url>`");
         }
+        return true;
+    }
 
-        // LOAD DATA
+    public static void loadStaticDataAndResources() {
         BotLogger.info("LOADING DATA");
         jda.getPresence().setActivity(Activity.customStatus("STARTING UP: Loading Data"));
         ApplicationEmojiService.uploadNewEmojis();
@@ -275,23 +278,16 @@ public class JdaService {
         SelectionManager.init();
         initializeWhitelistedRoles();
         TIGLHelper.validateTIGLness();
+    }
 
+    public static void indexGameNames() {
         jda.getPresence().setActivity(Activity.customStatus("STARTING UP: Indexing Game Names"));
-
         BotLogger.info("INDEXING GAME NAMES");
         GameManager.initialize();
         BotLogger.info("FINISHED INDEXING GAME NAMES");
-        if (GameManager.startManagedGamesWarmupIfNeeded()) {
-            BotLogger.info("STARTED BACKGROUND MANAGED GAME WARMUP");
-        } else {
-            BotLogger.info("DEFERRED BACKGROUND MANAGED GAME WARMUP UNTIL THIS PROCESS BECOMES ACTIVE");
-        }
+    }
 
-        if (DataMigrationManager.runMigrations()) {
-            BotLogger.info("FINISHED RUNNING MIGRATIONS");
-        }
-
-        // START CRONS
+    public static void registerAndStartCronJobs() {
         AutoPingCron.register();
         ReuploadStaleEmojisCron.register();
         LogCacheStatsCron.register();
@@ -311,8 +307,9 @@ public class JdaService {
         InteractionLogCron.register();
         LongExecutionHistoryCron.register();
         CategoryCleanupCron.register();
+    }
 
-        // BOT IS READY
+    public static void markProcessReady() {
         ActiveLeaseService.setCurrentProcessReady(true);
         BotLogger.info("BOT IS READY TO RECEIVE COMMANDS");
         if (GameManager.isManagedGamesWarmupComplete()) {

--- a/src/main/java/ti4/spring/api/PingController.java
+++ b/src/main/java/ti4/spring/api/PingController.java
@@ -1,16 +1,28 @@
 package ti4.spring.api;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import ti4.spring.service.deploy.ActiveLeaseService;
 
 @RestController
 @RequestMapping("/api/public/ping")
 public class PingController {
 
+    private final ActiveLeaseService activeLeaseService;
+
+    public PingController(ActiveLeaseService activeLeaseService) {
+        this.activeLeaseService = activeLeaseService;
+    }
+
     @GetMapping
     public ResponseEntity<String> ping() {
-        return ResponseEntity.ok("pong");
+        return ResponseEntity.status(
+                        activeLeaseService.isLeaseParticipationEnabled()
+                                ? HttpStatus.OK
+                                : HttpStatus.SERVICE_UNAVAILABLE)
+                .body(activeLeaseService.isLeaseParticipationEnabled() ? "pong" : "not takeover capable");
     }
 }

--- a/src/main/java/ti4/spring/service/deploy/ActiveLeaseRepository.java
+++ b/src/main/java/ti4/spring/service/deploy/ActiveLeaseRepository.java
@@ -1,5 +1,56 @@
 package ti4.spring.service.deploy;
 
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ActiveLeaseRepository extends JpaRepository<ActiveLeaseEntity, String> {}
+public interface ActiveLeaseRepository extends JpaRepository<ActiveLeaseEntity, String> {
+
+    @Modifying
+    @Query(value = """
+                    insert into active_lease (lease_key, instance_id, lease_expires_at, heartbeat_at)
+                    values (:leaseKey, :instanceId, :leaseExpiresAt, :heartbeatAt)
+                    on conflict (lease_key) do nothing
+                    """, nativeQuery = true)
+    int insertLeaseRowIfAbsent(
+            @Param("leaseKey") String leaseKey,
+            @Param("instanceId") String instanceId,
+            @Param("leaseExpiresAt") Instant leaseExpiresAt,
+            @Param("heartbeatAt") Instant heartbeatAt);
+
+    @Modifying
+    @Query("""
+            update ActiveLeaseEntity lease
+            set lease.instanceId = :instanceId,
+                lease.leaseExpiresAt = :leaseExpiresAt,
+                lease.heartbeatAt = :heartbeatAt
+            where lease.leaseKey = :leaseKey
+              and (
+                lease.instanceId = :instanceId
+                or lease.leaseExpiresAt is null
+                or lease.leaseExpiresAt < :now
+              )
+            """)
+    int claimLease(
+            @Param("leaseKey") String leaseKey,
+            @Param("instanceId") String instanceId,
+            @Param("leaseExpiresAt") Instant leaseExpiresAt,
+            @Param("heartbeatAt") Instant heartbeatAt,
+            @Param("now") Instant now);
+
+    @Modifying
+    @Query("""
+            update ActiveLeaseEntity lease
+            set lease.leaseExpiresAt = :leaseExpiresAt,
+                lease.heartbeatAt = :heartbeatAt
+            where lease.leaseKey = :leaseKey
+              and lease.instanceId = :instanceId
+            """)
+    int updateLeaseIfOwned(
+            @Param("leaseKey") String leaseKey,
+            @Param("instanceId") String instanceId,
+            @Param("leaseExpiresAt") Instant leaseExpiresAt,
+            @Param("heartbeatAt") Instant heartbeatAt);
+}

--- a/src/main/java/ti4/spring/service/deploy/ActiveLeaseService.java
+++ b/src/main/java/ti4/spring/service/deploy/ActiveLeaseService.java
@@ -1,15 +1,12 @@
 package ti4.spring.service.deploy;
 
-import jakarta.annotation.PostConstruct;
 import java.time.Instant;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import ti4.game.persistence.GameManager;
 import ti4.logging.BotLogger;
 import ti4.spring.context.SpringContext;
 
@@ -23,81 +20,85 @@ public class ActiveLeaseService {
 
     private final ActiveLeaseRepository activeLeaseRepository;
     private final LeaseProperties leaseProperties;
+    private final ActiveLeaseTransactionService activeLeaseTransactionService;
 
     private final String instanceId = UUID.randomUUID().toString();
     private final AtomicBoolean active = new AtomicBoolean(false);
     private final AtomicBoolean draining = new AtomicBoolean(false);
     private final AtomicBoolean ready = new AtomicBoolean(false);
-    private final AtomicBoolean leaseParticipationEnabled = new AtomicBoolean(true);
+    private final AtomicBoolean leaseParticipationEnabled = new AtomicBoolean(false);
+    private volatile Runnable onLeaseAcquired = () -> {};
 
-    @PostConstruct
-    void acquireOnStartup() {
-        boolean acquired = tryAcquireLease();
-        setActive(acquired);
+    public boolean beginLeaseParticipation(Runnable onLeaseAcquired) {
+        this.onLeaseAcquired = Objects.requireNonNull(onLeaseAcquired);
+        leaseParticipationEnabled.set(true);
+
+        boolean acquired = tryAcquireLease(onLeaseAcquired);
         if (acquired) {
             BotLogger.info("Acquired active lease for instance " + instanceId);
         } else {
             BotLogger.warning("Did not acquire active lease on startup for instance " + instanceId);
         }
+        return acquired;
     }
 
-    /** Attempts to acquire or steal an expired lease for the current process. */
-    @Transactional
     public boolean tryAcquireLease() {
-        Instant now = Instant.now();
-        Optional<ActiveLeaseEntity> existing = activeLeaseRepository.findById(leaseProperties.getLeaseKey());
-        if (existing.isPresent()) {
-            ActiveLeaseEntity lease = existing.get();
-            if (!instanceId.equals(lease.getInstanceId()) && !isExpired(lease, now)) {
-                return false;
-            }
+        if (!activeLeaseTransactionService.tryAcquireLease(instanceId)) {
+            return false;
         }
 
-        activeLeaseRepository.save(buildLease(now));
         setActive(true);
         setDraining(false);
-        GameManager.startManagedGamesWarmupIfNeeded();
+        onLeaseAcquired.run();
         return true;
     }
 
-    /** Extends the lease while this process remains active. */
-    @Transactional
+    public boolean tryAcquireLease(Runnable onLeaseAcquired) {
+        if (!activeLeaseTransactionService.tryAcquireLease(instanceId)) {
+            return false;
+        }
+
+        setActive(true);
+        setDraining(false);
+        onLeaseAcquired.run();
+        return true;
+    }
+
     public void renewLease() {
         if (!isActive()) {
             return;
         }
-        activeLeaseRepository.save(buildLease(Instant.now()));
+
+        if (!activeLeaseTransactionService.renewLease(instanceId)) {
+            BotLogger.warning("Active instance lost lease ownership: " + instanceId);
+            setReady(false);
+            setActive(false);
+        }
     }
 
-    /** Releases the lease if it is currently owned by this process. */
-    @Transactional
     public void releaseLease() {
-        Optional<ActiveLeaseEntity> existing = activeLeaseRepository.findById(leaseProperties.getLeaseKey());
-        if (existing.isPresent() && instanceId.equals(existing.get().getInstanceId())) {
-            activeLeaseRepository.delete(existing.get());
-        }
+        activeLeaseTransactionService.releaseLease(instanceId);
         setActive(false);
     }
 
-    /** Returns whether the shared lease row is still owned by this process. */
     public boolean stillOwnsLease() {
+        Instant now = Instant.now();
         return activeLeaseRepository
                 .findById(leaseProperties.getLeaseKey())
-                .map(lease -> instanceId.equals(lease.getInstanceId()))
+                .map(lease -> instanceId.equals(lease.getInstanceId())
+                        && lease.getLeaseExpiresAt() != null
+                        && lease.getLeaseExpiresAt().isAfter(now))
                 .orElse(false);
     }
 
-    /** Returns whether this process may perform persistent game mutations right now. */
     public boolean mayMutate() {
         return isActive() && stillOwnsLease();
     }
 
-    /** Returns whether this process is the currently active instance. */
     public boolean isActive() {
         return active.get();
     }
 
-    /** Marks this process active or inactive, clearing drain state when deactivating. */
     public void setActive(boolean active) {
         this.active.set(active);
         if (!active) {
@@ -105,37 +106,30 @@ public class ActiveLeaseService {
         }
     }
 
-    /** Returns whether this process is draining and refusing new work. */
     public boolean isDraining() {
         return draining.get();
     }
 
-    /** Marks this process as draining or not draining. */
     public void setDraining(boolean draining) {
         this.draining.set(draining);
     }
 
-    /** Returns whether this process should handle Discord interaction ingress. */
     public boolean shouldHandleDiscordInteraction() {
         return isActive() && !isDraining();
     }
 
-    /** Returns whether startup has completed for this process. */
     public boolean isReady() {
         return ready.get();
     }
 
-    /** Marks this process ready or not ready for normal traffic. */
     public void setReady(boolean ready) {
         this.ready.set(ready);
     }
 
-    /** Returns whether this process should currently serve normal HTTP traffic. */
     public boolean shouldServeTraffic() {
         return isReady() && mayMutate() && !isDraining();
     }
 
-    /** Initiates drain and closes the Spring context on a background thread. */
     public boolean requestDrain() {
         if (!isActive() || isDraining()) {
             return false;
@@ -149,12 +143,10 @@ public class ActiveLeaseService {
         return true;
     }
 
-    /** Returns the randomly generated identifier used for this process in the lease row. */
     public String currentInstanceId() {
         return instanceId;
     }
 
-    /** Returns a log prefix for non-serving process states, or an empty string for the active serving instance. */
     public String currentProcessLogPrefix() {
         if (shouldServeTraffic()) {
             return "";
@@ -175,13 +167,7 @@ public class ActiveLeaseService {
         }
 
         if (isActive()) {
-            if (stillOwnsLease()) {
-                renewLease();
-            } else {
-                BotLogger.warning("Active instance lost lease ownership: " + instanceId);
-                setReady(false);
-                setActive(false);
-            }
+            renewLease();
             return;
         }
 
@@ -195,20 +181,6 @@ public class ActiveLeaseService {
         }
     }
 
-    private ActiveLeaseEntity buildLease(Instant now) {
-        ActiveLeaseEntity lease = new ActiveLeaseEntity();
-        lease.setLeaseKey(leaseProperties.getLeaseKey());
-        lease.setInstanceId(instanceId);
-        lease.setHeartbeatAt(now);
-        lease.setLeaseExpiresAt(now.plusSeconds(leaseProperties.getLeaseDurationSeconds()));
-        return lease;
-    }
-
-    private boolean isExpired(ActiveLeaseEntity lease, Instant now) {
-        return lease.getLeaseExpiresAt() == null || lease.getLeaseExpiresAt().isBefore(now);
-    }
-
-    /** Returns current-process readiness, defaulting to false before Spring has initialized. */
     public static boolean isCurrentProcessReady() {
         try {
             return SpringContext.getBean(ActiveLeaseService.class).isReady();
@@ -217,7 +189,6 @@ public class ActiveLeaseService {
         }
     }
 
-    /** Updates current-process readiness if Spring has initialized. */
     public static void setCurrentProcessReady(boolean ready) {
         try {
             SpringContext.getBean(ActiveLeaseService.class).setReady(ready);
@@ -226,7 +197,6 @@ public class ActiveLeaseService {
         }
     }
 
-    /** Returns whether the current process should handle a Discord interaction. */
     public static boolean shouldHandleCurrentProcessInteraction() {
         try {
             return SpringContext.getBean(ActiveLeaseService.class).shouldHandleDiscordInteraction();
@@ -235,7 +205,6 @@ public class ActiveLeaseService {
         }
     }
 
-    /** Returns whether the current process should serve normal HTTP traffic. */
     public static boolean shouldCurrentProcessServeTraffic() {
         try {
             return SpringContext.getBean(ActiveLeaseService.class).shouldServeTraffic();
@@ -244,7 +213,6 @@ public class ActiveLeaseService {
         }
     }
 
-    /** Returns whether the current process should run active-instance scheduled work. */
     public static boolean shouldCurrentProcessRunScheduledWork() {
         try {
             ActiveLeaseService activeLeaseService = SpringContext.getBean(ActiveLeaseService.class);
@@ -254,7 +222,6 @@ public class ActiveLeaseService {
         }
     }
 
-    /** Returns a log prefix for non-serving process states, defaulting to startup when Spring is unavailable. */
     public static String getCurrentProcessLogPrefix() {
         try {
             return SpringContext.getBean(ActiveLeaseService.class).currentProcessLogPrefix();

--- a/src/main/java/ti4/spring/service/deploy/ActiveLeaseService.java
+++ b/src/main/java/ti4/spring/service/deploy/ActiveLeaseService.java
@@ -126,6 +126,10 @@ public class ActiveLeaseService {
         this.ready.set(ready);
     }
 
+    public boolean isLeaseParticipationEnabled() {
+        return leaseParticipationEnabled.get();
+    }
+
     public boolean shouldServeTraffic() {
         return isReady() && mayMutate() && !isDraining();
     }

--- a/src/main/java/ti4/spring/service/deploy/ActiveLeaseTransactionService.java
+++ b/src/main/java/ti4/spring/service/deploy/ActiveLeaseTransactionService.java
@@ -1,0 +1,41 @@
+package ti4.spring.service.deploy;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ActiveLeaseTransactionService {
+
+    private final ActiveLeaseRepository activeLeaseRepository;
+    private final LeaseProperties leaseProperties;
+
+    @Transactional
+    public boolean tryAcquireLease(String instanceId) {
+        Instant now = Instant.now();
+        String leaseKey = leaseProperties.getLeaseKey();
+        activeLeaseRepository.insertLeaseRowIfAbsent(leaseKey, "", Instant.EPOCH, Instant.EPOCH);
+        return activeLeaseRepository.claimLease(
+                        leaseKey, instanceId, now.plusSeconds(leaseProperties.getLeaseDurationSeconds()), now, now)
+                == 1;
+    }
+
+    @Transactional
+    public boolean renewLease(String instanceId) {
+        Instant now = Instant.now();
+        return activeLeaseRepository.updateLeaseIfOwned(
+                        leaseProperties.getLeaseKey(),
+                        instanceId,
+                        now.plusSeconds(leaseProperties.getLeaseDurationSeconds()),
+                        now)
+                == 1;
+    }
+
+    @Transactional
+    public void releaseLease(String instanceId) {
+        Instant now = Instant.now();
+        activeLeaseRepository.updateLeaseIfOwned(leaseProperties.getLeaseKey(), instanceId, now.minusSeconds(1), now);
+    }
+}

--- a/src/main/java/ti4/spring/service/jda/JdaLifecycleService.java
+++ b/src/main/java/ti4/spring/service/jda/JdaLifecycleService.java
@@ -1,6 +1,5 @@
 package ti4.spring.service.jda;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,21 +11,16 @@ import ti4.discord.JdaService;
 
 @Service
 @RequiredArgsConstructor
-class JdaLifecycleService {
+public class JdaLifecycleService {
 
     private final ApplicationArguments applicationArguments;
-
-    @PostConstruct
-    private void init() {
-        JdaService.initialize(resolveSourceArgs());
-    }
 
     @PreDestroy
     private void shutdown() {
         JdaService.shutdown();
     }
 
-    private String[] resolveSourceArgs() {
+    public String[] resolveSourceArgs() {
         String[] sourceArgs = applicationArguments.getSourceArgs();
         if (sourceArgs.length >= 3) {
             return sourceArgs;

--- a/src/main/java/ti4/spring/service/jda/JdaLifecycleService.java
+++ b/src/main/java/ti4/spring/service/jda/JdaLifecycleService.java
@@ -1,48 +1,14 @@
 package ti4.spring.service.jda;
 
 import jakarta.annotation.PreDestroy;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.ApplicationArguments;
 import org.springframework.stereotype.Service;
 import ti4.discord.JdaService;
 
 @Service
-@RequiredArgsConstructor
 public class JdaLifecycleService {
-
-    private final ApplicationArguments applicationArguments;
 
     @PreDestroy
     private void shutdown() {
         JdaService.shutdown();
-    }
-
-    public String[] resolveSourceArgs() {
-        String[] sourceArgs = applicationArguments.getSourceArgs();
-        if (sourceArgs.length >= 3) {
-            return sourceArgs;
-        }
-
-        // Compatibility bridge: the legacy startup path passes Discord config as positional args,
-        // while the Compose/docker-rollout deployment path provides the same values via env vars.
-        String botToken = System.getenv("DISCORD_BOT_TOKEN");
-        String botUserId = System.getenv("DISCORD_BOT_USERID");
-        String guildIdList = System.getenv("GUILDID_LIST");
-        if (isBlank(botToken) || isBlank(botUserId) || isBlank(guildIdList)) {
-            return sourceArgs;
-        }
-
-        List<String> resolvedArgs = new ArrayList<>();
-        resolvedArgs.add(botToken);
-        resolvedArgs.add(botUserId);
-        resolvedArgs.addAll(Arrays.asList(guildIdList.trim().split("\\s+")));
-        return resolvedArgs.toArray(String[]::new);
-    }
-
-    private boolean isBlank(String value) {
-        return value == null || value.isBlank();
     }
 }


### PR DESCRIPTION
## Summary
- move startup orchestration into explicit phases in `main()` and run lease-owned startup work through a named callback
- harden lease claiming/renewal/release with dedicated transactional operations and single-winner conditional updates
- abort startup when JDA or primary guild initialization fails instead of continuing into readiness and lease participation

## Test Plan
- `mvn -q -DskipTests compile`