### PR TITLE
Set Lazax contest cooldown to one hour

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/fow/PingActivePlayer.java
+++ b/src/main/java/ti4/discord/interactions/commands/fow/PingActivePlayer.java
@@ -11,7 +11,7 @@ import ti4.service.fow.GMService;
 
 class PingActivePlayer extends GameStateSubcommand {
 
-    private static final long PING_COOLDOWN = 3_600_000; // (1000 * 60 * 60); //one hour
+    private static final long PING_COOLDOWN = 28_800_000; // (1000 * 60 * 60 * 8); //eight hours
 
     public PingActivePlayer() {
         super(Constants.PING_ACTIVE_PLAYER, "Ping the active player in this game", true, true);

--- a/src/main/java/ti4/discord/interactions/commands/fow/PingActivePlayer.java
+++ b/src/main/java/ti4/discord/interactions/commands/fow/PingActivePlayer.java
@@ -11,7 +11,7 @@ import ti4.service.fow.GMService;
 
 class PingActivePlayer extends GameStateSubcommand {
 
-    private static final long PING_COOLDOWN = 28_800_000; // (1000 * 60 * 60 * 8); //eight hours
+    private static final long PING_COOLDOWN = 3_600_000; // (1000 * 60 * 60); //one hour
 
     public PingActivePlayer() {
         super(Constants.PING_ACTIVE_PLAYER, "Ping the active player in this game", true, true);

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -16,7 +16,7 @@ public class CombatContestSelectionService {
     private static final String MODE_DYNAMIC = "DYNAMIC";
     private static final int LOOKBACK_MINUTES = 60;
     private static final int MINIMUM_SAMPLE_COUNT = 8;
-    private static final int COOLDOWN_MINUTES = 30;
+    private static final int COOLDOWN_MINUTES = 60;
     private static final double TARGET_POSTS_PER_HOUR = 3.0;
     private static final double TARGET_FAIR_CANDIDATES_PER_HOUR = 4.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;


### PR DESCRIPTION
## Summary
- increase the Lazax combat contest posting cooldown from 30 minutes to 60 minutes
- revert the unrelated active-player ping cooldown change from the earlier mistaken commit

## Testing
- not run (constant change only)