### PR TITLE
Disable Lazax Fight Club promotion

### DIFF
--- a/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
+++ b/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
@@ -145,6 +145,7 @@ public class CombatReplayDebugController {
 
     private RuntimeStateResponse runtimeState() {
         return new RuntimeStateResponse(
+                settings.getPromotion().isEnabled(),
                 settings.getRuntime().isDiscordPostingEnabled(),
                 settings.getRuntime().isTrackAllCombatsAsCandidates(),
                 settings.getRuntime().isImmediatePromotionOnResolve());
@@ -191,7 +192,10 @@ public class CombatReplayDebugController {
     }
 
     private record RuntimeStateResponse(
-            boolean discordPostingEnabled, boolean trackAllCombatsAsCandidates, boolean immediatePromotionOnResolve) {}
+            boolean promotionEnabled,
+            boolean discordPostingEnabled,
+            boolean trackAllCombatsAsCandidates,
+            boolean immediatePromotionOnResolve) {}
 
     private record CandidateListResponse(RuntimeStateResponse runtime, List<CandidateSummary> candidates) {}
 

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -110,6 +110,7 @@ public class CombatContestSettings {
     @Getter
     @Setter
     public static class Promotion {
+        private boolean enabled = false;
         private int intervalSeconds = 60;
         private int candidateLookbackHours = 12;
         private int maxPromotionsPerHour = 1;

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -48,6 +48,7 @@ public class CombatReplayContestLifecycleService {
     private static final String CONTEST_CHANNEL_NAME_V1 = "lazax-war-archives-dev";
     private static final String CONTEST_CHANNEL_NAME_V2 = "lazax-war-archives";
     private static final long SHADOW_DISCORD_ID = 0L;
+    private static final String PROMOTION_DISABLED_REASON = "Candidate-to-contest promotion is disabled.";
     private static final List<String> PREDICTION_LOCK_TITLES = List.of(
             "The Wagers Open",
             "The Archives Open",
@@ -79,6 +80,8 @@ public class CombatReplayContestLifecycleService {
     private final ReplayDispatchSerializer payloadSerializer;
 
     public void promoteBestCandidateIfDue() {
+        if (!settings.getPromotion().isEnabled()) return;
+
         LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
         int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
         if (maxPromotionsPerHour <= 0) return;
@@ -111,6 +114,7 @@ public class CombatReplayContestLifecycleService {
 
     public ForcePromoteResult forcePromoteCandidate(Long candidateId) {
         if (candidateId == null) return ForcePromoteResult.rejected("candidateId is required");
+        if (!settings.getPromotion().isEnabled()) return ForcePromoteResult.rejected(PROMOTION_DISABLED_REASON);
 
         CombatCandidateEntity candidate =
                 candidateRepository.findById(candidateId).orElse(null);

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -1,0 +1,60 @@
+package ti4.contest.replay.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.dispatch.ReplayDispatchSerializer;
+import ti4.contest.replay.repository.CombatCandidateEventRepository;
+import ti4.contest.replay.repository.CombatCandidateRepository;
+import ti4.contest.replay.repository.CombatObservationRepository;
+import ti4.contest.replay.repository.CombatReplayContestRepository;
+
+class CombatReplayContestLifecycleServiceTest {
+
+    @Test
+    void promoteBestCandidateIfDueDoesNothingWhenCandidatePromotionIsDisabled() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(false);
+        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
+
+        service.promoteBestCandidateIfDue();
+
+        verifyNoInteractions(candidateRepository, replayContestRepository);
+    }
+
+    @Test
+    void forcePromoteCandidateRejectsWhenCandidatePromotionIsDisabled() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(false);
+        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
+
+        CombatReplayContestLifecycleService.ForcePromoteResult result = service.forcePromoteCandidate(1L);
+
+        assertFalse(result.promoted());
+        assertEquals("Candidate-to-contest promotion is disabled.", result.reason());
+        verifyNoInteractions(candidateRepository, replayContestRepository);
+    }
+
+    private CombatReplayContestLifecycleService service(
+            CombatContestSettings settings,
+            CombatCandidateRepository candidateRepository,
+            CombatReplayContestRepository replayContestRepository) {
+        return new CombatReplayContestLifecycleService(
+                settings,
+                candidateRepository,
+                mock(CombatObservationRepository.class),
+                replayContestRepository,
+                mock(CombatCandidateEventRepository.class),
+                mock(CombatReplayLeaderboardService.class),
+                mock(CombatReplaySideBetService.class),
+                mock(ReplayDispatchSerializer.class));
+    }
+}


### PR DESCRIPTION
## Summary
- Disable candidate-to-contest promotion in the Lazax Fight Club lifecycle service.
- Keep candidate collection, resolution, and existing replay execution paths untouched.
- Reject debug/immediate force promotion while the shutoff is active.

## Test Plan
- `mvn -Dtest=CombatReplayContestLifecycleServiceTest test`