### PR TITLE
fix: retune replay promotion scoring

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -173,10 +173,6 @@ public class CombatReplayService {
                 LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space);
         LazaxCombatSupport.FleetStrength defenderRemainingStrength =
                 LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space);
-        double attackerLossRatio =
-                computeLossRatio(observation.getAttackerStrength(), attackerRemainingStrength.value());
-        double defenderLossRatio =
-                computeLossRatio(observation.getDefenderStrength(), defenderRemainingStrength.value());
         int roundsObserved = candidateEventRepository
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
@@ -277,20 +273,22 @@ public class CombatReplayService {
             LazaxCombatSupport.FleetStrength defenderRemainingStrength,
             String winnerFaction,
             int roundsObserved) {
-        double attackerLossRatio =
-                computeLossRatio(observation.getAttackerStrength(), attackerRemainingStrength.value());
-        double defenderLossRatio =
-                computeLossRatio(observation.getDefenderStrength(), defenderRemainingStrength.value());
-        double roundScore = Math.sqrt(Math.max(0, roundsObserved));
-        double mutualLossScore =
-                Math.min(attackerLossRatio, defenderLossRatio) + ((attackerLossRatio + defenderLossRatio) / 2.0);
+        double weakerHp = Math.min(observation.getAttackerHp(), observation.getDefenderHp());
+        double weakerStrength = Math.min(observation.getAttackerStrength(), observation.getDefenderStrength());
+        double strongerStrength = Math.max(observation.getAttackerStrength(), observation.getDefenderStrength());
         double winnerRemainingHp = winnerFaction.equalsIgnoreCase(observation.getAttackerFaction())
                 ? attackerRemainingStrength.hp()
                 : defenderRemainingStrength.hp();
-        double totalInitialHp = observation.getAttackerHp() + observation.getDefenderHp();
-        double sizeFactor = Math.min(1.0, totalInitialHp / 12.0);
-        double clutchScore = sizeFactor * 3.0 * Math.exp(-0.9 * Math.max(0.0, winnerRemainingHp - 1.0));
-        return roundScore + clutchScore + (0.25 * mutualLossScore);
+        double winnerInitialHp = winnerFaction.equalsIgnoreCase(observation.getAttackerFaction())
+                ? observation.getAttackerHp()
+                : observation.getDefenderHp();
+        double sizeFactor = Math.min(1.0, weakerHp / 8.0);
+        double strengthRatio = safeRatio(weakerStrength, strongerStrength);
+        double winnerSurvivalRatio = safeRatio(winnerRemainingHp, winnerInitialHp);
+        double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
+        double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
+        double endingTensionScore = winnerRemainingHp <= 0 ? 0.0 : 5.0 * Math.exp(-6.0 * winnerSurvivalRatio);
+        return roundScore + openingBalanceScore + endingTensionScore;
     }
 
     public SelectionDebugView getSelectionDebugView() {
@@ -559,9 +557,9 @@ public class CombatReplayService {
         return buttonId.substring(secondUnderscore + 1);
     }
 
-    private static double computeLossRatio(double initialStrength, double remainingStrength) {
-        if (initialStrength <= 0) return 0.0;
-        return Math.max(0.0, Math.min(1.0, (initialStrength - remainingStrength) / initialStrength));
+    private static double safeRatio(double weaker, double stronger) {
+        if (stronger <= 0) return 0.0;
+        return Math.max(0.0, Math.min(1.0, weaker / stronger));
     }
 
     private record SelectionSnapshot(

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.entities.CombatObservationEntity;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
@@ -18,6 +19,48 @@ import ti4.contest.replay.repository.CombatObservationRepository;
 import ti4.spring.service.contest.CombatContestType;
 
 class CombatReplayServiceTest {
+
+    @Test
+    void promotionScorePrioritizesEndingTensionOverOpeningBalance() {
+        CombatObservationEntity blowout = observation(
+                10L, LocalDateTime.of(2026, 4, 23, 20, 22), "pbd22333", "307", 15, 20, 9, 9, 2.2, 2.6, 0.86, true, 10L);
+        blowout.setAttackerFaction("sol");
+        blowout.setDefenderFaction("mahact");
+
+        CombatObservationEntity squeaker = observation(
+                19L,
+                LocalDateTime.of(2026, 4, 23, 22, 41),
+                "pbd19963f",
+                "306",
+                22.5,
+                24.5,
+                16,
+                11,
+                4.5,
+                6.2,
+                0.77,
+                true,
+                19L);
+        squeaker.setAttackerFaction("naalu");
+        squeaker.setDefenderFaction("muaat");
+
+        double blowoutScore = CombatReplayService.computePromotionScore(
+                blowout,
+                new LazaxCombatSupport.FleetStrength(3.0, 0.0, 0.0),
+                new LazaxCombatSupport.FleetStrength(10.0, 6.0, 0.0),
+                "mahact",
+                3);
+        double squeakerScore = CombatReplayService.computePromotionScore(
+                squeaker,
+                new LazaxCombatSupport.FleetStrength(0.0, 0.0, 0.0),
+                new LazaxCombatSupport.FleetStrength(8.0, 3.0, 0.0),
+                "muaat",
+                4);
+
+        assertEquals(2.2033, blowoutScore, 0.0001);
+        assertEquals(3.6705, squeakerScore, 0.0001);
+        assertTrue(squeakerScore > blowoutScore);
+    }
 
     @Test
     void selectionDebugViewExposesObservationWindowDetails() {

--- a/src/test/java/ti4/game/UnitHolderTest.java
+++ b/src/test/java/ti4/game/UnitHolderTest.java
@@ -48,4 +48,15 @@ class UnitHolderTest {
 
         assertThat(sum(actuallyRemoved)).isEqualTo(2);
     }
+
+    @Test
+    void testUnitCountIncludesGalvanizedStates() {
+        Units.UnitKey unitKey = new Units.UnitKey(Units.UnitType.Dreadnought, "red");
+
+        UnitHolder unitHolder = new Space("whatever", new Point(0, 0));
+        unitHolder.addUnitsWithStates(unitKey, List.of(1, 2, 3, 4));
+
+        assertThat(unitHolder.getUnitCount(unitKey)).isEqualTo(10);
+        assertThat(unitHolder.getUnitCount()).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
## Summary
- replace the replay promotion score formula with a size-scaled round term, lighter opening-balance term, and stronger ending-tension term
- keep HP semantics aligned with the live scorer by basing tension on combat-participating ship HP rather than non-ship units left in space
- add a regression test covering a healthy-winner blowout versus a real squeaker

## Testing
- mvn -q spotless:apply -Dtest=CombatReplayServiceTest,CombatReplayContestLifecycleServiceTest test