### PR TITLE
fix: warm interaction handlers before lease participation

### DIFF
--- a/src/main/java/ti4/AsyncTI4DiscordBot.java
+++ b/src/main/java/ti4/AsyncTI4DiscordBot.java
@@ -8,6 +8,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import ti4.discord.JdaService;
+import ti4.discord.interactions.buttons.ButtonProcessor;
+import ti4.discord.interactions.listeners.ModalListener;
+import ti4.discord.interactions.selections.SelectionMenuProcessor;
 import ti4.game.persistence.GameManager;
 import ti4.game.persistence.migration.DataMigrationManager;
 import ti4.logging.BotLogger;
@@ -39,6 +42,11 @@ public class AsyncTI4DiscordBot {
         }
         JdaService.loadStaticDataAndResources();
         JdaService.indexGameNames();
+        BotLogger.info("WARMING INTERACTION HANDLERS");
+        ButtonProcessor.warmupKnownHandlers();
+        SelectionMenuProcessor.warmupKnownHandlers();
+        ModalListener.warmupKnownHandlers();
+        BotLogger.info("FINISHED WARMING INTERACTION HANDLERS");
         activeLeaseService.beginLeaseParticipation(AsyncTI4DiscordBot::runLeaseOwnedStartupWork);
         JdaService.registerAndStartCronJobs();
         JdaService.markProcessReady();

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -46,6 +46,10 @@ public class ButtonProcessor {
             AnnotationHandler.findKnownHandlers(ButtonContext.class, ButtonHandler.class);
     private static final ButtonRuntimeWarningService runtimeWarningService = new ButtonRuntimeWarningService();
 
+    public static void warmupKnownHandlers() {
+        knownButtons.size();
+    }
+
     public static void queue(ButtonInteractionEvent event) {
         BotLogger.logButton(event);
         User user = event.getUser();

--- a/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
@@ -19,7 +19,7 @@ import ti4.logging.RollbarManager;
 import ti4.service.game.GameNameService;
 import ti4.spring.service.deploy.ActiveLeaseService;
 
-final class ModalListener extends ListenerAdapter {
+public final class ModalListener extends ListenerAdapter {
 
     private static ModalListener instance;
 
@@ -28,6 +28,10 @@ final class ModalListener extends ListenerAdapter {
     public static ModalListener getInstance() {
         if (instance == null) instance = new ModalListener();
         return instance;
+    }
+
+    public static void warmupKnownHandlers() {
+        getInstance();
     }
 
     private ModalListener() {

--- a/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
+++ b/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
@@ -19,6 +19,10 @@ public final class SelectionMenuProcessor {
     private static final Map<String, Consumer<SelectionMenuContext>> knownMenus =
             AnnotationHandler.findKnownHandlers(SelectionMenuContext.class, SelectionHandler.class);
 
+    public static void warmupKnownHandlers() {
+        knownMenus.size();
+    }
+
     public static void queue(StringSelectInteractionEvent event) {
         String gameName = GameNameService.getGameNameFromChannel(event);
         ExecutorServiceManager.runAsync(


### PR DESCRIPTION
## Summary
- cherry-pick 366c5d108379325509d0895041e306d6257a86ac onto current master
- warm button, selection menu, and modal handlers before lease participation
- preserve the original fix on top of the latest base branch
