### PR TITLE
Lower Lazax minimum combat size floor to 8

### DIFF
--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -21,7 +21,7 @@ public class CombatContestSelectionService {
     private static final double TARGET_FAIR_CANDIDATES_PER_HOUR = 4.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
     private static final double MAX_TARGET_SELECTION_FRACTION = 1.0;
-    private static final double DEFAULT_COMBAT_SIZE_CUTOFF = 14.0;
+    private static final double DEFAULT_COMBAT_SIZE_CUTOFF = 8.0;
     private static final double DEFAULT_FAIRNESS_FLOOR = 0.72;
     private static final double MIN_FAIRNESS_FLOOR = 0.60;
     private static final double MAX_FAIRNESS_FLOOR = 0.85;

--- a/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
+++ b/src/test/java/ti4/spring/service/contest/CombatContestSelectionServiceTest.java
@@ -146,6 +146,28 @@ class CombatContestSelectionServiceTest {
         assertEquals(0.733_75, recomputed.averageFairness(), 0.0001);
     }
 
+    @Test
+    void recomputeAllowsCombatSizeCutoffToDropToNewMinimumFloor() {
+        CombatContestSampleRepository sampleRepository = mock(CombatContestSampleRepository.class);
+        CombatContestSelectionConfigRepository configRepository = mock(CombatContestSelectionConfigRepository.class);
+        CombatContestSelectionService selectionService =
+                new CombatContestSelectionService(sampleRepository, configRepository);
+        when(sampleRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(any()))
+                .thenReturn(List.of(
+                        sample(7, 0.90),
+                        sample(6, 0.88),
+                        sample(5, 0.85),
+                        sample(4, 0.83),
+                        sample(3, 0.80),
+                        sample(2, 0.78),
+                        sample(1, 0.76),
+                        sample(0.5, 0.74)));
+
+        CombatContestSelectionService.Settings recomputed = selectionService.recomputeAndPersistSettings();
+
+        assertEquals(8.0, recomputed.combatSizeCutoff(), 0.0001);
+    }
+
     private CombatContestSelectionConfigEntity configEntity(
             String mode, double combatSizeCutoff, double fairnessFloor) {
         CombatContestSelectionConfigEntity entity = new CombatContestSelectionConfigEntity();


### PR DESCRIPTION
## Summary
- lower the Lazax hard minimum combat size cutoff from 14 to 8
- add a focused selection-service test that proves recompute can now fall to the new floor

## Testing
- mvn -Dtest=CombatContestSelectionServiceTest test