### PR TITLE
Remove skipped AFB side bet buttons

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -76,6 +76,7 @@ public class CombatReplaySideBetService {
         List<Button> buttons = new ArrayList<>();
         String factionLabel = buttonFactionIdLabel(game, faction);
         for (CombatSideBetType type : CombatSideBetType.values()) {
+            if (type == CombatSideBetType.AFB_SKIPPED) continue;
             if (!type.isAvailable(safeInt(destroyerCount))) continue;
             buttons.add(Buttons.gray(
                     buttonId(contest.getId(), type, faction), buttonLabel(type, factionLabel), type.emoji()));


### PR DESCRIPTION
## Summary
- Hide the Skips AFB side bet from generated side bet option buttons
- Leave existing AFB_SKIPPED enum, parsing, placement validation, and resolution code intact for historical/manual handling

## Testing
- mvn -q -DskipTests compile