### PR TITLE
Reduce Lazax contest cooldown to 30 minutes

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -16,7 +16,7 @@ public class CombatContestSelectionService {
     private static final String MODE_DYNAMIC = "DYNAMIC";
     private static final int LOOKBACK_MINUTES = 60;
     private static final int MINIMUM_SAMPLE_COUNT = 8;
-    private static final int COOLDOWN_MINUTES = 60;
+    private static final int COOLDOWN_MINUTES = 30;
     private static final double TARGET_POSTS_PER_HOUR = 1.0;
     private static final double TARGET_FAIR_CANDIDATES_PER_HOUR = 4.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;


### PR DESCRIPTION
## Summary
- reduce the default Lazax contest cooldown from 60 minutes to 30 minutes
- leave the rest of the dynamic selection logic unchanged

## Test Plan
- mvn -Dtest=CombatContestSelectionServiceTest test