### PR TITLE
Annotate slow button timings and clarify timing labels

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/ButtonRuntimeWarningService.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonRuntimeWarningService.java
@@ -74,14 +74,14 @@ class ButtonRuntimeWarningService {
 
         String eventTime = DateTimeHelper.getTimestampFromMillisecondsEpoch(eventTimeMs);
 
-        String preprocessingTime = DateTimeHelper.getTimeRepresentationToMilliseconds(preprocessingTimeMs);
-        String processingTime = DateTimeHelper.getTimeRepresentationToMilliseconds(processingTimeMs);
+        String preprocessingTime = formatMillisecondsWithWarning(preprocessingTimeMs);
+        String processingTime = formatMillisecondsWithWarning(processingTimeMs);
 
-        String contextTime = DateTimeHelper.getTimeRepresentationToMilliseconds(contextCreationRuntimeMs);
-        String queueTime = DateTimeHelper.getTimeRepresentationToMilliseconds(timeInQueueMs);
-        String resolveTime = DateTimeHelper.getTimeRepresentationToMilliseconds(resolveRuntimeMs);
-        String saveTime = DateTimeHelper.getTimeRepresentationToMilliseconds(saveRuntimeMs);
-        String responseTime = DateTimeHelper.getTimeRepresentationToMilliseconds(processingEndTimeMs - eventTimeMs);
+        String contextTime = formatMillisecondsWithWarning(contextCreationRuntimeMs);
+        String queueTime = formatMillisecondsWithWarning(timeInQueueMs);
+        String resolveTime = formatMillisecondsWithWarning(resolveRuntimeMs);
+        String saveTime = formatMillisecondsWithWarning(saveRuntimeMs);
+        String responseTime = formatMillisecondsWithWarning(processingEndTimeMs - eventTimeMs);
 
         String message = event.getUser().getEffectiveName()
                 + " pressed button: "
@@ -94,9 +94,9 @@ class ButtonRuntimeWarningService {
                 + "\n> 📦 Queued for: `" + queueTime + "`"
                 + "\n> 🛠 Executed in: `" + resolveTime + "`"
                 + "\n> 💾 Saved in: `" + saveTime + "`"
-                + "\n> ⚡ Responded after: `" + responseTime + "`"
-                + "\n> ⚡ Preprocessing time: `" + preprocessingTime + "`"
-                + "\n> ⚡ Processing time: `" + processingTime + "`";
+                + "\n> ⚡ Total preprocessing time: `" + preprocessingTime + "`"
+                + "\n> ⚡ Total processing time: `" + processingTime + "`"
+                + "\n> 🕒 Total response time: `" + responseTime + "`";
 
         BotLogger.warning(message);
 
@@ -109,5 +109,13 @@ class ButtonRuntimeWarningService {
         }
 
         lastWarningTime = now;
+    }
+
+    private static String formatMillisecondsWithWarning(long runtimeMs) {
+        String formattedRuntime = DateTimeHelper.getTimeRepresentationToMilliseconds(runtimeMs);
+        if (runtimeMs > 500) {
+            return formattedRuntime + " ❗";
+        }
+        return formattedRuntime;
     }
 }


### PR DESCRIPTION
### Motivation
- Improve visibility of slow button handling by marking individual timing values that exceed a warning threshold.
- Make the timing report clearer by renaming some timing fields to indicate they represent totals.

### Description
- Replaced direct calls to `DateTimeHelper.getTimeRepresentationToMilliseconds` with a new helper `formatMillisecondsWithWarning(long)` that appends a ❗ when a runtime is over 500ms.
- Renamed message fields to `Total preprocessing time`, `Total processing time`, and `Total response time` for clearer reporting.
- Added the private static method `formatMillisecondsWithWarning` in `ButtonRuntimeWarningService` and updated all timing string variables to use it.

### Testing
- Ran the automated test suite with `mvn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2243fc30832db1fb0557bf66f7fc)