### PR TITLE
Fix combat replay contest handling

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -111,7 +111,7 @@ public class CombatContestSettings {
     @Setter
     public static class Promotion {
         private int intervalSeconds = 60;
-        private int candidateLookbackHours = 4;
+        private int candidateLookbackHours = 12;
         private int maxPromotionsPerHour = 1;
     }
 

--- a/src/main/java/ti4/contest/replay/core/CombatReplayTrackedEvent.java
+++ b/src/main/java/ti4/contest/replay/core/CombatReplayTrackedEvent.java
@@ -3,5 +3,6 @@ package ti4.contest.replay.core;
 public enum CombatReplayTrackedEvent {
     NONE,
     MORALE_BOOST,
-    SHIELDS_HOLDING
+    SHIELDS_HOLDING,
+    ROUT
 }

--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -156,7 +156,7 @@ public class LazaxCombatSupport {
         if (lawSection != null) {
             message.append("\n").append(lawSection);
         }
-        String effectSection = formatCombatEffectSection(attacker.getGame());
+        String effectSection = formatCombatEffectSection(tile, attacker.getGame());
         if (effectSection != null) {
             message.append("\n").append(effectSection);
         }
@@ -305,8 +305,8 @@ public class LazaxCombatSupport {
         return formatPlayerSummaryLine(player, CardEmojis.Agenda + " Prophecy of Ixth");
     }
 
-    private String formatCombatEffectSection(Game game) {
-        if (!isQuietusActive(game)) {
+    private String formatCombatEffectSection(Tile tile, Game game) {
+        if (!isQuietusActive(tile, game)) {
             return null;
         }
         return "## Combat Effects\n- " + FactionEmojis.Crimson + " " + UnitEmojis.flagship
@@ -397,14 +397,12 @@ public class LazaxCombatSupport {
         return builder.toString();
     }
 
-    private boolean isQuietusActive(Game game) {
-        if (game == null) return false;
+    private boolean isQuietusActive(Tile combatTile, Game game) {
+        if (combatTile == null || game == null) return false;
         Player quietusOwner = Helper.getPlayerFromUnit(game, "crimson_flagship");
         if (quietusOwner == null) return false;
-        return game.getTileMap().values().stream()
-                .map(Tile::getSpaceUnitHolder)
-                .filter(Objects::nonNull)
-                .anyMatch(holder -> holder.getTokenList().contains(Constants.TOKEN_BREACH_ACTIVE));
+        UnitHolder combatSpace = combatTile.getSpaceUnitHolder();
+        return combatSpace != null && combatSpace.getTokenList().contains(Constants.TOKEN_BREACH_ACTIVE);
     }
 
     private String formatPlayerSummaryLine(Player player, String summary) {

--- a/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
@@ -100,6 +100,12 @@ public class CombatCandidateEntity {
     @Column(name = "defender_destroyer_count", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private Integer defenderDestroyerCount = 0;
 
+    @Column(name = "attacker_has_assault_cannon", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean attackerHasAssaultCannon = false;
+
+    @Column(name = "defender_has_assault_cannon", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean defenderHasAssaultCannon = false;
+
     @Column(name = "attacker_rolled_afb", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean attackerRolledAfb = false;
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -118,6 +118,9 @@ public class CombatReplayContestLifecycleService {
         if (candidate.getStatus() != CombatCandidateStatus.RESOLVED) {
             return ForcePromoteResult.rejected("Candidate must be RESOLVED before promotion");
         }
+        if (candidate.getPromotionStatus() != CombatCandidatePromotionStatus.PENDING) {
+            return ForcePromoteResult.rejected("Candidate is not eligible for promotion");
+        }
 
         CombatReplayContestEntity existingContest =
                 replayContestRepository.findByCandidateId(candidateId).orElse(null);

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -498,6 +498,12 @@ public class CombatReplayService {
                 || trackedEvent == CombatReplayTrackedEvent.NONE) return;
         boolean moraleBoost = trackedEvent == CombatReplayTrackedEvent.MORALE_BOOST;
         boolean shieldsHolding = trackedEvent == CombatReplayTrackedEvent.SHIELDS_HOLDING;
+        boolean rout = trackedEvent == CombatReplayTrackedEvent.ROUT;
+        if (rout) {
+            candidate.setPromotionStatus(CombatCandidatePromotionStatus.EXPIRED);
+            candidate.setCancellationReason(firstNonBlank(
+                    candidate.getCancellationReason(), "Ineligible for promotion because Rout was played."));
+        }
         boolean attacker = player.getFaction().equalsIgnoreCase(candidate.getAttackerFaction());
         if (attacker) {
             candidate.setAttackerPlayedMoraleBoost(
@@ -673,7 +679,13 @@ public class CombatReplayService {
         candidate.setSideBetCompatible(true);
         candidate.setAttackerDestroyerCount(countDestroyersInCombat(tile, attacker));
         candidate.setDefenderDestroyerCount(countDestroyersInCombat(tile, defender));
+        candidate.setAttackerHasAssaultCannon(hasAssaultCannon(attacker));
+        candidate.setDefenderHasAssaultCannon(hasAssaultCannon(defender));
         return candidate;
+    }
+
+    private boolean hasAssaultCannon(Player player) {
+        return player != null && player.hasTech("asc");
     }
 
     private List<CombatCandidateEntity> getTrackingCandidates(Game game) {
@@ -781,6 +793,10 @@ public class CombatReplayService {
     private static double safeRatio(double weaker, double stronger) {
         if (stronger <= 0) return 0.0;
         return Math.max(0.0, Math.min(1.0, weaker / stronger));
+    }
+
+    private String firstNonBlank(String first, String fallback) {
+        return first == null || first.isBlank() ? fallback : first;
     }
 
     private record SelectionSnapshot(

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -76,12 +76,21 @@ public class CombatReplaySideBetService {
         List<Button> buttons = new ArrayList<>();
         String factionLabel = buttonFactionIdLabel(game, faction);
         for (CombatSideBetType type : CombatSideBetType.values()) {
-            if (type == CombatSideBetType.AFB_SKIPPED) continue;
-            if (!type.isAvailable(safeInt(destroyerCount))) continue;
+            if (!isAvailableForFaction(contest, type, faction, safeInt(destroyerCount))) continue;
             buttons.add(Buttons.gray(
                     buttonId(contest.getId(), type, faction), buttonLabel(type, factionLabel), type.emoji()));
         }
         return buttons;
+    }
+
+    private boolean isAvailableForFaction(
+            CombatReplayContestEntity contest, CombatSideBetType type, String faction, int destroyerCount) {
+        if (!type.isAvailable(destroyerCount)) return false;
+        if (type != CombatSideBetType.AFB_SKIPPED) return true;
+        if (contest == null || contest.getCandidateId() == null) return false;
+        CombatCandidateEntity candidate =
+                candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        return isAfbSkippedAvailable(candidate, faction);
     }
 
     @Transactional
@@ -394,7 +403,8 @@ public class CombatReplaySideBetService {
 
     private boolean isValidBet(CombatCandidateEntity candidate, CombatSideBetType betType, String targetFaction) {
         SideBetState state = stateFor(candidate, targetFaction);
-        return state != null && betType.isAvailable(state.destroyerCount());
+        if (state == null || !betType.isAvailable(state.destroyerCount())) return false;
+        return betType != CombatSideBetType.AFB_SKIPPED || isAfbSkippedAvailable(candidate, targetFaction);
     }
 
     private boolean isWinningBet(CombatCandidateEntity candidate, CombatContestSideBetEntity sideBet) {
@@ -402,7 +412,7 @@ public class CombatReplaySideBetService {
         if (state == null) return false;
         CombatSideBetType betType = sideBet.getBetType();
         return switch (betType) {
-            case AFB_SKIPPED -> betType.isAvailable(state.destroyerCount()) && !state.rolledAfb();
+            case AFB_SKIPPED -> isAfbSkippedAvailable(candidate, sideBet.getTargetFaction()) && !state.rolledAfb();
             case AFB_WHIFF -> betType.isAvailable(state.destroyerCount()) && state.afbWhiff();
             case ROUND_ONE_WHIFF -> state.roundOneWhiff();
             case ROUND_ONE_SLAM -> state.roundOneSlam();
@@ -438,6 +448,23 @@ public class CombatReplaySideBetService {
                     Boolean.TRUE.equals(candidate.getDefenderPlayedShieldsHolding()));
         }
         return null;
+    }
+
+    public boolean isAfbSkippedAvailable(CombatCandidateEntity candidate, String targetFaction) {
+        if (candidate == null || targetFaction == null) return false;
+        SideBetState state = stateFor(candidate, targetFaction);
+        if (state == null || !CombatSideBetType.AFB_SKIPPED.isAvailable(state.destroyerCount())) return false;
+        return !(state.destroyerCount() == 1 && opponentHasAssaultCannon(candidate, targetFaction));
+    }
+
+    private boolean opponentHasAssaultCannon(CombatCandidateEntity candidate, String targetFaction) {
+        if (targetFaction.equalsIgnoreCase(candidate.getAttackerFaction())) {
+            return Boolean.TRUE.equals(candidate.getDefenderHasAssaultCannon());
+        }
+        if (targetFaction.equalsIgnoreCase(candidate.getDefenderFaction())) {
+            return Boolean.TRUE.equals(candidate.getAttackerHasAssaultCannon());
+        }
+        return false;
     }
 
     private String getFactionEmoji(Game game, String faction) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
@@ -33,7 +33,7 @@ public class CombatReplaySideBetTriggerService {
         }
         if (rollType == CombatRollType.combatround
                 && round == 1
-                && CombatSideBetType.AFB_SKIPPED.isAvailable(destroyerCount)
+                && isAfbSkippedAvailable(candidate, player.getFaction())
                 && !hasRolledAfb(candidate, player.getFaction())) {
             announcements.add(announcement(player, "Skipped AFB!"));
         }
@@ -57,7 +57,7 @@ public class CombatReplaySideBetTriggerService {
         return switch (trackedEvent) {
             case MORALE_BOOST -> List.of(announcement(player, "Morale Boost!"));
             case SHIELDS_HOLDING -> List.of(announcement(player, "Shields Holding!"));
-            case NONE -> List.of();
+            case ROUT, NONE -> List.of();
         };
     }
 
@@ -85,6 +85,23 @@ public class CombatReplaySideBetTriggerService {
             return safeInt(candidate.getDefenderDestroyerCount());
         }
         return 0;
+    }
+
+    private boolean isAfbSkippedAvailable(CombatCandidateEntity candidate, String faction) {
+        if (faction == null || !CombatSideBetType.AFB_SKIPPED.isAvailable(destroyerCount(candidate, faction))) {
+            return false;
+        }
+        return !(destroyerCount(candidate, faction) == 1 && opponentHasAssaultCannon(candidate, faction));
+    }
+
+    private boolean opponentHasAssaultCannon(CombatCandidateEntity candidate, String faction) {
+        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
+            return Boolean.TRUE.equals(candidate.getDefenderHasAssaultCannon());
+        }
+        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
+            return Boolean.TRUE.equals(candidate.getAttackerHasAssaultCannon());
+        }
+        return false;
     }
 
     private boolean hasRolledAfb(CombatCandidateEntity candidate, String faction) {

--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -2333,6 +2333,10 @@ public class ActionCardHelper {
         if (actionCard == null || actionCard.getAlias() == null) return CombatReplayTrackedEvent.NONE;
         if (MORALE_BOOST_IDS.contains(actionCard.getAlias())) return CombatReplayTrackedEvent.MORALE_BOOST;
         if (SHIELDS_HOLDING_IDS.contains(actionCard.getAlias())) return CombatReplayTrackedEvent.SHIELDS_HOLDING;
+        if ("Rout".equalsIgnoreCase(actionCard.getName())
+                || actionCard.getAlias().startsWith("rout")) {
+            return CombatReplayTrackedEvent.ROUT;
+        }
         return CombatReplayTrackedEvent.NONE;
     }
 }

--- a/src/test/java/ti4/contest/replay/service/CombatReplaySideBetServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplaySideBetServiceTest.java
@@ -1,0 +1,54 @@
+package ti4.contest.replay.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.repository.CombatCandidateRepository;
+import ti4.contest.replay.repository.CombatContestSideBetRepository;
+import ti4.contest.replay.repository.CombatReplayContestRepository;
+import ti4.contest.replay.repository.CombatReplayLeaderboardEntryRepository;
+
+class CombatReplaySideBetServiceTest {
+
+    private final CombatReplaySideBetService service = new CombatReplaySideBetService(
+            new CombatContestSettings(),
+            mock(CombatReplayContestRepository.class),
+            mock(CombatCandidateRepository.class),
+            mock(CombatContestSideBetRepository.class),
+            mock(CombatReplayLeaderboardEntryRepository.class));
+
+    @Test
+    void afbSkippedAvailableForSideWithDestroyerUnlessSingleDestroyerIsFacingAssaultCannon() {
+        CombatCandidateEntity candidate = candidate(1, 2, false, true);
+
+        assertFalse(service.isAfbSkippedAvailable(candidate, "sol"));
+        assertTrue(service.isAfbSkippedAvailable(candidate, "yin"));
+    }
+
+    @Test
+    void afbSkippedUnavailableWithoutDestroyers() {
+        CombatCandidateEntity candidate = candidate(0, 1, false, false);
+
+        assertFalse(service.isAfbSkippedAvailable(candidate, "sol"));
+        assertTrue(service.isAfbSkippedAvailable(candidate, "yin"));
+    }
+
+    private CombatCandidateEntity candidate(
+            int attackerDestroyers,
+            int defenderDestroyers,
+            boolean attackerHasAssaultCannon,
+            boolean defenderHasAssaultCannon) {
+        CombatCandidateEntity candidate = new CombatCandidateEntity();
+        candidate.setAttackerFaction("sol");
+        candidate.setDefenderFaction("yin");
+        candidate.setAttackerDestroyerCount(attackerDestroyers);
+        candidate.setDefenderDestroyerCount(defenderDestroyers);
+        candidate.setAttackerHasAssaultCannon(attackerHasAssaultCannon);
+        candidate.setDefenderHasAssaultCannon(defenderHasAssaultCannon);
+        return candidate;
+    }
+}


### PR DESCRIPTION
## Summary
- Mark combat replay candidates ineligible for promotion when Rout is played, including forced promotion paths
- Restore Skips AFB side bets with Assault Cannon eligibility gating
- Scope Quietus combat tech/effect reporting to the active combat system and extend promotion selection lookback to 12 hours

## Test Plan
- mvn -q spotless:apply
- mvn -q -Dtest=CombatReplayServiceTest,CombatReplaySideBetServiceTest test
- mvn -q spotless:check -DskipTests
- mvn -q -DskipTests compile