### PR TITLE
fix: scale replay clutch score by combat size

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -105,7 +105,9 @@ public class CombatReplayPromotionScoreBackfillCron {
         double winnerRemainingHp = candidate.getWinnerFaction().equalsIgnoreCase(candidate.getAttackerFaction())
                 ? attackerRemainingStrength.hp()
                 : defenderRemainingStrength.hp();
-        double clutchScore = 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
+        double totalInitialHp = observation.getAttackerHp() + observation.getDefenderHp();
+        double sizeFactor = Math.min(1.0, totalInitialHp / 12.0);
+        double clutchScore = sizeFactor * 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
 
         candidate.setPromotionScore(roundScore + clutchScore + (0.25 * mutualLossScore));
         SpringContext.getBean(CombatCandidateRepository.class).save(candidate);

--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -15,6 +15,7 @@ import ti4.contest.replay.entities.CombatObservationEntity;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatObservationRepository;
+import ti4.contest.replay.service.CombatReplayService;
 import ti4.cron.CronManager;
 import ti4.game.Game;
 import ti4.game.Player;
@@ -92,24 +93,15 @@ public class CombatReplayPromotionScoreBackfillCron {
                 LazaxCombatSupport.calculateFleetStrength(snapshotGame, attacker, defender, tile, space);
         LazaxCombatSupport.FleetStrength defenderRemainingStrength =
                 LazaxCombatSupport.calculateFleetStrength(snapshotGame, defender, attacker, tile, space);
-        double attackerLossRatio =
-                computeLossRatio(observation.getAttackerStrength(), attackerRemainingStrength.value());
-        double defenderLossRatio =
-                computeLossRatio(observation.getDefenderStrength(), defenderRemainingStrength.value());
         int roundsObserved = SpringContext.getBean(CombatCandidateEventRepository.class)
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
-        double roundScore = Math.sqrt(Math.max(0, roundsObserved));
-        double mutualLossScore =
-                Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
-        double winnerRemainingHp = candidate.getWinnerFaction().equalsIgnoreCase(candidate.getAttackerFaction())
-                ? attackerRemainingStrength.hp()
-                : defenderRemainingStrength.hp();
-        double totalInitialHp = observation.getAttackerHp() + observation.getDefenderHp();
-        double sizeFactor = Math.min(1.0, totalInitialHp / 12.0);
-        double clutchScore = sizeFactor * 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
-
-        candidate.setPromotionScore(roundScore + clutchScore + (0.25 * mutualLossScore));
+        candidate.setPromotionScore(CombatReplayService.computePromotionScore(
+                observation,
+                attackerRemainingStrength,
+                defenderRemainingStrength,
+                candidate.getWinnerFaction(),
+                roundsObserved));
         SpringContext.getBean(CombatCandidateRepository.class).save(candidate);
         return true;
     }
@@ -129,10 +121,5 @@ public class CombatReplayPromotionScoreBackfillCron {
             }
         }
         return null;
-    }
-
-    private static double computeLossRatio(double initialStrength, double remainingStrength) {
-        if (initialStrength <= 0) return 0.0;
-        return Math.max(0.0, Math.min(1.0, (initialStrength - remainingStrength) / initialStrength));
     }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -180,22 +180,17 @@ public class CombatReplayService {
         int roundsObserved = candidateEventRepository
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
-        double roundScore = Math.sqrt(Math.max(0, roundsObserved));
-        double mutualLossScore =
-                Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
-        double winnerRemainingHp = winner.getFaction().equalsIgnoreCase(attacker.getFaction())
-                ? attackerRemainingStrength.hp()
-                : defenderRemainingStrength.hp();
-        double totalInitialHp = observation.getAttackerHp() + observation.getDefenderHp();
-        double sizeFactor = Math.min(1.0, totalInitialHp / 12.0);
-        double clutchScore = sizeFactor * 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
-
         candidate.setStatus(CombatCandidateStatus.RESOLVED);
         candidate.setResolvedAt(LocalDateTime.now());
         candidate.setWinnerFaction(winner.getFaction());
         candidate.setLoserFaction(loserFaction);
         candidate.setResolutionReason("Winner determined from remaining fleets.");
-        candidate.setPromotionScore(roundScore + clutchScore + (0.25 * mutualLossScore));
+        candidate.setPromotionScore(computePromotionScore(
+                observation,
+                attackerRemainingStrength,
+                defenderRemainingStrength,
+                winner.getFaction(),
+                roundsObserved));
         candidateRepository.save(candidate);
 
         appendTileRenderEvent(
@@ -274,6 +269,28 @@ public class CombatReplayService {
                 List.copyOf(weakerStrengthValues),
                 jointScoreCutoff,
                 List.copyOf(observations));
+    }
+
+    public static double computePromotionScore(
+            CombatObservationEntity observation,
+            LazaxCombatSupport.FleetStrength attackerRemainingStrength,
+            LazaxCombatSupport.FleetStrength defenderRemainingStrength,
+            String winnerFaction,
+            int roundsObserved) {
+        double attackerLossRatio =
+                computeLossRatio(observation.getAttackerStrength(), attackerRemainingStrength.value());
+        double defenderLossRatio =
+                computeLossRatio(observation.getDefenderStrength(), defenderRemainingStrength.value());
+        double roundScore = Math.sqrt(Math.max(0, roundsObserved));
+        double mutualLossScore =
+                Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
+        double winnerRemainingHp = winnerFaction.equalsIgnoreCase(observation.getAttackerFaction())
+                ? attackerRemainingStrength.hp()
+                : defenderRemainingStrength.hp();
+        double totalInitialHp = observation.getAttackerHp() + observation.getDefenderHp();
+        double sizeFactor = Math.min(1.0, totalInitialHp / 12.0);
+        double clutchScore = sizeFactor * 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
+        return roundScore + clutchScore + (0.25 * mutualLossScore);
     }
 
     public SelectionDebugView getSelectionDebugView() {
@@ -542,7 +559,7 @@ public class CombatReplayService {
         return buttonId.substring(secondUnderscore + 1);
     }
 
-    private double computeLossRatio(double initialStrength, double remainingStrength) {
+    private static double computeLossRatio(double initialStrength, double remainingStrength) {
         if (initialStrength <= 0) return 0.0;
         return Math.max(0.0, Math.min(1.0, (initialStrength - remainingStrength) / initialStrength));
     }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -186,7 +186,9 @@ public class CombatReplayService {
         double winnerRemainingHp = winner.getFaction().equalsIgnoreCase(attacker.getFaction())
                 ? attackerRemainingStrength.hp()
                 : defenderRemainingStrength.hp();
-        double clutchScore = 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
+        double totalInitialHp = observation.getAttackerHp() + observation.getDefenderHp();
+        double sizeFactor = Math.min(1.0, totalInitialHp / 12.0);
+        double clutchScore = sizeFactor * 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
 
         candidate.setStatus(CombatCandidateStatus.RESOLVED);
         candidate.setResolvedAt(LocalDateTime.now());


### PR DESCRIPTION
## Summary
- scale the replay clutch bonus by total initial combat HP so tiny knife fights score lower
- apply the same formula in the manual promotion-score backfill cron
- preserve the existing round and mutual-loss terms

## Testing
- mvn -q -Dtest=CombatReplayServiceTest test