### PR TITLE
fix: damp replay round scoring

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -99,6 +99,7 @@ public class CombatReplayPromotionScoreBackfillCron {
         int roundsObserved = SpringContext.getBean(CombatCandidateEventRepository.class)
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
+        double roundScore = Math.sqrt(Math.max(0, roundsObserved));
         double mutualLossScore =
                 Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
         double winnerRemainingHp = candidate.getWinnerFaction().equalsIgnoreCase(candidate.getAttackerFaction())
@@ -106,7 +107,7 @@ public class CombatReplayPromotionScoreBackfillCron {
                 : defenderRemainingStrength.hp();
         double clutchScore = 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
 
-        candidate.setPromotionScore(roundsObserved + clutchScore + (0.25 * mutualLossScore));
+        candidate.setPromotionScore(roundScore + clutchScore + (0.25 * mutualLossScore));
         SpringContext.getBean(CombatCandidateRepository.class).save(candidate);
         return true;
     }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -180,6 +180,7 @@ public class CombatReplayService {
         int roundsObserved = candidateEventRepository
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
+        double roundScore = Math.sqrt(Math.max(0, roundsObserved));
         double mutualLossScore =
                 Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
         double winnerRemainingHp = winner.getFaction().equalsIgnoreCase(attacker.getFaction())
@@ -192,7 +193,7 @@ public class CombatReplayService {
         candidate.setWinnerFaction(winner.getFaction());
         candidate.setLoserFaction(loserFaction);
         candidate.setResolutionReason("Winner determined from remaining fleets.");
-        candidate.setPromotionScore(roundsObserved + clutchScore + (0.25 * mutualLossScore));
+        candidate.setPromotionScore(roundScore + clutchScore + (0.25 * mutualLossScore));
         candidateRepository.save(candidate);
 
         appendTileRenderEvent(


### PR DESCRIPTION
## Summary
- replace raw `roundsObserved` with `sqrt(roundsObserved)` in replay promotion scoring
- apply the same round damping inside the manual replay promotion score backfill cron
- keep the current clutch-score and `0.25x` mutual-loss weighting unchanged

## Test Plan
- mvn -q -Dtest=CombatReplayServiceTest test

## Distribution
- rounds: 1 -> 1.000, 2 -> 1.414, 3 -> 1.732, 4 -> 2.000, 5 -> 2.236, 6 -> 2.449, 9 -> 3.000
- clutch: hp=1 -> 3.000, hp=2 -> 1.220, hp=3 -> 0.496, hp=4 -> 0.202, hp=5 -> 0.082, hp=6 -> 0.033