### PR TITLE
Add defender win promotion score bonus

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -389,7 +389,8 @@ public class CombatReplayService {
         double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
         double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
         double endingTensionScore = winnerRemainingHp <= 0 ? 0.0 : 5.0 * Math.exp(-6.0 * winnerSurvivalRatio);
-        return roundScore + openingBalanceScore + endingTensionScore;
+        double defenderWinBonus = winnerFaction.equalsIgnoreCase(observation.getDefenderFaction()) ? 1.0 : 0.0;
+        return roundScore + openingBalanceScore + endingTensionScore + defenderWinBonus;
     }
 
     public SelectionDebugView getSelectionDebugView() {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -57,9 +57,26 @@ class CombatReplayServiceTest {
                 "muaat",
                 4);
 
-        assertEquals(2.2033, blowoutScore, 0.0001);
-        assertEquals(3.6705, squeakerScore, 0.0001);
+        assertEquals(3.2033, blowoutScore, 0.0001);
+        assertEquals(4.6705, squeakerScore, 0.0001);
         assertTrue(squeakerScore > blowoutScore);
+    }
+
+    @Test
+    void promotionScoreAddsFlatBonusWhenDefenderWins() {
+        CombatObservationEntity observation = observation(
+                10L, LocalDateTime.of(2026, 4, 23, 20, 22), "pbd22333", "307", 12, 12, 8, 8, 2, 2, 1, true, 10L);
+        observation.setAttackerFaction("sol");
+        observation.setDefenderFaction("yin");
+
+        LazaxCombatSupport.FleetStrength attackerRemaining = new LazaxCombatSupport.FleetStrength(4.0, 2.0, 0.0);
+        LazaxCombatSupport.FleetStrength defenderRemaining = new LazaxCombatSupport.FleetStrength(4.0, 2.0, 0.0);
+        double attackerWinScore =
+                CombatReplayService.computePromotionScore(observation, attackerRemaining, defenderRemaining, "sol", 2);
+        double defenderWinScore =
+                CombatReplayService.computePromotionScore(observation, attackerRemaining, defenderRemaining, "yin", 2);
+
+        assertEquals(attackerWinScore + 1.0, defenderWinScore, 0.0001);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a flat +1.0 promotion score bonus when the defender wins a replay candidate combat
- keep the bonus in CombatReplayService.computePromotionScore so live resolution and the promotion-score backfill cron use the same algorithm
- update promotion score tests and add direct coverage for the defender-win delta

## Testing
- mvn -q spotless:apply
- mvn -q -Dtest=CombatReplayServiceTest test
- mvn -q -DskipTests compile