### PR TITLE
fix: penalize lopsided replay blowouts

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -1,0 +1,135 @@
+package ti4.contest.cron;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.experimental.UtilityClass;
+import ti4.contest.replay.core.CombatCandidateStatus;
+import ti4.contest.replay.core.CombatReplayRenderSnapshotSupport;
+import ti4.contest.replay.core.LazaxCombatSupport;
+import ti4.contest.replay.dispatch.ReplayDispatchPayload;
+import ti4.contest.replay.dispatch.ReplayDispatchSerializer;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatCandidateEventEntity;
+import ti4.contest.replay.entities.CombatObservationEntity;
+import ti4.contest.replay.repository.CombatCandidateEventRepository;
+import ti4.contest.replay.repository.CombatCandidateRepository;
+import ti4.contest.replay.repository.CombatObservationRepository;
+import ti4.cron.CronManager;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.game.UnitHolder;
+import ti4.helpers.Constants;
+import ti4.logging.BotLogger;
+import ti4.spring.context.SpringContext;
+import ti4.spring.service.deploy.ActiveLeaseService;
+
+@UtilityClass
+public class CombatReplayPromotionScoreBackfillCron {
+
+    private static final AtomicBoolean HAS_RUN = new AtomicBoolean(false);
+
+    public static void register() {
+        CronManager.registerManual(
+                CombatReplayPromotionScoreBackfillCron.class, CombatReplayPromotionScoreBackfillCron::runBackfill);
+    }
+
+    private static void runBackfill() {
+        if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        BotLogger.logCron("Running CombatReplayPromotionScoreBackfillCron.");
+        try {
+            runBackfillInternal();
+        } catch (Exception e) {
+            BotLogger.error("**CombatReplayPromotionScoreBackfillCron failed.**", e);
+        }
+        BotLogger.logCron("Finished CombatReplayPromotionScoreBackfillCron.");
+    }
+
+    private static void runBackfillInternal() {
+        if (!HAS_RUN.compareAndSet(false, true)) {
+            BotLogger.info("Combat replay promotion-score backfill already ran in this process.");
+            return;
+        }
+
+        CombatCandidateRepository candidateRepository = SpringContext.getBean(CombatCandidateRepository.class);
+        int updated = 0;
+        int skipped = 0;
+        for (CombatCandidateEntity candidate : candidateRepository.findByStatus(CombatCandidateStatus.RESOLVED)) {
+            if (recomputePromotionScore(candidate)) {
+                updated++;
+            } else {
+                skipped++;
+            }
+        }
+
+        BotLogger.info("Combat replay promotion-score backfill completed. Updated=" + updated + ", skipped=" + skipped);
+    }
+
+    private static boolean recomputePromotionScore(CombatCandidateEntity candidate) {
+        CombatObservationRepository observationRepository = SpringContext.getBean(CombatObservationRepository.class);
+        CombatObservationEntity observation =
+                observationRepository.findById(candidate.getObservationId()).orElse(null);
+        if (observation == null) return false;
+
+        String snapshotJson = extractLatestSnapshotJson(candidate.getId());
+        if (snapshotJson == null || snapshotJson.isBlank()) return false;
+
+        Game snapshotGame = CombatReplayRenderSnapshotSupport.restoreGame(snapshotJson);
+        if (snapshotGame == null) return false;
+
+        Player attacker = snapshotGame.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = snapshotGame.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        Tile tile = snapshotGame.getTileByPosition(candidate.getTilePosition());
+        UnitHolder space = tile == null ? null : tile.getUnitHolders().get(Constants.SPACE);
+        if (attacker == null
+                || defender == null
+                || tile == null
+                || space == null
+                || candidate.getWinnerFaction() == null) return false;
+
+        LazaxCombatSupport.FleetStrength attackerRemainingStrength =
+                LazaxCombatSupport.calculateFleetStrength(snapshotGame, attacker, defender, tile, space);
+        LazaxCombatSupport.FleetStrength defenderRemainingStrength =
+                LazaxCombatSupport.calculateFleetStrength(snapshotGame, defender, attacker, tile, space);
+        double attackerLossRatio =
+                computeLossRatio(observation.getAttackerStrength(), attackerRemainingStrength.value());
+        double defenderLossRatio =
+                computeLossRatio(observation.getDefenderStrength(), defenderRemainingStrength.value());
+        int roundsObserved = SpringContext.getBean(CombatCandidateEventRepository.class)
+                .findMaxRoundNumberByCandidateId(candidate.getId())
+                .orElse(0);
+        double mutualLossScore =
+                Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
+        double winnerRemainingHp = candidate.getWinnerFaction().equalsIgnoreCase(candidate.getAttackerFaction())
+                ? attackerRemainingStrength.hp()
+                : defenderRemainingStrength.hp();
+        double clutchScore = 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
+
+        candidate.setPromotionScore(roundsObserved + clutchScore + (0.25 * mutualLossScore));
+        SpringContext.getBean(CombatCandidateRepository.class).save(candidate);
+        return true;
+    }
+
+    private static String extractLatestSnapshotJson(Long candidateId) {
+        List<CombatCandidateEventEntity> events = SpringContext.getBean(CombatCandidateEventRepository.class)
+                .findByCandidateIdOrderBySequenceNumberAsc(candidateId);
+        Collections.reverse(events);
+        ReplayDispatchSerializer payloadSerializer = SpringContext.getBean(ReplayDispatchSerializer.class);
+        for (CombatCandidateEventEntity event : events) {
+            ReplayDispatchPayload payload = payloadSerializer.read(event);
+            if (payload instanceof ReplayDispatchPayload.HitAssignDispatch hitAssign) {
+                return hitAssign.combatStateSnapshotJson();
+            }
+            if (payload instanceof ReplayDispatchPayload.TileRenderMessageDispatch tileRenderMessage) {
+                return tileRenderMessage.combatStateSnapshotJson();
+            }
+        }
+        return null;
+    }
+
+    private static double computeLossRatio(double initialStrength, double remainingStrength) {
+        if (initialStrength <= 0) return 0.0;
+        return Math.max(0.0, Math.min(1.0, (initialStrength - remainingStrength) / initialStrength));
+    }
+}

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
@@ -23,6 +23,8 @@ public interface CombatCandidateRepository extends JpaRepository<CombatCandidate
 
     List<CombatCandidateEntity> findByGameNameAndStatus(String gameName, CombatCandidateStatus status);
 
+    List<CombatCandidateEntity> findByStatus(CombatCandidateStatus status);
+
     @Query("""
             select c from CombatCandidateEntity c
             where c.gameName = :gameName

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -169,24 +169,30 @@ public class CombatReplayService {
             return;
         }
 
-        double attackerRemaining = LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space)
-                .value();
-        double defenderRemaining = LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space)
-                .value();
-        double attackerLossRatio = computeLossRatio(observation.getAttackerStrength(), attackerRemaining);
-        double defenderLossRatio = computeLossRatio(observation.getDefenderStrength(), defenderRemaining);
+        LazaxCombatSupport.FleetStrength attackerRemainingStrength =
+                LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space);
+        LazaxCombatSupport.FleetStrength defenderRemainingStrength =
+                LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space);
+        double attackerLossRatio =
+                computeLossRatio(observation.getAttackerStrength(), attackerRemainingStrength.value());
+        double defenderLossRatio =
+                computeLossRatio(observation.getDefenderStrength(), defenderRemainingStrength.value());
         int roundsObserved = candidateEventRepository
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
         double mutualLossScore =
                 Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
+        double winnerRemainingHp = winner.getFaction().equalsIgnoreCase(attacker.getFaction())
+                ? attackerRemainingStrength.hp()
+                : defenderRemainingStrength.hp();
+        double clutchScore = 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
 
         candidate.setStatus(CombatCandidateStatus.RESOLVED);
         candidate.setResolvedAt(LocalDateTime.now());
         candidate.setWinnerFaction(winner.getFaction());
         candidate.setLoserFaction(loserFaction);
         candidate.setResolutionReason("Winner determined from remaining fleets.");
-        candidate.setPromotionScore(roundsObserved + mutualLossScore);
+        candidate.setPromotionScore(roundsObserved + clutchScore + (0.25 * mutualLossScore));
         candidateRepository.save(candidate);
 
         appendTileRenderEvent(

--- a/src/main/java/ti4/cron/CronManager.java
+++ b/src/main/java/ti4/cron/CronManager.java
@@ -30,6 +30,10 @@ public class CronManager {
         SCHEDULER.schedule(timedRunnable, initialDelay, unit);
     }
 
+    public static void registerManual(Class<?> clazz, Runnable runnable) {
+        CRONS.put(clazz.getSimpleName(), runnable);
+    }
+
     public static void schedulePeriodicallyAtTime(
             Class<?> clazz, Runnable runnable, int hour, int minute, ZoneId zoneId) {
         CRONS.put(clazz.getSimpleName(), runnable);

--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.function.Consumers;
 import ti4.contest.cron.CombatContestJanitorCron;
 import ti4.contest.cron.CombatReplayCron;
 import ti4.contest.cron.CombatReplayPromotionCron;
+import ti4.contest.cron.CombatReplayPromotionScoreBackfillCron;
 import ti4.contest.cron.CombatReplaySelectionCron;
 import ti4.cron.AutoPingCron;
 import ti4.cron.CategoryCleanupCron;
@@ -303,6 +304,7 @@ public class JdaService {
         CombatContestLeaderboardCron.register();
         CombatReplaySelectionCron.register();
         CombatReplayPromotionCron.register();
+        CombatReplayPromotionScoreBackfillCron.register();
         CombatReplayCron.register();
         CombatContestJanitorCron.register();
         InteractionLogCron.register();


### PR DESCRIPTION
## Summary
- subtract a small blowout penalty from replay promotion scores based on the gap between attacker and defender loss ratios
- keep the existing rounds-observed and mutual-loss scoring so close, bloody combats still rank well
- add a manual-only replay backfill cron that recomputes stored promotion scores once and refuses reruns after it starts

## Test Plan
- mvn -q -Dtest=CombatReplayServiceTest test