### PR TITLE
Fix replay promotion message splitting

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -607,8 +607,14 @@ public class CombatReplayContestLifecycleService {
             return sendDiscordMessage(channel, message, embeds);
         }
         try (FileUpload fileUpload = new TileGenerator(snapshotGame, null, null, 0, tilePosition).createFileUpload()) {
-            MessageCreateBuilder builder =
-                    new MessageCreateBuilder().addContent(message).addFiles(fileUpload);
+            List<String> messageParts = MessageHelper.splitLargeText(message, 2000);
+            for (int i = 0; i < Math.max(0, messageParts.size() - 1); i++) {
+                channel.sendMessage(messageParts.get(i)).complete();
+            }
+            MessageCreateBuilder builder = new MessageCreateBuilder().addFiles(fileUpload);
+            if (!messageParts.isEmpty()) {
+                builder.addContent(messageParts.get(messageParts.size() - 1));
+            }
             if (!embeds.isEmpty()) builder.addEmbeds(embeds);
             return channel.sendMessage(builder.build()).complete();
         }


### PR DESCRIPTION
## Summary
- split replay promotion tile-render messages before sending them to Discord
- send overflow text chunks first and keep the tile render upload on the final message
- preserve existing embed/file behavior without exceeding Discord's 2000 character content limit

## Testing
- mvn -q -DskipTests compile