### PR TITLE
Add Exploration Extravaganza homebrew: Planetary Stabilisation + Ghost Splice Experiment

### DIFF
--- a/src/main/java/ti4/model/Source.java
+++ b/src/main/java/ti4/model/Source.java
@@ -81,6 +81,7 @@ public class Source {
         memephilosopher,
         omega_phase,
         fowplus,
+        exploration_extravaganza,
 
         // eronous' stuff
         eronous,
@@ -198,6 +199,7 @@ public class Source {
                 case monuments -> "Monuments+ [Homebrew]";
                 case omega_phase -> "Omega Phase [Homebrew]";
                 case voices_of_the_council -> "Voices of the Council [Homebrew]";
+                case exploration_extravaganza -> "Exploration Extravaganza [Homebrew]";
                 default -> toString();
             };
         }

--- a/src/main/resources/data/abilities/exploration_extravaganza.json
+++ b/src/main/resources/data/abilities/exploration_extravaganza.json
@@ -1,0 +1,10 @@
+[
+    {
+        "id": "planetary_stabilisation",
+        "name": "Planetary Stabilisation",
+        "faction": "neutral",
+        "window": "ACTION",
+        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On 1-4, draw a random unused red tile; on 5-10, draw a random unused blue tile. Place it adjacent to an unactivated system that contains your ships, touching that system. If the placed system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then, you may spend trade goods equal to half your trade goods minus 1 for each tile touching the placed tile, to activate it with a token from your reinforcements and continue with a tactical action.",
+        "source": "exploration_extravaganza"
+    }
+]

--- a/src/main/resources/data/abilities/other.json
+++ b/src/main/resources/data/abilities/other.json
@@ -116,13 +116,5 @@
         "faction": "keleres",
         "permanentEffect": "During setup, choose an unplayed faction from among the Mentak, the Xxcha and The Argent Flight; take that faction's home system, command tokens and control markers. Additionally, take the Keleres Hero that corresponds to that faction",
         "source": "codex3"
-    },
-    {
-        "id": "planetary_stabilisation",
-        "name": "Planetary Stabilisation",
-        "faction": "neutral",
-        "window": "ACTION",
-        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On 1-4, draw a random unused red tile; on 5-10, draw a random unused blue tile. Place it adjacent to an unactivated system that contains your ships, touching that system. If the placed system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then, you may spend trade goods equal to half your trade goods minus 1 for each tile touching the placed tile, to activate it with a token from your reinforcements and continue with a tactical action.",
-        "source": "exploration_extravaganza"
     }
 ]

--- a/src/main/resources/data/abilities/other.json
+++ b/src/main/resources/data/abilities/other.json
@@ -116,5 +116,13 @@
         "faction": "keleres",
         "permanentEffect": "During setup, choose an unplayed faction from among the Mentak, the Xxcha and The Argent Flight; take that faction's home system, command tokens and control markers. Additionally, take the Keleres Hero that corresponds to that faction",
         "source": "codex3"
+    },
+    {
+        "id": "planetary_stabilisation",
+        "name": "Planetary Stabilisation",
+        "faction": "neutral",
+        "window": "ACTION",
+        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On 1-4, draw a random unused red tile; on 5-10, draw a random unused blue tile. Place it adjacent to an unactivated system that contains your ships, touching that system. If the placed system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then, you may spend trade goods equal to half your trade goods minus 1 for each tile touching the placed tile, to activate it with a token from your reinforcements and continue with a tactical action.",
+        "source": "exploration_extravaganza"
     }
 ]

--- a/src/main/resources/data/action_cards/exploration_extravaganza.json
+++ b/src/main/resources/data/action_cards/exploration_extravaganza.json
@@ -1,0 +1,10 @@
+[
+    {
+        "alias": "ee-ghost_splice",
+        "name": "Ghost Splice Experiment",
+        "phase": "Action",
+        "window": "Action",
+        "text": "Place a ghost wormhole token into a system. Then perform your Ghost hero ability.",
+        "source": "exploration_extravaganza"
+    }
+]

--- a/src/main/resources/data/action_cards/exploration_extravaganza.json
+++ b/src/main/resources/data/action_cards/exploration_extravaganza.json
@@ -1,7 +1,7 @@
 [
     {
-        "alias": "ee-ghost_splice",
-        "name": "Ghost Splice Experiment",
+        "alias": "ee-ghost",
+        "name": "Ghost Experiment",
         "phase": "Action",
         "window": "Action",
         "text": "Place a ghost wormhole token into a system. Then perform your Ghost hero ability.",

--- a/src/main/resources/data/sources/sources.json
+++ b/src/main/resources/data/sources/sources.json
@@ -282,5 +282,13 @@
         "data": [
             "Official channel: https://discord.com/channels/743629929484386395/1422472031949029396"
         ]
+    },
+    {
+        "source": "exploration_extravaganza",
+        "name": "Exploration Extravaganza",
+        "canal": "community",
+        "subcanal": "personal projs",
+        "credits": "paven",
+        "description": "Planetary Stabilisation action available to all players; Ghost Splice Experiment SC and AC"
     }
 ]

--- a/src/main/resources/data/strategy_cards/exploration_extravaganza.json
+++ b/src/main/resources/data/strategy_cards/exploration_extravaganza.json
@@ -2,7 +2,7 @@
     {
         "id": "ee9",
         "initiative": 9,
-        "name": "Ghost Splice Experiment",
+        "name": "Ghost Experiment",
         "primaryTexts": [
             "Place a ghost wormhole token into a system.",
             "Perform the Planetary Stabilisation action without spending a Command Counter from your Strategy Pool, choosing the result of the die roll.",

--- a/src/main/resources/data/strategy_cards/exploration_extravaganza.json
+++ b/src/main/resources/data/strategy_cards/exploration_extravaganza.json
@@ -1,0 +1,18 @@
+[
+    {
+        "id": "ee9",
+        "initiative": 9,
+        "name": "Ghost Splice Experiment",
+        "primaryTexts": [
+            "Place a ghost wormhole token into a system.",
+            "Perform the Planetary Stabilisation action without spending a Command Counter from your Strategy Pool, choosing the result of the die roll.",
+            "Then perform your Ghost hero ability."
+        ],
+        "secondaryTexts": [
+            "Spend 1 token from your strategy pool to perform the Planetary Stabilisation action without spending a Command Counter from your Strategy Pool. You may not activate the placed system."
+        ],
+        "imageFileName": "ee9",
+        "colourHexCode": "#9b59b6",
+        "source": "exploration_extravaganza"
+    }
+]


### PR DESCRIPTION
## Summary

Adds data-only support for **Exploration Extravaganza**, a homebrew variant that gives all players a generally available **Planetary Stabilisation** action, plus an optional Strategy Card 9 and Action Card.

- `data/abilities/exploration_extravaganza.json` — new file; `planetary_stabilisation` ability with `"faction": "neutral"` and `"window": "ACTION"` so it appears as a component action button for any player it is given to (via `/franken ability_add planetary_stabilisation`)
- `data/strategy_cards/exploration_extravaganza.json` — new file; SC 9 "Ghost Splice Experiment" (initiative 9)
- `data/action_cards/exploration_extravaganza.json` — new file; AC "Ghost Splice Experiment"
- `ti4/model/Source.java` — `exploration_extravaganza` added to `ComponentSource` enum
- `data/sources/sources.json` — source metadata entry added

## Notes

The SC 9 and AC have no automation (`automationID`) — they are text-only cards resolved manually at the table. The ability likewise has no bot enforcement; the die roll and tile placement are player-resolved.

At game start, give all players the ability with:
```
/franken ability_add planetary_stabilisation
```