### PR TITLE
Tune Lazax Dynamic Combat System

### DIFF
--- a/src/main/java/ti4/spring/api/publicstatus/CombatContestSelectionController.java
+++ b/src/main/java/ti4/spring/api/publicstatus/CombatContestSelectionController.java
@@ -29,6 +29,50 @@ public class CombatContestSelectionController {
     public ResponseEntity<String> getSelection() {
         CombatContestSelectionService.Snapshot snapshot =
                 combatContestSelectionService.recomputeAndGetSelectionSnapshot();
-        return ResponseEntity.ok(MAPPER.writeValueAsString(snapshot));
+        return ResponseEntity.ok(MAPPER.writeValueAsString(SelectionResponse.from(snapshot)));
     }
+
+    private record SelectionResponse(Metadata metadata, LiveWindow liveWindow, Thresholds thresholds, Tuning tuning) {
+
+        static SelectionResponse from(CombatContestSelectionService.Snapshot snapshot) {
+            CombatContestSelectionService.Settings settings = snapshot.settings();
+            return new SelectionResponse(
+                    new Metadata(settings.updatedAt(), snapshot.generatedAt(), settings.selectionMode()),
+                    new LiveWindow(
+                            settings.lookbackMinutes(),
+                            settings.windowSampleCount(),
+                            snapshot.sampleCountLastHour(),
+                            snapshot.observedCombatsPerHour()),
+                    new Thresholds(
+                            settings.combatSizeCutoff(),
+                            settings.combatSizePercentile(),
+                            settings.fairnessFloor(),
+                            settings.fairnessPercentile(),
+                            settings.averageFairness()),
+                    new Tuning(
+                            settings.targetPostsPerHour(),
+                            settings.targetSelectionFraction(),
+                            settings.cooldownMinutes(),
+                            settings.minimumSampleCount()));
+        }
+    }
+
+    private record Metadata(
+            java.time.LocalDateTime settingsUpdatedAt, java.time.LocalDateTime generatedAt, String selectionMode) {}
+
+    private record LiveWindow(
+            int lookbackMinutes,
+            int configuredWindowSampleCount,
+            int sampleCountLastHour,
+            double observedCombatsPerHour) {}
+
+    private record Thresholds(
+            double combatSizeCutoff,
+            double combatSizePercentile,
+            double fairnessFloor,
+            double fairnessPercentile,
+            double averageFairness) {}
+
+    private record Tuning(
+            double targetPostsPerHour, double targetSelectionFraction, int cooldownMinutes, int minimumSampleCount) {}
 }

--- a/src/main/java/ti4/spring/api/publicstatus/CombatContestSelectionController.java
+++ b/src/main/java/ti4/spring/api/publicstatus/CombatContestSelectionController.java
@@ -1,20 +1,34 @@
 package ti4.spring.api.publicstatus;
 
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import ti4.json.JsonMapperManager;
 import ti4.spring.service.contest.CombatContestSelectionService;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/public/contest")
 public class CombatContestSelectionController {
 
+    private static final JsonMapper MAPPER = JsonMapperManager.basic()
+            .rebuild()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .build();
+
     private final CombatContestSelectionService combatContestSelectionService;
 
-    @GetMapping("/selection")
-    public CombatContestSelectionService.Snapshot getSelection() {
-        return combatContestSelectionService.getSelectionSnapshot();
+    @SneakyThrows
+    @GetMapping(value = "/selection", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> getSelection() {
+        CombatContestSelectionService.Snapshot snapshot =
+                combatContestSelectionService.recomputeAndGetSelectionSnapshot();
+        return ResponseEntity.ok(MAPPER.writeValueAsString(snapshot));
     }
 }

--- a/src/main/java/ti4/spring/service/contest/CombatContestSampleEntity.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSampleEntity.java
@@ -47,6 +47,12 @@ public class CombatContestSampleEntity {
     @Column(name = "defender_hp", nullable = false)
     private Double defenderHp;
 
+    @Column(name = "attacker_expected_hits")
+    private Double attackerExpectedHits;
+
+    @Column(name = "defender_expected_hits")
+    private Double defenderExpectedHits;
+
     @Column(name = "weaker_strength", nullable = false)
     private Double weakerStrength;
 

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -184,7 +184,7 @@ public class CombatContestSelectionService {
                 entity.getFairnessWeight(),
                 entity.getCooldownMinutes(),
                 entity.getMinimumWeakerStrength(),
-                entity.getMinimumSampleCount());
+                MINIMUM_SAMPLE_COUNT);
     }
 
     private Settings defaultSettings(LocalDateTime now) {

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -2,7 +2,6 @@ package ti4.spring.service.contest;
 
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,15 +19,9 @@ public class CombatContestSelectionService {
     private static final int COOLDOWN_MINUTES = 60;
     private static final double TARGET_POSTS_PER_HOUR = 1.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
-    private static final double MAX_TARGET_SELECTION_FRACTION = 0.50;
-    private static final double DEFAULT_STRENGTH_SCALE = 28.0;
-    private static final double DEFAULT_HP_SCALE = 10.0;
-    private static final double DEFAULT_SCORE_CUTOFF = 0.78;
-    private static final double MINIMUM_WEAKER_STRENGTH = 8.0;
-    private static final double WEAKER_STRENGTH_WEIGHT = 0.30;
-    private static final double WEAKER_HP_WEIGHT = 0.20;
-    private static final double FAIRNESS_WEIGHT = 0.50;
-    private static final double SCALE_PERCENTILE = 0.90;
+    private static final double MAX_TARGET_SELECTION_FRACTION = 1.0;
+    private static final double DEFAULT_COMBAT_SIZE_CUTOFF = 14.0;
+    private static final double FAIRNESS_FLOOR = 0.72;
 
     private final CombatContestSampleRepository sampleRepository;
     private final CombatContestSelectionConfigRepository configRepository;
@@ -40,8 +33,21 @@ public class CombatContestSelectionService {
         loadPersistedSettings();
     }
 
-    public Evaluation evaluate(double attackerStrength, double defenderStrength, double attackerHp, double defenderHp) {
-        return evaluate(attackerStrength, defenderStrength, attackerHp, defenderHp, currentSettings);
+    public Evaluation evaluate(
+            double attackerStrength,
+            double defenderStrength,
+            double attackerHp,
+            double defenderHp,
+            double attackerExpectedHits,
+            double defenderExpectedHits) {
+        return evaluate(
+                attackerStrength,
+                defenderStrength,
+                attackerHp,
+                defenderHp,
+                attackerExpectedHits,
+                defenderExpectedHits,
+                currentSettings);
     }
 
     public Settings getCurrentSettings() {
@@ -58,6 +64,14 @@ public class CombatContestSelectionService {
         return new Snapshot(settings, sampleCountLastHour, observedCombatsPerHour, LocalDateTime.now());
     }
 
+    public Snapshot recomputeAndGetSelectionSnapshot() {
+        LocalDateTime now = LocalDateTime.now();
+        List<CombatContestSampleEntity> samples =
+                sampleRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(now.minusMinutes(LOOKBACK_MINUTES));
+        Settings recomputed = recomputeAndPersistSettings(samples, now);
+        return new Snapshot(recomputed, samples.size(), samples.size() * 60.0 / LOOKBACK_MINUTES, now);
+    }
+
     public void loadPersistedSettings() {
         configRepository.findById(CONFIG_ID).ifPresent(config -> currentSettings = fromEntity(config));
     }
@@ -66,6 +80,10 @@ public class CombatContestSelectionService {
         LocalDateTime now = LocalDateTime.now();
         List<CombatContestSampleEntity> samples =
                 sampleRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(now.minusMinutes(LOOKBACK_MINUTES));
+        return recomputeAndPersistSettings(samples, now);
+    }
+
+    private Settings recomputeAndPersistSettings(List<CombatContestSampleEntity> samples, LocalDateTime now) {
         Settings recomputed = recomputeSettings(samples, now);
         CombatContestSelectionConfigEntity entity = toEntity(recomputed);
         configRepository.save(entity);
@@ -75,6 +93,9 @@ public class CombatContestSelectionService {
 
     private Settings recomputeSettings(List<CombatContestSampleEntity> samples, LocalDateTime now) {
         if (samples.size() < MINIMUM_SAMPLE_COUNT) {
+            if (MODE_DYNAMIC.equals(currentSettings.selectionMode())) {
+                return preserveDynamicSettings(now, samples.size());
+            }
             Settings defaults = defaultSettings(now);
             return new Settings(
                     defaults.updatedAt(),
@@ -83,43 +104,10 @@ public class CombatContestSelectionService {
                     samples.size(),
                     defaults.targetPostsPerHour(),
                     defaults.targetSelectionFraction(),
-                    defaults.scoreCutoff(),
-                    defaults.strengthScale(),
-                    defaults.hpScale(),
-                    defaults.weakerStrengthWeight(),
-                    defaults.weakerHpWeight(),
-                    defaults.fairnessWeight(),
+                    defaults.combatSizeCutoff(),
+                    defaults.fairnessFloor(),
                     defaults.cooldownMinutes(),
-                    defaults.minimumWeakerStrength(),
                     defaults.minimumSampleCount());
-        }
-
-        double strengthScale = Math.max(
-                DEFAULT_STRENGTH_SCALE,
-                percentile(
-                        samples.stream()
-                                .map(CombatContestSampleEntity::getWeakerStrength)
-                                .toList(),
-                        SCALE_PERCENTILE));
-        double hpScale = Math.max(
-                DEFAULT_HP_SCALE,
-                percentile(
-                        samples.stream()
-                                .map(CombatContestSampleEntity::getWeakerHp)
-                                .toList(),
-                        SCALE_PERCENTILE));
-
-        List<Double> scores = new ArrayList<>(samples.size());
-        for (CombatContestSampleEntity sample : samples) {
-            scores.add(computeScore(
-                    sample.getWeakerStrength(),
-                    sample.getWeakerHp(),
-                    sample.getFairnessRatio(),
-                    strengthScale,
-                    hpScale,
-                    WEAKER_STRENGTH_WEIGHT,
-                    WEAKER_HP_WEIGHT,
-                    FAIRNESS_WEIGHT));
         }
 
         double observedCombatsPerHour = samples.size() * 60.0 / LOOKBACK_MINUTES;
@@ -127,7 +115,15 @@ public class CombatContestSelectionService {
                 TARGET_POSTS_PER_HOUR / Math.max(observedCombatsPerHour, 1.0),
                 MIN_TARGET_SELECTION_FRACTION,
                 MAX_TARGET_SELECTION_FRACTION);
-        double scoreCutoff = percentile(scores, 1.0 - targetSelectionFraction);
+        double combatSizeCutoff = samples.isEmpty()
+                ? DEFAULT_COMBAT_SIZE_CUTOFF
+                : Math.max(
+                        DEFAULT_COMBAT_SIZE_CUTOFF,
+                        percentile(
+                                samples.stream()
+                                        .map(CombatContestSampleEntity::getWeakerStrength)
+                                        .toList(),
+                                1.0 - targetSelectionFraction));
 
         return new Settings(
                 now,
@@ -136,14 +132,23 @@ public class CombatContestSelectionService {
                 samples.size(),
                 TARGET_POSTS_PER_HOUR,
                 targetSelectionFraction,
-                scoreCutoff,
-                strengthScale,
-                hpScale,
-                WEAKER_STRENGTH_WEIGHT,
-                WEAKER_HP_WEIGHT,
-                FAIRNESS_WEIGHT,
+                combatSizeCutoff,
+                FAIRNESS_FLOOR,
                 COOLDOWN_MINUTES,
-                MINIMUM_WEAKER_STRENGTH,
+                MINIMUM_SAMPLE_COUNT);
+    }
+
+    private Settings preserveDynamicSettings(LocalDateTime now, int sampleCount) {
+        return new Settings(
+                now,
+                MODE_DYNAMIC,
+                currentSettings.lookbackMinutes(),
+                sampleCount,
+                currentSettings.targetPostsPerHour(),
+                currentSettings.targetSelectionFraction(),
+                currentSettings.combatSizeCutoff(),
+                currentSettings.fairnessFloor(),
+                currentSettings.cooldownMinutes(),
                 MINIMUM_SAMPLE_COUNT);
     }
 
@@ -156,14 +161,14 @@ public class CombatContestSelectionService {
         entity.setWindowSampleCount(settings.windowSampleCount());
         entity.setTargetPostsPerHour(settings.targetPostsPerHour());
         entity.setTargetSelectionFraction(settings.targetSelectionFraction());
-        entity.setScoreCutoff(settings.scoreCutoff());
-        entity.setStrengthScale(settings.strengthScale());
-        entity.setHpScale(settings.hpScale());
-        entity.setWeakerStrengthWeight(settings.weakerStrengthWeight());
-        entity.setWeakerHpWeight(settings.weakerHpWeight());
-        entity.setFairnessWeight(settings.fairnessWeight());
+        entity.setScoreCutoff(settings.combatSizeCutoff());
+        entity.setStrengthScale(DEFAULT_COMBAT_SIZE_CUTOFF);
+        entity.setHpScale(0.0);
+        entity.setWeakerStrengthWeight(1.0);
+        entity.setWeakerHpWeight(0.0);
+        entity.setFairnessWeight(settings.fairnessFloor());
         entity.setCooldownMinutes(settings.cooldownMinutes());
-        entity.setMinimumWeakerStrength(settings.minimumWeakerStrength());
+        entity.setMinimumWeakerStrength(0.0);
         entity.setMinimumSampleCount(settings.minimumSampleCount());
         return entity;
     }
@@ -177,13 +182,8 @@ public class CombatContestSelectionService {
                 entity.getTargetPostsPerHour(),
                 entity.getTargetSelectionFraction(),
                 entity.getScoreCutoff(),
-                entity.getStrengthScale(),
-                entity.getHpScale(),
-                entity.getWeakerStrengthWeight(),
-                entity.getWeakerHpWeight(),
                 entity.getFairnessWeight(),
                 entity.getCooldownMinutes(),
-                entity.getMinimumWeakerStrength(),
                 MINIMUM_SAMPLE_COUNT);
     }
 
@@ -195,41 +195,46 @@ public class CombatContestSelectionService {
                 0,
                 TARGET_POSTS_PER_HOUR,
                 0.15,
-                DEFAULT_SCORE_CUTOFF,
-                DEFAULT_STRENGTH_SCALE,
-                DEFAULT_HP_SCALE,
-                WEAKER_STRENGTH_WEIGHT,
-                WEAKER_HP_WEIGHT,
-                FAIRNESS_WEIGHT,
+                DEFAULT_COMBAT_SIZE_CUTOFF,
+                FAIRNESS_FLOOR,
                 COOLDOWN_MINUTES,
-                MINIMUM_WEAKER_STRENGTH,
                 MINIMUM_SAMPLE_COUNT);
     }
 
     private Evaluation evaluate(
-            double attackerStrength, double defenderStrength, double attackerHp, double defenderHp, Settings settings) {
+            double attackerStrength,
+            double defenderStrength,
+            double attackerHp,
+            double defenderHp,
+            double attackerExpectedHits,
+            double defenderExpectedHits,
+            Settings settings) {
         double weakerStrength = Math.min(attackerStrength, defenderStrength);
         double strongerStrength = Math.max(attackerStrength, defenderStrength);
         double weakerHp = Math.min(attackerHp, defenderHp);
         double strongerHp = Math.max(attackerHp, defenderHp);
         double strengthFairnessRatio = computeFairnessRatio(weakerStrength, strongerStrength);
         double hpFairnessRatio = computeFairnessRatio(weakerHp, strongerHp);
-        double fairnessRatio = (strengthFairnessRatio + hpFairnessRatio) / 2.0;
-        double contestScore = computeScore(
-                weakerStrength,
-                weakerHp,
-                fairnessRatio,
-                settings.strengthScale(),
-                settings.hpScale(),
-                settings.weakerStrengthWeight(),
-                settings.weakerHpWeight(),
-                settings.fairnessWeight());
-        boolean eligible = weakerStrength >= settings.minimumWeakerStrength()
-                && attackerHp > 0
-                && defenderHp > 0
-                && contestScore >= settings.scoreCutoff();
+        double weakerExpectedHits = Math.min(attackerExpectedHits, defenderExpectedHits);
+        double strongerExpectedHits = Math.max(attackerExpectedHits, defenderExpectedHits);
+        double expectedHitsFairnessRatio = computeFairnessRatio(weakerExpectedHits, strongerExpectedHits);
+        double fairnessRatio = averageFairnessRatios(strengthFairnessRatio, hpFairnessRatio, expectedHitsFairnessRatio);
+        double contestScore = weakerStrength;
+        boolean eligible = fairnessRatio >= settings.fairnessFloor() && contestScore >= settings.combatSizeCutoff();
         return new Evaluation(
                 weakerStrength, strongerStrength, weakerHp, strongerHp, fairnessRatio, contestScore, eligible);
+    }
+
+    private double computeSampleFairnessRatio(CombatContestSampleEntity sample) {
+        if (sample.getAttackerExpectedHits() == null || sample.getDefenderExpectedHits() == null) {
+            return sample.getFairnessRatio();
+        }
+        return averageFairnessRatios(
+                computeFairnessRatio(sample.getWeakerStrength(), sample.getStrongerStrength()),
+                computeFairnessRatio(sample.getWeakerHp(), sample.getStrongerHp()),
+                computeFairnessRatio(
+                        Math.min(sample.getAttackerExpectedHits(), sample.getDefenderExpectedHits()),
+                        Math.max(sample.getAttackerExpectedHits(), sample.getDefenderExpectedHits())));
     }
 
     private double computeFairnessRatio(double weakerValue, double strongerValue) {
@@ -237,23 +242,13 @@ public class CombatContestSelectionService {
         return clamp(weakerValue / strongerValue, 0.0, 1.0);
     }
 
-    private double computeScore(
-            double weakerStrength,
-            double weakerHp,
-            double fairnessRatio,
-            double strengthScale,
-            double hpScale,
-            double weakerStrengthWeight,
-            double weakerHpWeight,
-            double fairnessWeight) {
-        return weakerStrengthWeight * normalize(weakerStrength, strengthScale)
-                + weakerHpWeight * normalize(weakerHp, hpScale)
-                + fairnessWeight * clamp(fairnessRatio, 0.0, 1.0);
-    }
-
-    private double normalize(double value, double scale) {
-        if (scale <= 0) return 0.0;
-        return clamp(value / scale, 0.0, 1.0);
+    private double averageFairnessRatios(double... fairnessRatios) {
+        if (fairnessRatios.length == 0) return 0.0;
+        double total = 0.0;
+        for (double fairnessRatio : fairnessRatios) {
+            total += fairnessRatio;
+        }
+        return total / fairnessRatios.length;
     }
 
     private double percentile(List<Double> values, double percentile) {
@@ -286,13 +281,13 @@ public class CombatContestSelectionService {
             int windowSampleCount,
             double targetPostsPerHour,
             double targetSelectionFraction,
-            double scoreCutoff,
-            double strengthScale,
-            double hpScale,
-            double weakerStrengthWeight,
-            double weakerHpWeight,
-            double fairnessWeight,
+            double combatSizeCutoff,
+            double fairnessFloor,
             int cooldownMinutes,
-            double minimumWeakerStrength,
-            int minimumSampleCount) {}
+            int minimumSampleCount) {
+
+        public double combatSizePercentile() {
+            return 1.0 - targetSelectionFraction;
+        }
+    }
 }

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -18,10 +18,13 @@ public class CombatContestSelectionService {
     private static final int MINIMUM_SAMPLE_COUNT = 8;
     private static final int COOLDOWN_MINUTES = 60;
     private static final double TARGET_POSTS_PER_HOUR = 1.0;
+    private static final double TARGET_FAIR_CANDIDATES_PER_HOUR = 4.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
     private static final double MAX_TARGET_SELECTION_FRACTION = 1.0;
     private static final double DEFAULT_COMBAT_SIZE_CUTOFF = 14.0;
-    private static final double FAIRNESS_FLOOR = 0.72;
+    private static final double DEFAULT_FAIRNESS_FLOOR = 0.72;
+    private static final double MIN_FAIRNESS_FLOOR = 0.60;
+    private static final double MAX_FAIRNESS_FLOOR = 0.85;
 
     private final CombatContestSampleRepository sampleRepository;
     private final CombatContestSelectionConfigRepository configRepository;
@@ -106,21 +109,37 @@ public class CombatContestSelectionService {
                     defaults.targetSelectionFraction(),
                     defaults.combatSizeCutoff(),
                     defaults.fairnessFloor(),
+                    defaults.fairnessPercentile(),
+                    defaults.averageFairness(),
                     defaults.cooldownMinutes(),
                     defaults.minimumSampleCount());
         }
 
+        List<Double> fairnessRatios =
+                samples.stream().map(this::computeSampleFairnessRatio).toList();
+        double averageFairness = average(fairnessRatios);
         double observedCombatsPerHour = samples.size() * 60.0 / LOOKBACK_MINUTES;
-        double targetSelectionFraction = clamp(
-                TARGET_POSTS_PER_HOUR / Math.max(observedCombatsPerHour, 1.0),
+        double fairnessSelectionFraction = clamp(
+                TARGET_FAIR_CANDIDATES_PER_HOUR / Math.max(observedCombatsPerHour, 1.0),
                 MIN_TARGET_SELECTION_FRACTION,
                 MAX_TARGET_SELECTION_FRACTION);
-        double combatSizeCutoff = samples.isEmpty()
+        double fairnessPercentile = 1.0 - fairnessSelectionFraction;
+        double fairnessFloor =
+                clamp(percentile(fairnessRatios, fairnessPercentile), MIN_FAIRNESS_FLOOR, MAX_FAIRNESS_FLOOR);
+        List<CombatContestSampleEntity> fairSamples = samples.stream()
+                .filter(sample -> computeSampleFairnessRatio(sample) >= fairnessFloor)
+                .toList();
+        double fairCombatsPerHour = fairSamples.size() * 60.0 / LOOKBACK_MINUTES;
+        double targetSelectionFraction = clamp(
+                TARGET_POSTS_PER_HOUR / Math.max(fairCombatsPerHour, 1.0),
+                MIN_TARGET_SELECTION_FRACTION,
+                MAX_TARGET_SELECTION_FRACTION);
+        double combatSizeCutoff = fairSamples.isEmpty()
                 ? DEFAULT_COMBAT_SIZE_CUTOFF
                 : Math.max(
                         DEFAULT_COMBAT_SIZE_CUTOFF,
                         percentile(
-                                samples.stream()
+                                fairSamples.stream()
                                         .map(CombatContestSampleEntity::getWeakerStrength)
                                         .toList(),
                                 1.0 - targetSelectionFraction));
@@ -133,7 +152,9 @@ public class CombatContestSelectionService {
                 TARGET_POSTS_PER_HOUR,
                 targetSelectionFraction,
                 combatSizeCutoff,
-                FAIRNESS_FLOOR,
+                fairnessFloor,
+                fairnessPercentile,
+                averageFairness,
                 COOLDOWN_MINUTES,
                 MINIMUM_SAMPLE_COUNT);
     }
@@ -148,6 +169,8 @@ public class CombatContestSelectionService {
                 currentSettings.targetSelectionFraction(),
                 currentSettings.combatSizeCutoff(),
                 currentSettings.fairnessFloor(),
+                currentSettings.fairnessPercentile(),
+                currentSettings.averageFairness(),
                 currentSettings.cooldownMinutes(),
                 MINIMUM_SAMPLE_COUNT);
     }
@@ -163,9 +186,9 @@ public class CombatContestSelectionService {
         entity.setTargetSelectionFraction(settings.targetSelectionFraction());
         entity.setScoreCutoff(settings.combatSizeCutoff());
         entity.setStrengthScale(DEFAULT_COMBAT_SIZE_CUTOFF);
-        entity.setHpScale(0.0);
+        entity.setHpScale(settings.averageFairness());
         entity.setWeakerStrengthWeight(1.0);
-        entity.setWeakerHpWeight(0.0);
+        entity.setWeakerHpWeight(settings.fairnessPercentile());
         entity.setFairnessWeight(settings.fairnessFloor());
         entity.setCooldownMinutes(settings.cooldownMinutes());
         entity.setMinimumWeakerStrength(0.0);
@@ -174,6 +197,12 @@ public class CombatContestSelectionService {
     }
 
     private Settings fromEntity(CombatContestSelectionConfigEntity entity) {
+        double fairnessPercentile = entity.getWeakerHpWeight() != null && entity.getWeakerHpWeight() > 0
+                ? entity.getWeakerHpWeight()
+                : 1.0 - entity.getTargetSelectionFraction();
+        double averageFairness = entity.getHpScale() != null && entity.getHpScale() > 0
+                ? entity.getHpScale()
+                : entity.getFairnessWeight();
         return new Settings(
                 entity.getUpdatedAt(),
                 entity.getSelectionMode(),
@@ -183,6 +212,8 @@ public class CombatContestSelectionService {
                 entity.getTargetSelectionFraction(),
                 entity.getScoreCutoff(),
                 entity.getFairnessWeight(),
+                fairnessPercentile,
+                averageFairness,
                 entity.getCooldownMinutes(),
                 MINIMUM_SAMPLE_COUNT);
     }
@@ -196,7 +227,9 @@ public class CombatContestSelectionService {
                 TARGET_POSTS_PER_HOUR,
                 0.15,
                 DEFAULT_COMBAT_SIZE_CUTOFF,
-                FAIRNESS_FLOOR,
+                DEFAULT_FAIRNESS_FLOOR,
+                0.85,
+                DEFAULT_FAIRNESS_FLOOR,
                 COOLDOWN_MINUTES,
                 MINIMUM_SAMPLE_COUNT);
     }
@@ -251,6 +284,15 @@ public class CombatContestSelectionService {
         return total / fairnessRatios.length;
     }
 
+    private double average(List<Double> values) {
+        if (values.isEmpty()) return 0.0;
+        double total = 0.0;
+        for (double value : values) {
+            total += value;
+        }
+        return total / values.size();
+    }
+
     private double percentile(List<Double> values, double percentile) {
         if (values.isEmpty()) return 0.0;
         List<Double> sorted = values.stream().sorted(Comparator.naturalOrder()).toList();
@@ -283,6 +325,8 @@ public class CombatContestSelectionService {
             double targetSelectionFraction,
             double combatSizeCutoff,
             double fairnessFloor,
+            double fairnessPercentile,
+            double averageFairness,
             int cooldownMinutes,
             int minimumSampleCount) {
 

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -46,6 +46,7 @@ import ti4.message.MessageHelper;
 import ti4.model.RelicModel;
 import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
+import ti4.service.combat.CombatRollType;
 import ti4.service.emoji.ColorEmojis;
 
 @Service
@@ -86,7 +87,9 @@ public class CombatContestService {
                     snapshot.attackerStrength(),
                     snapshot.defenderStrength(),
                     snapshot.attackerHp(),
-                    snapshot.defenderHp());
+                    snapshot.defenderHp(),
+                    snapshot.attackerExpectedHits(),
+                    snapshot.defenderExpectedHits());
             CombatContestSelectionService.Settings settings = selectionService.getCurrentSettings();
             boolean eligibleForContest =
                     evaluation.eligibleUnderCurrentThresholds() && !hasExcludedFlagship(attacker, defender);
@@ -247,13 +250,15 @@ public class CombatContestService {
         sample.setDefenderStrength(snapshot.defenderStrength());
         sample.setAttackerHp(snapshot.attackerHp());
         sample.setDefenderHp(snapshot.defenderHp());
+        sample.setAttackerExpectedHits(snapshot.attackerExpectedHits());
+        sample.setDefenderExpectedHits(snapshot.defenderExpectedHits());
         sample.setWeakerStrength(evaluation.weakerStrength());
         sample.setStrongerStrength(evaluation.strongerStrength());
         sample.setWeakerHp(evaluation.weakerHp());
         sample.setStrongerHp(evaluation.strongerHp());
         sample.setFairnessRatio(evaluation.fairnessRatio());
         sample.setContestScore(evaluation.contestScore());
-        sample.setScoreCutoffAtStart(settings.scoreCutoff());
+        sample.setScoreCutoffAtStart(settings.combatSizeCutoff());
         sample.setSelectionModeAtStart(settings.selectionMode());
         sample.setEligibleUnderCurrentThresholds(eligibleForContest);
         sample.setContestPosted(false);
@@ -295,12 +300,15 @@ public class CombatContestService {
                 defenderStrength.value(),
                 attackerStrength.hp(),
                 defenderStrength.hp(),
+                attackerStrength.expectedHits(),
+                defenderStrength.expectedHits(),
                 ratio);
     }
 
     private FleetStrength calculateFleetStrength(Game game, Player player, UnitHolder space) {
         double total = 0;
         double hp = 0;
+        double expectedHits = 0;
         for (UnitKey unitKey : space.getUnitKeys()) {
             if (!unitKey.getColorID().equalsIgnoreCase(player.getColorID())) {
                 continue;
@@ -315,6 +323,9 @@ public class CombatContestService {
 
             total += unitModel.getCost() * totalUnits;
             hp += totalUnits;
+            int combatDice = unitModel.getCombatDieCountForAbility(CombatRollType.combatround, player);
+            int hitsOn = unitModel.getCombatDieHitsOnForAbility(CombatRollType.combatround, player, space);
+            expectedHits += computeExpectedHits(totalUnits * combatDice, hitsOn);
             if (unitModel.getSustainDamage(player, space)) {
                 hp += undamagedUnits;
                 if (player.hasTech("nes")) {
@@ -322,7 +333,12 @@ public class CombatContestService {
                 }
             }
         }
-        return new FleetStrength(total, hp);
+        return new FleetStrength(total, hp, expectedHits);
+    }
+
+    private double computeExpectedHits(int totalDice, int hitsOn) {
+        if (totalDice <= 0 || hitsOn <= 0) return 0;
+        return totalDice * Math.max(0, 11 - hitsOn) / 10.0;
     }
 
     private String extractSpaceOnlySummary(String summary) {
@@ -1031,7 +1047,7 @@ public class CombatContestService {
 
     // ==================== Records ====================
 
-    private record FleetStrength(double value, double hp) {}
+    private record FleetStrength(double value, double hp, double expectedHits) {}
 
     private record SpaceCombatSnapshot(
             String parentPostText,
@@ -1041,5 +1057,7 @@ public class CombatContestService {
             double defenderStrength,
             double attackerHp,
             double defenderHp,
+            double attackerExpectedHits,
+            double defenderExpectedHits,
             double strengthRatio) {}
 }

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -46,7 +46,8 @@ import ti4.message.MessageHelper;
 import ti4.model.RelicModel;
 import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
-import ti4.service.combat.CombatRollType;
+import ti4.service.combat.CombatStatsService;
+import ti4.service.combat.CombatUnitSelectionHelper;
 import ti4.service.emoji.ColorEmojis;
 
 @Service
@@ -275,8 +276,8 @@ public class CombatContestService {
         UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
         if (space == null) return null;
 
-        FleetStrength attackerStrength = calculateFleetStrength(game, attacker, space);
-        FleetStrength defenderStrength = calculateFleetStrength(game, defender, space);
+        FleetStrength attackerStrength = calculateFleetStrength(game, attacker, defender, tile, space);
+        FleetStrength defenderStrength = calculateFleetStrength(game, defender, attacker, tile, space);
 
         double stronger = Math.max(attackerStrength.hp(), defenderStrength.hp());
         double weaker = Math.min(attackerStrength.hp(), defenderStrength.hp());
@@ -305,27 +306,26 @@ public class CombatContestService {
                 ratio);
     }
 
-    private FleetStrength calculateFleetStrength(Game game, Player player, UnitHolder space) {
+    private FleetStrength calculateFleetStrength(
+            Game game, Player player, Player opponent, Tile tile, UnitHolder space) {
         double total = 0;
         double hp = 0;
         double expectedHits = 0;
-        for (UnitKey unitKey : space.getUnitKeys()) {
-            if (!unitKey.getColorID().equalsIgnoreCase(player.getColorID())) {
-                continue;
-            }
-            UnitModel unitModel = player.getPriorityUnitByAsyncID(unitKey.asyncID(), space);
-            if (unitModel == null || !unitModel.getIsShip()) {
-                continue;
-            }
-            int totalUnits = space.getUnitCount(unitKey);
-            int damagedUnits = space.getDamagedUnitCount(unitKey);
+        Map<UnitModel, Integer> unitsInCombat = CombatUnitSelectionHelper.collectCombatRoundUnits(tile, space, player);
+        Map<String, Integer> damagedCountsByAsyncId = getDamagedCountsByAsyncId(tile, player);
+        for (Map.Entry<UnitModel, Integer> entry : unitsInCombat.entrySet()) {
+            UnitModel unitModel = entry.getKey();
+            if (unitModel == null) continue;
+
+            int totalUnits = entry.getValue();
+            int damagedUnits = Math.min(totalUnits, damagedCountsByAsyncId.getOrDefault(unitModel.getAsyncId(), 0));
             int undamagedUnits = Math.max(0, totalUnits - damagedUnits);
 
             total += unitModel.getCost() * totalUnits;
             hp += totalUnits;
-            int combatDice = unitModel.getCombatDieCountForAbility(CombatRollType.combatround, player);
-            int hitsOn = unitModel.getCombatDieHitsOnForAbility(CombatRollType.combatround, player, space);
-            expectedHits += computeExpectedHits(totalUnits * combatDice, hitsOn);
+            CombatStatsService.CombatRoundProfile combatProfile =
+                    CombatStatsService.getCombatRoundProfile(true, unitModel, player, tile, opponent);
+            expectedHits += computeExpectedHits(totalUnits * combatProfile.diceCount(), combatProfile.hitsOn());
             if (unitModel.getSustainDamage(player, space)) {
                 hp += undamagedUnits;
                 if (player.hasTech("nes")) {
@@ -334,6 +334,19 @@ public class CombatContestService {
             }
         }
         return new FleetStrength(total, hp, expectedHits);
+    }
+
+    private Map<String, Integer> getDamagedCountsByAsyncId(Tile tile, Player player) {
+        Map<String, Integer> damagedCountsByAsyncId = new HashMap<>();
+        for (UnitHolder unitHolder : tile.getUnitHolders().values()) {
+            for (UnitKey unitKey : unitHolder.getUnitKeys()) {
+                if (!unitKey.getColorID().equalsIgnoreCase(player.getColorID())) continue;
+                int damagedUnits = unitHolder.getDamagedUnitCount(unitKey);
+                if (damagedUnits <= 0) continue;
+                damagedCountsByAsyncId.merge(unitKey.asyncID(), damagedUnits, Integer::sum);
+            }
+        }
+        return damagedCountsByAsyncId;
     }
 
     private double computeExpectedHits(int totalDice, int hitsOn) {
@@ -512,8 +525,10 @@ public class CombatContestService {
         UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
         if (space == null || loser == null) return null;
 
-        double winnerRemaining = calculateFleetStrength(game, winner, space).value();
-        double loserRemaining = calculateFleetStrength(game, loser, space).value();
+        double winnerRemaining =
+                calculateFleetStrength(game, winner, loser, tile, space).value();
+        double loserRemaining =
+                calculateFleetStrength(game, loser, winner, tile, space).value();
         double winnerInitial = winner.getFaction().equalsIgnoreCase(contest.getAttackerFaction())
                 ? contest.getInitialStrengthAttacker()
                 : contest.getInitialStrengthDefender();

--- a/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
+++ b/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
@@ -1,11 +1,14 @@
 package ti4.spring.service.contest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -15,16 +18,31 @@ class CombatContestSelectionServiceTest {
             mock(CombatContestSampleRepository.class), mock(CombatContestSelectionConfigRepository.class));
 
     @Test
-    void fairnessAccountsForStrengthAndHpBalance() {
-        CombatContestSelectionService.Evaluation strengthMismatch = service.evaluate(20, 40, 10, 10);
-        CombatContestSelectionService.Evaluation hpMismatch = service.evaluate(20, 20, 5, 10);
-        CombatContestSelectionService.Evaluation balanced = service.evaluate(20, 20, 10, 10);
+    void fairnessAccountsForStrengthHpAndExpectedHitsBalance() {
+        CombatContestSelectionService.Evaluation strengthMismatch = service.evaluate(20, 40, 10, 10, 4, 4);
+        CombatContestSelectionService.Evaluation hpMismatch = service.evaluate(20, 20, 5, 10, 4, 4);
+        CombatContestSelectionService.Evaluation expectedHitsMismatch = service.evaluate(20, 20, 10, 10, 2, 4);
+        CombatContestSelectionService.Evaluation balanced = service.evaluate(20, 20, 10, 10, 4, 4);
 
-        assertEquals(0.75, strengthMismatch.fairnessRatio(), 0.0001);
-        assertEquals(0.75, hpMismatch.fairnessRatio(), 0.0001);
+        assertEquals(5.0 / 6.0, strengthMismatch.fairnessRatio(), 0.0001);
+        assertEquals(5.0 / 6.0, hpMismatch.fairnessRatio(), 0.0001);
+        assertEquals(5.0 / 6.0, expectedHitsMismatch.fairnessRatio(), 0.0001);
         assertEquals(1.0, balanced.fairnessRatio(), 0.0001);
-        assertTrue(balanced.contestScore() > strengthMismatch.contestScore());
-        assertTrue(balanced.contestScore() > hpMismatch.contestScore());
+    }
+
+    @Test
+    void eligibilityRequiresFairnessAndCombatSize() {
+        CombatContestSampleRepository sampleRepository = mock(CombatContestSampleRepository.class);
+        CombatContestSelectionConfigRepository configRepository = mock(CombatContestSelectionConfigRepository.class);
+        CombatContestSelectionService selectionService =
+                new CombatContestSelectionService(sampleRepository, configRepository);
+        when(configRepository.findById(1)).thenReturn(Optional.of(configEntity("DYNAMIC", 14.0, 0.72)));
+
+        selectionService.loadPersistedSettings();
+
+        assertTrue(selectionService.evaluate(20, 20, 10, 10, 4, 4).eligibleUnderCurrentThresholds());
+        assertFalse(selectionService.evaluate(13, 13, 10, 10, 4, 4).eligibleUnderCurrentThresholds());
+        assertFalse(selectionService.evaluate(20, 50, 10, 10, 2, 8).eligibleUnderCurrentThresholds());
     }
 
     @Test
@@ -41,19 +59,113 @@ class CombatContestSelectionServiceTest {
         entity.setWindowSampleCount(15);
         entity.setTargetPostsPerHour(1.0);
         entity.setTargetSelectionFraction(0.15);
-        entity.setScoreCutoff(0.78);
-        entity.setStrengthScale(28.0);
-        entity.setHpScale(10.0);
-        entity.setWeakerStrengthWeight(0.30);
-        entity.setWeakerHpWeight(0.20);
-        entity.setFairnessWeight(0.50);
+        entity.setScoreCutoff(14.0);
+        entity.setStrengthScale(14.0);
+        entity.setHpScale(0.0);
+        entity.setWeakerStrengthWeight(1.0);
+        entity.setWeakerHpWeight(0.0);
+        entity.setFairnessWeight(0.72);
         entity.setCooldownMinutes(60);
-        entity.setMinimumWeakerStrength(8.0);
+        entity.setMinimumWeakerStrength(0.0);
         entity.setMinimumSampleCount(24);
         when(configRepository.findById(1)).thenReturn(Optional.of(entity));
 
         selectionService.loadPersistedSettings();
 
         assertEquals(8, selectionService.getCurrentSettings().minimumSampleCount());
+        assertEquals(14.0, selectionService.getCurrentSettings().combatSizeCutoff(), 0.0001);
+        assertEquals(0.72, selectionService.getCurrentSettings().fairnessFloor(), 0.0001);
+    }
+
+    @Test
+    void recomputeKeepsDynamicModeWhenSampleWindowDrops() {
+        CombatContestSampleRepository sampleRepository = mock(CombatContestSampleRepository.class);
+        CombatContestSelectionConfigRepository configRepository = mock(CombatContestSelectionConfigRepository.class);
+        CombatContestSelectionService selectionService =
+                new CombatContestSelectionService(sampleRepository, configRepository);
+        CombatContestSelectionConfigEntity entity = new CombatContestSelectionConfigEntity();
+        entity.setId(1);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setSelectionMode("DYNAMIC");
+        entity.setLookbackMinutes(60);
+        entity.setWindowSampleCount(12);
+        entity.setTargetPostsPerHour(1.0);
+        entity.setTargetSelectionFraction(0.10);
+        entity.setScoreCutoff(16.0);
+        entity.setStrengthScale(14.0);
+        entity.setHpScale(0.0);
+        entity.setWeakerStrengthWeight(1.0);
+        entity.setWeakerHpWeight(0.0);
+        entity.setFairnessWeight(0.72);
+        entity.setCooldownMinutes(60);
+        entity.setMinimumWeakerStrength(0.0);
+        entity.setMinimumSampleCount(24);
+        when(configRepository.findById(1)).thenReturn(Optional.of(entity));
+        when(sampleRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(any()))
+                .thenReturn(List.of());
+
+        selectionService.loadPersistedSettings();
+        CombatContestSelectionService.Settings recomputed = selectionService.recomputeAndPersistSettings();
+
+        assertEquals("DYNAMIC", recomputed.selectionMode());
+        assertEquals(0, recomputed.windowSampleCount());
+        assertEquals(16.0, recomputed.combatSizeCutoff(), 0.0001);
+        assertEquals(0.72, recomputed.fairnessFloor(), 0.0001);
+        assertEquals(8, recomputed.minimumSampleCount());
+    }
+
+    @Test
+    void recomputeUsesFairCombatsToSetCombatSizeCutoff() {
+        CombatContestSampleRepository sampleRepository = mock(CombatContestSampleRepository.class);
+        CombatContestSelectionConfigRepository configRepository = mock(CombatContestSelectionConfigRepository.class);
+        CombatContestSelectionService selectionService =
+                new CombatContestSelectionService(sampleRepository, configRepository);
+        when(sampleRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(any()))
+                .thenReturn(List.of(
+                        sample(18, 0.80),
+                        sample(22, 0.76),
+                        sample(30, 0.90),
+                        sample(40, 0.50),
+                        sample(50, 0.60),
+                        sample(16, 0.74),
+                        sample(28, 0.85),
+                        sample(14, 0.72)));
+
+        CombatContestSelectionService.Settings recomputed = selectionService.recomputeAndPersistSettings();
+
+        assertEquals("DYNAMIC", recomputed.selectionMode());
+        assertEquals(0.125, recomputed.targetSelectionFraction(), 0.0001);
+        assertEquals(50.0, recomputed.combatSizeCutoff(), 0.0001);
+        assertEquals(0.875, recomputed.combatSizePercentile(), 0.0001);
+        assertEquals(0.72, recomputed.fairnessFloor(), 0.0001);
+    }
+
+    private CombatContestSelectionConfigEntity configEntity(
+            String mode, double combatSizeCutoff, double fairnessFloor) {
+        CombatContestSelectionConfigEntity entity = new CombatContestSelectionConfigEntity();
+        entity.setId(1);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setSelectionMode(mode);
+        entity.setLookbackMinutes(60);
+        entity.setWindowSampleCount(12);
+        entity.setTargetPostsPerHour(1.0);
+        entity.setTargetSelectionFraction(0.10);
+        entity.setScoreCutoff(combatSizeCutoff);
+        entity.setStrengthScale(14.0);
+        entity.setHpScale(0.0);
+        entity.setWeakerStrengthWeight(1.0);
+        entity.setWeakerHpWeight(0.0);
+        entity.setFairnessWeight(fairnessFloor);
+        entity.setCooldownMinutes(60);
+        entity.setMinimumWeakerStrength(0.0);
+        entity.setMinimumSampleCount(24);
+        return entity;
+    }
+
+    private CombatContestSampleEntity sample(double weakerStrength, double fairnessRatio) {
+        CombatContestSampleEntity sample = new CombatContestSampleEntity();
+        sample.setWeakerStrength(weakerStrength);
+        sample.setFairnessRatio(fairnessRatio);
+        return sample;
     }
 }

--- a/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
+++ b/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
@@ -75,6 +75,8 @@ class CombatContestSelectionServiceTest {
         assertEquals(8, selectionService.getCurrentSettings().minimumSampleCount());
         assertEquals(14.0, selectionService.getCurrentSettings().combatSizeCutoff(), 0.0001);
         assertEquals(0.72, selectionService.getCurrentSettings().fairnessFloor(), 0.0001);
+        assertEquals(0.85, selectionService.getCurrentSettings().fairnessPercentile(), 0.0001);
+        assertEquals(0.72, selectionService.getCurrentSettings().averageFairness(), 0.0001);
     }
 
     @Test
@@ -111,6 +113,8 @@ class CombatContestSelectionServiceTest {
         assertEquals(0, recomputed.windowSampleCount());
         assertEquals(16.0, recomputed.combatSizeCutoff(), 0.0001);
         assertEquals(0.72, recomputed.fairnessFloor(), 0.0001);
+        assertEquals(0.90, recomputed.fairnessPercentile(), 0.0001);
+        assertEquals(0.72, recomputed.averageFairness(), 0.0001);
         assertEquals(8, recomputed.minimumSampleCount());
     }
 
@@ -134,10 +138,12 @@ class CombatContestSelectionServiceTest {
         CombatContestSelectionService.Settings recomputed = selectionService.recomputeAndPersistSettings();
 
         assertEquals("DYNAMIC", recomputed.selectionMode());
-        assertEquals(0.125, recomputed.targetSelectionFraction(), 0.0001);
-        assertEquals(50.0, recomputed.combatSizeCutoff(), 0.0001);
-        assertEquals(0.875, recomputed.combatSizePercentile(), 0.0001);
-        assertEquals(0.72, recomputed.fairnessFloor(), 0.0001);
+        assertEquals(0.25, recomputed.targetSelectionFraction(), 0.0001);
+        assertEquals(30.0, recomputed.combatSizeCutoff(), 0.0001);
+        assertEquals(0.75, recomputed.combatSizePercentile(), 0.0001);
+        assertEquals(0.76, recomputed.fairnessFloor(), 0.0001);
+        assertEquals(0.50, recomputed.fairnessPercentile(), 0.0001);
+        assertEquals(0.733_75, recomputed.averageFairness(), 0.0001);
     }
 
     private CombatContestSelectionConfigEntity configEntity(

--- a/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
+++ b/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
@@ -3,7 +3,10 @@ package ti4.spring.service.contest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class CombatContestSelectionServiceTest {
@@ -22,5 +25,35 @@ class CombatContestSelectionServiceTest {
         assertEquals(1.0, balanced.fairnessRatio(), 0.0001);
         assertTrue(balanced.contestScore() > strengthMismatch.contestScore());
         assertTrue(balanced.contestScore() > hpMismatch.contestScore());
+    }
+
+    @Test
+    void loadPersistedSettingsUsesCurrentMinimumSampleCountConstant() {
+        CombatContestSampleRepository sampleRepository = mock(CombatContestSampleRepository.class);
+        CombatContestSelectionConfigRepository configRepository = mock(CombatContestSelectionConfigRepository.class);
+        CombatContestSelectionService selectionService =
+                new CombatContestSelectionService(sampleRepository, configRepository);
+        CombatContestSelectionConfigEntity entity = new CombatContestSelectionConfigEntity();
+        entity.setId(1);
+        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setSelectionMode("WARMUP");
+        entity.setLookbackMinutes(60);
+        entity.setWindowSampleCount(15);
+        entity.setTargetPostsPerHour(1.0);
+        entity.setTargetSelectionFraction(0.15);
+        entity.setScoreCutoff(0.78);
+        entity.setStrengthScale(28.0);
+        entity.setHpScale(10.0);
+        entity.setWeakerStrengthWeight(0.30);
+        entity.setWeakerHpWeight(0.20);
+        entity.setFairnessWeight(0.50);
+        entity.setCooldownMinutes(60);
+        entity.setMinimumWeakerStrength(8.0);
+        entity.setMinimumSampleCount(24);
+        when(configRepository.findById(1)).thenReturn(Optional.of(entity));
+
+        selectionService.loadPersistedSettings();
+
+        assertEquals(8, selectionService.getCurrentSettings().minimumSampleCount());
     }
 }


### PR DESCRIPTION
## Summary
- keep the Lazax selector in `DYNAMIC` once it has warmed up instead of falling back to `WARMUP`
- simplify selection to a fixed fairness gate plus a dynamic raw combat-size cutoff based on weaker-side resource value
- include expected hits in the fairness calculation and store expected-hit estimates on new combat samples
- recompute the public selection endpoint on request and return pretty JSON with readable fields like `combatSizeCutoff` and `combatSizePercentile`
- keep persisted settings compatible with older stored config values and older sample rows during rollout

## Test Plan
- mvn -q -Dtest=CombatContestSelectionServiceTest test
- mvn -q -DskipTests compile