### PR TITLE
Improve replay promotion media and results

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -105,7 +105,7 @@ public class CombatContestSettings {
     public static class ReplayExecution {
         private int startDelayMinutes = 10;
         private int replayIntervalSeconds = 15;
-        private int maxEventGapSeconds = 60;
+        private int maxEventGapSeconds = 30;
     }
 
     @Data

--- a/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
@@ -90,6 +90,9 @@ public class CombatCandidateEntity {
     @Column(name = "pre_replay_context_text", columnDefinition = "TEXT")
     private String preReplayContextText;
 
+    @Column(name = "initial_render_snapshot_json", columnDefinition = "TEXT")
+    private String initialRenderSnapshotJson;
+
     @Column(name = "promotion_score")
     private Double promotionScore;
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -28,6 +28,7 @@ import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.persistence.GameManager;
+import ti4.helpers.RandomHelper;
 import ti4.image.TileGenerator;
 import ti4.logging.BotLogger;
 
@@ -40,6 +41,26 @@ public class CombatReplayContestLifecycleService {
 
     private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives-dev";
     private static final long SHADOW_DISCORD_ID = 0L;
+    private static final List<String> PREDICTION_LOCK_TITLES = List.of(
+            "Final Wagers",
+            "Closing the Archives",
+            "Last Wagers",
+            "Final Predictions",
+            "The Betting Window Narrows",
+            "The Archives Seal Soon",
+            "Last Call Before First Fire",
+            "The War Ledger Closes");
+    private static final List<String> PREDICTION_LOCK_SUBTITLES = List.of(
+            "_The archives remain open for a few moments longer._",
+            "_The scribes still accept wagers before the first salvo._",
+            "_The war ledger has not yet been sealed._",
+            "_A few final predictions may yet be entered into the record._",
+            "_The Lazax recorders await your final judgment._",
+            "_Soon the record closes and steel decides the truth._",
+            "_The betting hall quiets as the battle draws near._",
+            "_The last whispers of speculation echo through the archives._",
+            "_Place your faith now; the guns will speak soon enough._",
+            "_The final odds are still being written in the margin._");
 
     private final CombatContestSettings settings;
     private final CombatCandidateRepository candidateRepository;
@@ -248,10 +269,11 @@ public class CombatReplayContestLifecycleService {
 
     private void announcePredictionLockCountdown(MessageChannel channel) {
         int startDelayMinutes = settings.getReplayExecution().getStartDelayMinutes();
-        String subtitle = "_The archives remain open for a few moments longer._";
+        String title = RandomHelper.pickRandomFromList(PREDICTION_LOCK_TITLES);
+        String subtitle = RandomHelper.pickRandomFromList(PREDICTION_LOCK_SUBTITLES);
         String message = startDelayMinutes <= 0
-                ? "## Final Wagers\n" + subtitle + "\nVoting is now locked. The combat begins immediately."
-                : "## Final Wagers\n" + subtitle + "\nVoting will be locked in **" + startDelayMinutes + "** "
+                ? "## " + title + "\n" + subtitle + "\nVoting is now locked. The combat begins immediately."
+                : "## " + title + "\n" + subtitle + "\nVoting will be locked in **" + startDelayMinutes + "** "
                         + (startDelayMinutes == 1 ? "minute" : "minutes") + ".";
         channel.sendMessage(message).complete();
     }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -18,6 +18,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import ti4.contest.replay.core.*;
 import ti4.contest.replay.dispatch.ReplayDispatchPayload;
@@ -365,9 +366,28 @@ public class CombatReplayContestLifecycleService {
     }
 
     private ThreadChannel createReplayThread(Message posted, CombatCandidateEntity winner) {
-        return posted.createThreadChannel("combat-archive-" + winner.getGameName() + "-" + winner.getTilePosition())
+        return posted.createThreadChannel(buildReplayThreadName(winner))
                 .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS)
                 .complete();
+    }
+
+    private String buildReplayThreadName(CombatCandidateEntity candidate) {
+        String attacker = normalizeThreadNamePart(candidate.getAttackerFaction());
+        String defender = normalizeThreadNamePart(candidate.getDefenderFaction());
+        String tilePosition = StringUtils.defaultIfBlank(candidate.getTilePosition(), "unknown");
+        String candidateId =
+                candidate.getId() == null ? "unknown" : candidate.getId().toString();
+        return "combat-archive-c" + candidateId + "-t" + tilePosition + "-" + attacker + "-v-" + defender;
+    }
+
+    private String normalizeThreadNamePart(String value) {
+        String normalized = StringUtils.defaultIfBlank(value, "unknown")
+                .trim()
+                .toLowerCase()
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("(^-+|-+$)", "");
+        if (normalized.isBlank()) return "unknown";
+        return StringUtils.abbreviate(normalized, 18);
     }
 
     private CombatReplayContestEntity buildReplayContest(

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -121,10 +121,10 @@ public class CombatReplayContestLifecycleService {
         if (contestChannel == null) return null;
 
         try {
-            Message posted = contestChannel.sendMessage(message).complete();
+            Message posted = postPromotionMessage(contestChannel, message, game, winner);
             addPredictionReactions(game, winner, posted);
             ThreadChannel thread = createReplayThread(posted, winner);
-            return persistPromotedReplayContest(
+            CombatReplayContestEntity contest = persistPromotedReplayContest(
                     game,
                     observation,
                     winner,
@@ -134,9 +134,41 @@ public class CombatReplayContestLifecycleService {
                     posted,
                     thread,
                     existingContest);
+            try {
+                announcePreReplayContextIfNeeded(thread != null ? thread : contestChannel, contest, winner);
+            } catch (Exception e) {
+                BotLogger.error("Failed to post replay context at promotion.", e);
+            }
+            return contest;
         } catch (Exception e) {
             BotLogger.error("Replay contest promotion failed.", e);
             return null;
+        }
+    }
+
+    @SneakyThrows
+    private Message postPromotionMessage(
+            TextChannel contestChannel, String message, Game game, CombatCandidateEntity candidate) {
+        String snapshotJson = candidate.getInitialRenderSnapshotJson();
+        if (snapshotJson == null || snapshotJson.isBlank()) {
+            return contestChannel.sendMessage(message).complete();
+        }
+
+        Game snapshotGame = CombatReplayRenderSnapshotSupport.restoreGame(snapshotJson, game);
+        if (snapshotGame == null) {
+            return contestChannel.sendMessage(message).complete();
+        }
+
+        snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
+                candidate.getAttackerFaction(), candidate.getDefenderFaction()));
+        try (FileUpload fileUpload =
+                new TileGenerator(snapshotGame, null, null, 0, candidate.getTilePosition()).createFileUpload()) {
+            return contestChannel
+                    .sendMessage(new MessageCreateBuilder()
+                            .addContent(message)
+                            .addFiles(fileUpload)
+                            .build())
+                    .complete();
         }
     }
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -135,7 +135,9 @@ public class CombatReplayContestLifecycleService {
                     thread,
                     existingContest);
             try {
-                announcePreReplayContextIfNeeded(thread != null ? thread : contestChannel, contest, winner);
+                MessageChannel replayChannel = thread != null ? thread : contestChannel;
+                announcePreReplayContextIfNeeded(replayChannel, contest, winner);
+                announcePredictionLockCountdown(replayChannel);
             } catch (Exception e) {
                 BotLogger.error("Failed to post replay context at promotion.", e);
             }
@@ -242,6 +244,15 @@ public class CombatReplayContestLifecycleService {
         }
         contest.setPreReplayContextPostedAt(LocalDateTime.now());
         replayContestRepository.save(contest);
+    }
+
+    private void announcePredictionLockCountdown(MessageChannel channel) {
+        int startDelayMinutes = settings.getReplayExecution().getStartDelayMinutes();
+        String message = startDelayMinutes <= 0
+                ? "## Final Wagers\nVoting is now locked. The combat begins immediately."
+                : "## Final Wagers\nVoting will be locked in **" + startDelayMinutes + "** "
+                        + (startDelayMinutes == 1 ? "minute" : "minutes") + ".";
+        channel.sendMessage(message).complete();
     }
 
     private void completeReplayContest(CombatReplayContestEntity contest) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -248,9 +248,10 @@ public class CombatReplayContestLifecycleService {
 
     private void announcePredictionLockCountdown(MessageChannel channel) {
         int startDelayMinutes = settings.getReplayExecution().getStartDelayMinutes();
+        String subtitle = "_The archives remain open for a few moments longer._";
         String message = startDelayMinutes <= 0
-                ? "## Final Wagers\nVoting is now locked. The combat begins immediately."
-                : "## Final Wagers\nVoting will be locked in **" + startDelayMinutes + "** "
+                ? "## Final Wagers\n" + subtitle + "\nVoting is now locked. The combat begins immediately."
+                : "## Final Wagers\n" + subtitle + "\nVoting will be locked in **" + startDelayMinutes + "** "
                         + (startDelayMinutes == 1 ? "minute" : "minutes") + ".";
         channel.sendMessage(message).complete();
     }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -108,7 +108,7 @@ public class CombatReplayLeaderboardService {
         ScoredContestResult result = scoreContest(candidate, lockedPrediction);
         MessageChannel threadOrChannel = getContestThreadOrChannel(replayContest);
         if (threadOrChannel != null) {
-            postPredictionPointsSummary(threadOrChannel, result.winningPredictions());
+            postPredictionResultsSummary(threadOrChannel, candidate, result);
         }
         maybePostLeaderboardAfterResolvedContest();
     }
@@ -243,7 +243,7 @@ public class CombatReplayLeaderboardService {
                     return left.discordUserName().compareToIgnoreCase(right.discordUserName());
                 })
                 .toList();
-        return new ScoredContestResult(summaries);
+        return new ScoredContestResult(totalPredictions, summaries);
     }
 
     private void applyContestResult(
@@ -281,14 +281,25 @@ public class CombatReplayLeaderboardService {
         return entry;
     }
 
-    private void postPredictionPointsSummary(
-            MessageChannel threadOrChannel, List<WinningPredictionSummary> winningPredictions) {
-        if (winningPredictions.isEmpty()) return;
-
-        String message = winningPredictions.stream()
-                .map(prediction -> getSafeLeaderboardName(prediction.discordUserName()) + " - "
-                        + prediction.totalPoints() + " points (+" + prediction.pointsAwarded() + ")")
-                .collect(Collectors.joining("\n", "## Prediction Points\n", ""));
+    private void postPredictionResultsSummary(
+            MessageChannel threadOrChannel, CombatCandidateEntity candidate, ScoredContestResult result) {
+        String winnerFaction = candidate.getWinnerFaction() == null ? "Unknown" : candidate.getWinnerFaction();
+        List<WinningPredictionSummary> winningPredictions = result.winningPredictions();
+        String message = "## Prediction Results\n"
+                + "Winner: **" + winnerFaction + "**\n"
+                + "Predictions locked: **" + result.totalPredictions() + "**\n"
+                + "Correct predictions: **" + winningPredictions.size() + "**";
+        if (result.totalPredictions() == 0) {
+            message += "\nNo predictions were locked for this contest.";
+        } else if (winningPredictions.isEmpty()) {
+            message += "\nNo one called it.";
+        } else {
+            message += "\n\n"
+                    + winningPredictions.stream()
+                            .map(prediction -> "<@" + prediction.discordUserId() + "> - " + prediction.totalPoints()
+                                    + " points (+" + prediction.pointsAwarded() + ")")
+                            .collect(Collectors.joining("\n"));
+        }
         MessageHelper.splitAndSentWithAction(message, threadOrChannel, null);
     }
 
@@ -333,7 +344,7 @@ public class CombatReplayLeaderboardService {
     private String buildLockedPredictionMessage(
             Game game, CombatCandidateEntity candidate, CombatReplayPredictionEntity lockedPrediction) {
         return "## Predictions Locked\n"
-                + "Votes are now frozen before the replay begins.\n"
+                + "Votes are now frozen before the combat begins.\n"
                 + getFactionEmoji(game, candidate.getAttackerFaction()) + " " + candidate.getAttackerFaction() + ": **"
                 + safeInt(lockedPrediction.getAttackerPredictionCount()) + "**\n"
                 + getFactionEmoji(game, candidate.getDefenderFaction()) + " " + candidate.getDefenderFaction() + ": **"
@@ -380,5 +391,5 @@ public class CombatReplayLeaderboardService {
     private record WinningPredictionSummary(
             String discordUserId, String discordUserName, int pointsAwarded, int totalPoints) {}
 
-    private record ScoredContestResult(List<WinningPredictionSummary> winningPredictions) {}
+    private record ScoredContestResult(int totalPredictions, List<WinningPredictionSummary> winningPredictions) {}
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -60,7 +60,11 @@ public class CombatReplayService {
 
         if (!eligible) return;
 
-        CombatCandidateEntity candidate = buildCandidate(observation, attacker, defender);
+        CombatCandidateEntity candidate = buildCandidate(
+                observation,
+                attacker,
+                defender,
+                CombatReplayRenderSnapshotSupport.captureHitAssignmentSnapshot(game, tile.getPosition()));
         candidateRepository.save(candidate);
 
         observation.setCandidateId(candidate.getId());
@@ -403,7 +407,7 @@ public class CombatReplayService {
     }
 
     private CombatCandidateEntity buildCandidate(
-            CombatObservationEntity observation, Player attacker, Player defender) {
+            CombatObservationEntity observation, Player attacker, Player defender, String initialRenderSnapshotJson) {
         CombatCandidateEntity candidate = new CombatCandidateEntity();
         candidate.setObservationId(observation.getId());
         candidate.setStatus(CombatCandidateStatus.TRACKING);
@@ -416,6 +420,7 @@ public class CombatReplayService {
         candidate.setAttackerFaction(attacker.getFaction());
         candidate.setDefenderFaction(defender.getFaction());
         candidate.setPreReplayContextText(LazaxCombatSupport.formatCombatTechSummary(attacker, defender));
+        candidate.setInitialRenderSnapshotJson(initialRenderSnapshotJson);
         return candidate;
     }
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -196,7 +196,8 @@ public class CombatReplayService {
                 winner.getFaction(),
                 "## Contest Result\n"
                         + winner.getFactionEmoji() + " " + winner.getUserName() + " won the space combat in "
-                        + tile.getRepresentationForButtons() + ".");
+                        + tile.getRepresentationForButtons() + ".\n"
+                        + "Game Link: [Open Game](https://asyncti4.com/game/" + game.getName() + ")");
     }
 
     private void cancelCandidate(Game game, CombatCandidateEntity candidate, String reason) {

--- a/src/main/java/ti4/game/Tile.java
+++ b/src/main/java/ti4/game/Tile.java
@@ -1,5 +1,6 @@
 package ti4.game;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.awt.Point;
@@ -59,10 +60,19 @@ public class Tile {
     @JsonIgnore
     private final HashMap<String, String> fogLabel = new LinkedHashMap<>();
 
-    public Tile(@JsonProperty("tileID") String tileID, @JsonProperty("position") String position) {
+    public Tile(String tileID, String position) {
+        this(tileID, position, (Map<String, UnitHolder>) null);
+    }
+
+    @JsonCreator
+    public Tile(
+            @JsonProperty("tileID") String tileID,
+            @JsonProperty("position") String position,
+            @JsonProperty("unitHolders") Map<String, UnitHolder> unitHolders) {
         this.tileID = tileID;
         this.position = position != null ? position.toLowerCase() : null;
         initPlanetsAndSpace(tileID);
+        mergeUnitHolders(unitHolders);
     }
 
     public Tile(String tileID, String position, Player player, Boolean fog_, String fogLabel_) {
@@ -98,6 +108,23 @@ public class Tile {
         if (tilePlanetPositions != null)
             tilePlanetPositions.forEach(
                     (planetName, position) -> unitHolders.put(planetName, new Planet(planetName, position)));
+    }
+
+    private void mergeUnitHolders(@Nullable Map<String, UnitHolder> unitHolders) {
+        if (unitHolders == null) return;
+
+        for (Map.Entry<String, UnitHolder> entry : unitHolders.entrySet()) {
+            UnitHolder incomingHolder = entry.getValue();
+            if (incomingHolder == null) continue;
+
+            String holderName = StringUtils.defaultIfBlank(entry.getKey(), incomingHolder.getName());
+            UnitHolder existingHolder = this.unitHolders.get(holderName);
+            if (existingHolder != null) {
+                existingHolder.inheritEverythingFrom(incomingHolder);
+            } else {
+                this.unitHolders.put(holderName, incomingHolder);
+            }
+        }
     }
 
     public static Predicate<Tile> tileMayHaveThundersEdge() {


### PR DESCRIPTION
## Summary
- attach the initial combat tile image to replay promotion posts when a stored snapshot is available
- preserve replay snapshot unit holders during restore so hit-assignment and promotion renders include units
- always post a replay prediction results summary, including no-prediction and no-winner cases
- reduce the default replay event gap clamp to 30 seconds and update the locked-votes copy

## Verification
- mvn -q spotless:apply
- mvn -q -DskipTests compile