### PR TITLE
Expand replay promotion lookback fallback

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -124,6 +124,6 @@ public class CombatContestSettings {
     @NoArgsConstructor
     public static class Runtime {
         private boolean discordPostingEnabled = true;
-        private String versionEnabled = "v1";
+        private String versionEnabled = "v2";
     }
 }

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -15,6 +15,7 @@ import tools.jackson.databind.ObjectMapper;
 public class CombatContestSettings {
 
     private static final ObjectMapper MAPPER = JsonMapperManager.basic();
+    public static final int PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS = 8;
 
     private CandidateSelection candidateSelection = new CandidateSelection();
     private Promotion promotion = new Promotion();

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -84,13 +84,26 @@ public class CombatReplayContestLifecycleService {
             return;
         }
 
-        List<CombatCandidateEntity> candidates = candidateRepository.findResolvedPromotionCandidates(
-                CombatCandidateStatus.RESOLVED,
-                CombatCandidatePromotionStatus.PENDING,
-                now.minusHours(settings.getPromotion().getCandidateLookbackHours()));
+        List<CombatCandidateEntity> candidates = findPromotionCandidates(now);
         CombatCandidateEntity winner = selectPromotionWinner(candidates);
         if (winner == null) return;
         promoteCandidate(winner);
+    }
+
+    private List<CombatCandidateEntity> findPromotionCandidates(LocalDateTime now) {
+        int configuredLookbackHours = settings.getPromotion().getCandidateLookbackHours();
+        int maxLookbackHours =
+                Math.max(configuredLookbackHours, CombatContestSettings.PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS);
+        for (int lookbackHours = configuredLookbackHours; lookbackHours <= maxLookbackHours; lookbackHours++) {
+            List<CombatCandidateEntity> candidates = candidateRepository.findResolvedPromotionCandidates(
+                    CombatCandidateStatus.RESOLVED,
+                    CombatCandidatePromotionStatus.PENDING,
+                    now.minusHours(lookbackHours));
+            if (!candidates.isEmpty()) {
+                return candidates;
+            }
+        }
+        return List.of();
     }
 
     public ForcePromoteResult forcePromoteCandidate(Long candidateId) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
@@ -36,10 +36,12 @@ public class CombatReplayJanitorService {
     }
 
     private void expireStaleResolvedCandidates(LocalDateTime now) {
+        int expirationLookbackHours = Math.max(
+                settings.getPromotion().getCandidateLookbackHours(),
+                CombatContestSettings.PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS);
         candidateRepository
                 .findByPromotionStatusAndResolvedAtBefore(
-                        CombatCandidatePromotionStatus.PENDING,
-                        now.minusHours(settings.getPromotion().getCandidateLookbackHours()))
+                        CombatCandidatePromotionStatus.PENDING, now.minusHours(expirationLookbackHours))
                 .stream()
                 .filter(candidate -> candidate.getStatus() == CombatCandidateStatus.RESOLVED)
                 .forEach(candidate -> {


### PR DESCRIPTION
## Summary
- expand replay promotion lookup from the configured lookback window in 1-hour steps when no promotable candidates are found
- stop expanding once candidates are found or the search reaches 8 hours
- align pending candidate expiration with the same 8-hour fallback ceiling so older candidates remain promotable during fallback lookup

## Verification
- mvn -q spotless:apply
- mvn -q -DskipTests compile