### PR TITLE
Replay resolved result images

### DIFF
--- a/src/main/java/ti4/contest/replay/dispatch/ReplayDispatchPayload.java
+++ b/src/main/java/ti4/contest/replay/dispatch/ReplayDispatchPayload.java
@@ -8,7 +8,8 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = ReplayDispatchPayload.DiscordMessageDispatch.class, name = "DISCORD_MESSAGE"),
-    @JsonSubTypes.Type(value = ReplayDispatchPayload.HitAssignDispatch.class, name = "HIT_ASSIGN")
+    @JsonSubTypes.Type(value = ReplayDispatchPayload.HitAssignDispatch.class, name = "HIT_ASSIGN"),
+    @JsonSubTypes.Type(value = ReplayDispatchPayload.TileRenderMessageDispatch.class, name = "TILE_RENDER_MESSAGE")
 })
 /**
  * Canonical persisted replay action model.
@@ -35,9 +36,26 @@ public interface ReplayDispatchPayload {
         return new HitAssignDispatch(tilePosition, combatStateSnapshotJson);
     }
 
+    static ReplayDispatchPayload tileRenderMessage(
+            String tilePosition, String combatStateSnapshotJson, String content) {
+        return new TileRenderMessageDispatch(
+                tilePosition, combatStateSnapshotJson, new DiscordMessage(content, List.of()));
+    }
+
+    static ReplayDispatchPayload tileRenderMessage(
+            String tilePosition, String combatStateSnapshotJson, String content, List<MessageEmbed> embeds) {
+        return new TileRenderMessageDispatch(
+                tilePosition,
+                combatStateSnapshotJson,
+                new DiscordMessage(content, ReplayDispatchSerializer.fromMessageEmbeds(embeds)));
+    }
+
     record DiscordMessageDispatch(DiscordMessage message) implements ReplayDispatchPayload {}
 
     record HitAssignDispatch(String tilePosition, String combatStateSnapshotJson) implements ReplayDispatchPayload {}
+
+    record TileRenderMessageDispatch(String tilePosition, String combatStateSnapshotJson, DiscordMessage message)
+            implements ReplayDispatchPayload {}
 
     record DiscordMessage(String content, List<DiscordEmbed> embeds) {
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -530,6 +530,10 @@ public class CombatReplayContestLifecycleService {
             postHitAssignmentReplayEvent(channel, game, candidate, event, hit);
             return;
         }
+        if (payload instanceof ReplayDispatchPayload.TileRenderMessageDispatch tileRender) {
+            postTileRenderReplayEvent(channel, game, candidate, event.getSummaryText(), tileRender);
+            return;
+        }
         if (payload instanceof ReplayDispatchPayload.DiscordMessageDispatch messageDispatch) {
             sendDiscordMessage(channel, messageDispatch.message(), event.getSummaryText());
             return;
@@ -545,9 +549,40 @@ public class CombatReplayContestLifecycleService {
             CombatCandidateEntity candidate,
             CombatCandidateEventEntity event,
             ReplayDispatchPayload.HitAssignDispatch payload) {
-        String message = event.getSummaryText();
-        String tilePosition = payload.tilePosition();
-        String snapshotJson = payload.combatStateSnapshotJson();
+        postTileRenderReplayEvent(
+                channel,
+                game,
+                candidate,
+                event.getSummaryText(),
+                List.of(),
+                payload.tilePosition(),
+                payload.combatStateSnapshotJson());
+    }
+
+    @SneakyThrows
+    private void postTileRenderReplayEvent(
+            MessageChannel channel,
+            Game game,
+            CombatCandidateEntity candidate,
+            String fallbackMessage,
+            ReplayDispatchPayload.TileRenderMessageDispatch payload) {
+        ReplayDispatchPayload.DiscordMessage replayMessage = payload.message();
+        String message = replayMessage == null ? fallbackMessage : replayMessage.content();
+        List<MessageEmbed> embeds =
+                replayMessage == null ? List.of() : ReplayDispatchSerializer.toMessageEmbeds(replayMessage.embeds());
+        postTileRenderReplayEvent(
+                channel, game, candidate, message, embeds, payload.tilePosition(), payload.combatStateSnapshotJson());
+    }
+
+    @SneakyThrows
+    private void postTileRenderReplayEvent(
+            MessageChannel channel,
+            Game game,
+            CombatCandidateEntity candidate,
+            String message,
+            List<MessageEmbed> embeds,
+            String tilePosition,
+            String snapshotJson) {
         if (tilePosition == null || snapshotJson == null) {
             channel.sendMessage(message).complete();
             return;
@@ -564,11 +599,12 @@ public class CombatReplayContestLifecycleService {
         }
 
         try (FileUpload fileUpload = new TileGenerator(snapshotGame, null, null, 0, tilePosition).createFileUpload()) {
-            channel.sendMessage(new MessageCreateBuilder()
-                            .addContent(message)
-                            .addFiles(fileUpload)
-                            .build())
-                    .complete();
+            MessageCreateBuilder builder =
+                    new MessageCreateBuilder().addContent(message).addFiles(fileUpload);
+            if (!embeds.isEmpty()) {
+                builder.addEmbeds(embeds);
+            }
+            channel.sendMessage(builder.build()).complete();
         }
     }
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -189,11 +189,13 @@ public class CombatReplayService {
         candidate.setPromotionScore(roundsObserved + mutualLossScore);
         candidateRepository.save(candidate);
 
-        appendDiscordEvent(
+        appendTileRenderEvent(
                 candidate,
                 CombatCandidateEventType.RESOLVED,
                 roundsObserved,
                 winner.getFaction(),
+                tile.getPosition(),
+                CombatReplayRenderSnapshotSupport.captureHitAssignmentSnapshot(game, tile.getPosition()),
                 "## Contest Result\n"
                         + winner.getFactionEmoji() + " " + winner.getUserName() + " won the space combat in "
                         + tile.getRepresentationForButtons() + ".\n"
@@ -471,6 +473,23 @@ public class CombatReplayService {
                 actorFaction,
                 message,
                 ReplayDispatchPayload.discordMessage(message, embed));
+    }
+
+    private void appendTileRenderEvent(
+            CombatCandidateEntity candidate,
+            CombatCandidateEventType eventType,
+            Integer roundNumber,
+            String actorFaction,
+            String tilePosition,
+            String snapshotJson,
+            String message) {
+        eventAppender.appendEvent(
+                candidate,
+                eventType,
+                roundNumber,
+                actorFaction,
+                message,
+                ReplayDispatchPayload.tileRenderMessage(tilePosition, snapshotJson, message));
     }
 
     private CombatCandidateEntity resolveCandidateForMirrorEvent(Game game, Player player, String sourceChannelName) {


### PR DESCRIPTION
## Summary
- add a replay dispatch payload for tile-rendered messages
- capture a resolved combat snapshot for replay result events
- replay the contest result with the rendered end-of-combat image

## Verification
- mvn -q spotless:apply
- mvn -q -DskipTests compile