### PR TITLE
More improvements to lazax replay system

### DIFF
--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -144,17 +144,12 @@ public class LazaxCombatSupport {
         Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
         Tile tile = game.getTileByPosition(candidate.getTilePosition());
         String tileRepresentation = tile == null ? candidate.getTilePosition() : tile.getRepresentationForButtons();
-        String activePlayerSummary = extractRecordedActivePlayerSummary(startSummaryText);
-        if (activePlayerSummary == null) {
-            activePlayerSummary = formatActivePlayerSummary(game);
-        }
         String attackerLine = formatReplayLegendLine(attacker, candidate.getAttackerFaction());
         String defenderLine = formatReplayLegendLine(defender, candidate.getDefenderFaction());
 
         String openerText = "## A New Combat Contest Has Emerged!\n"
                 + roleMention
                 + "\n"
-                + activePlayerSummary
                 + "**System:** " + tileRepresentation + "\n"
                 + "**Combat:** Space Combat\n"
                 + "**Predict the winner by reacting below.**\n"

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -28,6 +28,7 @@ import ti4.contest.replay.repository.*;
 import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.game.Tile;
 import ti4.game.persistence.GameManager;
 import ti4.helpers.RandomHelper;
 import ti4.image.TileGenerator;
@@ -183,6 +184,7 @@ public class CombatReplayContestLifecycleService {
             return contestChannel.sendMessage(message).complete();
         }
 
+        removeReplayCommandCounters(snapshotGame, candidate.getTilePosition());
         snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
                 candidate.getAttackerFaction(), candidate.getDefenderFaction()));
         try (FileUpload fileUpload =
@@ -560,6 +562,7 @@ public class CombatReplayContestLifecycleService {
             return;
         }
         if (candidate != null) {
+            removeReplayCommandCounters(snapshotGame, tilePosition);
             snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
                     candidate.getAttackerFaction(), candidate.getDefenderFaction()));
         }
@@ -571,6 +574,13 @@ public class CombatReplayContestLifecycleService {
                             .build())
                     .complete();
         }
+    }
+
+    private void removeReplayCommandCounters(Game snapshotGame, String tilePosition) {
+        if (snapshotGame == null || tilePosition == null || tilePosition.isBlank()) return;
+        Tile tile = snapshotGame.getTileByPosition(tilePosition);
+        if (tile == null) return;
+        tile.removeAllCC();
     }
 
     private void sendDiscordMessage(

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -43,25 +43,25 @@ public class CombatReplayContestLifecycleService {
     private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives-dev";
     private static final long SHADOW_DISCORD_ID = 0L;
     private static final List<String> PREDICTION_LOCK_TITLES = List.of(
-            "Final Wagers",
-            "Closing the Archives",
-            "Last Wagers",
-            "Final Predictions",
-            "The Betting Window Narrows",
-            "The Archives Seal Soon",
-            "Last Call Before First Fire",
-            "The War Ledger Closes");
+            "The Wagers Open",
+            "The Archives Open",
+            "Predictions Are Open",
+            "The War Ledger Opens",
+            "The Betting Hall Opens",
+            "Call for Predictions",
+            "The Scribes Await",
+            "Cast Your Wager");
     private static final List<String> PREDICTION_LOCK_SUBTITLES = List.of(
-            "_The archives remain open for a few moments longer._",
-            "_The scribes still accept wagers before the first salvo._",
-            "_The war ledger has not yet been sealed._",
-            "_A few final predictions may yet be entered into the record._",
-            "_The Lazax recorders await your final judgment._",
-            "_Soon the record closes and steel decides the truth._",
-            "_The betting hall quiets as the battle draws near._",
-            "_The last whispers of speculation echo through the archives._",
-            "_Place your faith now; the guns will speak soon enough._",
-            "_The final odds are still being written in the margin._");
+            "_The Lazax recorders now accept predictions for the coming clash._",
+            "_The archives invite your judgment before the battle unfolds._",
+            "_The war ledger opens to all who would call the victor._",
+            "_The betting hall stirs as a new contest enters the record._",
+            "_The scribes stand ready to record your chosen champion._",
+            "_A new combat has been entered into the annals; predictions are welcome._",
+            "_The archives seek your verdict before the first volleys are fired._",
+            "_The next battle stands before the record; declare your pick._",
+            "_The Lazax ledgers are open to those bold enough to choose a side._",
+            "_Another clash enters the chronicles; place your wager in the record._");
 
     private final CombatContestSettings settings;
     private final CombatCandidateRepository candidateRepository;
@@ -273,8 +273,8 @@ public class CombatReplayContestLifecycleService {
         String title = RandomHelper.pickRandomFromList(PREDICTION_LOCK_TITLES);
         String subtitle = RandomHelper.pickRandomFromList(PREDICTION_LOCK_SUBTITLES);
         String message = startDelayMinutes <= 0
-                ? "## " + title + "\n" + subtitle + "\nVoting is now locked. The combat begins immediately."
-                : "## " + title + "\n" + subtitle + "\nVoting will be locked in **" + startDelayMinutes + "** "
+                ? "## " + title + "\n" + subtitle + "\nVoting is now open. The combat begins immediately."
+                : "## " + title + "\n" + subtitle + "\nVoting is now open for **" + startDelayMinutes + "** "
                         + (startDelayMinutes == 1 ? "minute" : "minutes") + ".";
         channel.sendMessage(message).complete();
     }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
@@ -33,6 +34,7 @@ import ti4.game.persistence.GameManager;
 import ti4.helpers.RandomHelper;
 import ti4.image.TileGenerator;
 import ti4.logging.BotLogger;
+import ti4.spring.service.contest.CombatContestService;
 
 @Service
 @RequiredArgsConstructor
@@ -507,13 +509,11 @@ public class CombatReplayContestLifecycleService {
     }
 
     private String getLazaxRoleMention() {
-        // if (JdaService.guildPrimary == null) return "";
-        // Role role = JdaService.guildPrimary.getRolesByName(CombatContestService.LAZAX_MINIGAME_ROLE_NAME, true)
-        //         .stream()
-        //         .findFirst()
-        //         .orElse(null);
-        // return role == null ? "" : role.getAsMention();
-        return "";
+        if (JdaService.guildPrimary == null) return "";
+        Role role = JdaService.guildPrimary.getRolesByName(CombatContestService.LAZAX_MINIGAME_ROLE_NAME, true).stream()
+                .findFirst()
+                .orElse(null);
+        return role == null ? "" : role.getAsMention();
     }
 
     private Game loadGame(String gameName) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -282,8 +282,9 @@ public class CombatReplayContestLifecycleService {
     private void completeReplayContest(CombatReplayContestEntity contest) {
         CombatCandidateEntity candidate =
                 candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        Game game = candidate == null ? null : loadGame(candidate.getGameName());
         if (candidate != null) {
-            replayLeaderboardService.finalizeReplayLeaderboardContest(contest, candidate);
+            replayLeaderboardService.finalizeReplayLeaderboardContest(game, contest, candidate);
         }
 
         contest.setReplayStatus(CombatContestReplayStatus.COMPLETED);

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
 import org.springframework.stereotype.Service;
 import ti4.contest.replay.core.CombatContestReplayStatus;
 import ti4.contest.replay.core.CombatContestSettings;
@@ -30,7 +31,9 @@ import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.json.JsonMapperManager;
+import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
+import ti4.spring.service.contest.CombatContestService;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +44,8 @@ public class CombatReplayLeaderboardService {
 
     private static final double ZERO_EPSILON = 0.0001;
     private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives-dev";
+    private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
+    private static final String UNSUBSCRIBE_EMOJI = "\uD83D\uDD34";
     private static final Comparator<LockedPrediction> LOCKED_PREDICTION_COMPARATOR = Comparator.comparing(
                     LockedPrediction::discordUserName, String.CASE_INSENSITIVE_ORDER)
             .thenComparing(LockedPrediction::discordUserId);
@@ -93,7 +98,7 @@ public class CombatReplayLeaderboardService {
     }
 
     public void finalizeReplayLeaderboardContest(
-            CombatReplayContestEntity replayContest, CombatCandidateEntity candidate) {
+            Game game, CombatReplayContestEntity replayContest, CombatCandidateEntity candidate) {
         if (!settings.getRuntime().isDiscordPostingEnabled()) return;
         if (replayContest.getId() == null) return;
 
@@ -108,7 +113,10 @@ public class CombatReplayLeaderboardService {
         ScoredContestResult result = scoreContest(candidate, lockedPrediction);
         MessageChannel threadOrChannel = getContestThreadOrChannel(replayContest);
         if (threadOrChannel != null) {
-            postPredictionResultsSummary(threadOrChannel, candidate, result);
+            postPredictionResultsSummary(threadOrChannel, candidate, result, () -> {
+                postParticipantFollowup(game, candidate, threadOrChannel);
+                postSubscriptionPrompt(threadOrChannel);
+            });
         }
         maybePostLeaderboardAfterResolvedContest();
     }
@@ -282,7 +290,10 @@ public class CombatReplayLeaderboardService {
     }
 
     private void postPredictionResultsSummary(
-            MessageChannel threadOrChannel, CombatCandidateEntity candidate, ScoredContestResult result) {
+            MessageChannel threadOrChannel,
+            CombatCandidateEntity candidate,
+            ScoredContestResult result,
+            Runnable afterPost) {
         String winnerFaction = candidate.getWinnerFaction() == null ? "Unknown" : candidate.getWinnerFaction();
         List<WinningPredictionSummary> winningPredictions = result.winningPredictions();
         String message = "## Prediction Results\n"
@@ -300,7 +311,35 @@ public class CombatReplayLeaderboardService {
                                     + " points (+" + prediction.pointsAwarded() + ")")
                             .collect(Collectors.joining("\n"));
         }
-        MessageHelper.splitAndSentWithAction(message, threadOrChannel, null);
+        MessageHelper.splitAndSentWithAction(message, threadOrChannel, ignored -> {
+            if (afterPost != null) {
+                afterPost.run();
+            }
+        });
+    }
+
+    private void postParticipantFollowup(Game game, CombatCandidateEntity candidate, MessageChannel threadOrChannel) {
+        if (game == null) return;
+        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        if (attacker == null || defender == null) return;
+
+        String message = "## Summons From The Archives\n"
+                + "<@" + attacker.getUserID() + "> <@" + defender.getUserID() + ">\n"
+                + "By decree of the Lazax War Game, your fleets have been judged worthy of remembrance. "
+                + "If it pleases the honored claimants, tarry a moment and read the commentaries, acclaim, and quiet condemnation recorded above concerning your struggle.";
+        MessageHelper.sendMessageToChannel(threadOrChannel, message);
+    }
+
+    private void postSubscriptionPrompt(MessageChannel threadOrChannel) {
+        String message = "Did you like this? React " + SUBSCRIBE_EMOJI
+                + " to subscribe to more, " + UNSUBSCRIBE_EMOJI
+                + " to opt out if already subscribed.\n"
+                + CombatContestService.LAZAX_MINIGAME_SUBSCRIPTION_MARKER;
+        MessageHelper.splitAndSentWithAction(message, threadOrChannel, postedMessage -> {
+            postedMessage.addReaction(Emoji.fromUnicode(SUBSCRIBE_EMOJI)).queue(null, BotLogger::catchRestError);
+            postedMessage.addReaction(Emoji.fromUnicode(UNSUBSCRIBE_EMOJI)).queue(null, BotLogger::catchRestError);
+        });
     }
 
     private void maybePostLeaderboardAfterResolvedContest() {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -113,7 +113,7 @@ public class CombatReplayLeaderboardService {
         ScoredContestResult result = scoreContest(candidate, lockedPrediction);
         MessageChannel threadOrChannel = getContestThreadOrChannel(replayContest);
         if (threadOrChannel != null) {
-            postPredictionResultsSummary(threadOrChannel, candidate, result, () -> {
+            postPredictionResultsSummary(game, threadOrChannel, candidate, result, () -> {
                 postParticipantFollowup(game, candidate, threadOrChannel);
                 postSubscriptionPrompt(threadOrChannel);
             });
@@ -290,14 +290,15 @@ public class CombatReplayLeaderboardService {
     }
 
     private void postPredictionResultsSummary(
+            Game game,
             MessageChannel threadOrChannel,
             CombatCandidateEntity candidate,
             ScoredContestResult result,
             Runnable afterPost) {
-        String winnerFaction = candidate.getWinnerFaction() == null ? "Unknown" : candidate.getWinnerFaction();
+        String winnerDisplay = getWinnerDisplay(game, candidate);
         List<WinningPredictionSummary> winningPredictions = result.winningPredictions();
         String message = "## Prediction Results\n"
-                + "Winner: **" + winnerFaction + "**\n"
+                + "Winner: " + winnerDisplay + "\n"
                 + "Predictions locked: **" + result.totalPredictions() + "**\n"
                 + "Correct predictions: **" + winningPredictions.size() + "**";
         if (result.totalPredictions() == 0) {
@@ -316,6 +317,16 @@ public class CombatReplayLeaderboardService {
                 afterPost.run();
             }
         });
+    }
+
+    private String getWinnerDisplay(Game game, CombatCandidateEntity candidate) {
+        if (game != null && candidate.getWinnerFaction() != null) {
+            Player winner = game.getPlayerFromColorOrFaction(candidate.getWinnerFaction());
+            if (winner != null) {
+                return winner.getFactionEmoji() + " **" + getSafeLeaderboardName(winner.getUserName()) + "**";
+            }
+        }
+        return "**" + (candidate.getWinnerFaction() == null ? "Unknown" : candidate.getWinnerFaction()) + "**";
     }
 
     private void postParticipantFollowup(Game game, CombatCandidateEntity candidate, MessageChannel threadOrChannel) {

--- a/src/main/java/ti4/game/Planet.java
+++ b/src/main/java/ti4/game/Planet.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import lombok.Getter;
 import lombok.Setter;
 import ti4.helpers.Constants;
 import ti4.helpers.Helper;
+import ti4.helpers.Units.UnitKey;
 import ti4.image.Mapper;
 import ti4.model.AttachmentModel;
 import ti4.model.PlanetModel;
@@ -59,9 +61,19 @@ public class Planet extends UnitHolder {
     @Getter
     private float radius;
 
+    public Planet(String name, Point holderCenterPosition) {
+        this(name, holderCenterPosition, null, null, null, null);
+    }
+
     @JsonCreator
-    public Planet(@JsonProperty("name") String name, @JsonProperty("holderCenterPosition") Point holderCenterPosition) {
-        super(name, holderCenterPosition);
+    public Planet(
+            @JsonProperty("name") String name,
+            @JsonProperty("holderCenterPosition") Point holderCenterPosition,
+            @JsonProperty("unitsByState") Map<UnitKey, List<Integer>> unitsByState,
+            @JsonProperty("ccList") Set<String> ccList,
+            @JsonProperty("controlList") Set<String> controlList,
+            @JsonProperty("tokenList") Set<String> tokenList) {
+        super(name, holderCenterPosition, unitsByState, ccList, controlList, tokenList);
         PlanetModel planetInfo = Mapper.getPlanet(name);
         if (planetInfo != null) {
             if (planetInfo.getPlanetTypes() != null) {


### PR DESCRIPTION
## Summary
- rewrite the replay voting announcement so it presents voting as opening, with randomized open-themed titles and subtitles
- add the old post-result followups to replay completion: the participant summons message plus the Lazax subscription prompt and reactions
- show the replay prediction-results winner as the resolved player identity with faction emoji instead of the raw faction id
- remove the active-player line from the replay promotion opener
- preserve planet state in replay snapshots so ground units, planet control, and planet tokens survive restore
- strip command counters from Lazax replay renders so system activations are not shown in promotion or replay images

## Verification
- mvn -q spotless:apply
- mvn -q -DskipTests compile