### PR TITLE
refactor: clean up replay service flow

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -1,6 +1,5 @@
 package ti4.contest.cron;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.experimental.UtilityClass;
@@ -68,9 +67,9 @@ public class CombatReplayPromotionScoreBackfillCron {
     }
 
     private static boolean recomputePromotionScore(CombatCandidateEntity candidate) {
-        CombatObservationRepository observationRepository = SpringContext.getBean(CombatObservationRepository.class);
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
+        CombatObservationEntity observation = SpringContext.getBean(CombatObservationRepository.class)
+                .findById(candidate.getObservationId())
+                .orElse(null);
         if (observation == null) return false;
 
         String snapshotJson = extractLatestSnapshotJson(candidate.getId());
@@ -109,9 +108,9 @@ public class CombatReplayPromotionScoreBackfillCron {
     private static String extractLatestSnapshotJson(Long candidateId) {
         List<CombatCandidateEventEntity> events = SpringContext.getBean(CombatCandidateEventRepository.class)
                 .findByCandidateIdOrderBySequenceNumberAsc(candidateId);
-        Collections.reverse(events);
         ReplayDispatchSerializer payloadSerializer = SpringContext.getBean(ReplayDispatchSerializer.class);
-        for (CombatCandidateEventEntity event : events) {
+        for (int i = events.size() - 1; i >= 0; i--) {
+            CombatCandidateEventEntity event = events.get(i);
             ReplayDispatchPayload payload = payloadSerializer.read(event);
             if (payload instanceof ReplayDispatchPayload.HitAssignDispatch hitAssign) {
                 return hitAssign.combatStateSnapshotJson();

--- a/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
+++ b/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
@@ -90,41 +90,29 @@ public class CombatReplayDebugController {
     public ResponseEntity<String> getCandidate(@PathVariable Long candidateId) {
         CombatCandidateEntity candidate =
                 candidateRepository.findById(candidateId).orElse(null);
-        if (candidate == null) {
-            return ResponseEntity.notFound().build();
-        }
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        CombatReplayContestEntity contest =
-                replayContestRepository.findByCandidateId(candidateId).orElse(null);
-        List<EventResponse> events =
-                candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidateId).stream()
-                        .map(this::toEventResponse)
-                        .toList();
-        return ok(new CandidateDetailResponse(runtimeState(), candidate, observation, contest, events));
+        if (candidate == null) return ResponseEntity.notFound().build();
+        return ok(buildCandidateDetailResponse(candidate));
     }
 
     @GetMapping(value = "/candidates/{candidateId}/promote", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> forcePromoteCandidate(@PathVariable Long candidateId) {
         CombatCandidateEntity candidate =
                 candidateRepository.findById(candidateId).orElse(null);
-        if (candidate == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (candidate == null) return ResponseEntity.notFound().build();
 
         CombatReplayContestLifecycleService.ForcePromoteResult result =
                 contestLifecycleService.forcePromoteCandidate(candidateId);
         CombatReplayContestEntity contest = result.contest() != null
                 ? result.contest()
                 : replayContestRepository.findByCandidateId(candidateId).orElse(null);
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        List<EventResponse> events =
-                candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidateId).stream()
-                        .map(this::toEventResponse)
-                        .toList();
         return ok(new ForcePromoteResponse(
-                runtimeState(), result.promoted(), result.reason(), candidate, observation, contest, events));
+                runtimeState(),
+                result.promoted(),
+                result.reason(),
+                candidate,
+                observationRepository.findById(candidate.getObservationId()).orElse(null),
+                contest,
+                loadEvents(candidateId)));
     }
 
     @GetMapping(value = "/contests", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -142,20 +130,19 @@ public class CombatReplayDebugController {
     public ResponseEntity<String> getContest(@PathVariable Long contestId) {
         CombatReplayContestEntity contest =
                 replayContestRepository.findById(contestId).orElse(null);
-        if (contest == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (contest == null) return ResponseEntity.notFound().build();
         CombatCandidateEntity candidate =
                 candidateRepository.findById(contest.getCandidateId()).orElse(null);
-        CombatObservationEntity observation = candidate == null
-                ? null
-                : observationRepository.findById(candidate.getObservationId()).orElse(null);
-        List<EventResponse> events = candidate == null
-                ? List.of()
-                : candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId()).stream()
-                        .map(this::toEventResponse)
-                        .toList();
-        return ok(new ContestDetailResponse(runtimeState(), contest, candidate, observation, events));
+        return ok(new ContestDetailResponse(
+                runtimeState(),
+                contest,
+                candidate,
+                candidate == null
+                        ? null
+                        : observationRepository
+                                .findById(candidate.getObservationId())
+                                .orElse(null),
+                candidate == null ? List.of() : loadEvents(candidate.getId())));
     }
 
     private ResponseEntity<String> ok(Object body) {
@@ -179,25 +166,39 @@ public class CombatReplayDebugController {
     }
 
     private CandidateSummary toCandidateSummary(CombatCandidateEntity candidate) {
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        CombatReplayContestEntity contest =
-                replayContestRepository.findByCandidateId(candidate.getId()).orElse(null);
-        long eventCount = candidateEventRepository
-                .findByCandidateIdOrderBySequenceNumberAsc(candidate.getId())
-                .size();
-        return new CandidateSummary(candidate, observation, contest, eventCount);
+        return new CandidateSummary(
+                candidate,
+                observationRepository.findById(candidate.getObservationId()).orElse(null),
+                replayContestRepository.findByCandidateId(candidate.getId()).orElse(null),
+                eventCount(candidate.getId()));
     }
 
     private ContestSummary toContestSummary(CombatReplayContestEntity contest) {
         CombatCandidateEntity candidate =
                 candidateRepository.findById(contest.getCandidateId()).orElse(null);
-        long eventCount = candidate == null
-                ? 0
-                : candidateEventRepository
-                        .findByCandidateIdOrderBySequenceNumberAsc(candidate.getId())
-                        .size();
+        long eventCount = candidate == null ? 0 : eventCount(candidate.getId());
         return new ContestSummary(contest, candidate, eventCount);
+    }
+
+    private CandidateDetailResponse buildCandidateDetailResponse(CombatCandidateEntity candidate) {
+        return new CandidateDetailResponse(
+                runtimeState(),
+                candidate,
+                observationRepository.findById(candidate.getObservationId()).orElse(null),
+                replayContestRepository.findByCandidateId(candidate.getId()).orElse(null),
+                loadEvents(candidate.getId()));
+    }
+
+    private List<EventResponse> loadEvents(Long candidateId) {
+        return candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidateId).stream()
+                .map(this::toEventResponse)
+                .toList();
+    }
+
+    private long eventCount(Long candidateId) {
+        return candidateEventRepository
+                .findByCandidateIdOrderBySequenceNumberAsc(candidateId)
+                .size();
     }
 
     private EventResponse toEventResponse(CombatCandidateEventEntity event) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -107,15 +107,11 @@ public class CombatReplayContestLifecycleService {
     }
 
     public ForcePromoteResult forcePromoteCandidate(Long candidateId) {
-        if (candidateId == null) {
-            return ForcePromoteResult.rejected("candidateId is required");
-        }
+        if (candidateId == null) return ForcePromoteResult.rejected("candidateId is required");
 
         CombatCandidateEntity candidate =
                 candidateRepository.findById(candidateId).orElse(null);
-        if (candidate == null) {
-            return ForcePromoteResult.rejected("Candidate not found");
-        }
+        if (candidate == null) return ForcePromoteResult.rejected("Candidate not found");
         if (candidate.getStatus() != CombatCandidateStatus.RESOLVED) {
             return ForcePromoteResult.rejected("Candidate must be RESOLVED before promotion");
         }
@@ -134,7 +130,9 @@ public class CombatReplayContestLifecycleService {
     }
 
     private CombatReplayContestEntity promoteCandidate(CombatCandidateEntity winner) {
-        return promoteCandidate(winner, null);
+        return promoteCandidate(
+                winner,
+                replayContestRepository.findByCandidateId(winner.getId()).orElse(null));
     }
 
     private CombatReplayContestEntity promoteCandidate(
@@ -160,26 +158,13 @@ public class CombatReplayContestLifecycleService {
         if (contestChannel == null) return null;
 
         try {
+            LocalDateTime promotedAt = LocalDateTime.now();
             Message posted = postPromotionMessage(contestChannel, message, game, winner);
             addPredictionReactions(game, winner, posted);
             ThreadChannel thread = createReplayThread(posted, winner);
             CombatReplayContestEntity contest = persistPromotedReplayContest(
-                    game,
-                    observation,
-                    winner,
-                    message,
-                    LocalDateTime.now(),
-                    contestChannel,
-                    posted,
-                    thread,
-                    existingContest);
-            try {
-                MessageChannel replayChannel = thread != null ? thread : contestChannel;
-                announcePreReplayContextIfNeeded(replayChannel, contest, winner);
-                announcePredictionLockCountdown(replayChannel);
-            } catch (Exception e) {
-                BotLogger.error("Failed to post replay context at promotion.", e);
-            }
+                    game, observation, winner, message, promotedAt, contestChannel, posted, thread, existingContest);
+            postPromotionContext(thread != null ? thread : contestChannel, contest, winner);
             return contest;
         } catch (Exception e) {
             BotLogger.error("Replay contest promotion failed.", e);
@@ -190,28 +175,13 @@ public class CombatReplayContestLifecycleService {
     @SneakyThrows
     private Message postPromotionMessage(
             TextChannel contestChannel, String message, Game game, CombatCandidateEntity candidate) {
-        String snapshotJson = candidate.getInitialRenderSnapshotJson();
-        if (snapshotJson == null || snapshotJson.isBlank()) {
-            return contestChannel.sendMessage(message).complete();
-        }
-
-        Game snapshotGame = CombatReplayRenderSnapshotSupport.restoreGame(snapshotJson, game);
-        if (snapshotGame == null) {
-            return contestChannel.sendMessage(message).complete();
-        }
-
-        removeReplayCommandCounters(snapshotGame, candidate.getTilePosition());
-        snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
-                candidate.getAttackerFaction(), candidate.getDefenderFaction()));
-        try (FileUpload fileUpload =
-                new TileGenerator(snapshotGame, null, null, 0, candidate.getTilePosition()).createFileUpload()) {
-            return contestChannel
-                    .sendMessage(new MessageCreateBuilder()
-                            .addContent(message)
-                            .addFiles(fileUpload)
-                            .build())
-                    .complete();
-        }
+        return sendTileRenderMessage(
+                contestChannel,
+                message,
+                List.of(),
+                restoreReplayGame(
+                        candidate.getInitialRenderSnapshotJson(), game, candidate, candidate.getTilePosition()),
+                candidate.getTilePosition());
     }
 
     public void runReplayTick() {
@@ -235,26 +205,21 @@ public class CombatReplayContestLifecycleService {
             return;
         }
 
-        CombatCandidateEntity candidate =
-                candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        CombatCandidateEntity candidate = loadCandidate(contest.getCandidateId());
         Game game = candidate == null ? null : loadGame(candidate.getGameName());
         try {
-            if (settings.getRuntime().isDiscordPostingEnabled()) {
-                MessageChannel channel = getContestThreadOrChannel(contest);
-                if (channel == null) {
-                    rescheduleReplay(contest, "Replay channel unavailable.");
-                    return;
-                }
-                if (contest.getReplayStatus() == CombatContestReplayStatus.PENDING
-                        && candidate != null
-                        && game != null) {
-                    announcePreReplayContextIfNeeded(channel, contest, candidate);
-                    replayLeaderboardService.lockPredictionsAtReplayStart(game, contest, candidate);
-                    replayLeaderboardService.announceLockedPredictionsIfNeeded(channel, game, contest, candidate);
-                }
-                if (shouldPostReplayEvent(event)) {
-                    postReplayEvent(channel, game, candidate, event);
-                }
+            MessageChannel channel = getContestThreadOrChannel(contest);
+            if (channel == null) {
+                rescheduleReplay(contest, "Replay channel unavailable.");
+                return;
+            }
+            if (contest.getReplayStatus() == CombatContestReplayStatus.PENDING && candidate != null && game != null) {
+                announcePreReplayContextIfNeeded(channel, contest, candidate);
+                replayLeaderboardService.lockPredictionsAtReplayStart(game, contest, candidate);
+                replayLeaderboardService.announceLockedPredictionsIfNeeded(channel, game, contest, candidate);
+            }
+            if (event.getEventType() != CombatCandidateEventType.START) {
+                postReplayEvent(channel, game, candidate, event);
             }
             CombatCandidateEventEntity nextEvent = candidateEventRepository
                     .findByCandidateIdAndSequenceNumber(contest.getCandidateId(), contest.getNextEventSequence() + 1)
@@ -272,10 +237,6 @@ public class CombatReplayContestLifecycleService {
             return;
         }
         replayContestRepository.save(contest);
-    }
-
-    private boolean shouldPostReplayEvent(CombatCandidateEventEntity event) {
-        return event != null && event.getEventType() != CombatCandidateEventType.START;
     }
 
     private void announcePreReplayContextIfNeeded(
@@ -301,9 +262,18 @@ public class CombatReplayContestLifecycleService {
         channel.sendMessage(message).complete();
     }
 
+    private void postPromotionContext(
+            MessageChannel replayChannel, CombatReplayContestEntity contest, CombatCandidateEntity winner) {
+        try {
+            announcePreReplayContextIfNeeded(replayChannel, contest, winner);
+            announcePredictionLockCountdown(replayChannel);
+        } catch (Exception e) {
+            BotLogger.error("Failed to post replay context at promotion.", e);
+        }
+    }
+
     private void completeReplayContest(CombatReplayContestEntity contest) {
-        CombatCandidateEntity candidate =
-                candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        CombatCandidateEntity candidate = loadCandidate(contest.getCandidateId());
         Game game = candidate == null ? null : loadGame(candidate.getGameName());
         if (candidate != null) {
             replayLeaderboardService.finalizeReplayLeaderboardContest(game, contest, candidate);
@@ -333,9 +303,6 @@ public class CombatReplayContestLifecycleService {
             CombatCandidateEventEntity currentEvent,
             CombatCandidateEventEntity nextEvent,
             Duration maxReplayEventGap) {
-        if (maxReplayEventGap == null) {
-            maxReplayEventGap = Duration.ofMinutes(1);
-        }
         if (replayedAt == null
                 || currentEvent == null
                 || nextEvent == null
@@ -552,7 +519,7 @@ public class CombatReplayContestLifecycleService {
             MessageChannel channel, Game game, CombatCandidateEntity candidate, CombatCandidateEventEntity event) {
         ReplayDispatchPayload payload = payloadSerializer.read(event);
         if (payload == null) {
-            channel.sendMessage(event.getSummaryText()).complete();
+            sendDiscordMessage(channel, event.getSummaryText(), List.of());
             return;
         }
 
@@ -569,7 +536,7 @@ public class CombatReplayContestLifecycleService {
             return;
         }
 
-        channel.sendMessage(event.getSummaryText()).complete();
+        sendDiscordMessage(channel, event.getSummaryText(), List.of());
     }
 
     @SneakyThrows
@@ -584,7 +551,7 @@ public class CombatReplayContestLifecycleService {
                 game,
                 candidate,
                 event.getSummaryText(),
-                List.of(),
+                null,
                 payload.tilePosition(),
                 payload.combatStateSnapshotJson());
     }
@@ -597,7 +564,8 @@ public class CombatReplayContestLifecycleService {
             String fallbackMessage,
             ReplayDispatchPayload.TileRenderMessageDispatch payload) {
         ReplayDispatchPayload.DiscordMessage replayMessage = payload.message();
-        String message = replayMessage == null ? fallbackMessage : replayMessage.content();
+        String message =
+                replayMessage == null ? fallbackMessage : firstNonBlank(replayMessage.content(), fallbackMessage);
         List<MessageEmbed> embeds =
                 replayMessage == null ? List.of() : ReplayDispatchSerializer.toMessageEmbeds(replayMessage.embeds());
         postTileRenderReplayEvent(
@@ -613,61 +581,69 @@ public class CombatReplayContestLifecycleService {
             List<MessageEmbed> embeds,
             String tilePosition,
             String snapshotJson) {
-        if (tilePosition == null || snapshotJson == null) {
-            channel.sendMessage(message).complete();
-            return;
-        }
+        sendTileRenderMessage(
+                channel, message, embeds, restoreReplayGame(snapshotJson, game, candidate, tilePosition), tilePosition);
+    }
 
+    private Game restoreReplayGame(
+            String snapshotJson, Game game, CombatCandidateEntity candidate, String tilePosition) {
+        if (tilePosition == null || snapshotJson == null) return null;
         Game snapshotGame = CombatReplayRenderSnapshotSupport.restoreGame(snapshotJson, game);
-        if (snapshotGame == null) {
-            channel.sendMessage(message).complete();
-            return;
-        }
-        if (candidate != null) {
-            removeReplayCommandCounters(snapshotGame, tilePosition);
-            snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
-                    candidate.getAttackerFaction(), candidate.getDefenderFaction()));
-        }
+        if (snapshotGame == null || candidate == null) return snapshotGame;
+        removeReplayCommandCounters(snapshotGame, tilePosition);
+        snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
+                candidate.getAttackerFaction(), candidate.getDefenderFaction()));
+        return snapshotGame;
+    }
 
+    @SneakyThrows
+    private Message sendTileRenderMessage(
+            MessageChannel channel, String message, List<MessageEmbed> embeds, Game snapshotGame, String tilePosition) {
+        if (snapshotGame == null) {
+            return sendDiscordMessage(channel, message, embeds);
+        }
         try (FileUpload fileUpload = new TileGenerator(snapshotGame, null, null, 0, tilePosition).createFileUpload()) {
             MessageCreateBuilder builder =
                     new MessageCreateBuilder().addContent(message).addFiles(fileUpload);
-            if (!embeds.isEmpty()) {
-                builder.addEmbeds(embeds);
-            }
-            channel.sendMessage(builder.build()).complete();
+            if (!embeds.isEmpty()) builder.addEmbeds(embeds);
+            return channel.sendMessage(builder.build()).complete();
         }
     }
 
     private void removeReplayCommandCounters(Game snapshotGame, String tilePosition) {
-        if (snapshotGame == null || tilePosition == null || tilePosition.isBlank()) return;
+        if (tilePosition == null || tilePosition.isBlank()) return;
         Tile tile = snapshotGame.getTileByPosition(tilePosition);
         if (tile == null) return;
         tile.removeAllCC();
     }
 
-    private void sendDiscordMessage(
+    private Message sendDiscordMessage(
             MessageChannel channel, ReplayDispatchPayload.DiscordMessage message, String fallbackContent) {
         if (message == null) {
-            channel.sendMessage(fallbackContent).complete();
-            return;
+            return channel.sendMessage(fallbackContent).complete();
         }
+        return sendDiscordMessage(
+                channel,
+                firstNonBlank(message.content(), fallbackContent),
+                ReplayDispatchSerializer.toMessageEmbeds(message.embeds()));
+    }
 
-        String content = firstNonBlank(message.content(), fallbackContent);
-        List<MessageEmbed> embeds = ReplayDispatchSerializer.toMessageEmbeds(message.embeds());
+    private Message sendDiscordMessage(MessageChannel channel, String content, List<MessageEmbed> embeds) {
         if (embeds.isEmpty()) {
-            channel.sendMessage(content).complete();
-            return;
+            return channel.sendMessage(content).complete();
         }
         if (content == null || content.isBlank()) {
-            channel.sendMessageEmbeds(embeds).complete();
-            return;
+            return channel.sendMessageEmbeds(embeds).complete();
         }
-        channel.sendMessage(content).addEmbeds(embeds).complete();
+        return channel.sendMessage(content).addEmbeds(embeds).complete();
     }
 
     private String firstNonBlank(String value, String fallback) {
         return value != null && !value.isBlank() ? value : fallback;
+    }
+
+    private CombatCandidateEntity loadCandidate(Long candidateId) {
+        return candidateRepository.findById(candidateId).orElse(null);
     }
 
     public record ForcePromoteResult(boolean promoted, String reason, CombatReplayContestEntity contest) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -551,7 +551,7 @@ public class CombatReplayContestLifecycleService {
                 game,
                 candidate,
                 event.getSummaryText(),
-                null,
+                List.of(),
                 payload.tilePosition(),
                 payload.combatStateSnapshotJson());
     }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
@@ -26,11 +26,10 @@ public class CombatReplayJanitorService {
 
     public void runJanitor() {
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime observationCutoff = now.minusDays(settings.getRetention().getObservationRetentionDays());
 
         expireStaleResolvedCandidates(now);
-
-        observationRepository.deleteAll(observationRepository.findByStartedAtBefore(
-                now.minusDays(settings.getRetention().getObservationRetentionDays())));
+        observationRepository.deleteAll(observationRepository.findByStartedAtBefore(observationCutoff));
         deleteExpiredCandidateEvents(now);
         clearCompletedReplayErrors();
     }
@@ -51,8 +50,8 @@ public class CombatReplayJanitorService {
     }
 
     private void deleteExpiredCandidateEvents(LocalDateTime now) {
-        List<CombatCandidateEventEntity> oldEvents = candidateEventRepository.findByOccurredAtBefore(
-                now.minusDays(settings.getRetention().getEventRetentionDays()));
+        LocalDateTime retentionCutoff = now.minusDays(settings.getRetention().getEventRetentionDays());
+        List<CombatCandidateEventEntity> oldEvents = candidateEventRepository.findByOccurredAtBefore(retentionCutoff);
         if (oldEvents.isEmpty()) return;
 
         List<Long> candidateIds = oldEvents.stream()
@@ -71,10 +70,7 @@ public class CombatReplayJanitorService {
             CombatCandidateEntity candidate = candidatesById.get(event.getCandidateId());
             if (candidate == null || candidate.getStatus() == CombatCandidateStatus.TRACKING) continue;
 
-            LocalDateTime terminalAt =
-                    candidate.getPromotedAt() != null ? candidate.getPromotedAt() : candidate.getResolvedAt();
-            if (terminalAt == null
-                    || terminalAt.isAfter(now.minusDays(settings.getRetention().getEventRetentionDays()))) {
+            if (!isPastRetentionCutoff(candidate, retentionCutoff)) {
                 continue;
             }
 
@@ -94,5 +90,11 @@ public class CombatReplayJanitorService {
                     contest.setReplayError(null);
                     replayContestRepository.save(contest);
                 });
+    }
+
+    private boolean isPastRetentionCutoff(CombatCandidateEntity candidate, LocalDateTime retentionCutoff) {
+        LocalDateTime terminalAt =
+                candidate.getPromotedAt() != null ? candidate.getPromotedAt() : candidate.getResolvedAt();
+        return terminalAt != null && !terminalAt.isAfter(retentionCutoff);
     }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -75,8 +75,9 @@ public class CombatReplayService {
 
     public void onButtonInteractionSettled(Game game, Player player, ButtonInteractionEvent event) {
         for (CombatCandidateEntity candidate : getTrackingCandidates(game)) {
-            if (evaluateCandidateCompletion(game, candidate)) continue;
-            trackHitAssignments(game, player, event, candidate);
+            if (!evaluateCandidateCompletion(game, candidate)) {
+                trackHitAssignments(game, player, event, candidate);
+            }
         }
     }
 
@@ -122,38 +123,54 @@ public class CombatReplayService {
                 .filter(Player::isRealPlayer)
                 .filter(player -> !player.isDummy())
                 .toList();
-        if (remainingShipPlayers.size() == 1) {
-            if (!hasRecordedRoll(candidate)) {
-                cancelCandidate(game, candidate, "The tracked space combat ended before any dice were rolled.");
-                return true;
+        boolean hasRecordedRoll = hasRecordedRoll(candidate);
+        return switch (remainingShipPlayers.size()) {
+            case 0 -> {
+                cancelCandidate(
+                        game,
+                        candidate,
+                        hasRecordedRoll
+                                ? "The tracked space combat ended with no ships remaining."
+                                : "The tracked space combat ended before any dice were rolled.");
+                yield true;
             }
-            Player winner = remainingShipPlayers.getFirst();
-            String loserFaction = winner.getFaction().equalsIgnoreCase(candidate.getAttackerFaction())
-                    ? candidate.getDefenderFaction()
-                    : candidate.getAttackerFaction();
-            resolveCandidate(game, candidate, tile, winner, loserFaction);
-            return true;
-        }
-        if (remainingShipPlayers.isEmpty()) {
-            String reason = hasRecordedRoll(candidate)
-                    ? "The tracked space combat ended with no ships remaining."
-                    : "The tracked space combat ended before any dice were rolled.";
-            cancelCandidate(game, candidate, reason);
-            return true;
-        }
-        if (remainingShipPlayers.size() > 2) {
-            cancelCandidate(game, candidate, "The tracked space combat no longer has exactly two sides.");
-            return true;
-        }
-        boolean containsBothParticipants = remainingShipPlayers.stream()
+            case 1 -> {
+                if (!hasRecordedRoll) {
+                    cancelCandidate(game, candidate, "The tracked space combat ended before any dice were rolled.");
+                    yield true;
+                }
+                Player winner = remainingShipPlayers.getFirst();
+                resolveCandidate(game, candidate, tile, winner, loserFaction(candidate, winner));
+                yield true;
+            }
+            case 2 -> {
+                if (containsOnlyOriginalParticipants(candidate, remainingShipPlayers)) {
+                    yield false;
+                }
+                cancelCandidate(
+                        game, candidate, "The tracked space combat drifted away from the original participants.");
+                yield true;
+            }
+            default -> {
+                cancelCandidate(game, candidate, "The tracked space combat no longer has exactly two sides.");
+                yield true;
+            }
+        };
+    }
+
+    private boolean containsOnlyOriginalParticipants(
+            CombatCandidateEntity candidate, List<Player> remainingShipPlayers) {
+        return remainingShipPlayers.stream()
                 .map(Player::getFaction)
                 .allMatch(faction -> faction.equalsIgnoreCase(candidate.getAttackerFaction())
                         || faction.equalsIgnoreCase(candidate.getDefenderFaction()));
-        if (!containsBothParticipants) {
-            cancelCandidate(game, candidate, "The tracked space combat drifted away from the original participants.");
-            return true;
+    }
+
+    private String loserFaction(CombatCandidateEntity candidate, Player winner) {
+        if (winner.getFaction().equalsIgnoreCase(candidate.getAttackerFaction())) {
+            return candidate.getDefenderFaction();
         }
-        return false;
+        return candidate.getAttackerFaction();
     }
 
     private void resolveCandidate(
@@ -161,22 +178,11 @@ public class CombatReplayService {
         CombatObservationEntity observation =
                 observationRepository.findById(candidate.getObservationId()).orElse(null);
         if (observation == null) return;
-        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
-        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
-        UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
-        if (attacker == null || defender == null || space == null) {
+        ResolutionState resolution = buildResolutionState(game, candidate, tile);
+        if (resolution == null) {
             cancelCandidate(game, candidate, "The tracked space combat could not be resolved cleanly.");
             return;
         }
-
-        LazaxCombatSupport.FleetStrength attackerRemainingStrength =
-                LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space);
-        LazaxCombatSupport.FleetStrength defenderRemainingStrength =
-                LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space);
-        double attackerLossRatio =
-                computeLossRatio(observation.getAttackerStrength(), attackerRemainingStrength.value());
-        double defenderLossRatio =
-                computeLossRatio(observation.getDefenderStrength(), defenderRemainingStrength.value());
         int roundsObserved = candidateEventRepository
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
@@ -187,8 +193,8 @@ public class CombatReplayService {
         candidate.setResolutionReason("Winner determined from remaining fleets.");
         candidate.setPromotionScore(computePromotionScore(
                 observation,
-                attackerRemainingStrength,
-                defenderRemainingStrength,
+                resolution.attackerRemainingStrength(),
+                resolution.defenderRemainingStrength(),
                 winner.getFaction(),
                 roundsObserved));
         candidateRepository.save(candidate);
@@ -245,6 +251,18 @@ public class CombatReplayService {
                         candidate.getTilePosition(),
                         CombatReplayRenderSnapshotSupport.captureHitAssignmentSnapshot(
                                 game, candidate.getTilePosition())));
+    }
+
+    private ResolutionState buildResolutionState(Game game, CombatCandidateEntity candidate, Tile tile) {
+        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
+        if (attacker == null || defender == null || space == null) {
+            return null;
+        }
+        return new ResolutionState(
+                LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space),
+                LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space));
     }
 
     public void refreshSelectionSnapshot() {
@@ -593,4 +611,8 @@ public class CombatReplayService {
             double weakerStrengthPercentile,
             double jointScore,
             boolean eligibleAsCandidate) {}
+
+    private record ResolutionState(
+            LazaxCombatSupport.FleetStrength attackerRemainingStrength,
+            LazaxCombatSupport.FleetStrength defenderRemainingStrength) {}
 }


### PR DESCRIPTION
## Summary
- streamline replay resolution and contest lifecycle helpers
- simplify replay debug and janitor service data flow
- clean up replay backfill snapshot extraction logic

## Testing
- mvn -q spotless:apply -Dtest=CombatReplayServiceTest,CombatReplayContestLifecycleServiceTest test