### PR TITLE
Fix Lazax contest cooldown and fairness scoring

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestRepository.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestRepository.java
@@ -11,7 +11,9 @@ public interface CombatContestRepository extends JpaRepository<CombatContestEnti
     @Query(value = """
             select *
             from combat_predictor_contest
-            where dice_rolled is null or dice_rolled = true
+            where status <> 'CANCELLED'
+               or dice_rolled is null
+               or dice_rolled = true
             order by posted_at desc
             limit 1
             """, nativeQuery = true)

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -212,7 +212,9 @@ public class CombatContestSelectionService {
         double strongerStrength = Math.max(attackerStrength, defenderStrength);
         double weakerHp = Math.min(attackerHp, defenderHp);
         double strongerHp = Math.max(attackerHp, defenderHp);
-        double fairnessRatio = strongerHp <= 0 ? 0.0 : weakerHp / strongerHp;
+        double strengthFairnessRatio = computeFairnessRatio(weakerStrength, strongerStrength);
+        double hpFairnessRatio = computeFairnessRatio(weakerHp, strongerHp);
+        double fairnessRatio = (strengthFairnessRatio + hpFairnessRatio) / 2.0;
         double contestScore = computeScore(
                 weakerStrength,
                 weakerHp,
@@ -228,6 +230,11 @@ public class CombatContestSelectionService {
                 && contestScore >= settings.scoreCutoff();
         return new Evaluation(
                 weakerStrength, strongerStrength, weakerHp, strongerHp, fairnessRatio, contestScore, eligible);
+    }
+
+    private double computeFairnessRatio(double weakerValue, double strongerValue) {
+        if (strongerValue <= 0) return 0.0;
+        return clamp(weakerValue / strongerValue, 0.0, 1.0);
     }
 
     private double computeScore(

--- a/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
+++ b/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
@@ -1,0 +1,26 @@
+package ti4.spring.service.contest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class CombatContestSelectionServiceTest {
+
+    private final CombatContestSelectionService service = new CombatContestSelectionService(
+            mock(CombatContestSampleRepository.class), mock(CombatContestSelectionConfigRepository.class));
+
+    @Test
+    void fairnessAccountsForStrengthAndHpBalance() {
+        CombatContestSelectionService.Evaluation strengthMismatch = service.evaluate(20, 40, 10, 10);
+        CombatContestSelectionService.Evaluation hpMismatch = service.evaluate(20, 20, 5, 10);
+        CombatContestSelectionService.Evaluation balanced = service.evaluate(20, 20, 10, 10);
+
+        assertEquals(0.75, strengthMismatch.fairnessRatio(), 0.0001);
+        assertEquals(0.75, hpMismatch.fairnessRatio(), 0.0001);
+        assertEquals(1.0, balanced.fairnessRatio(), 0.0001);
+        assertTrue(balanced.contestScore() > strengthMismatch.contestScore());
+        assertTrue(balanced.contestScore() > hpMismatch.contestScore());
+    }
+}


### PR DESCRIPTION
## Summary
- exclude only cancelled no-roll Lazax contests from the cooldown calculation so pending combats still block new contests
- update contest fairness to average the strength balance and HP balance instead of only using HP
- add a unit test covering fairness penalties for strength and HP mismatches

## Test Plan
- mvn -q -Dtest=CombatContestSelectionServiceTest test
- mvn -q -DskipTests compile