### PR TITLE
Enforce single TIBot container after deploy

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -116,6 +116,33 @@ jobs:
                 curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING INITIAL TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
                 docker compose -f "$compose_file" up -d tibot
               fi
+
+              timestamp=$(date "+%F %T.%3N")
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`VERIFYING SINGLE TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+              running_tibot_containers="$(docker ps -q --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --filter "label=com.docker.compose.service=tibot" || true)"
+              running_tibot_count="$(printf '%s\n' "$running_tibot_containers" | sed '/^$/d' | wc -l | tr -d ' ')"
+              if [ "$running_tibot_count" -gt 1 ]; then
+                desired_tibot_container="$(docker ps -q --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --filter "label=com.docker.compose.service=tibot" --filter "ancestor=${IMAGE_REPOSITORY}:${IMAGE_TAG}" | head -n 1 || true)"
+                if [ -z "$desired_tibot_container" ]; then
+                  desired_tibot_container="$(printf '%s\n' "$running_tibot_containers" | sed '/^$/d' | head -n 1)"
+                fi
+
+                echo "Found $running_tibot_count running tibot containers. Keeping $desired_tibot_container and removing extras..."
+                for container in $running_tibot_containers; do
+                  if [ "$container" != "$desired_tibot_container" ]; then
+                    docker stop --time 600 "$container"
+                    docker rm "$container"
+                  fi
+                done
+              fi
+
+              running_tibot_containers="$(docker ps -q --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --filter "label=com.docker.compose.service=tibot" || true)"
+              running_tibot_count="$(printf '%s\n' "$running_tibot_containers" | sed '/^$/d' | wc -l | tr -d ' ')"
+              if [ "$running_tibot_count" -ne 1 ]; then
+                echo "Expected exactly one running tibot container, found $running_tibot_count" >&2
+                docker ps --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --filter "label=com.docker.compose.service=tibot"
+                exit 1
+              fi
               
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`CLEANING UP DOCKER\"}" $DISCORD_WEBHOOK_URL


### PR DESCRIPTION
## Summary
- add a post-rollout reconciliation step to keep only one running compose-managed tibot container
- prefer the newly deployed image when choosing which container to keep
- fail deployment if the workflow cannot confirm exactly one tibot container remains

## Test Plan
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-to-production.yml")'\n- ruby -e 'require "yaml"; print YAML.load_file(".github/workflows/deploy-to-production.yml").fetch("jobs").fetch("build").fetch("steps")[0].fetch("with").fetch("script")' | sh -n\n- git diff --check -- .github/workflows/deploy-to-production.yml