### PR TITLE
Bake side bet trigger announcements into replays

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -20,6 +20,7 @@ import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.Constants;
+import ti4.service.combat.CombatRollType;
 import ti4.service.combat.CombatUnitSelectionHelper;
 import ti4.service.emoji.TechEmojis;
 import ti4.spring.context.SpringContext;
@@ -39,6 +40,7 @@ public class CombatReplayService {
     private final CombatCandidateRepository candidateRepository;
     private final CombatCandidateEventRepository candidateEventRepository;
     private final CombatReplayEventAppender eventAppender;
+    private final CombatReplaySideBetTriggerService sideBetTriggerService;
     private volatile SelectionSnapshot selectionSnapshot;
 
     @PostConstruct
@@ -94,7 +96,7 @@ public class CombatReplayService {
             Player opponent,
             Tile tile,
             String message,
-            String rollType,
+            CombatRollType rollType,
             boolean whiff,
             boolean slam) {
         CombatCandidateEntity candidate = getTrackingCandidate(game, tile.getPosition());
@@ -104,6 +106,8 @@ public class CombatReplayService {
         updateCandidateRollTracking(candidate, player, rollType, whiff, slam, round);
         appendDiscordEvent(
                 candidate, CombatCandidateEventType.ROLL, round, player.getFaction(), "## Roll Update\n" + message);
+        appendSideBetTriggerEvents(
+                candidate, sideBetTriggerService.fromRoll(candidate, player, rollType, whiff, slam, round));
     }
 
     @Transactional
@@ -125,13 +129,9 @@ public class CombatReplayService {
         if (candidate == null) return;
         updateCandidateEventTracking(candidate, player, trackedEvent);
 
-        appendDiscordEvent(
-                candidate,
-                CombatCandidateEventType.INFO,
-                null,
-                player.getFaction(),
-                "## " + header + "\n" + player.getRepresentation() + " " + name,
-                embed);
+        String message = "## " + header + "\n" + player.getRepresentation() + " " + name;
+        appendDiscordEvent(candidate, CombatCandidateEventType.INFO, null, player.getFaction(), message, embed);
+        appendSideBetTriggerEvents(candidate, sideBetTriggerService.fromTrackedEvent(candidate, player, trackedEvent));
     }
 
     public void mirrorRetreatDeclared(Game game, Player player, String sourceChannelName) {
@@ -286,6 +286,8 @@ public class CombatReplayService {
                         + tile.getRepresentationForButtons() + ".\n"
                         + "Game " + game.getName() + ": [Open Game](https://asyncti4.com/game/" + game.getName()
                         + ")");
+        appendSideBetTriggerEvents(
+                candidate, CombatCandidateEventType.RESOLVED, sideBetTriggerService.fromResolution(candidate, winner));
 
         if (settings.getRuntime().isImmediatePromotionOnResolve()) {
             SpringContext.getBean(CombatReplayContestLifecycleService.class).forcePromoteCandidate(candidate.getId());
@@ -427,11 +429,16 @@ public class CombatReplayService {
     }
 
     private void updateCandidateRollTracking(
-            CombatCandidateEntity candidate, Player player, String rollType, boolean whiff, boolean slam, int round) {
+            CombatCandidateEntity candidate,
+            Player player,
+            CombatRollType rollType,
+            boolean whiff,
+            boolean slam,
+            int round) {
         if (candidate == null || player == null) return;
-        boolean rolledAfb = "AFB".equalsIgnoreCase(rollType);
+        boolean rolledAfb = rollType == CombatRollType.AFB;
         boolean afbWhiff = rolledAfb && whiff;
-        boolean roundOneCombatRoll = "combatround".equalsIgnoreCase(rollType) && round == 1;
+        boolean roundOneCombatRoll = rollType == CombatRollType.combatround && round == 1;
         boolean roundOneWhiff = roundOneCombatRoll && whiff;
         boolean roundOneSlam = roundOneCombatRoll && slam;
         if (!rolledAfb && !afbWhiff && !roundOneWhiff && !roundOneSlam) return;
@@ -441,6 +448,21 @@ public class CombatReplayService {
             markDefenderRollFlags(candidate, rolledAfb, afbWhiff, roundOneWhiff, roundOneSlam);
         }
         candidateRepository.save(candidate);
+    }
+
+    private void appendSideBetTriggerEvents(
+            CombatCandidateEntity candidate,
+            List<CombatReplaySideBetTriggerService.SideBetTriggerAnnouncement> announcements) {
+        appendSideBetTriggerEvents(candidate, CombatCandidateEventType.INFO, announcements);
+    }
+
+    private void appendSideBetTriggerEvents(
+            CombatCandidateEntity candidate,
+            CombatCandidateEventType eventType,
+            List<CombatReplaySideBetTriggerService.SideBetTriggerAnnouncement> announcements) {
+        for (CombatReplaySideBetTriggerService.SideBetTriggerAnnouncement announcement : announcements) {
+            appendDiscordEvent(candidate, eventType, null, announcement.faction(), announcement.message());
+        }
     }
 
     private void markAttackerRollFlags(

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
@@ -1,0 +1,106 @@
+package ti4.contest.replay.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import ti4.contest.replay.core.CombatReplayTrackedEvent;
+import ti4.contest.replay.core.CombatSideBetType;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.game.Player;
+import ti4.service.combat.CombatRollType;
+
+@Service
+public class CombatReplaySideBetTriggerService {
+
+    public List<SideBetTriggerAnnouncement> fromRoll(
+            CombatCandidateEntity candidate,
+            Player player,
+            CombatRollType rollType,
+            boolean whiff,
+            boolean slam,
+            int round) {
+        if (candidate == null
+                || player == null
+                || rollType == null
+                || !Boolean.TRUE.equals(candidate.getSideBetCompatible())) {
+            return List.of();
+        }
+
+        List<SideBetTriggerAnnouncement> announcements = new ArrayList<>();
+        int destroyerCount = destroyerCount(candidate, player.getFaction());
+        if (rollType == CombatRollType.AFB && whiff && CombatSideBetType.AFB_WHIFF.isAvailable(destroyerCount)) {
+            announcements.add(announcement(player, "AFB Whiff!"));
+        }
+        if (rollType == CombatRollType.combatround
+                && round == 1
+                && CombatSideBetType.AFB_SKIPPED.isAvailable(destroyerCount)
+                && !hasRolledAfb(candidate, player.getFaction())) {
+            announcements.add(announcement(player, "Skipped AFB!"));
+        }
+        if (rollType == CombatRollType.combatround && round == 1 && whiff) {
+            announcements.add(announcement(player, "Round 1 Whiff!"));
+        }
+        if (rollType == CombatRollType.combatround && round == 1 && slam) {
+            announcements.add(announcement(player, "Slam!"));
+        }
+        return announcements;
+    }
+
+    public List<SideBetTriggerAnnouncement> fromTrackedEvent(
+            CombatCandidateEntity candidate, Player player, CombatReplayTrackedEvent trackedEvent) {
+        if (candidate == null
+                || player == null
+                || trackedEvent == null
+                || !Boolean.TRUE.equals(candidate.getSideBetCompatible())) {
+            return List.of();
+        }
+        return switch (trackedEvent) {
+            case MORALE_BOOST -> List.of(announcement(player, "Morale Boost!"));
+            case SHIELDS_HOLDING -> List.of(announcement(player, "Shields Holding!"));
+            case NONE -> List.of();
+        };
+    }
+
+    public List<SideBetTriggerAnnouncement> fromResolution(CombatCandidateEntity candidate, Player winner) {
+        if (candidate == null
+                || winner == null
+                || !Boolean.TRUE.equals(candidate.getSideBetCompatible())
+                || !Boolean.TRUE.equals(candidate.getWinnerOneHpRemaining())) {
+            return List.of();
+        }
+        return List.of(announcement(winner, "Wins on 1 HP!"));
+    }
+
+    private SideBetTriggerAnnouncement announcement(Player player, String triggerLabel) {
+        return new SideBetTriggerAnnouncement(
+                player.getFaction(), "### " + player.getFactionEmoji() + " " + triggerLabel);
+    }
+
+    private int destroyerCount(CombatCandidateEntity candidate, String faction) {
+        if (faction == null) return 0;
+        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
+            return safeInt(candidate.getAttackerDestroyerCount());
+        }
+        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
+            return safeInt(candidate.getDefenderDestroyerCount());
+        }
+        return 0;
+    }
+
+    private boolean hasRolledAfb(CombatCandidateEntity candidate, String faction) {
+        if (faction == null) return false;
+        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
+            return Boolean.TRUE.equals(candidate.getAttackerRolledAfb());
+        }
+        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
+            return Boolean.TRUE.equals(candidate.getDefenderRolledAfb());
+        }
+        return false;
+    }
+
+    private int safeInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    public record SideBetTriggerAnnouncement(String faction, String message) {}
+}

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -336,7 +336,7 @@ public class CombatRollService {
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
         SpringContext.getBean(CombatContestService.class)
                 .mirrorCombatRoll(
-                        game, player, opponent, tile, message, rollType.name(), rollResult.whiff(), rollResult.slam());
+                        game, player, opponent, tile, message, rollType, rollResult.whiff(), rollResult.slam());
         if (message.contains("adding +1, at the risk of your")) {
             Button thalnosButton = Buttons.green(
                     "startThalnos_" + tile.getPosition() + "_" + unitHolderName, "Roll Thalnos", ExploreEmojis.Relic);

--- a/src/main/java/ti4/spring/service/contest/CombatContestService.java
+++ b/src/main/java/ti4/spring/service/contest/CombatContestService.java
@@ -49,6 +49,7 @@ import ti4.logging.LogOrigin;
 import ti4.message.MessageHelper;
 import ti4.model.RelicModel;
 import ti4.model.TechnologyModel;
+import ti4.service.combat.CombatRollType;
 import ti4.service.emoji.ColorEmojis;
 import ti4.service.emoji.TechEmojis;
 
@@ -149,7 +150,7 @@ public class CombatContestService {
             Player opponent,
             Tile tile,
             String message,
-            String rollType,
+            CombatRollType rollType,
             boolean whiff,
             boolean slam) {
         runReplayHook(

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -70,7 +70,8 @@ class CombatReplayServiceTest {
                 observationRepository,
                 mock(CombatCandidateRepository.class),
                 mock(CombatCandidateEventRepository.class),
-                mock(CombatReplayEventAppender.class));
+                mock(CombatReplayEventAppender.class),
+                mock(CombatReplaySideBetTriggerService.class));
 
         CombatObservationEntity first = observation(
                 1L, LocalDateTime.of(2026, 4, 22, 10, 0), "pbd100", "19", 20, 40, 8, 8, 3, 3, 0.80, true, 11L);


### PR DESCRIPTION
## Summary
- add a focused side-bet trigger service for live mirrored roll/card/resolution events
- bake trigger announcements into the replay stream as normal Discord replay messages
- carry CombatRollType through the mirror pipeline instead of string roll type matching
- render trigger announcements as one-line headers like `### :Yin: AFB Whiff!`

## Testing
- mvn -q spotless:apply
- mvn -q -DskipTests compile