### PR TITLE
Increase replay candidate selection rate

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -27,7 +27,7 @@ public class CombatReplayService {
 
     private static final Pattern SYSTEM_TILE_PATTERN = Pattern.compile("-system-([^-]+)-");
     private static final int LOOKBACK_MINUTES = 60;
-    private static final int TARGET_CANDIDATES_PER_HOUR = 1;
+    private static final int TARGET_CANDIDATES_PER_HOUR = 4;
 
     private final CombatObservationRepository observationRepository;
     private final CombatCandidateRepository candidateRepository;

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -17,7 +17,7 @@ public class CombatContestSelectionService {
     private static final int LOOKBACK_MINUTES = 60;
     private static final int MINIMUM_SAMPLE_COUNT = 8;
     private static final int COOLDOWN_MINUTES = 30;
-    private static final double TARGET_POSTS_PER_HOUR = 3.0;
+    private static final double TARGET_POSTS_PER_HOUR = 4.0;
     private static final double TARGET_FAIR_CANDIDATES_PER_HOUR = 4.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
     private static final double MAX_TARGET_SELECTION_FRACTION = 1.0;

--- a/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestSelectionService.java
@@ -17,7 +17,7 @@ public class CombatContestSelectionService {
     private static final int LOOKBACK_MINUTES = 60;
     private static final int MINIMUM_SAMPLE_COUNT = 8;
     private static final int COOLDOWN_MINUTES = 30;
-    private static final double TARGET_POSTS_PER_HOUR = 4.0;
+    private static final double TARGET_POSTS_PER_HOUR = 3.0;
     private static final double TARGET_FAIR_CANDIDATES_PER_HOUR = 4.0;
     private static final double MIN_TARGET_SELECTION_FRACTION = 0.08;
     private static final double MAX_TARGET_SELECTION_FRACTION = 1.0;


### PR DESCRIPTION
## Summary
- revert the earlier legacy contest-selector tweak
- increase the new replay system selection target from 1 candidate per hour to 4 candidates per hour
- this lowers the replay joint-score cutoff so roughly the top 4 observations in the lookback window qualify instead of only the top 1

## Notes
- replay promotion is still scheduled hourly in the lifecycle service; this change only affects replay candidate selection

## Testing
- not run (constant change only)