### PR TITLE
Refactor button runtime stats and timing types

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -415,13 +415,13 @@ public class ButtonProcessor {
 
     public static String getButtonProcessingStatistics() {
         var decimalFormatter = new DecimalFormat("#.##");
-        double thresholdMissPercent = runtimeWarningService.getTotalRuntimeSubmissionCount() == 0
+        double thresholdMissPercent = runtimeWarningService.getRuntimeSubmissionCount() == 0
                 ? 0
-                : (double) runtimeWarningService.getTotalRuntimeThresholdMissCount()
-                        / runtimeWarningService.getTotalRuntimeSubmissionCount();
+                : (double) runtimeWarningService.getRuntimeThresholdMissCount()
+                        / runtimeWarningService.getRuntimeSubmissionCount();
         return "Button Processor Statistics: " + DateTimeHelper.getCurrentTimestamp()
                 + "\n> Total button presses: "
-                + runtimeWarningService.getTotalRuntimeSubmissionCount()
+                + runtimeWarningService.getRuntimeSubmissionCount()
                 + "\n> Threshold misses: "
                 + decimalFormatter.format(thresholdMissPercent) + "%"
                 + "\n> Average preprocessing time: "

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -55,6 +55,9 @@ public class ButtonProcessor {
     }
 
     public static void queue(ButtonInteractionEvent event) {
+        var buttonContext = new ButtonContext(event);
+        if (!buttonContext.isValid()) return;
+
         BotLogger.logButton(event);
         User user = event.getUser();
         UserSettings userSettings = UserSettingsManager.get(user.getId());
@@ -63,11 +66,6 @@ public class ButtonProcessor {
         UserSettingsManager.save(userSettings);
 
         String gameName = GameNameService.getGameNameFromChannel(event);
-        var buttonContext = new ButtonContext(event);
-        if (!buttonContext.isValid()) {
-            BotLogger.warning(new LogOrigin(event), "Invalid button context.");
-            return;
-        }
         ExecutorServiceManager.runAsyncWithLock(
                 eventToString(event, gameName),
                 gameName,

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -415,10 +415,7 @@ public class ButtonProcessor {
 
     public static String getButtonProcessingStatistics() {
         var decimalFormatter = new DecimalFormat("#.##");
-        double thresholdMissPercent = runtimeWarningService.getRuntimeSubmissionCount() == 0
-                ? 0
-                : (double) runtimeWarningService.getRuntimeThresholdMissCount()
-                        / runtimeWarningService.getRuntimeSubmissionCount();
+        double thresholdMissPercent = runtimeWarningService.getThresholdMissPercent();
         return "Button Processor Statistics: " + DateTimeHelper.getCurrentTimestamp()
                 + "\n> Total button presses: "
                 + runtimeWarningService.getRuntimeSubmissionCount()

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonRuntimeWarningService.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonRuntimeWarningService.java
@@ -122,4 +122,8 @@ class ButtonRuntimeWarningService {
     synchronized double getAverageProcessingTime() {
         return runtimeSubmissionCount == 0 ? 0 : totalProcessingTime / (double) runtimeSubmissionCount;
     }
+
+    synchronized double getThresholdMissPercent() {
+        return runtimeSubmissionCount == 0 ? 0 : runtimeThresholdMissCount / (double) runtimeSubmissionCount;
+    }
 }

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonRuntimeWarningService.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonRuntimeWarningService.java
@@ -1,6 +1,6 @@
 package ti4.discord.interactions.buttons;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Getter;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import ti4.helpers.ButtonHelper;
@@ -14,22 +14,22 @@ class ButtonRuntimeWarningService {
     private static final int RUNTIME_WARNING_COUNT_THRESHOLD = 20;
 
     private int runtimeWarningCount;
-    private LocalDateTime pauseWarningsUntil = LocalDateTime.now();
-    private LocalDateTime lastWarningTime = LocalDateTime.now();
+    private Instant pauseWarningsUntil = Instant.now();
+    private Instant lastWarningTime = Instant.now();
 
     @Getter
-    private int totalRuntimeSubmissionCount;
+    private long runtimeSubmissionCount;
 
     @Getter
-    private int totalRuntimeThresholdMissCount;
+    private long runtimeThresholdMissCount;
 
     @Getter
-    private double averageProcessingTime;
+    private long totalProcessingTime;
 
     @Getter
-    private double averagePreprocessingTime;
+    private long totalPreprocessingTime;
 
-    void submitNewRuntime(
+    synchronized void submitNewRuntime(
             ButtonInteractionEvent event,
             long processingStartTimeMs,
             long processingEndTimeMs,
@@ -38,35 +38,31 @@ class ButtonRuntimeWarningService {
             long resolveRuntimeMs,
             long saveRuntimeMs) {
 
-        totalRuntimeSubmissionCount++;
+        runtimeSubmissionCount++;
 
         long processingTimeMs = processingEndTimeMs - processingStartTimeMs;
-        averageProcessingTime = ((averageProcessingTime * (totalRuntimeSubmissionCount - 1)) + processingTimeMs)
-                / totalRuntimeSubmissionCount;
+        totalProcessingTime += processingTimeMs;
 
         long eventTimeMs = DateTimeHelper.getLongDateTimeFromDiscordSnowflake(event.getInteraction());
         long preprocessingTimeMs = processingStartTimeMs - eventTimeMs;
-
-        averagePreprocessingTime =
-                ((averagePreprocessingTime * (totalRuntimeSubmissionCount - 1)) + preprocessingTimeMs)
-                        / totalRuntimeSubmissionCount;
+        totalPreprocessingTime += preprocessingTimeMs;
 
         SREStats.recordButtonPreprocessingMillis(preprocessingTimeMs);
         SREStats.recordButtonProcessingMillis(processingTimeMs);
 
-        var now = LocalDateTime.now();
-        if (now.minusMinutes(1).isAfter(lastWarningTime)) {
+        var now = Instant.now();
+        if (lastWarningTime.isBefore(now.minusSeconds(60))) {
             runtimeWarningCount = 0;
         }
 
-        boolean slowPreprocess = preprocessingTimeMs > WARNING_THRESHOLD_MILLISECONDS;
-        boolean slowExecution = processingTimeMs > WARNING_THRESHOLD_MILLISECONDS;
+        boolean slowPreprocess = preprocessingTimeMs >= WARNING_THRESHOLD_MILLISECONDS;
+        boolean slowExecution = processingTimeMs >= WARNING_THRESHOLD_MILLISECONDS;
 
         if (!slowPreprocess && !slowExecution) {
             return;
         }
 
-        totalRuntimeThresholdMissCount++;
+        runtimeThresholdMissCount++;
 
         if (pauseWarningsUntil.isAfter(now)) {
             return;
@@ -81,7 +77,7 @@ class ButtonRuntimeWarningService {
         String queueTime = formatMillisecondsWithWarning(timeInQueueMs);
         String resolveTime = formatMillisecondsWithWarning(resolveRuntimeMs);
         String saveTime = formatMillisecondsWithWarning(saveRuntimeMs);
-        String responseTime = formatMillisecondsWithWarning(processingEndTimeMs - eventTimeMs);
+        String responseTime = DateTimeHelper.getTimeRepresentationToMilliseconds(processingEndTimeMs - eventTimeMs);
 
         String message = event.getUser().getEffectiveName()
                 + " pressed button: "
@@ -100,10 +96,10 @@ class ButtonRuntimeWarningService {
 
         BotLogger.warning(message);
 
-        ++runtimeWarningCount;
+        runtimeWarningCount++;
 
         if (runtimeWarningCount > RUNTIME_WARNING_COUNT_THRESHOLD) {
-            pauseWarningsUntil = now.plusMinutes(5);
+            pauseWarningsUntil = now.plusSeconds(300);
             BotLogger.error("**Buttons are processing slowly. Pausing warnings for 5 minutes.**");
             runtimeWarningCount = 0;
         }
@@ -113,9 +109,17 @@ class ButtonRuntimeWarningService {
 
     private static String formatMillisecondsWithWarning(long runtimeMs) {
         String formattedRuntime = DateTimeHelper.getTimeRepresentationToMilliseconds(runtimeMs);
-        if (runtimeMs > 500) {
+        if (runtimeMs >= WARNING_THRESHOLD_MILLISECONDS) {
             return formattedRuntime + " ❗";
         }
         return formattedRuntime;
+    }
+
+    synchronized double getAveragePreprocessingTime() {
+        return runtimeSubmissionCount == 0 ? 0 : totalPreprocessingTime / (double) runtimeSubmissionCount;
+    }
+
+    synchronized double getAverageProcessingTime() {
+        return runtimeSubmissionCount == 0 ? 0 : totalProcessingTime / (double) runtimeSubmissionCount;
     }
 }

--- a/src/main/java/ti4/discord/interactions/listeners/ButtonListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ButtonListener.java
@@ -76,27 +76,32 @@ class ButtonListener extends ListenerAdapter {
     private static final class EventLatencyChecker {
 
         private static final long THRESHOLD_MS = 1000;
-        private static final Duration WINDOW = Duration.ofMinutes(5);
+        private static final Duration WARNING_COOLDOWN_WINDOW = Duration.ofMinutes(5);
         private static final int EVENT_COUNT_THRESHOLD = 10;
 
         private static final ConcurrentLinkedDeque<Long> slowEvents = new ConcurrentLinkedDeque<>();
         private static final AtomicLong lastWarningTimeMs = new AtomicLong(0);
 
         static void check(GenericInteractionCreateEvent event) {
+            long now = System.currentTimeMillis();
+            long lastWarning = lastWarningTimeMs.get();
+
+            if (now - lastWarning < WARNING_COOLDOWN_WINDOW.toMillis()) {
+                return;
+            }
+
             long eventTimeMs = DateTimeHelper.getLongDateTimeFromDiscordSnowflake(event.getInteraction());
-            long latencyMs = System.currentTimeMillis() - eventTimeMs;
+            long latencyMs = now - eventTimeMs;
 
             if (latencyMs <= THRESHOLD_MS) {
                 return;
             }
 
-            long now = System.currentTimeMillis();
-
             slowEvents.addLast(now);
 
             // trim old entries outside 5-minute window
             Long ts;
-            long windowMs = WINDOW.toMillis();
+            long windowMs = WARNING_COOLDOWN_WINDOW.toMillis();
 
             while ((ts = slowEvents.peekFirst()) != null && now - ts > windowMs) {
                 slowEvents.pollFirst();
@@ -106,17 +111,14 @@ class ButtonListener extends ListenerAdapter {
                 return;
             }
 
-            long lastWarn = lastWarningTimeMs.get();
-            if (now - lastWarn < windowMs) {
+            if (!lastWarningTimeMs.compareAndSet(lastWarning, now)) {
                 return;
             }
-
-            lastWarningTimeMs.set(now);
 
             slowEvents.clear();
 
             BotLogger.error("⚠ **High Discord/JDA latency detected: " + EVENT_COUNT_THRESHOLD
-                    + "+ slow events in the last " + WINDOW.toMinutes() + "  minutes.**");
+                    + "+ slow events in the last " + WARNING_COOLDOWN_WINDOW.toMinutes() + "  minutes.**");
         }
     }
 }


### PR DESCRIPTION
Replace LocalDateTime with Instant and switch runtime counters to long; store total processing/preprocessing times instead of running averages and expose synchronized getters for computed averages. Make submitNewRuntime synchronized, adjust threshold checks to use >=, change warning pause to seconds, and use DateTimeHelper for response time formatting. Update ButtonProcessor to call the renamed accessors.