### PR TITLE
Improve combat contest follow-up context and relay events

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatCandidateEventType.java
+++ b/src/main/java/ti4/contest/replay/core/CombatCandidateEventType.java
@@ -6,6 +6,9 @@ public enum CombatCandidateEventType {
     HIT_ASSIGN,
     CARD,
     AGENT,
+    LEADER,
+    RETREAT,
+    ASSAULT,
     INFO,
     RESOLVED,
     CANCELLED

--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -5,25 +5,35 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatObservationEntity;
 import ti4.game.Game;
+import ti4.game.Leader;
 import ti4.game.Player;
 import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.helpers.ButtonHelper;
+import ti4.helpers.ButtonHelperModifyUnits;
 import ti4.helpers.Constants;
+import ti4.helpers.Helper;
 import ti4.helpers.Units.UnitKey;
 import ti4.image.Mapper;
 import ti4.json.JsonMapperManager;
-import ti4.model.RelicModel;
+import ti4.model.LeaderModel;
 import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
+import ti4.service.agenda.IsPlayerElectedService;
 import ti4.service.combat.CombatStatsService;
 import ti4.service.combat.CombatUnitSelectionHelper;
+import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.ColorEmojis;
+import ti4.service.emoji.ExploreEmojis;
+import ti4.service.emoji.FactionEmojis;
+import ti4.service.emoji.LeaderEmojis;
+import ti4.service.emoji.UnitEmojis;
 import ti4.spring.service.contest.CombatContestType;
 
 @UtilityClass
@@ -34,7 +44,18 @@ public class LazaxCombatSupport {
 
     private static final Set<String> COMBAT_SUMMARY_TECH_ALIASES = Set.of("da", "asc", "x89", "x89c4");
     private static final Set<String> COMBAT_SUMMARY_RELIC_ALIASES = Set.of(
-            "metalivoidarmaments", "metalivoidshielding", "lightrailordnance", "baldrick_crownofthalnos", "pi_thalnos");
+            "metalivoidarmaments",
+            "metalivoidshielding",
+            "lightrailordnance",
+            "thalnos",
+            "baldrick_crownofthalnos",
+            "pi_thalnos");
+    private static final Set<String> SPACE_COMBAT_AGENT_IDS =
+            Set.of("titansagent", "bastionagent", "letnevagent", "nomadagentthundarian", "yinagent");
+    private static final Set<String> SPACE_COMBAT_COMMANDER_IDS =
+            Set.of("redcreusscommander", "crimsoncommander", "mentakcommander", "ralnelcommander");
+    private static final Set<String> SPACE_COMBAT_HERO_IDS =
+            Set.of("mentakhero", "keleresherokuuasi", "redcreusshero", "crimsonhero", "bastionhero");
     private static final Comparator<TechnologyModel> TECH_COMPARATOR = Comparator.comparingInt(
                     LazaxCombatSupport::getTechTypeOrder)
             .thenComparingInt(tech -> tech.getRequirements().orElse("").length())
@@ -120,7 +141,7 @@ public class LazaxCombatSupport {
         return new FleetStrength(total, hp, expectedHits);
     }
 
-    public String formatCombatTechSummary(Player attacker, Player defender) {
+    public String formatCombatTechSummary(Tile tile, Player attacker, Player defender) {
         if (attacker == null || defender == null) return null;
 
         StringBuilder message = new StringBuilder("## Combat Technologies\n")
@@ -130,6 +151,18 @@ public class LazaxCombatSupport {
         String relicSection = formatCombatRelicSection(attacker, defender);
         if (relicSection != null) {
             message.append("\n\n").append(relicSection);
+        }
+        String lawSection = formatCombatLawSection(attacker, defender);
+        if (lawSection != null) {
+            message.append("\n\n").append(lawSection);
+        }
+        String effectSection = formatCombatEffectSection(attacker.getGame());
+        if (effectSection != null) {
+            message.append("\n\n").append(effectSection);
+        }
+        String leaderSection = formatCombatLeaderSection(tile, attacker, defender);
+        if (leaderSection != null) {
+            message.append("\n\n").append(leaderSection);
         }
         return message.toString();
     }
@@ -153,6 +186,7 @@ public class LazaxCombatSupport {
                 + "**System:** " + tileRepresentation + "\n"
                 + "**Combat:** Space Combat\n"
                 + "**Predict the winner by reacting below.**\n"
+                + "_Losers get -4 points._\n"
                 + attackerLine + "\n"
                 + defenderLine;
         String boardSummary = extractRecordedBoardSummary(startSummaryText);
@@ -227,13 +261,162 @@ public class LazaxCombatSupport {
                 .filter(COMBAT_SUMMARY_RELIC_ALIASES::contains)
                 .map(Mapper::getRelic)
                 .filter(Objects::nonNull)
-                .map(RelicModel::getName)
+                .map(relic -> ExploreEmojis.Relic + " " + relic.getName())
                 .sorted(String::compareToIgnoreCase)
                 .reduce((left, right) -> left + ", " + right)
                 .orElse(null);
         if (relicSummary == null) return null;
 
         return formatPlayerSummaryLine(player, relicSummary);
+    }
+
+    private String formatCombatLawSection(Player attacker, Player defender) {
+        String attackerLaw = formatCombatLawLine(attacker);
+        String defenderLaw = formatCombatLawLine(defender);
+        if (attackerLaw == null && defenderLaw == null) return null;
+
+        StringBuilder section = new StringBuilder("## Laws");
+        if (attackerLaw != null) {
+            section.append("\n").append(attackerLaw);
+        }
+        if (defenderLaw != null) {
+            section.append("\n").append(defenderLaw);
+        }
+        return section.toString();
+    }
+
+    private String formatCombatLawLine(Player player) {
+        if (!IsPlayerElectedService.isPlayerElected(player.getGame(), player, "prophecy")) {
+            return null;
+        }
+        return formatPlayerSummaryLine(player, CardEmojis.Agenda + " Prophecy of Ixth");
+    }
+
+    private String formatCombatEffectSection(Game game) {
+        if (!isQuietusActive(game)) {
+            return null;
+        }
+        return "## Combat Effects\n- " + FactionEmojis.Crimson + " " + UnitEmojis.flagship
+                + " Quietus: active Breach in play, opposing unit abilities are canceled.";
+    }
+
+    private String formatCombatLeaderSection(Tile tile, Player attacker, Player defender) {
+        Game game = attacker.getGame();
+        if (tile == null) return null;
+
+        StringBuilder section = new StringBuilder("## Leaders");
+        boolean hasLines = false;
+
+        for (Player player : game.getRealPlayers()) {
+            String line = formatCombatAgentLine(player);
+            if (line == null) continue;
+            section.append("\n").append(line);
+            hasLines = true;
+        }
+
+        String attackerLine = formatCombatParticipantLeaderLine(game, tile, attacker);
+        if (attackerLine != null) {
+            section.append("\n").append(attackerLine);
+            hasLines = true;
+        }
+
+        String defenderLine = formatCombatParticipantLeaderLine(game, tile, defender);
+        if (defenderLine != null) {
+            section.append("\n").append(defenderLine);
+            hasLines = true;
+        }
+
+        return hasLines ? section.toString() : null;
+    }
+
+    private String formatCombatAgentLine(Player player) {
+        String summary = SPACE_COMBAT_AGENT_IDS.stream()
+                .filter(player::hasUnexhaustedLeader)
+                .map(player::getLeaderByID)
+                .flatMap(Optional::stream)
+                .filter(leader -> !leader.isActive())
+                .map(Leader::getLeaderModel)
+                .flatMap(Optional::stream)
+                .map(LazaxCombatSupport::formatLeaderSummary)
+                .reduce((left, right) -> left + ", " + right)
+                .orElse(null);
+        if (summary == null) return null;
+        return formatPlayerSummaryLine(player, summary);
+    }
+
+    private String formatCombatParticipantLeaderLine(Game game, Tile tile, Player player) {
+        String ownSummary = buildOwnCombatLeaderSummary(game, tile, player);
+        String allianceSummary = buildAllianceCommanderSummary(player);
+        if (ownSummary == null && allianceSummary == null) {
+            return null;
+        }
+        String summary = ownSummary;
+        if (summary == null) {
+            summary = allianceSummary;
+        } else if (allianceSummary != null) {
+            summary += ", " + allianceSummary;
+        }
+        return formatPlayerSummaryLine(player, summary);
+    }
+
+    private String buildOwnCombatLeaderSummary(Game game, Tile tile, Player player) {
+        return player.getLeaders().stream()
+                .filter(leader -> !leader.isLocked())
+                .filter(leader -> !leader.isExhausted())
+                .filter(leader -> !leader.isActive())
+                .filter(leader -> SPACE_COMBAT_COMMANDER_IDS.contains(leader.getId())
+                        || SPACE_COMBAT_HERO_IDS.contains(leader.getId()))
+                .filter(leader -> isApplicableCombatLeader(game, tile, player, leader.getId()))
+                .map(Leader::getLeaderModel)
+                .flatMap(Optional::stream)
+                .map(LazaxCombatSupport::formatLeaderSummary)
+                .reduce((left, right) -> left + ", " + right)
+                .orElse(null);
+    }
+
+    private String buildAllianceCommanderSummary(Player player) {
+        Game game = player.getGame();
+        return player.getPromissoryNotesInPlayArea().stream()
+                .filter(pnId -> pnId.contains("_an") || "dspnceld".equals(pnId))
+                .map(game::getPNOwner)
+                .filter(Objects::nonNull)
+                .filter(owner -> !owner.equals(player))
+                .flatMap(owner -> owner.getLeaders().stream())
+                .filter(leader -> SPACE_COMBAT_COMMANDER_IDS.contains(leader.getId()))
+                .filter(leader -> !leader.isLocked())
+                .filter(leader -> !leader.isExhausted())
+                .filter(leader -> !leader.isActive())
+                .map(Leader::getLeaderModel)
+                .flatMap(Optional::stream)
+                .map(model -> formatLeaderSummary(model) + " (alliance)")
+                .reduce((left, right) -> left + ", " + right)
+                .orElse(null);
+    }
+
+    private boolean isApplicableCombatLeader(Game game, Tile tile, Player player, String leaderId) {
+        if ("keleresherokuuasi".equals(leaderId)) {
+            return ButtonHelper.doesPlayerOwnAPlanetInThisSystem(tile, player, game);
+        }
+        if ("ralnelcommander".equals(leaderId)) {
+            return !ButtonHelperModifyUnits.getRetreatSystemButtons(player, game, game.getActiveSystem(), false, false)
+                    .isEmpty();
+        }
+        return true;
+    }
+
+    private String formatLeaderSummary(LeaderModel leaderModel) {
+        return LeaderEmojis.getLeaderTypeEmoji(leaderModel.getType()) + " " + leaderModel.getLeaderEmoji() + " "
+                + leaderModel.getName();
+    }
+
+    private boolean isQuietusActive(Game game) {
+        if (game == null) return false;
+        Player quietusOwner = Helper.getPlayerFromUnit(game, "crimson_flagship");
+        if (quietusOwner == null) return false;
+        return game.getTileMap().values().stream()
+                .map(Tile::getSpaceUnitHolder)
+                .filter(Objects::nonNull)
+                .anyMatch(holder -> holder.getTokenList().contains(Constants.TOKEN_BREACH_ACTIVE));
     }
 
     private String formatPlayerSummaryLine(Player player, String summary) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -42,6 +42,7 @@ import ti4.spring.service.contest.CombatContestService;
 public class CombatReplayLeaderboardService {
 
     private static final double ZERO_EPSILON = 0.0001;
+    private static final int WRONG_PREDICTION_PENALTY = -4;
     private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
     private static final String UNSUBSCRIBE_EMOJI = "\uD83D\uDD34";
     private static final String CONTEST_CHANNEL_NAME_V1 = "lazax-war-archives-dev";
@@ -272,6 +273,8 @@ public class CombatReplayLeaderboardService {
             if (winningUserIds.contains(prediction.discordUserId())) {
                 entry.setCorrectPredictions(safeInt(entry.getCorrectPredictions()) + 1);
                 entry.setTotalPoints(safeInt(entry.getTotalPoints()) + pointsAwarded);
+            } else {
+                entry.setTotalPoints(Math.max(0, safeInt(entry.getTotalPoints()) + WRONG_PREDICTION_PENALTY));
             }
             entry.setUpdatedAt(now);
         }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -105,11 +105,48 @@ public class CombatReplayService {
                 embed);
     }
 
+    public void mirrorRetreatDeclared(Game game, Player player, String sourceChannelName) {
+        CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
+        if (candidate == null) return;
+
+        appendDiscordEvent(
+                candidate,
+                CombatCandidateEventType.RETREAT,
+                getCurrentRound(game, candidate),
+                player.getFaction(),
+                "## Retreat\n" + player.getRepresentationNoPing() + " announced a retreat.");
+    }
+
+    public void mirrorRetreatResolved(Game game, Player player, String destination, String sourceChannelName) {
+        CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
+        if (candidate == null) return;
+
+        appendDiscordEvent(
+                candidate,
+                CombatCandidateEventType.RETREAT,
+                getCurrentRound(game, candidate),
+                player.getFaction(),
+                "## Retreat\n" + player.getRepresentationNoPing() + " retreated to " + destination + ".");
+    }
+
+    public void mirrorAssaultCannonAssigned(Game game, Player player, String sourceChannelName) {
+        CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
+        if (candidate == null) return;
+
+        appendDiscordEvent(
+                candidate,
+                CombatCandidateEventType.ASSAULT,
+                getCurrentRound(game, candidate),
+                player.getFaction(),
+                "## Combat Ability\n" + player.getRepresentationNoPing() + " used _Assault Cannon_.");
+    }
+
     private CombatCandidateEventType mapEventType(String header) {
         String normalized = header == null ? "" : header.trim().toLowerCase();
         return switch (normalized) {
             case "action card" -> CombatCandidateEventType.CARD;
             case "agent" -> CombatCandidateEventType.AGENT;
+            case "leader", "hero", "commander", "envoy" -> CombatCandidateEventType.LEADER;
             default -> CombatCandidateEventType.INFO;
         };
     }
@@ -450,7 +487,8 @@ public class CombatReplayService {
         candidate.setCombatType(observation.getCombatType());
         candidate.setAttackerFaction(attacker.getFaction());
         candidate.setDefenderFaction(defender.getFaction());
-        candidate.setPreReplayContextText(LazaxCombatSupport.formatCombatTechSummary(attacker, defender));
+        candidate.setPreReplayContextText(LazaxCombatSupport.formatCombatTechSummary(
+                attacker.getGame().getTileByPosition(observation.getTilePosition()), attacker, defender));
         candidate.setInitialRenderSnapshotJson(initialRenderSnapshotJson);
         return candidate;
     }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/combat/CombatButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/combat/CombatButtonHandler.java
@@ -20,6 +20,8 @@ import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.model.TemporaryCombatModifierModel;
 import ti4.service.fow.FOWCombatThreadMirroring;
+import ti4.spring.context.SpringContext;
+import ti4.spring.service.contest.CombatContestService;
 
 @UtilityClass
 class CombatButtonHandler {
@@ -171,6 +173,8 @@ class CombatButtonHandler {
             MessageHelper.sendMessageToChannel(event.getMessageChannel(), msg);
         }
         FOWCombatThreadMirroring.mirrorMessage(event, game, msg.replace("## ", ""));
+        SpringContext.getBean(CombatContestService.class)
+                .mirrorRetreatDeclared(game, player, event.getChannel().getName());
 
         if (Helper.getCCCount(game, player.getColor()) > 15) {
             MessageHelper.sendMessageToChannel(

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/combat/RetreatButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/combat/RetreatButtonHandler.java
@@ -22,6 +22,8 @@ import ti4.service.emoji.MiscEmojis;
 import ti4.service.fow.FOWCombatThreadMirroring;
 import ti4.service.fow.LoreService;
 import ti4.service.unit.CheckUnitContainmentService;
+import ti4.spring.context.SpringContext;
+import ti4.spring.service.contest.CombatContestService;
 
 @UtilityClass
 class RetreatButtonHandler {
@@ -94,6 +96,12 @@ class RetreatButtonHandler {
                 event.getMessageChannel(),
                 player.getRepresentationNoPing() + " retreated all units in space to "
                         + game.getTileByPosition(pos2).getRepresentationForButtons(game, player) + ".");
+        SpringContext.getBean(CombatContestService.class)
+                .mirrorRetreatResolved(
+                        game,
+                        player,
+                        game.getTileByPosition(pos2).getRepresentationForButtons(game, player),
+                        event.getChannel().getName());
         LoreService.showSystemLore(player, game, pos2, LoreService.TRIGGER.CONTROLLED);
         FOWCombatThreadMirroring.mirrorMessage(
                 event, game, player.getRepresentationNoPing() + " retreated all units in space.");

--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -59,6 +59,8 @@ import ti4.service.unit.MoveUnitService;
 import ti4.service.unit.ParsedUnit;
 import ti4.service.unit.RemoveUnitService;
 import ti4.service.unit.RemoveUnitService.RemovedUnit;
+import ti4.spring.context.SpringContext;
+import ti4.spring.service.contest.CombatContestService;
 
 public final class ButtonHelperModifyUnits {
 
@@ -2462,6 +2464,9 @@ public final class ButtonHelperModifyUnits {
         } else {
             MessageHelper.sendMessageToChannel(
                     event.getMessageChannel(), player.getRepresentation(false, false) + " used _Assault Cannon_.");
+            SpringContext.getBean(CombatContestService.class)
+                    .mirrorAssaultCannonAssigned(
+                            game, player, event.getChannel().getName());
             msg = opponent.getRepresentationUnfogged()
                     + ", your opponent used _Assault Cannon_, forcing you to destroy a non-fighter ship. Please assign it with buttons.";
             buttons = ButtonHelper.getButtonsForRemovingAllUnitsInSystem(opponent, game, tile, "assaultcannoncombat");

--- a/src/main/java/ti4/helpers/ComponentActionHelper.java
+++ b/src/main/java/ti4/helpers/ComponentActionHelper.java
@@ -44,6 +44,8 @@ import ti4.service.turn.StartTurnService;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.CheckUnitContainmentService;
 import ti4.service.unit.DestroyUnitService;
+import ti4.spring.context.SpringContext;
+import ti4.spring.service.contest.CombatContestService;
 
 @UtilityClass
 public class ComponentActionHelper {
@@ -537,6 +539,24 @@ public class ComponentActionHelper {
                 } else if (buttonID.contains("hero")) {
                     PlayHeroService.playHero(
                             event, game, p1, p1.getLeader(buttonID).orElse(null));
+                } else {
+                    LeaderModel leaderModel = Mapper.getLeader(buttonID);
+                    if (leaderModel != null) {
+                        String leaderType =
+                                switch (leaderModel.getType()) {
+                                    case "commander" -> "Commander";
+                                    case "envoy" -> "Envoy";
+                                    default -> "Leader";
+                                };
+                        SpringContext.getBean(CombatContestService.class)
+                                .mirrorCombatEvent(
+                                        game,
+                                        p1,
+                                        leaderType,
+                                        "used _" + leaderModel.getName() + "_.",
+                                        leaderModel.getRepresentationEmbed(),
+                                        event.getChannel().getName());
+                    }
                 }
             }
             case "relic" -> resolveRelicComponentAction(game, p1, event, buttonID);

--- a/src/main/java/ti4/spring/service/contest/CombatContestPredictionRepository.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestPredictionRepository.java
@@ -14,7 +14,7 @@ public interface CombatContestPredictionRepository extends JpaRepository<CombatC
 
     @Query("""
             select p.discordUserId as discordUserId,
-                   sum(p.pointsAwarded) as totalPoints
+                   case when sum(p.pointsAwarded) < 0 then 0 else sum(p.pointsAwarded) end as totalPoints
             from CombatContestPredictionEntity p
             where p.pointsAwarded is not null
               and p.discordUserId in :discordUserIds
@@ -25,13 +25,13 @@ public interface CombatContestPredictionRepository extends JpaRepository<CombatC
     @Query("""
             select p.discordUserId as discordUserId,
                    max(p.discordUserName) as discordUserName,
-                   sum(p.pointsAwarded) as totalPoints,
+                   case when sum(p.pointsAwarded) < 0 then 0 else sum(p.pointsAwarded) end as totalPoints,
                    count(p.id) as predictionCount,
                    sum(case when p.correct = true then 1 else 0 end) as correctPredictions
             from CombatContestPredictionEntity p
             where p.pointsAwarded is not null
             group by p.discordUserId
-            order by sum(p.pointsAwarded) desc,
+            order by case when sum(p.pointsAwarded) < 0 then 0 else sum(p.pointsAwarded) end desc,
                      sum(case when p.correct = true then 1 else 0 end) desc,
                      max(p.discordUserName) asc
             """)

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -66,6 +66,7 @@ public class CombatContestService {
     private static final Set<String> COMBAT_SUMMARY_RELIC_ALIASES = Set.of(
             "metalivoidarmaments", "metalivoidshielding", "lightrailordnance", "baldrick_crownofthalnos", "pi_thalnos");
     private static final double ZERO_EPSILON = 0.0001;
+    private static final int WRONG_PREDICTION_PENALTY = -4;
     private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
     private static final String UNSUBSCRIBE_EMOJI = "\uD83D\uDD34";
     private static final Set<CombatContestStatus> ACTIVE_STATUSES = Set.of(CombatContestStatus.POSTED);
@@ -194,6 +195,35 @@ public class CombatContestService {
         }
     }
 
+    public void mirrorRetreatDeclared(Game game, Player player, String sourceChannelName) {
+        runReplayHook(
+                game,
+                "retreat declaration mirror",
+                () -> combatReplayService.mirrorRetreatDeclared(game, player, sourceChannelName));
+        if (isReplayV2Enabled()) return;
+        relayContestMessage(game, player, "## Retreat\n" + player.getRepresentationNoPing() + " announced a retreat.");
+    }
+
+    public void mirrorRetreatResolved(Game game, Player player, String destination, String sourceChannelName) {
+        runReplayHook(
+                game,
+                "retreat resolution mirror",
+                () -> combatReplayService.mirrorRetreatResolved(game, player, destination, sourceChannelName));
+        if (isReplayV2Enabled()) return;
+        relayContestMessage(
+                game, player, "## Retreat\n" + player.getRepresentationNoPing() + " retreated to " + destination + ".");
+    }
+
+    public void mirrorAssaultCannonAssigned(Game game, Player player, String sourceChannelName) {
+        runReplayHook(
+                game,
+                "assault cannon mirror",
+                () -> combatReplayService.mirrorAssaultCannonAssigned(game, player, sourceChannelName));
+        if (isReplayV2Enabled()) return;
+        relayContestMessage(
+                game, player, "## Combat Ability\n" + player.getRepresentationNoPing() + " used _Assault Cannon_.");
+    }
+
     public boolean postLeaderboard() {
         if (isReplayV2Enabled()) {
             return combatReplayLeaderboardService.postLeaderboard();
@@ -218,6 +248,18 @@ public class CombatContestService {
     private boolean isReplayV2Enabled() {
         String versionEnabled = replaySettings.getRuntime().getVersionEnabled();
         return "v2".equalsIgnoreCase(versionEnabled);
+    }
+
+    private void relayContestMessage(Game game, Player player, String message) {
+        List<CombatContestEntity> activeContests =
+                repository.findByGameNameAndStatusIn(game.getName(), ACTIVE_STATUSES);
+        if (activeContests.isEmpty()) return;
+        for (CombatContestEntity contest : activeContests) {
+            if (!matchesParticipant(contest, player)) continue;
+            MessageChannel threadOrChannel = getContestThreadOrChannel(contest);
+            if (threadOrChannel == null) continue;
+            MessageHelper.splitAndSentWithAction(message, threadOrChannel, null);
+        }
     }
 
     // ==================== Contest Creation & Eligibility ====================
@@ -650,7 +692,10 @@ public class CombatContestService {
         for (CombatContestPredictionEntity prediction : predictions) {
             boolean correct = prediction.getPredictedFaction().equalsIgnoreCase(contest.getWinnerFaction());
             prediction.setCorrect(correct);
-            prediction.setPointsAwarded(correct ? calculatePredictionPoints(winnerPredictions, totalPredictions) : 0);
+            prediction.setPointsAwarded(
+                    correct
+                            ? calculatePredictionPoints(winnerPredictions, totalPredictions)
+                            : WRONG_PREDICTION_PENALTY);
         }
         predictionRepository.saveAll(predictions);
         return predictions;
@@ -821,6 +866,7 @@ public class CombatContestService {
                 + "**System:** " + tile.getRepresentationForButtons() + "\n"
                 + "**Combat:** Space Combat\n"
                 + "**Predict the winner by reacting below.**\n"
+                + "_Losers get -4 points._\n"
                 + "- " + attackerLegend + "\n"
                 + "- " + defenderLegend;
     }
@@ -977,7 +1023,8 @@ public class CombatContestService {
     private void postCombatTechSummary(Game game, CombatContestEntity contest, MessageChannel threadOrChannel) {
         Player attacker = game.getPlayerFromColorOrFaction(contest.getAttackerFaction());
         Player defender = game.getPlayerFromColorOrFaction(contest.getDefenderFaction());
-        String message = LazaxCombatSupport.formatCombatTechSummary(attacker, defender);
+        Tile tile = game.getTileByPosition(contest.getTilePosition());
+        String message = LazaxCombatSupport.formatCombatTechSummary(tile, attacker, defender);
         if (message == null || message.isBlank()) return;
         MessageHelper.sendMessageToChannel(threadOrChannel, message);
     }


### PR DESCRIPTION
## Summary
- expand the combat contest follow-up summary with relevant relics, laws, Quietus, and usable combat leaders
- relay retreat, assault cannon, and broader combat leader events into contest threads
- add the wrong-prediction penalty text and scoring updates, including leaderboard flooring at zero

## Testing
- mvn -q spotless:apply
- mvn -q -Dtest=CombatReplayServiceTest test
- mvn -q -DskipTests compile