### PR TITLE
Fix replay contest thread routing

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -32,6 +32,7 @@ import ti4.game.Player;
 import ti4.game.Tile;
 import ti4.game.persistence.GameManager;
 import ti4.helpers.RandomHelper;
+import ti4.helpers.ThreadGetter;
 import ti4.image.TileGenerator;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
@@ -484,11 +485,13 @@ public class CombatReplayContestLifecycleService {
 
     private MessageChannel getContestThreadOrChannel(CombatReplayContestEntity contest) {
         if (JdaService.guildPrimary == null) return null;
+        TextChannel contestChannel = JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
+        if (contestChannel == null) return null;
         if (contest.getPublicThreadId() != null) {
-            ThreadChannel thread = JdaService.guildPrimary.getThreadChannelById(contest.getPublicThreadId());
+            ThreadChannel thread = ThreadGetter.getThreadInChannelById(contestChannel, contest.getPublicThreadId());
             if (thread != null) return thread;
         }
-        return JdaService.guildPrimary.getTextChannelById(contest.getPublicChannelId());
+        return contestChannel;
     }
 
     private TextChannel getContestChannel() {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
@@ -32,6 +33,7 @@ import ti4.contest.replay.service.CombatReplaySideBetService.SideBetResolution;
 import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.helpers.ThreadGetter;
 import ti4.json.JsonMapperManager;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
@@ -97,6 +99,7 @@ public class CombatReplayLeaderboardService {
         replayPredictionRepository.save(lockedPrediction);
     }
 
+    @Transactional
     public void clearLockedPredictions(Long replayContestId) {
         if (replayContestId == null) return;
         replayPredictionRepository.deleteByContestId(replayContestId);
@@ -401,11 +404,13 @@ public class CombatReplayLeaderboardService {
 
     private MessageChannel getContestThreadOrChannel(CombatReplayContestEntity contest) {
         if (JdaService.guildPrimary == null) return null;
+        TextChannel contestChannel = getContestPublicChannel(contest.getPublicChannelId());
+        if (contestChannel == null) return null;
         if (contest.getPublicThreadId() != null) {
-            ThreadChannel thread = JdaService.guildPrimary.getThreadChannelById(contest.getPublicThreadId());
+            ThreadChannel thread = ThreadGetter.getThreadInChannelById(contestChannel, contest.getPublicThreadId());
             if (thread != null) return thread;
         }
-        return getContestPublicChannel(contest.getPublicChannelId());
+        return contestChannel;
     }
 
     private String getFactionEmoji(Game game, String faction) {

--- a/src/main/java/ti4/helpers/ThreadGetter.java
+++ b/src/main/java/ti4/helpers/ThreadGetter.java
@@ -3,7 +3,9 @@ package ti4.helpers;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.requests.restaction.ThreadChannelAction;
@@ -11,6 +13,48 @@ import ti4.logging.BotLogger;
 
 @UtilityClass
 public class ThreadGetter {
+
+    @Nullable
+    public static ThreadChannel getThreadInChannelById(@Nonnull TextChannel channel, long threadId) {
+        Guild guild = channel.getGuild();
+        ThreadChannel cachedThread = guild.getThreadChannelById(threadId);
+        if (cachedThread != null) return reopenIfNeeded(cachedThread);
+
+        try {
+            ThreadChannel activeThread = guild.retrieveActiveThreads().complete().stream()
+                    .filter(thread -> thread.getIdLong() == threadId)
+                    .findFirst()
+                    .orElse(null);
+            if (activeThread != null) return reopenIfNeeded(activeThread);
+        } catch (Exception e) {
+            BotLogger.error("Failed to retrieve active thread " + threadId + " in channel " + channel.getJumpUrl(), e);
+        }
+
+        try {
+            ThreadChannel archivedPrivateThread = channel.retrieveArchivedPrivateThreadChannels().complete().stream()
+                    .filter(thread -> thread.getIdLong() == threadId)
+                    .findFirst()
+                    .orElse(null);
+            if (archivedPrivateThread != null) return reopenIfNeeded(archivedPrivateThread);
+        } catch (Exception e) {
+            BotLogger.error(
+                    "Failed to retrieve archived private thread " + threadId + " in channel " + channel.getJumpUrl(),
+                    e);
+        }
+
+        try {
+            ThreadChannel archivedPublicThread = channel.retrieveArchivedPublicThreadChannels().complete().stream()
+                    .filter(thread -> thread.getIdLong() == threadId)
+                    .findFirst()
+                    .orElse(null);
+            if (archivedPublicThread != null) return reopenIfNeeded(archivedPublicThread);
+        } catch (Exception e) {
+            BotLogger.error(
+                    "Failed to retrieve archived public thread " + threadId + " in channel " + channel.getJumpUrl(), e);
+        }
+
+        return null;
+    }
 
     public static void getThreadInChannel(
             @Nonnull TextChannel channel, @Nonnull String threadName, Consumer<ThreadChannel> consumer) {
@@ -96,6 +140,13 @@ public class ThreadGetter {
         } else {
             consumer.accept(thread);
         }
+    }
+
+    private static ThreadChannel reopenIfNeeded(@Nonnull ThreadChannel thread) {
+        if (thread.isArchived()) {
+            thread.getManager().setArchived(false).complete();
+        }
+        return thread;
     }
 
     private static void createNewThreadChannel(


### PR DESCRIPTION
## Summary
- Resolve replay contest threads through cache, active thread retrieval, and archived thread retrieval before falling back to the public channel.
- Reopen archived contest threads before posting replay and leaderboard follow-up messages.

## Test Plan
- mvn -q -DskipTests compile