### PR TITLE
Update combat side bet points

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -1,6 +1,7 @@
 package ti4.contest.cron;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.experimental.UtilityClass;
 import ti4.contest.replay.core.CombatCandidateStatus;
@@ -31,8 +32,11 @@ public class CombatReplayPromotionScoreBackfillCron {
     private static final AtomicBoolean HAS_RUN = new AtomicBoolean(false);
 
     public static void register() {
-        CronManager.registerManual(
-                CombatReplayPromotionScoreBackfillCron.class, CombatReplayPromotionScoreBackfillCron::runBackfill);
+        CronManager.scheduleOnce(
+                CombatReplayPromotionScoreBackfillCron.class,
+                CombatReplayPromotionScoreBackfillCron::runBackfill,
+                0,
+                TimeUnit.SECONDS);
     }
 
     private static void runBackfill() {

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -144,6 +144,6 @@ public class CombatContestSettings {
     public static class SideBets {
         private boolean enableSideBets = true;
         private int maxBetsPerUser = 5;
-        private int costPoints = 1;
+        private int costPoints = 2;
     }
 }

--- a/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
+++ b/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
@@ -7,13 +7,13 @@ import ti4.service.emoji.TI4Emoji;
 import ti4.service.emoji.UnitEmojis;
 
 public enum CombatSideBetType {
-    AFB_SKIPPED("Skips AFB", UnitEmojis.destroyer, 1, 3),
-    AFB_WHIFF("AFB Whiff", UnitEmojis.destroyer, 2, 3),
-    ROUND_ONE_WHIFF("R1 Whiff", DiceEmojis.d10red_1, 0, 5),
-    ROUND_ONE_SLAM("R1 Slam", DiceEmojis.d10green_0, 0, 7),
-    MORALE_BOOST("Plays Morale Boost", CardEmojis.ActionCard, 0, 5),
-    SHIELDS_HOLDING("Plays Shields Holding", CardEmojis.ActionCard, 0, 5),
-    WINNER_ONE_HP("Wins On 1\uFE0F\u20E3 HP", "1\uFE0F\u20E3", 0, 15);
+    AFB_SKIPPED("Skips AFB", UnitEmojis.destroyer, 1, 6),
+    AFB_WHIFF("AFB Whiff", UnitEmojis.destroyer, 2, 4),
+    ROUND_ONE_WHIFF("R1 Whiff", DiceEmojis.d10red_1, 0, 10),
+    ROUND_ONE_SLAM("R1 Slam", DiceEmojis.d10green_0, 0, 30),
+    MORALE_BOOST("Plays Morale Boost", CardEmojis.ActionCard, 0, 8),
+    SHIELDS_HOLDING("Plays Shields Holding", CardEmojis.ActionCard, 0, 8),
+    WINNER_ONE_HP("Wins On 1\uFE0F\u20E3 HP", "1\uFE0F\u20E3", 0, 35);
 
     private final String label;
     private final TI4Emoji emoji;

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -391,7 +391,7 @@ public class CombatReplayService {
         double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
         double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
         double endingTensionScore = winnerRemainingHp <= 0 ? 0.0 : 5.0 * Math.exp(-6.0 * winnerSurvivalRatio);
-        double defenderWinBonus = winnerFaction.equalsIgnoreCase(observation.getDefenderFaction()) ? 1.0 : 0.0;
+        double defenderWinBonus = winnerFaction.equalsIgnoreCase(observation.getDefenderFaction()) ? 0.5 : 0.0;
         return roundScore + openingBalanceScore + endingTensionScore + defenderWinBonus;
     }
 

--- a/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
@@ -1,0 +1,30 @@
+package ti4.contest.replay.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CombatSideBetTypeTest {
+
+    @Test
+    void usesConfiguredSideBetCost() {
+        CombatContestSettings settings = new CombatContestSettings();
+
+        assertEquals(2, settings.getSideBets().getCostPoints());
+    }
+
+    @Test
+    void usesConfiguredSideBetPayouts() {
+        Map<CombatSideBetType, Integer> expectedPayouts = Map.of(
+                CombatSideBetType.AFB_SKIPPED, 6,
+                CombatSideBetType.AFB_WHIFF, 4,
+                CombatSideBetType.ROUND_ONE_WHIFF, 10,
+                CombatSideBetType.ROUND_ONE_SLAM, 30,
+                CombatSideBetType.MORALE_BOOST, 8,
+                CombatSideBetType.SHIELDS_HOLDING, 8,
+                CombatSideBetType.WINNER_ONE_HP, 35);
+
+        expectedPayouts.forEach((type, expectedPayout) -> assertEquals(expectedPayout, type.profitPoints()));
+    }
+}

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -57,13 +57,13 @@ class CombatReplayServiceTest {
                 "muaat",
                 4);
 
-        assertEquals(3.2033, blowoutScore, 0.0001);
-        assertEquals(4.6705, squeakerScore, 0.0001);
+        assertEquals(2.7033, blowoutScore, 0.0001);
+        assertEquals(4.1705, squeakerScore, 0.0001);
         assertTrue(squeakerScore > blowoutScore);
     }
 
     @Test
-    void promotionScoreAddsFlatBonusWhenDefenderWins() {
+    void promotionScoreAddsHalfPointBonusWhenDefenderWins() {
         CombatObservationEntity observation = observation(
                 10L, LocalDateTime.of(2026, 4, 23, 20, 22), "pbd22333", "307", 12, 12, 8, 8, 2, 2, 1, true, 10L);
         observation.setAttackerFaction("sol");
@@ -76,7 +76,7 @@ class CombatReplayServiceTest {
         double defenderWinScore =
                 CombatReplayService.computePromotionScore(observation, attackerRemaining, defenderRemaining, "yin", 2);
 
-        assertEquals(attackerWinScore + 1.0, defenderWinScore, 0.0001);
+        assertEquals(attackerWinScore + 0.5, defenderWinScore, 0.0001);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Increase side bet cost from 1 point to 2 points
- Update side bet payouts, including explicit overrides for R1 Slam, AFB Whiff, Morale Boost, Shields Holding, and 1 HP wins
- Add regression coverage for side bet cost and payout constants

## Test Plan
- mvn -Dtest=CombatSideBetTypeTest test