### PR TITLE
Normalize game names and tweak persistence

### DIFF
--- a/src/main/java/ti4/game/persistence/GameFileLockManager.java
+++ b/src/main/java/ti4/game/persistence/GameFileLockManager.java
@@ -3,7 +3,9 @@ package ti4.game.persistence;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 final class GameFileLockManager {
 
     private static final ConcurrentHashMap<String, ReentrantReadWriteLock> locks = new ConcurrentHashMap<>();

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -113,9 +113,6 @@ class GameLoadService {
     public static Game load(String gameName) {
         return GameFileLockManager.wrapWithReadLock(gameName, () -> {
             File gameFile = Storage.getGameFile(gameName + GAME_FILE_EXTENSION);
-            if (!gameFile.exists()) {
-                return null;
-            }
             return readGame(gameFile);
         });
     }
@@ -127,7 +124,7 @@ class GameLoadService {
     @Nullable
     private static Game readGame(@NotNull File gameFile) {
         if (!gameFile.exists()) {
-            BotLogger.critical("Could not load map, map file does not exist: " + gameFile.getAbsolutePath());
+            BotLogger.critical("Could not load map, file does not exist: " + gameFile.getAbsolutePath());
             return null;
         }
         try {
@@ -136,7 +133,7 @@ class GameLoadService {
                     .listIterator();
             game.setOwnerID(gameFileLines.next());
             game.setOwnerName(gameFileLines.next());
-            game.setName(gameFileLines.next());
+            game.setName(gameFileLines.next().toLowerCase());
             while (gameFileLines.hasNext()) {
                 String data = gameFileLines.next();
                 if (MAPINFO.equals(data)) {

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -143,7 +143,7 @@ class GameSaveService {
             writer.write(System.lineSeparator());
             writer.write(game.getOwnerName());
             writer.write(System.lineSeparator());
-            writer.write(game.getName());
+            writer.write(game.getName().toLowerCase());
             writer.write(System.lineSeparator());
             saveGameInfo(writer, game);
 


### PR DESCRIPTION
Annotate GameFileLockManager with Lombok's @UtilityClass. Persist game names in lowercase (save uses game.getName().toLowerCase()) and read names as lowercase (readGame lowercases the name). Remove the earlier pipeline lowercasing and simplify load flow by delegating the existence check and logging to readGame; also update the log message text.