### PR TITLE
Increase Lazax contest target posts per hour

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -17,7 +17,7 @@ public class CombatContestSelectionService {
     private static final int LOOKBACK_MINUTES = 60;
     private static final int MINIMUM_SAMPLE_COUNT = 8;
     private static final int COOLDOWN_MINUTES = 30;
-    private static final double TARGET_POSTS_PER_HOUR = 1.0;
+    private static final double TARGET_POSTS_PER_HOUR = 3.0;
     private static final double TARGET_FAIR_CANDIDATES_PER_HOUR = 4.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
     private static final double MAX_TARGET_SELECTION_FRACTION = 1.0;

--- a/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
+++ b/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
@@ -138,9 +138,9 @@ class CombatContestSelectionServiceTest {
         CombatContestSelectionService.Settings recomputed = selectionService.recomputeAndPersistSettings();
 
         assertEquals("DYNAMIC", recomputed.selectionMode());
-        assertEquals(0.25, recomputed.targetSelectionFraction(), 0.0001);
-        assertEquals(30.0, recomputed.combatSizeCutoff(), 0.0001);
-        assertEquals(0.75, recomputed.combatSizePercentile(), 0.0001);
+        assertEquals(0.75, recomputed.targetSelectionFraction(), 0.0001);
+        assertEquals(22.0, recomputed.combatSizeCutoff(), 0.0001);
+        assertEquals(0.25, recomputed.combatSizePercentile(), 0.0001);
         assertEquals(0.76, recomputed.fairnessFloor(), 0.0001);
         assertEquals(0.50, recomputed.fairnessPercentile(), 0.0001);
         assertEquals(0.733_75, recomputed.averageFairness(), 0.0001);


### PR DESCRIPTION
## Summary
- raise the Lazax contest target posts per hour from 1 to 3
- update the selection-service test expectations to reflect the more permissive combat-size cutoff

## Testing
- mvn -Dtest=CombatContestSelectionServiceTest test