### PR TITLE
Add Untangled Space homebrew: Planetary Stabilisation + Ghost Experiment

### DIFF
--- a/src/main/java/ti4/model/Source.java
+++ b/src/main/java/ti4/model/Source.java
@@ -98,6 +98,12 @@ public class Source {
             return super.toString().toLowerCase();
         }
 
+        /**
+         * Converts a string identifier to the corresponding ComponentSource enum value.
+         *
+         * @param id the string identifier
+         * @return the ComponentSource enum value, or null if not found
+         */
         public static ComponentSource fromString(String id) {
             for (ComponentSource source : values()) {
                 if (source.toString().equals(id)) {
@@ -147,6 +153,7 @@ public class Source {
 
         public boolean isHiddenFromSearch(ComponentSource source) {
             if (this == source) return false;
+
             return !isOfficial();
         }
 
@@ -172,6 +179,10 @@ public class Source {
             return emoji == null ? "" : emoji.toString();
         }
 
+        /**
+         * Switch to Source Model and \data\sources\ once they are completed
+         * @return
+         */
         public String prettyName() {
             return switch (this) {
                 case base -> "Twilight Imperium 4th Edition (Base Game)";
@@ -188,7 +199,6 @@ public class Source {
                 case monuments -> "Monuments+ [Homebrew]";
                 case omega_phase -> "Omega Phase [Homebrew]";
                 case voices_of_the_council -> "Voices of the Council [Homebrew]";
-                case untangled_space -> "Untangled Space [Homebrew]";
                 default -> toString();
             };
         }

--- a/src/main/java/ti4/model/Source.java
+++ b/src/main/java/ti4/model/Source.java
@@ -81,6 +81,7 @@ public class Source {
         memephilosopher,
         omega_phase,
         fowplus,
+        untangled_space,
 
         // eronous' stuff
         eronous,
@@ -97,12 +98,6 @@ public class Source {
             return super.toString().toLowerCase();
         }
 
-        /**
-         * Converts a string identifier to the corresponding ComponentSource enum value.
-         *
-         * @param id the string identifier
-         * @return the ComponentSource enum value, or null if not found
-         */
         public static ComponentSource fromString(String id) {
             for (ComponentSource source : values()) {
                 if (source.toString().equals(id)) {
@@ -152,7 +147,6 @@ public class Source {
 
         public boolean isHiddenFromSearch(ComponentSource source) {
             if (this == source) return false;
-
             return !isOfficial();
         }
 
@@ -178,10 +172,6 @@ public class Source {
             return emoji == null ? "" : emoji.toString();
         }
 
-        /**
-         * Switch to Source Model and \data\sources\ once they are completed
-         * @return
-         */
         public String prettyName() {
             return switch (this) {
                 case base -> "Twilight Imperium 4th Edition (Base Game)";
@@ -198,6 +188,7 @@ public class Source {
                 case monuments -> "Monuments+ [Homebrew]";
                 case omega_phase -> "Omega Phase [Homebrew]";
                 case voices_of_the_council -> "Voices of the Council [Homebrew]";
+                case untangled_space -> "Untangled Space [Homebrew]";
                 default -> toString();
             };
         }

--- a/src/main/resources/data/abilities/untangled_space.json
+++ b/src/main/resources/data/abilities/untangled_space.json
@@ -4,7 +4,7 @@
         "name": "Planetary Stabilisation",
         "faction": "neutral",
         "window": "ACTION",
-        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On a result of 1–4, draw a random unused red tile; on a result of 5–10, draw a random unused blue tile. Place that tile adjacent to an unactivated system containing your ships, so that it is touching a system. If the system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then you may spend half your trade goods minus 1 for each tile touching the placed tile, to activate it with a token from your reinforcements and continue with a tactical action.",
+        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On a result of 1–4, draw a random unused red tile; on a result of 5–10, draw a random unused blue tile. Place that tile adjacent to an unactivated system containing your ships, so that it is touching a system. If the system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then you may activate the placed system with a token from your reinforcements and continue with a tactical action. If you do, spend trade goods equal to half your trade goods (rounded down), minus 1 for each system tile adjacent to the placed system (minimum 0).",
         "source": "untangled_space"
     }
 ]

--- a/src/main/resources/data/abilities/untangled_space.json
+++ b/src/main/resources/data/abilities/untangled_space.json
@@ -4,7 +4,7 @@
         "name": "Planetary Stabilisation",
         "faction": "neutral",
         "window": "ACTION",
-        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On 1-4, draw a random unused red tile; on 5-10, draw a random unused blue tile. Place it adjacent to an unactivated system that contains your ships, touching that system. If the placed system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then, you may spend trade goods equal to half your trade goods minus 1 for each tile touching the placed tile, to activate it with a token from your reinforcements and continue with a tactical action.",
+        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On a result of 1–4, draw a random unused red tile; on a result of 5–10, draw a random unused blue tile. Place that tile adjacent to an unactivated system containing your ships, so that it is touching a system. If the system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then you may spend half your trade goods minus 1 for each tile touching the placed tile, to activate it with a token from your reinforcements and continue with a tactical action.",
         "source": "untangled_space"
     }
 ]

--- a/src/main/resources/data/abilities/untangled_space.json
+++ b/src/main/resources/data/abilities/untangled_space.json
@@ -1,0 +1,10 @@
+[
+    {
+        "id": "planetary_stabilisation",
+        "name": "Planetary Stabilisation",
+        "faction": "neutral",
+        "window": "ACTION",
+        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On 1-4, draw a random unused red tile; on 5-10, draw a random unused blue tile. Place it adjacent to an unactivated system that contains your ships, touching that system. If the placed system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then, you may spend trade goods equal to half your trade goods minus 1 for each tile touching the placed tile, to activate it with a token from your reinforcements and continue with a tactical action.",
+        "source": "untangled_space"
+    }
+]

--- a/src/main/resources/data/action_cards/untangled_space.json
+++ b/src/main/resources/data/action_cards/untangled_space.json
@@ -4,7 +4,7 @@
         "name": "Ghost Experiment",
         "phase": "Action",
         "window": "Action",
-        "text": "Place a ghost wormhole token into a system. Then perform your Ghost hero ability.",
+        "text": "Place a ghost wormhole token into a system. Then perform the Ghost hero ability.",
         "source": "untangled_space"
     }
 ]

--- a/src/main/resources/data/action_cards/untangled_space.json
+++ b/src/main/resources/data/action_cards/untangled_space.json
@@ -1,0 +1,10 @@
+[
+    {
+        "alias": "us-ghost",
+        "name": "Ghost Experiment",
+        "phase": "Action",
+        "window": "Action",
+        "text": "Place a ghost wormhole token into a system. Then perform your Ghost hero ability.",
+        "source": "untangled_space"
+    }
+]

--- a/src/main/resources/data/action_cards/untangled_space.json
+++ b/src/main/resources/data/action_cards/untangled_space.json
@@ -4,7 +4,7 @@
         "name": "Ghost Experiment",
         "phase": "Action",
         "window": "Action",
-        "text": "Place a ghost wormhole token into a system. Then perform the Ghost hero ability.",
+        "text": "Place a Creuss wormhole token into a system. Then perform the Creuss Paradigm or hero ability.",
         "source": "untangled_space"
     }
 ]

--- a/src/main/resources/data/sources/sources.json
+++ b/src/main/resources/data/sources/sources.json
@@ -288,7 +288,7 @@
         "name": "Untangled Space",
         "canal": "community",
         "subcanal": "personal projs",
-        "credits": "paven",
+        "credits": "pvn",
         "description": "Planetary Stabilisation action available to all players; Ghost Experiment SC and AC"
     }
 ]

--- a/src/main/resources/data/sources/sources.json
+++ b/src/main/resources/data/sources/sources.json
@@ -282,5 +282,13 @@
         "data": [
             "Official channel: https://discord.com/channels/743629929484386395/1422472031949029396"
         ]
+    },
+    {
+        "source": "untangled_space",
+        "name": "Untangled Space",
+        "canal": "community",
+        "subcanal": "personal projs",
+        "credits": "paven",
+        "description": "Planetary Stabilisation action available to all players; Ghost Experiment SC and AC"
     }
 ]

--- a/src/main/resources/data/strategy_card_sets/strategyCardSets.json
+++ b/src/main/resources/data/strategy_card_sets/strategyCardSets.json
@@ -409,5 +409,12 @@
     "scIDs": ["tf1", "tf2", "tf3", "tf4", "tf5", "tf6", "tf7", "tf8"],
     "description": "The 8 strategy cards used in Twilight's Fall",
     "source": "twilights_fall"
+  },
+  {
+    "name": "Twilight Fall: Untangled Space",
+    "alias": "untangled_space",
+    "scIDs": ["tf1", "tf2", "tf3", "tf4", "tf5", "tf6", "tf7", "tf8", "us9"],
+    "description": "Twilight Fall's strategy cards with the Untangled Space 9th card",
+    "source": "untangled_space"
   }
 ]

--- a/src/main/resources/data/strategy_cards/untangled_space.json
+++ b/src/main/resources/data/strategy_cards/untangled_space.json
@@ -4,8 +4,8 @@
         "initiative": 9,
         "name": "Ghost Experiment",
         "primaryTexts": [
-            "Place a ghost wormhole token into a system. Then perform the Planetary Stabilisation action, without spending a Command Counter and trade goods, also picking the result of the die roll.",
-            "Then perform the Ghost hero ability."
+            "Place a Creuss wormhole token into a system. Then perform the Planetary Stabilisation action, without spending a Command Counter and trade goods, also picking the result of the die roll.",
+            "Then perform the Creuss Paradigm or hero ability."
         ],
         "secondaryTexts": [
             "Then perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, but you are not allowed to activate the system."

--- a/src/main/resources/data/strategy_cards/untangled_space.json
+++ b/src/main/resources/data/strategy_cards/untangled_space.json
@@ -4,7 +4,7 @@
         "initiative": 9,
         "name": "Ghost Experiment",
         "primaryTexts": [
-            "Place a ghost wormhole token into a system. Then perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, picking the result of the die roll.",
+            "Place a ghost wormhole token into a system. Then perform the Planetary Stabilisation action, without spending a Command Counter and trade goods, also picking the result of the die roll.",
             "Then perform the Ghost hero ability."
         ],
         "secondaryTexts": [

--- a/src/main/resources/data/strategy_cards/untangled_space.json
+++ b/src/main/resources/data/strategy_cards/untangled_space.json
@@ -4,12 +4,11 @@
         "initiative": 9,
         "name": "Ghost Experiment",
         "primaryTexts": [
-            "Place a ghost wormhole token into a system.",
-            "Perform the Planetary Stabilisation action without spending a Command Counter from your Strategy Pool, choosing the result of the die roll.",
-            "Then perform your Ghost hero ability."
+            "Place a ghost wormhole token into a system. Then perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, picking the result of the die roll.",
+            "Then perform the Ghost hero ability."
         ],
         "secondaryTexts": [
-            "Spend 1 token from your strategy pool to perform the Planetary Stabilisation action without spending a Command Counter from your Strategy Pool. You may not activate the placed system."
+            "Then perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, but you are not allowed to activate the system."
         ],
         "imageFileName": "us9",
         "colourHexCode": "#9b59b6",

--- a/src/main/resources/data/strategy_cards/untangled_space.json
+++ b/src/main/resources/data/strategy_cards/untangled_space.json
@@ -8,7 +8,7 @@
             "Then perform the Ghost hero ability."
         ],
         "secondaryTexts": [
-            "Then perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, but you are not allowed to activate the system."
+            "Perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, but you are not allowed to activate the system."
         ],
         "imageFileName": "us9",
         "colourHexCode": "#9b59b6",

--- a/src/main/resources/data/strategy_cards/untangled_space.json
+++ b/src/main/resources/data/strategy_cards/untangled_space.json
@@ -1,0 +1,18 @@
+[
+    {
+        "id": "us9",
+        "initiative": 9,
+        "name": "Ghost Experiment",
+        "primaryTexts": [
+            "Place a ghost wormhole token into a system.",
+            "Perform the Planetary Stabilisation action without spending a Command Counter from your Strategy Pool, choosing the result of the die roll.",
+            "Then perform your Ghost hero ability."
+        ],
+        "secondaryTexts": [
+            "Spend 1 token from your strategy pool to perform the Planetary Stabilisation action without spending a Command Counter from your Strategy Pool. You may not activate the placed system."
+        ],
+        "imageFileName": "us9",
+        "colourHexCode": "#9b59b6",
+        "source": "untangled_space"
+    }
+]

--- a/src/main/resources/data/strategy_cards/untangled_space.json
+++ b/src/main/resources/data/strategy_cards/untangled_space.json
@@ -8,9 +8,8 @@
             "Then perform the Ghost hero ability."
         ],
         "secondaryTexts": [
-            "Perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, but you are not allowed to activate the system."
+            "Then perform the Planetary Stabilisation action, without spending a Command Counter from your Strategy Pool, but you are not allowed to activate the system."
         ],
-        "imageFileName": "us9",
         "colourHexCode": "#9b59b6",
         "source": "untangled_space"
     }


### PR DESCRIPTION
## Summary

Adds data-only support for **Untangled Space**, a homebrew variant for Twilight's Fall that gives all players a generally available **Planetary Stabilisation** action, plus an optional Strategy Card 9 and Action Card.

- `data/abilities/untangled_space.json` — new file; `planetary_stabilisation` ability with `"faction": "neutral"` and `"window": "ACTION"` so it appears as a component action button for any player it is given to (via `/franken ability_add planetary_stabilisation`)
- `data/strategy_cards/untangled_space.json` — new file; SC 9 "Ghost Experiment" (initiative 9)
- `data/action_cards/untangled_space.json` — new file; AC "Ghost Experiment"
- `ti4/model/Source.java` — `untangled_space` added to `ComponentSource` enum
- `data/sources/sources.json` — source metadata entry added

## Notes

The SC 9 and AC have no automation (`automationID`) — text-only cards resolved manually. The ability likewise has no bot enforcement; die roll and tile placement are player-resolved.

At game start, give all players the ability with:
```
/franken ability_add planetary_stabilisation
```