### PR TITLE
Add reload-corrupted-saves developer command

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
@@ -19,6 +19,7 @@ public class DeveloperCommand implements ParentCommand {
                     new ButtonProcessingStatistics(),
                     new CacheStatistics(),
                     new RestoreGame(),
+                    new ReloadAllCorruptedSaves(),
                     new RunCron(),
                     new RunAgainstAllGames(),
                     new CustomCommand(),

--- a/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
@@ -19,7 +19,7 @@ public class DeveloperCommand implements ParentCommand {
                     new ButtonProcessingStatistics(),
                     new CacheStatistics(),
                     new RestoreGame(),
-                    new ReloadAllCorruptedSaves(),
+                    new ReloadCorruptedSaves(),
                     new RunCron(),
                     new RunAgainstAllGames(),
                     new CustomCommand(),

--- a/src/main/java/ti4/discord/interactions/commands/developer/ReloadAllCorruptedSaves.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/ReloadAllCorruptedSaves.java
@@ -1,0 +1,59 @@
+package ti4.discord.interactions.commands.developer;
+
+import java.util.HashSet;
+import java.util.Set;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.game.Game;
+import ti4.game.persistence.GameManager;
+import ti4.game.persistence.ManagedGame;
+import ti4.logging.BotLogger;
+import ti4.message.MessageHelper;
+
+class ReloadAllCorruptedSaves extends Subcommand {
+
+    ReloadAllCorruptedSaves() {
+        super("run_against_all_games", "Runs this custom code against all games.");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        MessageHelper.sendMessageToChannel(event.getChannel(), "Running custom command against all games.");
+
+        Set<String> reloadedGames = new HashSet<>();
+        Set<String> failedReloadedGames = new HashSet<>();
+        var managedGames = GameManager.getManagedGames();
+        for (ManagedGame managedGame : managedGames) {
+            try {
+                managedGame.getGame();
+            } catch (Exception e) {
+                if (tryReload(managedGame.getName())) reloadedGames.add(managedGame.getName());
+                else failedReloadedGames.add(managedGame.getName());
+            }
+        }
+
+        MessageHelper.sendMessageToChannel(
+                event.getChannel(),
+                "Finished reloading games."
+                        + "\nReloaded games: " + reloadedGames
+                        + "\nFailed reloaded games: " + failedReloadedGames);
+    }
+
+    private boolean tryReload(String name) {
+        Game reloadedGame = null;
+        try {
+            reloadedGame = GameManager.reload(name);
+        } catch (Exception e) {
+            BotLogger.error("Error while reloading game " + name + ". Needs someone to fix it manually.", e);
+        }
+        if (reloadedGame != null) {
+            MessageChannel messageChannel = reloadedGame.getMainGameChannel();
+            MessageHelper.sendMessageToChannel(
+                    messageChannel,
+                    "Developer reloaded your game from its latest undo file, probably migration or hot fix related.");
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
@@ -11,10 +11,10 @@ import ti4.game.persistence.ManagedGame;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 
-class ReloadAllCorruptedSaves extends Subcommand {
+class ReloadCorruptedSaves extends Subcommand {
 
-    ReloadAllCorruptedSaves() {
-        super("run_against_all_games", "Runs this custom code against all games.");
+    ReloadCorruptedSaves() {
+        super("reload_corrupted_saves", "Runs this custom code against all games.");
     }
 
     @Override

--- a/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
@@ -18,8 +18,8 @@ class ReloadCorruptedSaves extends Subcommand {
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        MessageHelper.sendMessageToChannel(event.getChannel(),
-            "Reloading all corrupted saves. This will take a while.");
+        MessageHelper.sendMessageToChannel(
+                event.getChannel(), "Reloading all corrupted saves. This will take a while.");
 
         int successCount = 0;
         var reloadedGames = new HashSet<String>();

--- a/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
@@ -1,7 +1,6 @@
 package ti4.discord.interactions.commands.developer;
 
 import java.util.HashSet;
-import java.util.Set;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.discord.interactions.commands.Subcommand;
@@ -19,14 +18,17 @@ class ReloadCorruptedSaves extends Subcommand {
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        MessageHelper.sendMessageToChannel(event.getChannel(), "Running custom command against all games.");
+        MessageHelper.sendMessageToChannel(event.getChannel(),
+            "Reloading all corrupted saves. This will take a while.");
 
-        Set<String> reloadedGames = new HashSet<>();
-        Set<String> failedReloadedGames = new HashSet<>();
+        int successCount = 0;
+        var reloadedGames = new HashSet<String>();
+        var failedReloadedGames = new HashSet<String>();
         var managedGames = GameManager.getManagedGames();
         for (ManagedGame managedGame : managedGames) {
             try {
                 managedGame.getGame();
+                successCount++;
             } catch (Exception e) {
                 if (tryReload(managedGame.getName())) reloadedGames.add(managedGame.getName());
                 else failedReloadedGames.add(managedGame.getName());
@@ -36,6 +38,7 @@ class ReloadCorruptedSaves extends Subcommand {
         MessageHelper.sendMessageToChannel(
                 event.getChannel(),
                 "Finished reloading games."
+                        + "\nSuccessfully loaded: " + successCount + " games"
                         + "\nReloaded games: " + reloadedGames
                         + "\nFailed reloaded games: " + failedReloadedGames);
     }

--- a/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/ReloadCorruptedSaves.java
@@ -39,8 +39,8 @@ class ReloadCorruptedSaves extends Subcommand {
                 event.getChannel(),
                 "Finished reloading games."
                         + "\nSuccessfully loaded: " + successCount + " games"
-                        + "\nReloaded games: " + reloadedGames
-                        + "\nFailed reloaded games: " + failedReloadedGames);
+                        + "\nReloaded: " + reloadedGames
+                        + "\nFailed to reload: " + failedReloadedGames);
     }
 
     private boolean tryReload(String name) {

--- a/src/main/java/ti4/game/persistence/GameManager.java
+++ b/src/main/java/ti4/game/persistence/GameManager.java
@@ -153,11 +153,11 @@ public class GameManager {
     public static Game reload(String gameName) {
         waitFor(GAME_NAMES_LOADED_LATCH);
         Game game = GameLoadService.load(gameName);
-        handleMissingMatchingManagedGame(game);
         if (game == null) {
             game = GameUndoService.loadUndoForMissingGame(gameName);
             handleUndo(game);
         }
+        handleMissingMatchingManagedGame(game);
         return game;
     }
 


### PR DESCRIPTION
Register a new Developer subcommand (ReloadAllCorruptedSaves) that scans all managed games, attempts to reload those whose load() threw exceptions, and reports successes/failures to the invoking channel and to each reloaded game's main channel. Also adjust GameManager.reload ordering: move handleMissingMatchingManagedGame(...) to after undo-based recovery so managed-game handling runs against the possibly restored game. These changes provide a developer tool to recover games with corrupted saves and fix a reload logic ordering bug.