### PR TITLE
Replay followup fixes and enum persistence migration

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -1,6 +1,5 @@
 package ti4.contest.cron;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.experimental.UtilityClass;
@@ -68,9 +67,9 @@ public class CombatReplayPromotionScoreBackfillCron {
     }
 
     private static boolean recomputePromotionScore(CombatCandidateEntity candidate) {
-        CombatObservationRepository observationRepository = SpringContext.getBean(CombatObservationRepository.class);
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
+        CombatObservationEntity observation = SpringContext.getBean(CombatObservationRepository.class)
+                .findById(candidate.getObservationId())
+                .orElse(null);
         if (observation == null) return false;
 
         String snapshotJson = extractLatestSnapshotJson(candidate.getId());
@@ -109,9 +108,9 @@ public class CombatReplayPromotionScoreBackfillCron {
     private static String extractLatestSnapshotJson(Long candidateId) {
         List<CombatCandidateEventEntity> events = SpringContext.getBean(CombatCandidateEventRepository.class)
                 .findByCandidateIdOrderBySequenceNumberAsc(candidateId);
-        Collections.reverse(events);
         ReplayDispatchSerializer payloadSerializer = SpringContext.getBean(ReplayDispatchSerializer.class);
-        for (CombatCandidateEventEntity event : events) {
+        for (int i = events.size() - 1; i >= 0; i--) {
+            CombatCandidateEventEntity event = events.get(i);
             ReplayDispatchPayload payload = payloadSerializer.read(event);
             if (payload instanceof ReplayDispatchPayload.HitAssignDispatch hitAssign) {
                 return hitAssign.combatStateSnapshotJson();

--- a/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
+++ b/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
@@ -90,41 +90,29 @@ public class CombatReplayDebugController {
     public ResponseEntity<String> getCandidate(@PathVariable Long candidateId) {
         CombatCandidateEntity candidate =
                 candidateRepository.findById(candidateId).orElse(null);
-        if (candidate == null) {
-            return ResponseEntity.notFound().build();
-        }
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        CombatReplayContestEntity contest =
-                replayContestRepository.findByCandidateId(candidateId).orElse(null);
-        List<EventResponse> events =
-                candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidateId).stream()
-                        .map(this::toEventResponse)
-                        .toList();
-        return ok(new CandidateDetailResponse(runtimeState(), candidate, observation, contest, events));
+        if (candidate == null) return ResponseEntity.notFound().build();
+        return ok(buildCandidateDetailResponse(candidate));
     }
 
     @GetMapping(value = "/candidates/{candidateId}/promote", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> forcePromoteCandidate(@PathVariable Long candidateId) {
         CombatCandidateEntity candidate =
                 candidateRepository.findById(candidateId).orElse(null);
-        if (candidate == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (candidate == null) return ResponseEntity.notFound().build();
 
         CombatReplayContestLifecycleService.ForcePromoteResult result =
                 contestLifecycleService.forcePromoteCandidate(candidateId);
         CombatReplayContestEntity contest = result.contest() != null
                 ? result.contest()
                 : replayContestRepository.findByCandidateId(candidateId).orElse(null);
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        List<EventResponse> events =
-                candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidateId).stream()
-                        .map(this::toEventResponse)
-                        .toList();
         return ok(new ForcePromoteResponse(
-                runtimeState(), result.promoted(), result.reason(), candidate, observation, contest, events));
+                runtimeState(),
+                result.promoted(),
+                result.reason(),
+                candidate,
+                observationRepository.findById(candidate.getObservationId()).orElse(null),
+                contest,
+                loadEvents(candidateId)));
     }
 
     @GetMapping(value = "/contests", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -142,20 +130,19 @@ public class CombatReplayDebugController {
     public ResponseEntity<String> getContest(@PathVariable Long contestId) {
         CombatReplayContestEntity contest =
                 replayContestRepository.findById(contestId).orElse(null);
-        if (contest == null) {
-            return ResponseEntity.notFound().build();
-        }
+        if (contest == null) return ResponseEntity.notFound().build();
         CombatCandidateEntity candidate =
                 candidateRepository.findById(contest.getCandidateId()).orElse(null);
-        CombatObservationEntity observation = candidate == null
-                ? null
-                : observationRepository.findById(candidate.getObservationId()).orElse(null);
-        List<EventResponse> events = candidate == null
-                ? List.of()
-                : candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId()).stream()
-                        .map(this::toEventResponse)
-                        .toList();
-        return ok(new ContestDetailResponse(runtimeState(), contest, candidate, observation, events));
+        return ok(new ContestDetailResponse(
+                runtimeState(),
+                contest,
+                candidate,
+                candidate == null
+                        ? null
+                        : observationRepository
+                                .findById(candidate.getObservationId())
+                                .orElse(null),
+                candidate == null ? List.of() : loadEvents(candidate.getId())));
     }
 
     private ResponseEntity<String> ok(Object body) {
@@ -175,36 +162,54 @@ public class CombatReplayDebugController {
     }
 
     private RuntimeStateResponse runtimeState() {
-        return new RuntimeStateResponse(settings.getRuntime().isDiscordPostingEnabled());
+        return new RuntimeStateResponse(
+                settings.getRuntime().isDiscordPostingEnabled(),
+                settings.getRuntime().isTrackAllCombatsAsCandidates(),
+                settings.getRuntime().isImmediatePromotionOnResolve());
     }
 
     private CandidateSummary toCandidateSummary(CombatCandidateEntity candidate) {
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        CombatReplayContestEntity contest =
-                replayContestRepository.findByCandidateId(candidate.getId()).orElse(null);
-        long eventCount = candidateEventRepository
-                .findByCandidateIdOrderBySequenceNumberAsc(candidate.getId())
-                .size();
-        return new CandidateSummary(candidate, observation, contest, eventCount);
+        return new CandidateSummary(
+                candidate,
+                observationRepository.findById(candidate.getObservationId()).orElse(null),
+                replayContestRepository.findByCandidateId(candidate.getId()).orElse(null),
+                eventCount(candidate.getId()));
     }
 
     private ContestSummary toContestSummary(CombatReplayContestEntity contest) {
         CombatCandidateEntity candidate =
                 candidateRepository.findById(contest.getCandidateId()).orElse(null);
-        long eventCount = candidate == null
-                ? 0
-                : candidateEventRepository
-                        .findByCandidateIdOrderBySequenceNumberAsc(candidate.getId())
-                        .size();
+        long eventCount = candidate == null ? 0 : eventCount(candidate.getId());
         return new ContestSummary(contest, candidate, eventCount);
+    }
+
+    private CandidateDetailResponse buildCandidateDetailResponse(CombatCandidateEntity candidate) {
+        return new CandidateDetailResponse(
+                runtimeState(),
+                candidate,
+                observationRepository.findById(candidate.getObservationId()).orElse(null),
+                replayContestRepository.findByCandidateId(candidate.getId()).orElse(null),
+                loadEvents(candidate.getId()));
+    }
+
+    private List<EventResponse> loadEvents(Long candidateId) {
+        return candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidateId).stream()
+                .map(this::toEventResponse)
+                .toList();
+    }
+
+    private long eventCount(Long candidateId) {
+        return candidateEventRepository
+                .findByCandidateIdOrderBySequenceNumberAsc(candidateId)
+                .size();
     }
 
     private EventResponse toEventResponse(CombatCandidateEventEntity event) {
         return new EventResponse(event, payloadSerializer.read(event));
     }
 
-    private record RuntimeStateResponse(boolean discordPostingEnabled) {}
+    private record RuntimeStateResponse(
+            boolean discordPostingEnabled, boolean trackAllCombatsAsCandidates, boolean immediatePromotionOnResolve) {}
 
     private record CandidateListResponse(RuntimeStateResponse runtime, List<CandidateSummary> candidates) {}
 

--- a/src/main/java/ti4/contest/replay/core/CombatCandidateEventType.java
+++ b/src/main/java/ti4/contest/replay/core/CombatCandidateEventType.java
@@ -4,11 +4,6 @@ public enum CombatCandidateEventType {
     START,
     ROLL,
     HIT_ASSIGN,
-    CARD,
-    AGENT,
-    LEADER,
-    RETREAT,
-    ASSAULT,
     INFO,
     RESOLVED,
     CANCELLED

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -108,9 +108,15 @@ public class CombatContestSettings {
     @Data
     @NoArgsConstructor
     public static class ReplayExecution {
-        private int startDelayMinutes = 10;
-        private int replayIntervalSeconds = 15;
-        private int maxEventGapSeconds = 30;
+        // prod settings
+        // private int startDelayMinutes = 10;
+        // private int replayIntervalSeconds = 15;
+        // private int maxEventGapSeconds = 30;
+
+        // dev settings
+        private int startDelayMinutes = 0;
+        private int replayIntervalSeconds = 1;
+        private int maxEventGapSeconds = 1;
     }
 
     @Data
@@ -125,5 +131,12 @@ public class CombatContestSettings {
     public static class Runtime {
         private boolean discordPostingEnabled = true;
         private String versionEnabled = "v2";
+        // prod settings
+        // private boolean trackAllCombatsAsCandidates = false;
+        // private boolean immediatePromotionOnResolve = false;
+
+        // dev settings
+        private boolean trackAllCombatsAsCandidates = true;
+        private boolean immediatePromotionOnResolve = true;
     }
 }

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -109,14 +109,14 @@ public class CombatContestSettings {
     @NoArgsConstructor
     public static class ReplayExecution {
         // prod settings
-        // private int startDelayMinutes = 10;
-        // private int replayIntervalSeconds = 15;
-        // private int maxEventGapSeconds = 30;
+        private int startDelayMinutes = 10;
+        private int replayIntervalSeconds = 15;
+        private int maxEventGapSeconds = 30;
 
         // dev settings
-        private int startDelayMinutes = 0;
-        private int replayIntervalSeconds = 1;
-        private int maxEventGapSeconds = 1;
+        //        private int startDelayMinutes = 0;
+        //        private int replayIntervalSeconds = 1;
+        //        private int maxEventGapSeconds = 1;
     }
 
     @Data
@@ -132,11 +132,11 @@ public class CombatContestSettings {
         private boolean discordPostingEnabled = true;
         private String versionEnabled = "v2";
         // prod settings
-        // private boolean trackAllCombatsAsCandidates = false;
-        // private boolean immediatePromotionOnResolve = false;
+        private boolean trackAllCombatsAsCandidates = false;
+        private boolean immediatePromotionOnResolve = false;
 
         // dev settings
-        private boolean trackAllCombatsAsCandidates = true;
-        private boolean immediatePromotionOnResolve = true;
+        //        private boolean trackAllCombatsAsCandidates = true;
+        //        private boolean immediatePromotionOnResolve = true;
     }
 }

--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -42,7 +42,7 @@ import ti4.spring.service.contest.CombatContestType;
  */
 public class LazaxCombatSupport {
 
-    private static final Set<String> COMBAT_SUMMARY_TECH_ALIASES = Set.of("da", "asc", "x89", "x89c4");
+    private static final Set<String> COMBAT_SUMMARY_TECH_ALIASES = Set.of("da", "asc", "gls", "x89", "x89c4");
     private static final Set<String> COMBAT_SUMMARY_RELIC_ALIASES = Set.of(
             "metalivoidarmaments",
             "metalivoidshielding",
@@ -150,19 +150,19 @@ public class LazaxCombatSupport {
                 .append(formatCombatTechLine(defender));
         String relicSection = formatCombatRelicSection(attacker, defender);
         if (relicSection != null) {
-            message.append("\n\n").append(relicSection);
+            message.append("\n").append(relicSection);
         }
         String lawSection = formatCombatLawSection(attacker, defender);
         if (lawSection != null) {
-            message.append("\n\n").append(lawSection);
+            message.append("\n").append(lawSection);
         }
         String effectSection = formatCombatEffectSection(attacker.getGame());
         if (effectSection != null) {
-            message.append("\n\n").append(effectSection);
+            message.append("\n").append(effectSection);
         }
         String leaderSection = formatCombatLeaderSection(tile, attacker, defender);
         if (leaderSection != null) {
-            message.append("\n\n").append(leaderSection);
+            message.append("\n").append(leaderSection);
         }
         return message.toString();
     }
@@ -234,10 +234,18 @@ public class LazaxCombatSupport {
                         || tech.isUnitUpgrade()
                         || COMBAT_SUMMARY_TECH_ALIASES.contains(tech.getAlias()))
                 .sorted(TECH_COMPARATOR)
-                .map(tech -> tech.getCondensedReqsEmojis(false) + " " + tech.getName())
+                .map(tech -> formatCombatTech(player, tech))
                 .reduce((left, right) -> left + ", " + right)
                 .orElse("No technologies");
         return formatPlayerSummaryLine(player, techSummary);
+    }
+
+    private String formatCombatTech(Player player, TechnologyModel tech) {
+        String techSummary = tech.getCondensedReqsEmojis(false) + " " + tech.getName();
+        if (!player.getExhaustedTechs().contains(tech.getAlias())) {
+            return techSummary;
+        }
+        return "~~" + techSummary + "~~";
     }
 
     private String formatCombatRelicSection(Player attacker, Player defender) {
@@ -286,7 +294,8 @@ public class LazaxCombatSupport {
     }
 
     private String formatCombatLawLine(Player player) {
-        if (!IsPlayerElectedService.isPlayerElected(player.getGame(), player, "prophecy")) {
+        Game game = player.getGame();
+        if (game == null || !IsPlayerElectedService.isPlayerElected(game, player, "prophecy")) {
             return null;
         }
         return formatPlayerSummaryLine(player, CardEmojis.Agenda + " Prophecy of Ixth");
@@ -302,7 +311,7 @@ public class LazaxCombatSupport {
 
     private String formatCombatLeaderSection(Tile tile, Player attacker, Player defender) {
         Game game = attacker.getGame();
-        if (tile == null) return null;
+        if (game == null || tile == null) return null;
 
         StringBuilder section = new StringBuilder("## Leaders");
         boolean hasLines = false;
@@ -376,6 +385,7 @@ public class LazaxCombatSupport {
 
     private String buildAllianceCommanderSummary(Player player) {
         Game game = player.getGame();
+        if (game == null) return null;
         return player.getPromissoryNotesInPlayArea().stream()
                 .filter(pnId -> pnId.contains("_an") || "dspnceld".equals(pnId))
                 .map(game::getPNOwner)

--- a/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
@@ -2,8 +2,6 @@ package ti4.contest.replay.entities;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,11 +37,9 @@ public class CombatCandidateEntity {
     @Column(name = "observation_id", nullable = false, unique = true)
     private Long observationId;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CombatCandidateStatus status;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "promotion_status", nullable = false)
     private CombatCandidatePromotionStatus promotionStatus;
 
@@ -65,7 +61,6 @@ public class CombatCandidateEntity {
     @Column(name = "tile_position", nullable = false)
     private String tilePosition;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "combat_type", nullable = false)
     private CombatContestType combatType;
 

--- a/src/main/java/ti4/contest/replay/entities/CombatCandidateEventEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatCandidateEventEntity.java
@@ -2,8 +2,6 @@ package ti4.contest.replay.entities;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -44,7 +42,6 @@ public class CombatCandidateEventEntity {
     @Column(name = "sequence_number", nullable = false)
     private Integer sequenceNumber;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "event_type", nullable = false)
     private CombatCandidateEventType eventType;
 

--- a/src/main/java/ti4/contest/replay/entities/CombatObservationEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatObservationEntity.java
@@ -2,8 +2,6 @@ package ti4.contest.replay.entities;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -46,7 +44,6 @@ public class CombatObservationEntity {
     @Column(name = "tile_position", nullable = false)
     private String tilePosition;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "combat_type", nullable = false)
     private CombatContestType combatType;
 

--- a/src/main/java/ti4/contest/replay/entities/CombatReplayContestEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatReplayContestEntity.java
@@ -2,8 +2,6 @@ package ti4.contest.replay.entities;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -47,7 +45,6 @@ public class CombatReplayContestEntity {
     @Column(name = "public_thread_id")
     private Long publicThreadId;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "replay_status", nullable = false)
     private CombatContestReplayStatus replayStatus;
 

--- a/src/main/java/ti4/contest/replay/persistence/CombatCandidateEventTypeConverter.java
+++ b/src/main/java/ti4/contest/replay/persistence/CombatCandidateEventTypeConverter.java
@@ -1,0 +1,26 @@
+package ti4.contest.replay.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ti4.contest.replay.core.CombatCandidateEventType;
+
+@Converter(autoApply = true)
+public class CombatCandidateEventTypeConverter implements AttributeConverter<CombatCandidateEventType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CombatCandidateEventType attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public CombatCandidateEventType convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return switch (dbData) {
+            case "CARD", "AGENT", "LEADER", "RETREAT", "TECH_USE", "ASSAULT", "GRAVITON" ->
+                CombatCandidateEventType.INFO;
+            default -> CombatCandidateEventType.valueOf(dbData);
+        };
+    }
+}

--- a/src/main/java/ti4/contest/replay/persistence/CombatCandidatePromotionStatusConverter.java
+++ b/src/main/java/ti4/contest/replay/persistence/CombatCandidatePromotionStatusConverter.java
@@ -1,0 +1,20 @@
+package ti4.contest.replay.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ti4.contest.replay.core.CombatCandidatePromotionStatus;
+
+@Converter(autoApply = true)
+public class CombatCandidatePromotionStatusConverter
+        implements AttributeConverter<CombatCandidatePromotionStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CombatCandidatePromotionStatus attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public CombatCandidatePromotionStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : CombatCandidatePromotionStatus.valueOf(dbData);
+    }
+}

--- a/src/main/java/ti4/contest/replay/persistence/CombatCandidateStatusConverter.java
+++ b/src/main/java/ti4/contest/replay/persistence/CombatCandidateStatusConverter.java
@@ -1,0 +1,19 @@
+package ti4.contest.replay.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ti4.contest.replay.core.CombatCandidateStatus;
+
+@Converter(autoApply = true)
+public class CombatCandidateStatusConverter implements AttributeConverter<CombatCandidateStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CombatCandidateStatus attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public CombatCandidateStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : CombatCandidateStatus.valueOf(dbData);
+    }
+}

--- a/src/main/java/ti4/contest/replay/persistence/CombatContestReplayStatusConverter.java
+++ b/src/main/java/ti4/contest/replay/persistence/CombatContestReplayStatusConverter.java
@@ -1,0 +1,19 @@
+package ti4.contest.replay.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ti4.contest.replay.core.CombatContestReplayStatus;
+
+@Converter(autoApply = true)
+public class CombatContestReplayStatusConverter implements AttributeConverter<CombatContestReplayStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CombatContestReplayStatus attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public CombatContestReplayStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : CombatContestReplayStatus.valueOf(dbData);
+    }
+}

--- a/src/main/java/ti4/contest/replay/persistence/CombatContestStatusConverter.java
+++ b/src/main/java/ti4/contest/replay/persistence/CombatContestStatusConverter.java
@@ -1,0 +1,19 @@
+package ti4.contest.replay.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ti4.spring.service.contest.CombatContestStatus;
+
+@Converter(autoApply = true)
+public class CombatContestStatusConverter implements AttributeConverter<CombatContestStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CombatContestStatus attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public CombatContestStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : CombatContestStatus.valueOf(dbData);
+    }
+}

--- a/src/main/java/ti4/contest/replay/persistence/CombatContestTypeConverter.java
+++ b/src/main/java/ti4/contest/replay/persistence/CombatContestTypeConverter.java
@@ -1,0 +1,19 @@
+package ti4.contest.replay.persistence;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ti4.spring.service.contest.CombatContestType;
+
+@Converter(autoApply = true)
+public class CombatContestTypeConverter implements AttributeConverter<CombatContestType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CombatContestType attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public CombatContestType convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : CombatContestType.valueOf(dbData);
+    }
+}

--- a/src/main/java/ti4/contest/replay/persistence/CombatReplayEnumConstraintMigration.java
+++ b/src/main/java/ti4/contest/replay/persistence/CombatReplayEnumConstraintMigration.java
@@ -1,0 +1,376 @@
+package ti4.contest.replay.persistence;
+
+import jakarta.annotation.PostConstruct;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.Set;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import ti4.logging.BotLogger;
+
+@Component
+@RequiredArgsConstructor
+public class CombatReplayEnumConstraintMigration {
+
+    private final DataSource dataSource;
+
+    @PostConstruct
+    void migrate() {
+        try (Connection connection = dataSource.getConnection()) {
+            if (!isSqlite(connection) || !needsMigration(connection)) {
+                return;
+            }
+
+            boolean originalAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                execute(connection, "PRAGMA foreign_keys = OFF");
+                migrateCombatCandidate(connection);
+                migrateCombatObservation(connection);
+                migrateCombatContest(connection);
+                migrateCombatCandidateEvent(connection);
+                migrateCombatPredictorContest(connection);
+                connection.commit();
+                BotLogger.info("Combat replay enum constraint migration completed.");
+            } catch (SQLException e) {
+                connection.rollback();
+                throw new IllegalStateException("Failed to migrate replay enum constraints.", e);
+            } finally {
+                try {
+                    execute(connection, "PRAGMA foreign_keys = ON");
+                } catch (SQLException e) {
+                    BotLogger.warning("Failed to re-enable SQLite foreign keys after replay enum migration.", e);
+                }
+                connection.setAutoCommit(originalAutoCommit);
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to inspect replay schema for enum constraint migration.", e);
+        }
+    }
+
+    private boolean isSqlite(Connection connection) throws SQLException {
+        DatabaseMetaData metadata = connection.getMetaData();
+        String url = metadata.getURL();
+        return url != null && url.startsWith("jdbc:sqlite:");
+    }
+
+    private boolean needsMigration(Connection connection) throws SQLException {
+        return tableNeedsMigration(connection, "combat_candidate")
+                || tableNeedsMigration(connection, "combat_observation")
+                || tableNeedsMigration(connection, "combat_contest")
+                || tableNeedsMigration(connection, "combat_candidate_event")
+                || tableNeedsMigration(connection, "combat_predictor_contest");
+    }
+
+    private boolean tableNeedsMigration(Connection connection, String tableName) throws SQLException {
+        String tableSql = getTableSql(connection, tableName);
+        return tableSql != null && tableSql.toLowerCase().contains("check");
+    }
+
+    private String getTableSql(Connection connection, String tableName) throws SQLException {
+        try (var preparedStatement =
+                connection.prepareStatement("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?")) {
+            preparedStatement.setString(1, tableName);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return null;
+                }
+                return resultSet.getString(1);
+            }
+        }
+    }
+
+    private Set<String> getColumnNames(Connection connection, String tableName) throws SQLException {
+        Set<String> columnNames = new HashSet<>();
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("PRAGMA table_info(" + tableName + ")")) {
+            while (resultSet.next()) {
+                columnNames.add(resultSet.getString("name"));
+            }
+        }
+        return columnNames;
+    }
+
+    private void migrateCombatCandidate(Connection connection) throws SQLException {
+        if (!tableNeedsMigration(connection, "combat_candidate")) {
+            return;
+        }
+
+        execute(connection, "DROP TABLE IF EXISTS combat_candidate_new");
+        execute(connection, """
+                CREATE TABLE combat_candidate_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    observation_id BIGINT NOT NULL UNIQUE,
+                    status VARCHAR(255) NOT NULL,
+                    promotion_status VARCHAR(255) NOT NULL,
+                    next_event_sequence INTEGER NOT NULL,
+                    started_at DATETIME NOT NULL,
+                    resolved_at DATETIME,
+                    promoted_at DATETIME,
+                    game_name VARCHAR(255) NOT NULL,
+                    tile_position VARCHAR(255) NOT NULL,
+                    combat_type VARCHAR(255) NOT NULL,
+                    attacker_faction VARCHAR(255) NOT NULL,
+                    defender_faction VARCHAR(255) NOT NULL,
+                    winner_faction VARCHAR(255),
+                    loser_faction VARCHAR(255),
+                    resolution_reason TEXT,
+                    cancellation_reason TEXT,
+                    pre_replay_context_text TEXT,
+                    initial_render_snapshot_json TEXT,
+                    promotion_score DOUBLE
+                )
+                """);
+        execute(connection, """
+                INSERT INTO combat_candidate_new (
+                    id, observation_id, status, promotion_status, next_event_sequence,
+                    started_at, resolved_at, promoted_at, game_name, tile_position, combat_type,
+                    attacker_faction, defender_faction, winner_faction, loser_faction,
+                    resolution_reason, cancellation_reason, pre_replay_context_text,
+                    initial_render_snapshot_json, promotion_score
+                )
+                SELECT
+                    id, observation_id, status, promotion_status, next_event_sequence,
+                    started_at, resolved_at, promoted_at, game_name, tile_position, combat_type,
+                    attacker_faction, defender_faction, winner_faction, loser_faction,
+                    resolution_reason, cancellation_reason, pre_replay_context_text,
+                    initial_render_snapshot_json, promotion_score
+                FROM combat_candidate
+                """);
+        execute(connection, "DROP TABLE combat_candidate");
+        execute(connection, "ALTER TABLE combat_candidate_new RENAME TO combat_candidate");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_candidate_status_started_at ON combat_candidate(status, started_at)");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_candidate_promotion_resolved_at ON combat_candidate(promotion_status, resolved_at)");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_candidate_game_tile_status ON combat_candidate(game_name, tile_position, status)");
+        execute(connection, "CREATE INDEX idx_combat_candidate_promoted_at ON combat_candidate(promoted_at)");
+    }
+
+    private void migrateCombatObservation(Connection connection) throws SQLException {
+        if (!tableNeedsMigration(connection, "combat_observation")) {
+            return;
+        }
+
+        execute(connection, "DROP TABLE IF EXISTS combat_observation_new");
+        execute(connection, """
+                CREATE TABLE combat_observation_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    started_at DATETIME NOT NULL,
+                    game_name VARCHAR(255) NOT NULL,
+                    tile_position VARCHAR(255) NOT NULL,
+                    combat_type VARCHAR(255) NOT NULL,
+                    attacker_faction VARCHAR(255) NOT NULL,
+                    defender_faction VARCHAR(255) NOT NULL,
+                    attacker_strength DOUBLE NOT NULL,
+                    defender_strength DOUBLE NOT NULL,
+                    attacker_hp DOUBLE NOT NULL,
+                    defender_hp DOUBLE NOT NULL,
+                    attacker_expected_hits DOUBLE NOT NULL,
+                    defender_expected_hits DOUBLE NOT NULL,
+                    fairness_ratio DOUBLE NOT NULL,
+                    joint_score DOUBLE NOT NULL,
+                    eligible_as_candidate BOOLEAN NOT NULL,
+                    candidate_id BIGINT UNIQUE
+                )
+                """);
+        execute(connection, """
+                INSERT INTO combat_observation_new (
+                    id, started_at, game_name, tile_position, combat_type,
+                    attacker_faction, defender_faction, attacker_strength, defender_strength,
+                    attacker_hp, defender_hp, attacker_expected_hits, defender_expected_hits,
+                    fairness_ratio, joint_score, eligible_as_candidate, candidate_id
+                )
+                SELECT
+                    id, started_at, game_name, tile_position, combat_type,
+                    attacker_faction, defender_faction, attacker_strength, defender_strength,
+                    attacker_hp, defender_hp, attacker_expected_hits, defender_expected_hits,
+                    fairness_ratio, joint_score, eligible_as_candidate, candidate_id
+                FROM combat_observation
+                """);
+        execute(connection, "DROP TABLE combat_observation");
+        execute(connection, "ALTER TABLE combat_observation_new RENAME TO combat_observation");
+        execute(connection, "CREATE INDEX idx_combat_observation_started_at ON combat_observation(started_at)");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_observation_eligible_started_at ON combat_observation(eligible_as_candidate, started_at)");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_observation_game_tile_started_at ON combat_observation(game_name, tile_position, started_at)");
+    }
+
+    private void migrateCombatContest(Connection connection) throws SQLException {
+        if (!tableNeedsMigration(connection, "combat_contest")) {
+            return;
+        }
+
+        execute(connection, "DROP TABLE IF EXISTS combat_contest_new");
+        execute(connection, """
+                CREATE TABLE combat_contest_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    candidate_id BIGINT NOT NULL UNIQUE,
+                    posted_at DATETIME NOT NULL,
+                    public_channel_id BIGINT NOT NULL,
+                    public_message_id BIGINT NOT NULL,
+                    public_thread_id BIGINT,
+                    replay_status VARCHAR(255) NOT NULL,
+                    replay_start_at DATETIME NOT NULL,
+                    next_replay_at DATETIME NOT NULL,
+                    next_event_sequence INTEGER NOT NULL,
+                    replay_completed_at DATETIME,
+                    pre_replay_context_posted_at DATETIME,
+                    leaderboard_posted_at DATETIME,
+                    replay_error TEXT
+                )
+                """);
+        execute(connection, """
+                INSERT INTO combat_contest_new (
+                    id, candidate_id, posted_at, public_channel_id, public_message_id,
+                    public_thread_id, replay_status, replay_start_at, next_replay_at,
+                    next_event_sequence, replay_completed_at, pre_replay_context_posted_at,
+                    leaderboard_posted_at, replay_error
+                )
+                SELECT
+                    id, candidate_id, posted_at, public_channel_id, public_message_id,
+                    public_thread_id, replay_status, replay_start_at, next_replay_at,
+                    next_event_sequence, replay_completed_at, pre_replay_context_posted_at,
+                    leaderboard_posted_at, replay_error
+                FROM combat_contest
+                """);
+        execute(connection, "DROP TABLE combat_contest");
+        execute(connection, "ALTER TABLE combat_contest_new RENAME TO combat_contest");
+        execute(
+                connection,
+                "CREATE INDEX idx_replay_contest_replay_status_due ON combat_contest(replay_status, next_replay_at)");
+        execute(connection, "CREATE INDEX idx_replay_contest_posted_at ON combat_contest(posted_at)");
+    }
+
+    private void migrateCombatCandidateEvent(Connection connection) throws SQLException {
+        if (!tableNeedsMigration(connection, "combat_candidate_event")) {
+            return;
+        }
+
+        execute(connection, "DROP TABLE IF EXISTS combat_candidate_event_new");
+        execute(connection, """
+                CREATE TABLE combat_candidate_event_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    candidate_id BIGINT NOT NULL,
+                    occurred_at DATETIME NOT NULL,
+                    sequence_number INTEGER NOT NULL,
+                    event_type VARCHAR(255) NOT NULL,
+                    round_number INTEGER,
+                    actor_faction VARCHAR(255),
+                    summary_text TEXT NOT NULL,
+                    payload_json TEXT
+                )
+                """);
+        execute(connection, """
+                INSERT INTO combat_candidate_event_new (
+                    id, candidate_id, occurred_at, sequence_number, event_type,
+                    round_number, actor_faction, summary_text, payload_json
+                )
+                SELECT
+                    id, candidate_id, occurred_at, sequence_number, event_type,
+                    round_number, actor_faction, summary_text, payload_json
+                FROM combat_candidate_event
+                """);
+        execute(connection, "DROP TABLE combat_candidate_event");
+        execute(connection, "ALTER TABLE combat_candidate_event_new RENAME TO combat_candidate_event");
+        execute(
+                connection,
+                "CREATE UNIQUE INDEX idx_combat_candidate_event_candidate_sequence ON combat_candidate_event(candidate_id, sequence_number)");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_candidate_event_candidate_occurred_at ON combat_candidate_event(candidate_id, occurred_at)");
+    }
+
+    private void migrateCombatPredictorContest(Connection connection) throws SQLException {
+        if (!tableNeedsMigration(connection, "combat_predictor_contest")) {
+            return;
+        }
+
+        String combatTypeSourceColumn =
+                getColumnNames(connection, "combat_predictor_contest").contains("combat_type")
+                        ? "combat_type"
+                        : "combatType";
+
+        execute(connection, "DROP TABLE IF EXISTS combat_predictor_contest_new");
+        execute(connection, """
+                CREATE TABLE combat_predictor_contest_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    status VARCHAR(255) NOT NULL,
+                    combat_type VARCHAR(255) NOT NULL,
+                    game_name VARCHAR(255) NOT NULL,
+                    tile_position VARCHAR(255) NOT NULL,
+                    tile_representation TEXT NOT NULL,
+                    attacker_faction VARCHAR(255) NOT NULL,
+                    defender_faction VARCHAR(255) NOT NULL,
+                    attacker_color VARCHAR(255) NOT NULL,
+                    defender_color VARCHAR(255) NOT NULL,
+                    public_channel_id BIGINT,
+                    public_message_id BIGINT,
+                    public_thread_id BIGINT,
+                    source_combat_thread_id BIGINT,
+                    posted_at DATETIME NOT NULL,
+                    resolved_at DATETIME,
+                    leaderboard_posted_at DATETIME,
+                    winner_faction VARCHAR(255),
+                    loser_faction VARCHAR(255),
+                    initial_summary_text TEXT NOT NULL,
+                    active_player_summary TEXT,
+                    initial_strength_attacker DOUBLE NOT NULL,
+                    initial_strength_defender DOUBLE NOT NULL,
+                    initial_hp_attacker DOUBLE,
+                    initial_hp_defender DOUBLE,
+                    dice_rolled BOOLEAN,
+                    attacker_hit_assigned_round INTEGER,
+                    defender_hit_assigned_round INTEGER,
+                    last_posted_hit_image_round INTEGER
+                )
+                """);
+        execute(connection, """
+                INSERT INTO combat_predictor_contest_new (
+                    id, status, combat_type, game_name, tile_position, tile_representation,
+                    attacker_faction, defender_faction, attacker_color, defender_color,
+                    public_channel_id, public_message_id, public_thread_id, source_combat_thread_id,
+                    posted_at, resolved_at, leaderboard_posted_at, winner_faction, loser_faction,
+                    initial_summary_text, active_player_summary, initial_strength_attacker,
+                    initial_strength_defender, initial_hp_attacker, initial_hp_defender, dice_rolled,
+                    attacker_hit_assigned_round, defender_hit_assigned_round, last_posted_hit_image_round
+                )
+                SELECT
+                    id, status, %s, game_name, tile_position, tile_representation,
+                    attacker_faction, defender_faction, attacker_color, defender_color,
+                    public_channel_id, public_message_id, public_thread_id, source_combat_thread_id,
+                    posted_at, resolved_at, leaderboard_posted_at, winner_faction, loser_faction,
+                    initial_summary_text, active_player_summary, initial_strength_attacker,
+                    initial_strength_defender, initial_hp_attacker, initial_hp_defender, dice_rolled,
+                    attacker_hit_assigned_round, defender_hit_assigned_round, last_posted_hit_image_round
+                FROM combat_predictor_contest
+                """.formatted(combatTypeSourceColumn));
+        execute(connection, "DROP TABLE combat_predictor_contest");
+        execute(connection, "ALTER TABLE combat_predictor_contest_new RENAME TO combat_predictor_contest");
+        execute(connection, "CREATE INDEX idx_combat_contest_posted_at ON combat_predictor_contest(posted_at)");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_contest_game_status ON combat_predictor_contest(game_name, status)");
+        execute(
+                connection,
+                "CREATE INDEX idx_combat_contest_lookup ON combat_predictor_contest(game_name, tile_position, combat_type, status, posted_at)");
+    }
+
+    private void execute(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -107,15 +107,11 @@ public class CombatReplayContestLifecycleService {
     }
 
     public ForcePromoteResult forcePromoteCandidate(Long candidateId) {
-        if (candidateId == null) {
-            return ForcePromoteResult.rejected("candidateId is required");
-        }
+        if (candidateId == null) return ForcePromoteResult.rejected("candidateId is required");
 
         CombatCandidateEntity candidate =
                 candidateRepository.findById(candidateId).orElse(null);
-        if (candidate == null) {
-            return ForcePromoteResult.rejected("Candidate not found");
-        }
+        if (candidate == null) return ForcePromoteResult.rejected("Candidate not found");
         if (candidate.getStatus() != CombatCandidateStatus.RESOLVED) {
             return ForcePromoteResult.rejected("Candidate must be RESOLVED before promotion");
         }
@@ -134,7 +130,9 @@ public class CombatReplayContestLifecycleService {
     }
 
     private CombatReplayContestEntity promoteCandidate(CombatCandidateEntity winner) {
-        return promoteCandidate(winner, null);
+        return promoteCandidate(
+                winner,
+                replayContestRepository.findByCandidateId(winner.getId()).orElse(null));
     }
 
     private CombatReplayContestEntity promoteCandidate(
@@ -160,26 +158,13 @@ public class CombatReplayContestLifecycleService {
         if (contestChannel == null) return null;
 
         try {
+            LocalDateTime promotedAt = LocalDateTime.now();
             Message posted = postPromotionMessage(contestChannel, message, game, winner);
             addPredictionReactions(game, winner, posted);
             ThreadChannel thread = createReplayThread(posted, winner);
             CombatReplayContestEntity contest = persistPromotedReplayContest(
-                    game,
-                    observation,
-                    winner,
-                    message,
-                    LocalDateTime.now(),
-                    contestChannel,
-                    posted,
-                    thread,
-                    existingContest);
-            try {
-                MessageChannel replayChannel = thread != null ? thread : contestChannel;
-                announcePreReplayContextIfNeeded(replayChannel, contest, winner);
-                announcePredictionLockCountdown(replayChannel);
-            } catch (Exception e) {
-                BotLogger.error("Failed to post replay context at promotion.", e);
-            }
+                    game, observation, winner, message, promotedAt, contestChannel, posted, thread, existingContest);
+            postPromotionContext(thread != null ? thread : contestChannel, contest, winner);
             return contest;
         } catch (Exception e) {
             BotLogger.error("Replay contest promotion failed.", e);
@@ -190,28 +175,13 @@ public class CombatReplayContestLifecycleService {
     @SneakyThrows
     private Message postPromotionMessage(
             TextChannel contestChannel, String message, Game game, CombatCandidateEntity candidate) {
-        String snapshotJson = candidate.getInitialRenderSnapshotJson();
-        if (snapshotJson == null || snapshotJson.isBlank()) {
-            return contestChannel.sendMessage(message).complete();
-        }
-
-        Game snapshotGame = CombatReplayRenderSnapshotSupport.restoreGame(snapshotJson, game);
-        if (snapshotGame == null) {
-            return contestChannel.sendMessage(message).complete();
-        }
-
-        removeReplayCommandCounters(snapshotGame, candidate.getTilePosition());
-        snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
-                candidate.getAttackerFaction(), candidate.getDefenderFaction()));
-        try (FileUpload fileUpload =
-                new TileGenerator(snapshotGame, null, null, 0, candidate.getTilePosition()).createFileUpload()) {
-            return contestChannel
-                    .sendMessage(new MessageCreateBuilder()
-                            .addContent(message)
-                            .addFiles(fileUpload)
-                            .build())
-                    .complete();
-        }
+        return sendTileRenderMessage(
+                contestChannel,
+                message,
+                List.of(),
+                restoreReplayGame(
+                        candidate.getInitialRenderSnapshotJson(), game, candidate, candidate.getTilePosition()),
+                candidate.getTilePosition());
     }
 
     public void runReplayTick() {
@@ -235,26 +205,21 @@ public class CombatReplayContestLifecycleService {
             return;
         }
 
-        CombatCandidateEntity candidate =
-                candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        CombatCandidateEntity candidate = loadCandidate(contest.getCandidateId());
         Game game = candidate == null ? null : loadGame(candidate.getGameName());
         try {
-            if (settings.getRuntime().isDiscordPostingEnabled()) {
-                MessageChannel channel = getContestThreadOrChannel(contest);
-                if (channel == null) {
-                    rescheduleReplay(contest, "Replay channel unavailable.");
-                    return;
-                }
-                if (contest.getReplayStatus() == CombatContestReplayStatus.PENDING
-                        && candidate != null
-                        && game != null) {
-                    announcePreReplayContextIfNeeded(channel, contest, candidate);
-                    replayLeaderboardService.lockPredictionsAtReplayStart(game, contest, candidate);
-                    replayLeaderboardService.announceLockedPredictionsIfNeeded(channel, game, contest, candidate);
-                }
-                if (shouldPostReplayEvent(event)) {
-                    postReplayEvent(channel, game, candidate, event);
-                }
+            MessageChannel channel = getContestThreadOrChannel(contest);
+            if (channel == null) {
+                rescheduleReplay(contest, "Replay channel unavailable.");
+                return;
+            }
+            if (contest.getReplayStatus() == CombatContestReplayStatus.PENDING && candidate != null && game != null) {
+                announcePreReplayContextIfNeeded(channel, contest, candidate);
+                replayLeaderboardService.lockPredictionsAtReplayStart(game, contest, candidate);
+                replayLeaderboardService.announceLockedPredictionsIfNeeded(channel, game, contest, candidate);
+            }
+            if (event.getEventType() != CombatCandidateEventType.START) {
+                postReplayEvent(channel, game, candidate, event);
             }
             CombatCandidateEventEntity nextEvent = candidateEventRepository
                     .findByCandidateIdAndSequenceNumber(contest.getCandidateId(), contest.getNextEventSequence() + 1)
@@ -272,10 +237,6 @@ public class CombatReplayContestLifecycleService {
             return;
         }
         replayContestRepository.save(contest);
-    }
-
-    private boolean shouldPostReplayEvent(CombatCandidateEventEntity event) {
-        return event != null && event.getEventType() != CombatCandidateEventType.START;
     }
 
     private void announcePreReplayContextIfNeeded(
@@ -301,9 +262,18 @@ public class CombatReplayContestLifecycleService {
         channel.sendMessage(message).complete();
     }
 
+    private void postPromotionContext(
+            MessageChannel replayChannel, CombatReplayContestEntity contest, CombatCandidateEntity winner) {
+        try {
+            announcePreReplayContextIfNeeded(replayChannel, contest, winner);
+            announcePredictionLockCountdown(replayChannel);
+        } catch (Exception e) {
+            BotLogger.error("Failed to post replay context at promotion.", e);
+        }
+    }
+
     private void completeReplayContest(CombatReplayContestEntity contest) {
-        CombatCandidateEntity candidate =
-                candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        CombatCandidateEntity candidate = loadCandidate(contest.getCandidateId());
         Game game = candidate == null ? null : loadGame(candidate.getGameName());
         if (candidate != null) {
             replayLeaderboardService.finalizeReplayLeaderboardContest(game, contest, candidate);
@@ -333,9 +303,6 @@ public class CombatReplayContestLifecycleService {
             CombatCandidateEventEntity currentEvent,
             CombatCandidateEventEntity nextEvent,
             Duration maxReplayEventGap) {
-        if (maxReplayEventGap == null) {
-            maxReplayEventGap = Duration.ofMinutes(1);
-        }
         if (replayedAt == null
                 || currentEvent == null
                 || nextEvent == null
@@ -552,7 +519,7 @@ public class CombatReplayContestLifecycleService {
             MessageChannel channel, Game game, CombatCandidateEntity candidate, CombatCandidateEventEntity event) {
         ReplayDispatchPayload payload = payloadSerializer.read(event);
         if (payload == null) {
-            channel.sendMessage(event.getSummaryText()).complete();
+            sendDiscordMessage(channel, event.getSummaryText(), List.of());
             return;
         }
 
@@ -569,7 +536,7 @@ public class CombatReplayContestLifecycleService {
             return;
         }
 
-        channel.sendMessage(event.getSummaryText()).complete();
+        sendDiscordMessage(channel, event.getSummaryText(), List.of());
     }
 
     @SneakyThrows
@@ -584,7 +551,7 @@ public class CombatReplayContestLifecycleService {
                 game,
                 candidate,
                 event.getSummaryText(),
-                List.of(),
+                null,
                 payload.tilePosition(),
                 payload.combatStateSnapshotJson());
     }
@@ -597,7 +564,8 @@ public class CombatReplayContestLifecycleService {
             String fallbackMessage,
             ReplayDispatchPayload.TileRenderMessageDispatch payload) {
         ReplayDispatchPayload.DiscordMessage replayMessage = payload.message();
-        String message = replayMessage == null ? fallbackMessage : replayMessage.content();
+        String message =
+                replayMessage == null ? fallbackMessage : firstNonBlank(replayMessage.content(), fallbackMessage);
         List<MessageEmbed> embeds =
                 replayMessage == null ? List.of() : ReplayDispatchSerializer.toMessageEmbeds(replayMessage.embeds());
         postTileRenderReplayEvent(
@@ -613,61 +581,69 @@ public class CombatReplayContestLifecycleService {
             List<MessageEmbed> embeds,
             String tilePosition,
             String snapshotJson) {
-        if (tilePosition == null || snapshotJson == null) {
-            channel.sendMessage(message).complete();
-            return;
-        }
+        sendTileRenderMessage(
+                channel, message, embeds, restoreReplayGame(snapshotJson, game, candidate, tilePosition), tilePosition);
+    }
 
+    private Game restoreReplayGame(
+            String snapshotJson, Game game, CombatCandidateEntity candidate, String tilePosition) {
+        if (tilePosition == null || snapshotJson == null) return null;
         Game snapshotGame = CombatReplayRenderSnapshotSupport.restoreGame(snapshotJson, game);
-        if (snapshotGame == null) {
-            channel.sendMessage(message).complete();
-            return;
-        }
-        if (candidate != null) {
-            removeReplayCommandCounters(snapshotGame, tilePosition);
-            snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
-                    candidate.getAttackerFaction(), candidate.getDefenderFaction()));
-        }
+        if (snapshotGame == null || candidate == null) return snapshotGame;
+        removeReplayCommandCounters(snapshotGame, tilePosition);
+        snapshotGame.setName(CombatReplayRenderSnapshotSupport.buildReplaySnapshotName(
+                candidate.getAttackerFaction(), candidate.getDefenderFaction()));
+        return snapshotGame;
+    }
 
+    @SneakyThrows
+    private Message sendTileRenderMessage(
+            MessageChannel channel, String message, List<MessageEmbed> embeds, Game snapshotGame, String tilePosition) {
+        if (snapshotGame == null) {
+            return sendDiscordMessage(channel, message, embeds);
+        }
         try (FileUpload fileUpload = new TileGenerator(snapshotGame, null, null, 0, tilePosition).createFileUpload()) {
             MessageCreateBuilder builder =
                     new MessageCreateBuilder().addContent(message).addFiles(fileUpload);
-            if (!embeds.isEmpty()) {
-                builder.addEmbeds(embeds);
-            }
-            channel.sendMessage(builder.build()).complete();
+            if (!embeds.isEmpty()) builder.addEmbeds(embeds);
+            return channel.sendMessage(builder.build()).complete();
         }
     }
 
     private void removeReplayCommandCounters(Game snapshotGame, String tilePosition) {
-        if (snapshotGame == null || tilePosition == null || tilePosition.isBlank()) return;
+        if (tilePosition == null || tilePosition.isBlank()) return;
         Tile tile = snapshotGame.getTileByPosition(tilePosition);
         if (tile == null) return;
         tile.removeAllCC();
     }
 
-    private void sendDiscordMessage(
+    private Message sendDiscordMessage(
             MessageChannel channel, ReplayDispatchPayload.DiscordMessage message, String fallbackContent) {
         if (message == null) {
-            channel.sendMessage(fallbackContent).complete();
-            return;
+            return channel.sendMessage(fallbackContent).complete();
         }
+        return sendDiscordMessage(
+                channel,
+                firstNonBlank(message.content(), fallbackContent),
+                ReplayDispatchSerializer.toMessageEmbeds(message.embeds()));
+    }
 
-        String content = firstNonBlank(message.content(), fallbackContent);
-        List<MessageEmbed> embeds = ReplayDispatchSerializer.toMessageEmbeds(message.embeds());
+    private Message sendDiscordMessage(MessageChannel channel, String content, List<MessageEmbed> embeds) {
         if (embeds.isEmpty()) {
-            channel.sendMessage(content).complete();
-            return;
+            return channel.sendMessage(content).complete();
         }
         if (content == null || content.isBlank()) {
-            channel.sendMessageEmbeds(embeds).complete();
-            return;
+            return channel.sendMessageEmbeds(embeds).complete();
         }
-        channel.sendMessage(content).addEmbeds(embeds).complete();
+        return channel.sendMessage(content).addEmbeds(embeds).complete();
     }
 
     private String firstNonBlank(String value, String fallback) {
         return value != null && !value.isBlank() ? value : fallback;
+    }
+
+    private CombatCandidateEntity loadCandidate(Long candidateId) {
+        return candidateRepository.findById(candidateId).orElse(null);
     }
 
     public record ForcePromoteResult(boolean promoted, String reason, CombatReplayContestEntity contest) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -551,7 +551,7 @@ public class CombatReplayContestLifecycleService {
                 game,
                 candidate,
                 event.getSummaryText(),
-                null,
+                List.of(),
                 payload.tilePosition(),
                 payload.combatStateSnapshotJson());
     }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
@@ -26,11 +26,10 @@ public class CombatReplayJanitorService {
 
     public void runJanitor() {
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime observationCutoff = now.minusDays(settings.getRetention().getObservationRetentionDays());
 
         expireStaleResolvedCandidates(now);
-
-        observationRepository.deleteAll(observationRepository.findByStartedAtBefore(
-                now.minusDays(settings.getRetention().getObservationRetentionDays())));
+        observationRepository.deleteAll(observationRepository.findByStartedAtBefore(observationCutoff));
         deleteExpiredCandidateEvents(now);
         clearCompletedReplayErrors();
     }
@@ -51,8 +50,8 @@ public class CombatReplayJanitorService {
     }
 
     private void deleteExpiredCandidateEvents(LocalDateTime now) {
-        List<CombatCandidateEventEntity> oldEvents = candidateEventRepository.findByOccurredAtBefore(
-                now.minusDays(settings.getRetention().getEventRetentionDays()));
+        LocalDateTime retentionCutoff = now.minusDays(settings.getRetention().getEventRetentionDays());
+        List<CombatCandidateEventEntity> oldEvents = candidateEventRepository.findByOccurredAtBefore(retentionCutoff);
         if (oldEvents.isEmpty()) return;
 
         List<Long> candidateIds = oldEvents.stream()
@@ -71,10 +70,7 @@ public class CombatReplayJanitorService {
             CombatCandidateEntity candidate = candidatesById.get(event.getCandidateId());
             if (candidate == null || candidate.getStatus() == CombatCandidateStatus.TRACKING) continue;
 
-            LocalDateTime terminalAt =
-                    candidate.getPromotedAt() != null ? candidate.getPromotedAt() : candidate.getResolvedAt();
-            if (terminalAt == null
-                    || terminalAt.isAfter(now.minusDays(settings.getRetention().getEventRetentionDays()))) {
+            if (!isPastRetentionCutoff(candidate, retentionCutoff)) {
                 continue;
             }
 
@@ -94,5 +90,11 @@ public class CombatReplayJanitorService {
                     contest.setReplayError(null);
                     replayContestRepository.save(contest);
                 });
+    }
+
+    private boolean isPastRetentionCutoff(CombatCandidateEntity candidate, LocalDateTime retentionCutoff) {
+        LocalDateTime terminalAt =
+                candidate.getPromotedAt() != null ? candidate.getPromotedAt() : candidate.getResolvedAt();
+        return terminalAt != null && !terminalAt.isAfter(retentionCutoff);
     }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -19,6 +19,8 @@ import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.Constants;
+import ti4.service.emoji.TechEmojis;
+import ti4.spring.context.SpringContext;
 import ti4.spring.service.contest.CombatContestType;
 
 @Service
@@ -43,8 +45,10 @@ public class CombatReplayService {
     }
 
     public void onSpaceCombatStarted(Game game, Player attacker, Player defender, Tile tile) {
-        if (!LazaxCombatSupport.isEligibleGame(game)
-                || !LazaxCombatSupport.isEligibleCombat(game, attacker, defender, tile)) {
+        boolean trackAllCombatsAsCandidates = settings.getRuntime().isTrackAllCombatsAsCandidates();
+        if (!trackAllCombatsAsCandidates
+                && (!LazaxCombatSupport.isEligibleGame(game)
+                        || !LazaxCombatSupport.isEligibleCombat(game, attacker, defender, tile))) {
             return;
         }
 
@@ -92,13 +96,12 @@ public class CombatReplayService {
 
     public void mirrorCombatEvent(
             Game game, Player player, String header, String name, MessageEmbed embed, String sourceChannelName) {
-        CombatCandidateEventType eventType = mapEventType(header);
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
 
         appendDiscordEvent(
                 candidate,
-                eventType,
+                CombatCandidateEventType.INFO,
                 null,
                 player.getFaction(),
                 "## " + header + "\n" + player.getRepresentation() + " " + name,
@@ -111,7 +114,7 @@ public class CombatReplayService {
 
         appendDiscordEvent(
                 candidate,
-                CombatCandidateEventType.RETREAT,
+                CombatCandidateEventType.INFO,
                 getCurrentRound(game, candidate),
                 player.getFaction(),
                 "## Retreat\n" + player.getRepresentationNoPing() + " announced a retreat.");
@@ -123,7 +126,7 @@ public class CombatReplayService {
 
         appendDiscordEvent(
                 candidate,
-                CombatCandidateEventType.RETREAT,
+                CombatCandidateEventType.INFO,
                 getCurrentRound(game, candidate),
                 player.getFaction(),
                 "## Retreat\n" + player.getRepresentationNoPing() + " retreated to " + destination + ".");
@@ -135,20 +138,30 @@ public class CombatReplayService {
 
         appendDiscordEvent(
                 candidate,
-                CombatCandidateEventType.ASSAULT,
+                CombatCandidateEventType.INFO,
                 getCurrentRound(game, candidate),
                 player.getFaction(),
-                "## Combat Ability\n" + player.getRepresentationNoPing() + " used _Assault Cannon_.");
+                "## Combat Ability\n"
+                        + TechEmojis.WarfareTech
+                        + " "
+                        + player.getRepresentationNoPing()
+                        + " used _Assault Cannon_.");
     }
 
-    private CombatCandidateEventType mapEventType(String header) {
-        String normalized = header == null ? "" : header.trim().toLowerCase();
-        return switch (normalized) {
-            case "action card" -> CombatCandidateEventType.CARD;
-            case "agent" -> CombatCandidateEventType.AGENT;
-            case "leader", "hero", "commander", "envoy" -> CombatCandidateEventType.LEADER;
-            default -> CombatCandidateEventType.INFO;
-        };
+    public void mirrorGravitonExhausted(Game game, Player player, String sourceChannelName) {
+        CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
+        if (candidate == null) return;
+
+        appendDiscordEvent(
+                candidate,
+                CombatCandidateEventType.INFO,
+                getCurrentRound(game, candidate),
+                player.getFaction(),
+                "## Combat Ability\n"
+                        + TechEmojis.CyberneticTech
+                        + " "
+                        + player.getRepresentationNoPing()
+                        + " exhausted _Graviton Laser System_.");
     }
 
     private boolean evaluateCandidateCompletion(Game game, CombatCandidateEntity candidate) {
@@ -159,38 +172,53 @@ public class CombatReplayService {
                 .filter(Player::isRealPlayer)
                 .filter(player -> !player.isDummy())
                 .toList();
-        if (remainingShipPlayers.size() == 1) {
-            if (!hasRecordedRoll(candidate)) {
-                cancelCandidate(game, candidate, "The tracked space combat ended before any dice were rolled.");
-                return true;
+        boolean hasRecordedRoll = hasRecordedRoll(candidate);
+        return switch (remainingShipPlayers.size()) {
+            case 0 -> {
+                cancelCandidate(
+                        game,
+                        candidate,
+                        hasRecordedRoll
+                                ? "The tracked space combat ended with no ships remaining."
+                                : "The tracked space combat ended before any dice were rolled.");
+                yield true;
             }
-            Player winner = remainingShipPlayers.getFirst();
-            String loserFaction = winner.getFaction().equalsIgnoreCase(candidate.getAttackerFaction())
-                    ? candidate.getDefenderFaction()
-                    : candidate.getAttackerFaction();
-            resolveCandidate(game, candidate, tile, winner, loserFaction);
-            return true;
-        }
-        if (remainingShipPlayers.isEmpty()) {
-            String reason = hasRecordedRoll(candidate)
-                    ? "The tracked space combat ended with no ships remaining."
-                    : "The tracked space combat ended before any dice were rolled.";
-            cancelCandidate(game, candidate, reason);
-            return true;
-        }
-        if (remainingShipPlayers.size() > 2) {
-            cancelCandidate(game, candidate, "The tracked space combat no longer has exactly two sides.");
-            return true;
-        }
-        boolean containsBothParticipants = remainingShipPlayers.stream()
+            case 1 -> {
+                if (!hasRecordedRoll) {
+                    cancelCandidate(game, candidate, "The tracked space combat ended before any dice were rolled.");
+                    yield true;
+                }
+                Player winner = remainingShipPlayers.getFirst();
+                resolveCandidate(game, candidate, tile, winner, loserFaction(candidate, winner));
+                yield true;
+            }
+            case 2 -> {
+                if (containsOnlyOriginalParticipants(candidate, remainingShipPlayers)) {
+                    yield false;
+                }
+                cancelCandidate(
+                        game, candidate, "The tracked space combat drifted away from the original participants.");
+                yield true;
+            }
+            default -> {
+                cancelCandidate(game, candidate, "The tracked space combat no longer has exactly two sides.");
+                yield true;
+            }
+        };
+    }
+
+    private boolean containsOnlyOriginalParticipants(
+            CombatCandidateEntity candidate, List<Player> remainingShipPlayers) {
+        return remainingShipPlayers.stream()
                 .map(Player::getFaction)
                 .allMatch(faction -> faction.equalsIgnoreCase(candidate.getAttackerFaction())
                         || faction.equalsIgnoreCase(candidate.getDefenderFaction()));
-        if (!containsBothParticipants) {
-            cancelCandidate(game, candidate, "The tracked space combat drifted away from the original participants.");
-            return true;
-        }
-        return false;
+    }
+
+    private String loserFaction(CombatCandidateEntity candidate, Player winner) {
+        return winner.getFaction().equalsIgnoreCase(candidate.getAttackerFaction())
+                ? candidate.getDefenderFaction()
+                : candidate.getAttackerFaction();
     }
 
     private void resolveCandidate(
@@ -198,18 +226,11 @@ public class CombatReplayService {
         CombatObservationEntity observation =
                 observationRepository.findById(candidate.getObservationId()).orElse(null);
         if (observation == null) return;
-        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
-        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
-        UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
-        if (attacker == null || defender == null || space == null) {
+        ResolutionState resolution = buildResolutionState(game, candidate, tile);
+        if (resolution == null) {
             cancelCandidate(game, candidate, "The tracked space combat could not be resolved cleanly.");
             return;
         }
-
-        LazaxCombatSupport.FleetStrength attackerRemainingStrength =
-                LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space);
-        LazaxCombatSupport.FleetStrength defenderRemainingStrength =
-                LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space);
         int roundsObserved = candidateEventRepository
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
@@ -220,8 +241,8 @@ public class CombatReplayService {
         candidate.setResolutionReason("Winner determined from remaining fleets.");
         candidate.setPromotionScore(computePromotionScore(
                 observation,
-                attackerRemainingStrength,
-                defenderRemainingStrength,
+                resolution.attackerRemainingStrength(),
+                resolution.defenderRemainingStrength(),
                 winner.getFaction(),
                 roundsObserved));
         candidateRepository.save(candidate);
@@ -238,6 +259,10 @@ public class CombatReplayService {
                         + tile.getRepresentationForButtons() + ".\n"
                         + "Game " + game.getName() + ": [Open Game](https://asyncti4.com/game/" + game.getName()
                         + ")");
+
+        if (settings.getRuntime().isImmediatePromotionOnResolve()) {
+            SpringContext.getBean(CombatReplayContestLifecycleService.class).forcePromoteCandidate(candidate.getId());
+        }
     }
 
     private void cancelCandidate(Game game, CombatCandidateEntity candidate, String reason) {
@@ -278,6 +303,18 @@ public class CombatReplayService {
                         candidate.getTilePosition(),
                         CombatReplayRenderSnapshotSupport.captureHitAssignmentSnapshot(
                                 game, candidate.getTilePosition())));
+    }
+
+    private ResolutionState buildResolutionState(Game game, CombatCandidateEntity candidate, Tile tile) {
+        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
+        if (attacker == null || defender == null || space == null) {
+            return null;
+        }
+        return new ResolutionState(
+                LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space),
+                LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space));
     }
 
     public void refreshSelectionSnapshot() {
@@ -388,6 +425,9 @@ public class CombatReplayService {
     }
 
     private boolean isEligibleCandidate(Game game, Player attacker, Player defender, Tile tile, Evaluation evaluation) {
+        if (settings.getRuntime().isTrackAllCombatsAsCandidates()) {
+            return getTrackingCandidate(game, tile.getPosition()) == null;
+        }
         return evaluation.eligible()
                 && !LazaxCombatSupport.hasExcludedFlagship(attacker, defender)
                 && getTrackingCandidate(game, tile.getPosition()) == null;
@@ -629,4 +669,8 @@ public class CombatReplayService {
             double weakerStrengthPercentile,
             double jointScore,
             boolean eligibleAsCandidate) {}
+
+    private record ResolutionState(
+            LazaxCombatSupport.FleetStrength attackerRemainingStrength,
+            LazaxCombatSupport.FleetStrength defenderRemainingStrength) {}
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -142,10 +142,10 @@ public class CombatReplayService {
                 getCurrentRound(game, candidate),
                 player.getFaction(),
                 "## Combat Ability\n"
-                        + TechEmojis.WarfareTech
-                        + " "
                         + player.getRepresentationNoPing()
-                        + " used _Assault Cannon_.");
+                        + " used _Assault Cannon_ "
+                        + TechEmojis.WarfareTech
+                        + ".");
     }
 
     public void mirrorGravitonExhausted(Game game, Player player, String sourceChannelName) {
@@ -158,10 +158,10 @@ public class CombatReplayService {
                 getCurrentRound(game, candidate),
                 player.getFaction(),
                 "## Combat Ability\n"
-                        + TechEmojis.CyberneticTech
-                        + " "
                         + player.getRepresentationNoPing()
-                        + " exhausted _Graviton Laser System_.");
+                        + " exhausted _Graviton Laser System_ "
+                        + TechEmojis.CyberneticTech
+                        + ".");
     }
 
     private boolean evaluateCandidateCompletion(Game game, CombatCandidateEntity candidate) {

--- a/src/main/java/ti4/service/tech/PlayerTechService.java
+++ b/src/main/java/ti4/service/tech/PlayerTechService.java
@@ -12,6 +12,7 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.buttons.handlers.faction.other.zephyrion.ZephyrionBountyButtonHandler;
 import ti4.discord.interactions.routing.ButtonHandler;
@@ -57,6 +58,7 @@ import ti4.service.turn.StartTurnService;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.CheckUnitContainmentService;
 import ti4.settings.users.UserSettingsManager;
+import ti4.spring.context.SpringContext;
 
 @UtilityClass
 public class PlayerTechService {
@@ -239,6 +241,11 @@ public class PlayerTechService {
                         event.getMessageChannel(),
                         player.getRepresentation()
                                 + " exhausted _Graviton Laser System_. The auto-assign hits button for SPACE CANNON OFFENSE fire will now kill fighters last.");
+                if (event instanceof ButtonInteractionEvent buttonEvent) {
+                    SpringContext.getBean(CombatReplayService.class)
+                            .mirrorGravitonExhausted(
+                                    game, player, buttonEvent.getChannel().getName());
+                }
                 game.setStoredValue(player.getFaction() + "graviton", "true");
                 deleteTheOneButtonIfButtonEvent(event);
             }

--- a/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestEntity.java
@@ -2,8 +2,6 @@ package ti4.spring.service.contest;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,12 +29,10 @@ public class CombatContestEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CombatContestStatus status;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "combat_type", nullable = false)
     private CombatContestType combatType;
 
     @Column(name = "game_name", nullable = false)

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -221,10 +221,10 @@ public class CombatContestService {
                 game,
                 player,
                 "## Combat Ability\n"
-                        + TechEmojis.WarfareTech
-                        + " "
                         + player.getRepresentationNoPing()
-                        + " used _Assault Cannon_.");
+                        + " used _Assault Cannon_ "
+                        + TechEmojis.WarfareTech
+                        + ".");
     }
 
     public boolean postLeaderboard() {

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -41,7 +41,6 @@ import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.Constants;
-import ti4.helpers.Units.UnitKey;
 import ti4.image.Mapper;
 import ti4.image.TileGenerator;
 import ti4.logging.BotLogger;
@@ -49,10 +48,8 @@ import ti4.logging.LogOrigin;
 import ti4.message.MessageHelper;
 import ti4.model.RelicModel;
 import ti4.model.TechnologyModel;
-import ti4.model.UnitModel;
-import ti4.service.combat.CombatStatsService;
-import ti4.service.combat.CombatUnitSelectionHelper;
 import ti4.service.emoji.ColorEmojis;
+import ti4.service.emoji.TechEmojis;
 
 @Service
 @RequiredArgsConstructor
@@ -62,7 +59,7 @@ public class CombatContestService {
     public static final String LAZAX_MINIGAME_ROLE_NAME = "Lazax Minigame";
     private static final String CONTEST_CHANNEL_NAME = "lazax-war-archives";
     private static final String THREAD_SUMMARY_HEADER = "## Combat Units\n";
-    private static final Set<String> COMBAT_SUMMARY_TECH_ALIASES = Set.of("da", "asc", "x89", "x89c4");
+    private static final Set<String> COMBAT_SUMMARY_TECH_ALIASES = Set.of("da", "asc", "gls", "x89", "x89c4");
     private static final Set<String> COMBAT_SUMMARY_RELIC_ALIASES = Set.of(
             "metalivoidarmaments", "metalivoidshielding", "lightrailordnance", "baldrick_crownofthalnos", "pi_thalnos");
     private static final double ZERO_EPSILON = 0.0001;
@@ -221,7 +218,13 @@ public class CombatContestService {
                 () -> combatReplayService.mirrorAssaultCannonAssigned(game, player, sourceChannelName));
         if (isReplayV2Enabled()) return;
         relayContestMessage(
-                game, player, "## Combat Ability\n" + player.getRepresentationNoPing() + " used _Assault Cannon_.");
+                game,
+                player,
+                "## Combat Ability\n"
+                        + TechEmojis.WarfareTech
+                        + " "
+                        + player.getRepresentationNoPing()
+                        + " used _Assault Cannon_.");
     }
 
     public boolean postLeaderboard() {
@@ -359,8 +362,10 @@ public class CombatContestService {
         UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
         if (space == null) return null;
 
-        FleetStrength attackerStrength = calculateFleetStrength(game, attacker, defender, tile, space);
-        FleetStrength defenderStrength = calculateFleetStrength(game, defender, attacker, tile, space);
+        FleetStrength attackerStrength =
+                toFleetStrength(LazaxCombatSupport.calculateFleetStrength(game, attacker, defender, tile, space));
+        FleetStrength defenderStrength =
+                toFleetStrength(LazaxCombatSupport.calculateFleetStrength(game, defender, attacker, tile, space));
 
         double stronger = Math.max(attackerStrength.hp(), defenderStrength.hp());
         double weaker = Math.min(attackerStrength.hp(), defenderStrength.hp());
@@ -389,52 +394,13 @@ public class CombatContestService {
                 ratio);
     }
 
-    private FleetStrength calculateFleetStrength(
-            Game game, Player player, Player opponent, Tile tile, UnitHolder space) {
-        double total = 0;
-        double hp = 0;
-        double expectedHits = 0;
-        Map<UnitModel, Integer> unitsInCombat = CombatUnitSelectionHelper.collectCombatRoundUnits(tile, space, player);
-        Map<String, Integer> damagedCountsByAsyncId = getDamagedCountsByAsyncId(tile, player);
-        for (Map.Entry<UnitModel, Integer> entry : unitsInCombat.entrySet()) {
-            UnitModel unitModel = entry.getKey();
-            if (unitModel == null) continue;
-
-            int totalUnits = entry.getValue();
-            int damagedUnits = Math.min(totalUnits, damagedCountsByAsyncId.getOrDefault(unitModel.getAsyncId(), 0));
-            int undamagedUnits = Math.max(0, totalUnits - damagedUnits);
-
-            total += unitModel.getCost() * totalUnits;
-            hp += totalUnits;
-            CombatStatsService.CombatRoundProfile combatProfile =
-                    CombatStatsService.getCombatRoundProfile(true, unitModel, player, tile, opponent);
-            expectedHits += computeExpectedHits(totalUnits * combatProfile.diceCount(), combatProfile.hitsOn());
-            if (unitModel.getSustainDamage(player, space)) {
-                hp += undamagedUnits;
-                if (player.hasTech("nes")) {
-                    hp += undamagedUnits;
-                }
-            }
-        }
-        return new FleetStrength(total, hp, expectedHits);
-    }
-
-    private Map<String, Integer> getDamagedCountsByAsyncId(Tile tile, Player player) {
-        Map<String, Integer> damagedCountsByAsyncId = new HashMap<>();
-        for (UnitHolder unitHolder : tile.getUnitHolders().values()) {
-            for (UnitKey unitKey : unitHolder.getUnitKeys()) {
-                if (!unitKey.getColorID().equalsIgnoreCase(player.getColorID())) continue;
-                int damagedUnits = unitHolder.getDamagedUnitCount(unitKey);
-                if (damagedUnits <= 0) continue;
-                damagedCountsByAsyncId.merge(unitKey.asyncID(), damagedUnits, Integer::sum);
-            }
-        }
-        return damagedCountsByAsyncId;
-    }
-
     private double computeExpectedHits(int totalDice, int hitsOn) {
         if (totalDice <= 0 || hitsOn <= 0) return 0;
         return totalDice * Math.max(0, 11 - hitsOn) / 10.0;
+    }
+
+    private FleetStrength toFleetStrength(LazaxCombatSupport.FleetStrength fleetStrength) {
+        return new FleetStrength(fleetStrength.value(), fleetStrength.hp(), fleetStrength.expectedHits());
     }
 
     private String extractSpaceOnlySummary(String summary) {
@@ -608,10 +574,10 @@ public class CombatContestService {
         UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
         if (space == null || loser == null) return null;
 
-        double winnerRemaining =
-                calculateFleetStrength(game, winner, loser, tile, space).value();
-        double loserRemaining =
-                calculateFleetStrength(game, loser, winner, tile, space).value();
+        double winnerRemaining = LazaxCombatSupport.calculateFleetStrength(game, winner, loser, tile, space)
+                .value();
+        double loserRemaining = LazaxCombatSupport.calculateFleetStrength(game, loser, winner, tile, space)
+                .value();
         double winnerInitial = winner.getFaction().equalsIgnoreCase(contest.getAttackerFaction())
                 ? contest.getInitialStrengthAttacker()
                 : contest.getInitialStrengthDefender();
@@ -892,10 +858,18 @@ public class CombatContestService {
                         || tech.isUnitUpgrade()
                         || COMBAT_SUMMARY_TECH_ALIASES.contains(tech.getAlias()))
                 .sorted(TECH_COMPARATOR)
-                .map(tech -> tech.getCondensedReqsEmojis(false) + " " + tech.getName())
+                .map(tech -> formatCombatTech(player, tech))
                 .reduce((left, right) -> left + ", " + right)
                 .orElse("No technologies");
         return formatPlayerSummaryLine(player, techSummary);
+    }
+
+    private String formatCombatTech(Player player, TechnologyModel tech) {
+        String techSummary = tech.getCondensedReqsEmojis(false) + " " + tech.getName();
+        if (!player.getExhaustedTechs().contains(tech.getAlias())) {
+            return techSummary;
+        }
+        return "~~" + techSummary + "~~";
     }
 
     private String formatCombatRelicSection(Player attacker, Player defender) {


### PR DESCRIPTION
## Summary
- add the replay follow-up polish for combat context, relayed events, and local testing flags
- simplify replay event typing and mirror combat tech use with the correct messaging and emoji placement
- migrate replay-related enum columns away from SQLite CHECK constraints with startup repair logic and string converters

## Test Plan
- mvn spotless:apply
- mvn -q -DskipTests compile