### PR TITLE
Expand replay rollout controls and posting behavior

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayCron.java
@@ -16,7 +16,7 @@ public class CombatReplayCron {
 
     public static void register() {
         CronManager.schedulePeriodically(
-                CombatReplayCron.class, CombatReplayCron::runReplayTick, 5, 5, TimeUnit.SECONDS);
+                CombatReplayCron.class, CombatReplayCron::runReplayTick, 2, 2, TimeUnit.SECONDS);
     }
 
     private static void runReplayTick() {

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -118,6 +118,6 @@ public class CombatContestSettings {
     @Data
     @NoArgsConstructor
     public static class Runtime {
-        private boolean discordPostingEnabled = false;
+        private boolean discordPostingEnabled = true;
     }
 }

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -70,6 +70,10 @@ public class CombatContestSettings {
         require(replayExecution.maxEventGapSeconds >= 0, "replayExecution.maxEventGapSeconds must be >= 0.");
         require(retention.observationRetentionDays > 0, "retention.observationRetentionDays must be > 0.");
         require(retention.eventRetentionDays > 0, "retention.eventRetentionDays must be > 0.");
+        require(runtime.versionEnabled != null, "runtime.versionEnabled is required.");
+        require(
+                "v1".equalsIgnoreCase(runtime.versionEnabled) || "v2".equalsIgnoreCase(runtime.versionEnabled),
+                "runtime.versionEnabled must be 'v1' or 'v2'.");
     }
 
     private void require(boolean condition, String message) {
@@ -119,5 +123,6 @@ public class CombatContestSettings {
     @NoArgsConstructor
     public static class Runtime {
         private boolean discordPostingEnabled = true;
+        private String versionEnabled = "v1";
     }
 }

--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -285,7 +285,8 @@ public class LazaxCombatSupport {
             Game game, Tile tile, Player attacker, Player defender, String activePlayerSummary) {
         return "## Lazax Candidate Recorded\n"
                 + "**Game:** `" + game.getName() + "`\n"
-                + "**Game Link:** [Open Game](https://asyncti4.com/game/" + game.getName() + ")\n"
+                + "**Game " + game.getName() + ":** [Open Game](https://asyncti4.com/game/" + game.getName()
+                + ")\n"
                 + activePlayerSummary
                 + "**System:** " + tile.getRepresentationForButtons() + "\n"
                 + "**Combat:** Space Combat\n"

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -43,7 +43,8 @@ import ti4.spring.service.contest.CombatContestService;
  */
 public class CombatReplayContestLifecycleService {
 
-    private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives-dev";
+    private static final String CONTEST_CHANNEL_NAME_V1 = "lazax-war-archives-dev";
+    private static final String CONTEST_CHANNEL_NAME_V2 = "lazax-war-archives";
     private static final long SHADOW_DISCORD_ID = 0L;
     private static final List<String> PREDICTION_LOCK_TITLES = List.of(
             "The Wagers Open",
@@ -246,8 +247,12 @@ public class CombatReplayContestLifecycleService {
                     .findByCandidateIdAndSequenceNumber(contest.getCandidateId(), contest.getNextEventSequence() + 1)
                     .orElse(null);
             contest.setNextEventSequence(contest.getNextEventSequence() + 1);
-            contest.setReplayStatus(CombatContestReplayStatus.REPLAYING);
             contest.setReplayError(null);
+            if (nextEvent == null) {
+                completeReplayContest(contest);
+                return;
+            }
+            contest.setReplayStatus(CombatContestReplayStatus.REPLAYING);
             contest.setNextReplayAt(computeConfiguredNextReplayAt(LocalDateTime.now(), event, nextEvent));
         } catch (Exception e) {
             rescheduleReplay(contest, e.getMessage());
@@ -503,9 +508,18 @@ public class CombatReplayContestLifecycleService {
 
     private TextChannel getContestChannel() {
         if (JdaService.guildPrimary == null) return null;
-        return JdaService.guildPrimary.getTextChannelsByName(CONTEST_CHANNEL_NAME, true).stream()
+        return JdaService.guildPrimary.getTextChannelsByName(getContestChannelName(), true).stream()
                 .findFirst()
                 .orElse(null);
+    }
+
+    private String getContestChannelName() {
+        return isReplayV2Enabled() ? CONTEST_CHANNEL_NAME_V2 : CONTEST_CHANNEL_NAME_V1;
+    }
+
+    private boolean isReplayV2Enabled() {
+        String versionEnabled = settings.getRuntime().getVersionEnabled();
+        return "v2".equalsIgnoreCase(versionEnabled);
     }
 
     private String getLazaxRoleMention() {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -18,7 +18,6 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import org.springframework.stereotype.Service;
-import ti4.contest.replay.core.CombatContestReplayStatus;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
@@ -43,9 +42,10 @@ import ti4.spring.service.contest.CombatContestService;
 public class CombatReplayLeaderboardService {
 
     private static final double ZERO_EPSILON = 0.0001;
-    private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives-dev";
     private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
     private static final String UNSUBSCRIBE_EMOJI = "\uD83D\uDD34";
+    private static final String CONTEST_CHANNEL_NAME_V1 = "lazax-war-archives-dev";
+    private static final String CONTEST_CHANNEL_NAME_V2 = "lazax-war-archives";
     private static final Comparator<LockedPrediction> LOCKED_PREDICTION_COMPARATOR = Comparator.comparing(
                     LockedPrediction::discordUserName, String.CASE_INSENSITIVE_ORDER)
             .thenComparing(LockedPrediction::discordUserId);
@@ -101,12 +101,13 @@ public class CombatReplayLeaderboardService {
             Game game, CombatReplayContestEntity replayContest, CombatCandidateEntity candidate) {
         if (!settings.getRuntime().isDiscordPostingEnabled()) return;
         if (replayContest.getId() == null) return;
+        if (replayContest.getLeaderboardPostedAt() != null) return;
 
         CombatReplayPredictionEntity lockedPrediction = replayPredictionRepository
                 .findByContestId(replayContest.getId())
                 .orElse(null);
         if (lockedPrediction == null) {
-            maybePostLeaderboardAfterResolvedContest();
+            markLeaderboardPostedIfPublished(replayContest);
             return;
         }
 
@@ -118,7 +119,7 @@ public class CombatReplayLeaderboardService {
                 postSubscriptionPrompt(threadOrChannel);
             });
         }
-        maybePostLeaderboardAfterResolvedContest();
+        markLeaderboardPostedIfPublished(replayContest);
     }
 
     public boolean postLeaderboard() {
@@ -353,16 +354,9 @@ public class CombatReplayLeaderboardService {
         });
     }
 
-    private void maybePostLeaderboardAfterResolvedContest() {
-        List<CombatReplayContestEntity> pendingBatch = replayContestRepository
-                .findTop5ByReplayStatusAndReplayCompletedAtIsNotNullAndLeaderboardPostedAtIsNullOrderByReplayCompletedAtAsc(
-                        CombatContestReplayStatus.COMPLETED);
-        if (pendingBatch.size() < 5) return;
+    private void markLeaderboardPostedIfPublished(CombatReplayContestEntity replayContest) {
         if (!postLeaderboard()) return;
-
-        LocalDateTime postedAt = LocalDateTime.now();
-        pendingBatch.forEach(contest -> contest.setLeaderboardPostedAt(postedAt));
-        replayContestRepository.saveAll(pendingBatch);
+        replayContest.setLeaderboardPostedAt(LocalDateTime.now());
     }
 
     private TextChannel getContestPublicChannel(Long publicChannelId) {
@@ -372,9 +366,18 @@ public class CombatReplayLeaderboardService {
 
     private TextChannel getContestPublicChannelByName() {
         if (JdaService.guildPrimary == null) return null;
-        return JdaService.guildPrimary.getTextChannelsByName(CONTEST_CHANNEL_NAME, true).stream()
+        return JdaService.guildPrimary.getTextChannelsByName(getContestChannelName(), true).stream()
                 .findFirst()
                 .orElse(null);
+    }
+
+    private String getContestChannelName() {
+        return isReplayV2Enabled() ? CONTEST_CHANNEL_NAME_V2 : CONTEST_CHANNEL_NAME_V1;
+    }
+
+    private boolean isReplayV2Enabled() {
+        String versionEnabled = settings.getRuntime().getVersionEnabled();
+        return "v2".equalsIgnoreCase(versionEnabled);
     }
 
     private MessageChannel getContestThreadOrChannel(CombatReplayContestEntity contest) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -199,7 +199,8 @@ public class CombatReplayService {
                 "## Contest Result\n"
                         + winner.getFactionEmoji() + " " + winner.getUserName() + " won the space combat in "
                         + tile.getRepresentationForButtons() + ".\n"
-                        + "Game Link: [Open Game](https://asyncti4.com/game/" + game.getName() + ")");
+                        + "Game " + game.getName() + ": [Open Game](https://asyncti4.com/game/" + game.getName()
+                        + ")");
     }
 
     private void cancelCandidate(Game game, CombatCandidateEntity candidate, String reason) {

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -30,7 +30,9 @@ import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.LazaxCombatSupport;
+import ti4.contest.replay.service.CombatReplayLeaderboardService;
 import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.JdaService;
 import ti4.game.Game;
@@ -76,6 +78,8 @@ public class CombatContestService {
     private final CombatContestPredictionRepository predictionRepository;
     private final CombatContestSampleRepository sampleRepository;
     private final CombatContestSelectionService selectionService;
+    private final CombatContestSettings replaySettings;
+    private final CombatReplayLeaderboardService combatReplayLeaderboardService;
     private final CombatReplayService combatReplayService;
 
     // ==================== Public Entry Points ====================
@@ -83,6 +87,7 @@ public class CombatContestService {
     public void onSpaceCombatStarted(Game game, Player attacker, Player defender, Tile tile) {
         runReplayHook(
                 game, "combat start", () -> combatReplayService.onSpaceCombatStarted(game, attacker, defender, tile));
+        if (isReplayV2Enabled()) return;
         try {
             if (!isEligibleGame(game) || !isEligibleCombat(game, attacker, defender, tile)) return;
 
@@ -125,6 +130,7 @@ public class CombatContestService {
     public void onButtonInteractionSettled(Game game, Player player, ButtonInteractionEvent event) {
         runReplayHook(
                 game, "button settlement", () -> combatReplayService.onButtonInteractionSettled(game, player, event));
+        if (isReplayV2Enabled()) return;
         try {
             List<CombatContestEntity> activeContests =
                     repository.findByGameNameAndStatusIn(game.getName(), ACTIVE_STATUSES);
@@ -144,6 +150,7 @@ public class CombatContestService {
                 game,
                 "roll mirror",
                 () -> combatReplayService.mirrorCombatRoll(game, player, opponent, tile, message, rollType, hits));
+        if (isReplayV2Enabled()) return;
         try {
             CombatContestEntity contest = repository
                     .findFirstByGameNameAndTilePositionAndCombatTypeAndStatusInOrderByPostedAtDesc(
@@ -169,6 +176,7 @@ public class CombatContestService {
                 game,
                 "event mirror",
                 () -> combatReplayService.mirrorCombatEvent(game, player, header, name, embed, sourceChannelName));
+        if (isReplayV2Enabled()) return;
         try {
             List<CombatContestEntity> activeContests =
                     repository.findByGameNameAndStatusIn(game.getName(), ACTIVE_STATUSES);
@@ -187,6 +195,9 @@ public class CombatContestService {
     }
 
     public boolean postLeaderboard() {
+        if (isReplayV2Enabled()) {
+            return combatReplayLeaderboardService.postLeaderboard();
+        }
         String message = buildLeaderboardMessage();
         if (message == null) return false;
 
@@ -202,6 +213,11 @@ public class CombatContestService {
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Replay combat hook failed on " + action + ".", e);
         }
+    }
+
+    private boolean isReplayV2Enabled() {
+        String versionEnabled = replaySettings.getRuntime().getVersionEnabled();
+        return "v2".equalsIgnoreCase(versionEnabled);
     }
 
     // ==================== Contest Creation & Eligibility ====================


### PR DESCRIPTION
## Summary
- reduce the replay cron wake interval from 5 seconds to 2 seconds while keeping replay event pacing gated by settings
- enable replay Discord posting by default
- include the game name in replay game-link labels
- finalize replay contests in the same tick as the final contest-result event instead of waiting for another replay tick
- add `runtime.versionEnabled` (`v1`/`v2`) to the replay settings
- route replay posting and replay leaderboard posts to `lazax-war-archives-dev` in `v1` and `lazax-war-archives` in `v2`
- disable the old `CombatContestService` public flow under `v2` after running the replay hooks, and proxy old leaderboard posting to the replay leaderboard under `v2`
- publish the replay global leaderboard in the main archive channel after every replay contest resolution instead of batching every 5 contests

## Verification
- mvn -q spotless:apply
- mvn -q -DskipTests compile