### PR TITLE
Expose replay selection observations in debug snapshot

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -255,11 +255,16 @@ public class CombatReplayService {
         List<Double> weakerStrengthValues = window.stream()
                 .map(observation -> Math.min(observation.getAttackerStrength(), observation.getDefenderStrength()))
                 .toList();
+        double jointScoreCutoff = computeCutoff(window, fairnessValues, weakerStrengthValues);
+        List<SelectionObservationDebugView> observations = window.stream()
+                .map(observation -> toSelectionObservationDebugView(observation, fairnessValues, weakerStrengthValues))
+                .toList();
         selectionSnapshot = new SelectionSnapshot(
                 window.size(),
                 List.copyOf(fairnessValues),
                 List.copyOf(weakerStrengthValues),
-                computeCutoff(window, fairnessValues, weakerStrengthValues));
+                jointScoreCutoff,
+                List.copyOf(observations));
     }
 
     public SelectionDebugView getSelectionDebugView() {
@@ -270,7 +275,8 @@ public class CombatReplayService {
                 snapshot.windowSize(),
                 snapshot.jointScoreCutoff(),
                 average(snapshot.fairnessValues()),
-                average(snapshot.weakerStrengthValues()));
+                average(snapshot.weakerStrengthValues()),
+                snapshot.observations());
     }
 
     private boolean isSpaceCombatHitAssignment(Game game, Player player, ButtonInteractionEvent event) {
@@ -362,6 +368,20 @@ public class CombatReplayService {
             List<Double> weakerStrengthValues,
             double weakerStrength) {
         return percentileRank(fairnessValues, fairnessRatio) * percentileRank(weakerStrengthValues, weakerStrength);
+    }
+
+    private SelectionObservationDebugView toSelectionObservationDebugView(
+            CombatObservationEntity observation, List<Double> fairnessValues, List<Double> weakerStrengthValues) {
+        double weakerStrength = Math.min(observation.getAttackerStrength(), observation.getDefenderStrength());
+        double fairnessPercentile = percentileRank(fairnessValues, observation.getFairnessRatio());
+        double weakerStrengthPercentile = percentileRank(weakerStrengthValues, weakerStrength);
+        return new SelectionObservationDebugView(
+                observation,
+                weakerStrength,
+                fairnessPercentile,
+                weakerStrengthPercentile,
+                fairnessPercentile * weakerStrengthPercentile,
+                Boolean.TRUE.equals(observation.getEligibleAsCandidate()));
     }
 
     private double computeCutoff(
@@ -531,7 +551,11 @@ public class CombatReplayService {
             List<String> specialLines) {}
 
     private record SelectionSnapshot(
-            int windowSize, List<Double> fairnessValues, List<Double> weakerStrengthValues, double jointScoreCutoff) {
+            int windowSize,
+            List<Double> fairnessValues,
+            List<Double> weakerStrengthValues,
+            double jointScoreCutoff,
+            List<SelectionObservationDebugView> observations) {
         private boolean hasWindow() {
             return windowSize > 0;
         }
@@ -545,5 +569,14 @@ public class CombatReplayService {
             int windowSize,
             double jointScoreCutoff,
             double averageFairnessRatio,
-            double averageWeakerStrength) {}
+            double averageWeakerStrength,
+            List<SelectionObservationDebugView> observations) {}
+
+    public record SelectionObservationDebugView(
+            CombatObservationEntity observation,
+            double weakerStrength,
+            double fairnessPercentile,
+            double weakerStrengthPercentile,
+            double jointScore,
+            boolean eligibleAsCandidate) {}
 }

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -1,0 +1,100 @@
+package ti4.contest.replay.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.entities.CombatObservationEntity;
+import ti4.contest.replay.repository.CombatCandidateEventRepository;
+import ti4.contest.replay.repository.CombatCandidateRepository;
+import ti4.contest.replay.repository.CombatObservationRepository;
+import ti4.spring.service.contest.CombatContestType;
+
+class CombatReplayServiceTest {
+
+    @Test
+    void selectionDebugViewExposesObservationWindowDetails() {
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayService service = new CombatReplayService(
+                observationRepository,
+                mock(CombatCandidateRepository.class),
+                mock(CombatCandidateEventRepository.class),
+                mock(CombatReplayEventAppender.class));
+
+        CombatObservationEntity first = observation(
+                1L, LocalDateTime.of(2026, 4, 22, 10, 0), "pbd100", "19", 20, 40, 8, 8, 3, 3, 0.80, true, 11L);
+        CombatObservationEntity second = observation(
+                2L, LocalDateTime.of(2026, 4, 22, 10, 5), "pbd101", "20", 30, 30, 10, 10, 4, 4, 1.00, true, 12L);
+        CombatObservationEntity third = observation(
+                3L, LocalDateTime.of(2026, 4, 22, 10, 10), "pbd102", "21", 10, 20, 6, 6, 2, 2, 0.60, false, null);
+        when(observationRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(any()))
+                .thenReturn(List.of(first, second, third));
+
+        service.refreshSelectionSnapshot();
+        CombatReplayService.SelectionDebugView view = service.getSelectionDebugView();
+
+        assertEquals(3, view.windowSize());
+        assertEquals(0.80, view.averageFairnessRatio(), 0.0001);
+        assertEquals(20.0, view.averageWeakerStrength(), 0.0001);
+        assertEquals(1.0 / 9.0, view.jointScoreCutoff(), 0.0001);
+        assertEquals(3, view.observations().size());
+
+        CombatReplayService.SelectionObservationDebugView firstObservation =
+                view.observations().getFirst();
+        assertEquals(1L, firstObservation.observation().getId());
+        assertEquals("pbd100", firstObservation.observation().getGameName());
+        assertEquals(20.0, firstObservation.weakerStrength(), 0.0001);
+        assertEquals(2.0 / 3.0, firstObservation.fairnessPercentile(), 0.0001);
+        assertEquals(2.0 / 3.0, firstObservation.weakerStrengthPercentile(), 0.0001);
+        assertEquals(4.0 / 9.0, firstObservation.jointScore(), 0.0001);
+        assertTrue(firstObservation.eligibleAsCandidate());
+        assertEquals(11L, firstObservation.observation().getCandidateId());
+
+        CombatReplayService.SelectionObservationDebugView lastObservation =
+                view.observations().get(2);
+        assertFalse(lastObservation.eligibleAsCandidate());
+        assertEquals("pbd102", lastObservation.observation().getGameName());
+        assertEquals(1.0 / 9.0, lastObservation.jointScore(), 0.0001);
+    }
+
+    private CombatObservationEntity observation(
+            Long id,
+            LocalDateTime startedAt,
+            String gameName,
+            String tilePosition,
+            double attackerStrength,
+            double defenderStrength,
+            double attackerHp,
+            double defenderHp,
+            double attackerExpectedHits,
+            double defenderExpectedHits,
+            double fairnessRatio,
+            boolean eligibleAsCandidate,
+            Long candidateId) {
+        CombatObservationEntity observation = new CombatObservationEntity();
+        observation.setId(id);
+        observation.setStartedAt(startedAt);
+        observation.setGameName(gameName);
+        observation.setTilePosition(tilePosition);
+        observation.setCombatType(CombatContestType.SPACE);
+        observation.setAttackerFaction("hacan");
+        observation.setDefenderFaction("sol");
+        observation.setAttackerStrength(attackerStrength);
+        observation.setDefenderStrength(defenderStrength);
+        observation.setAttackerHp(attackerHp);
+        observation.setDefenderHp(defenderHp);
+        observation.setAttackerExpectedHits(attackerExpectedHits);
+        observation.setDefenderExpectedHits(defenderExpectedHits);
+        observation.setFairnessRatio(fairnessRatio);
+        observation.setJointScore(0.0);
+        observation.setEligibleAsCandidate(eligibleAsCandidate);
+        observation.setCandidateId(candidateId);
+        return observation;
+    }
+}


### PR DESCRIPTION
## Summary
- expose the full persisted combat observations on `/api/public/contest/replay/selection`
- include the derived percentile and joint score values used to calculate the replay selection cutoff
- add a focused service test covering the observation snapshot payload

## Test Plan
- mvn test -Dtest=CombatReplayServiceTest,CombatContestSelectionServiceTest