### PR TITLE
Fix combat replay snapshots and side bet payouts

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -17,7 +17,7 @@ public class CombatContestSettings {
     public static final int PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS = 8;
 
     @Setter(AccessLevel.NONE)
-    private boolean isProd = true;
+    private boolean isProd = false;
 
     private CandidateSelection candidateSelection = new CandidateSelection();
     private Promotion promotion = new Promotion();

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -17,7 +17,7 @@ public class CombatContestSettings {
     public static final int PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS = 8;
 
     @Setter(AccessLevel.NONE)
-    private boolean isProd = false;
+    private boolean isProd = true;
 
     private CandidateSelection candidateSelection = new CandidateSelection();
     private Promotion promotion = new Promotion();

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -79,7 +79,7 @@ public class CombatContestSettings {
 
     private void applyEnvironmentDefaults() {
         if (isProd) {
-            replayExecution.setStartDelayMinutes(10);
+            replayExecution.setStartDelayMinutes(15);
             replayExecution.setReplayIntervalSeconds(15);
             replayExecution.setMaxEventGapSeconds(30);
             runtime.setDevMode(false);
@@ -123,7 +123,7 @@ public class CombatContestSettings {
     @Getter
     @Setter
     public static class ReplayExecution {
-        private int startDelayMinutes = 10;
+        private int startDelayMinutes = 15;
         private int replayIntervalSeconds = 15;
         private int maxEventGapSeconds = 30;
     }

--- a/src/main/java/ti4/contest/replay/core/CombatReplayDecoys.java
+++ b/src/main/java/ti4/contest/replay/core/CombatReplayDecoys.java
@@ -97,8 +97,6 @@ public class CombatReplayDecoys {
     }
 
     private void addDecoyUnits(List<DecoyUnit> decoyUnits, Player player, Tile tile) {
-        if (!player.hasAbility("decoy")) return;
-
         UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
         for (UnitKey unitKey : space.getUnitsByState().keySet()) {
             if (!player.getColorID().equals(unitKey.getColorID())) continue;

--- a/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
+++ b/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
@@ -13,7 +13,7 @@ public enum CombatSideBetType {
     /** Current AFB side bet: player skips available anti-fighter barrage. */
     AFB_SKIPPED("Skips AFB", UnitEmojis.destroyer, 1, 6),
     /** Current AFB side bet: player rolls AFB and scores zero hits. */
-    AFB_WHIFF("AFB Whiff", UnitEmojis.destroyer, 2, 4),
+    AFB_WHIFF("AFB Whiff", UnitEmojis.destroyer, 0, 4),
     /** Current dynamic side bet: player scores zero hits in their first combat roll. */
     ROUND_ONE_WHIFF("R1 Whiff", DiceEmojis.d10red_1, 0, 10),
     /** Current dynamic side bet: every die in player's first combat roll hits. */

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateEventRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateEventRepository.java
@@ -22,5 +22,8 @@ public interface CombatCandidateEventRepository extends JpaRepository<CombatCand
     @Query("select max(e.roundNumber) from CombatCandidateEventEntity e where e.candidateId = :candidateId")
     Optional<Integer> findMaxRoundNumberByCandidateId(@Param("candidateId") Long candidateId);
 
+    @Query("select max(e.sequenceNumber) from CombatCandidateEventEntity e where e.candidateId = :candidateId")
+    Optional<Integer> findMaxSequenceNumberByCandidateId(@Param("candidateId") Long candidateId);
+
     List<CombatCandidateEventEntity> findByOccurredAtBefore(LocalDateTime occurredAt);
 }

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
@@ -1,11 +1,8 @@
 package ti4.contest.replay.repository;
 
-import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import ti4.contest.replay.core.CombatCandidatePromotionStatus;
@@ -15,10 +12,6 @@ import ti4.contest.replay.entities.CombatCandidateEntity;
 public interface CombatCandidateRepository extends JpaRepository<CombatCandidateEntity, Long> {
     CombatCandidateEntity findFirstByGameNameAndTilePositionAndStatus(
             String gameName, String tilePosition, CombatCandidateStatus status);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select c from CombatCandidateEntity c where c.id = :id")
-    Optional<CombatCandidateEntity> findByIdForUpdate(@Param("id") Long id);
 
     List<CombatCandidateEntity> findByGameNameAndStatus(String gameName, CombatCandidateStatus status);
 

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayLeaderboardEntryRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayLeaderboardEntryRepository.java
@@ -1,23 +1,16 @@
 package ti4.contest.replay.repository;
 
-import jakarta.persistence.LockModeType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
 
 public interface CombatReplayLeaderboardEntryRepository
         extends JpaRepository<CombatReplayLeaderboardEntryEntity, Long> {
     List<CombatReplayLeaderboardEntryEntity> findByDiscordUserIdIn(Collection<String> discordUserIds);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select e from CombatReplayLeaderboardEntryEntity e where e.discordUserId = :discordUserId")
-    Optional<CombatReplayLeaderboardEntryEntity> findByDiscordUserIdForUpdate(
-            @Param("discordUserId") String discordUserId);
+    Optional<CombatReplayLeaderboardEntryEntity> findByDiscordUserId(String discordUserId);
 
     List<CombatReplayLeaderboardEntryEntity>
             findTop10ByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc();

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayPredictionRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayPredictionRepository.java
@@ -6,6 +6,4 @@ import ti4.contest.replay.entities.CombatReplayPredictionEntity;
 
 public interface CombatReplayPredictionRepository extends JpaRepository<CombatReplayPredictionEntity, Long> {
     Optional<CombatReplayPredictionEntity> findByContestId(Long contestId);
-
-    void deleteByContestId(Long contestId);
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -80,8 +80,10 @@ public class CombatReplayContestLifecycleService {
         if (!settings.getPromotion().isEnabled()) return;
 
         LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        if (now.getMinute() != 0) return;
         int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
         if (maxPromotionsPerHour <= 0) return;
+        if (replayContestRepository.countByPostedAtGreaterThanEqual(now.minusHours(2)) > 0) return;
         if (replayContestRepository.countByPostedAtGreaterThanEqual(now.truncatedTo(ChronoUnit.HOURS))
                 >= maxPromotionsPerHour) {
             return;

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -29,6 +29,7 @@ import ti4.contest.replay.repository.*;
 import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.game.Tile;
 import ti4.game.persistence.GameManager;
 import ti4.helpers.RandomHelper;
 import ti4.helpers.ThreadGetter;
@@ -156,10 +157,7 @@ public class CombatReplayContestLifecycleService {
         Game game = loadGame(winner.getGameName());
         if (game == null) return null;
 
-        String startSummaryText = candidateEventRepository
-                .findByCandidateIdAndSequenceNumber(winner.getId(), 1)
-                .map(CombatCandidateEventEntity::getSummaryText)
-                .orElse(null);
+        String startSummaryText = snapshotStartSummaryText(winner);
         String message = LazaxCombatSupport.formatReplayAnnouncement(
                 game, observation, winner, getLazaxRoleMention(), startSummaryText);
         if (!settings.getRuntime().isDiscordPostingEnabled()) {
@@ -182,6 +180,22 @@ public class CombatReplayContestLifecycleService {
             BotLogger.error("Replay contest promotion failed.", e);
             return null;
         }
+    }
+
+    String snapshotStartSummaryText(CombatCandidateEntity candidate) {
+        if (StringUtils.isBlank(candidate.getInitialRenderSnapshotJson())) return null;
+
+        Game snapshotGame = CombatReplayTileRenderer.render(
+                candidate.getInitialRenderSnapshotJson(), candidate.getInitialRenderSnapshotJson());
+        if (snapshotGame == null) return null;
+        Player attacker = snapshotGame.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = snapshotGame.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        Tile tile = snapshotGame.getTileByPosition(candidate.getTilePosition());
+        if (attacker == null || defender == null || tile == null) return null;
+
+        LazaxCombatSupport.SpaceCombatSnapshot snapshot =
+                LazaxCombatSupport.buildSpaceCombatSnapshot(snapshotGame, attacker, defender, tile);
+        return snapshot == null ? null : snapshot.replaySummaryText();
     }
 
     @SneakyThrows

--- a/src/main/java/ti4/contest/replay/service/CombatReplayEventAppender.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayEventAppender.java
@@ -1,6 +1,5 @@
 package ti4.contest.replay.service;
 
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,8 +23,7 @@ public class CombatReplayEventAppender {
     private final CombatCandidateEventRepository candidateEventRepository;
     private final ReplayDispatchSerializer payloadSerializer;
 
-    @Transactional
-    public void appendEvent(
+    public synchronized void appendEvent(
             CombatCandidateEntity candidate,
             CombatCandidateEventType eventType,
             Integer roundNumber,
@@ -33,16 +31,17 @@ public class CombatReplayEventAppender {
             String summaryText,
             ReplayDispatchPayload payload) {
         CombatCandidateEntity freshCandidate =
-                candidateRepository.findByIdForUpdate(candidate.getId()).orElse(null);
+                candidateRepository.findById(candidate.getId()).orElse(null);
         if (freshCandidate == null) return;
         if (freshCandidate.getStatus() != CombatCandidateStatus.TRACKING
                 && eventType != CombatCandidateEventType.RESOLVED
                 && eventType != CombatCandidateEventType.CANCELLED) return;
 
+        int sequenceNumber = nextSequenceNumber(freshCandidate);
         CombatCandidateEventEntity event = new CombatCandidateEventEntity();
         event.setCandidateId(freshCandidate.getId());
         event.setOccurredAt(LocalDateTime.now());
-        event.setSequenceNumber(freshCandidate.getNextEventSequence());
+        event.setSequenceNumber(sequenceNumber);
         event.setEventType(eventType);
         event.setRoundNumber(roundNumber);
         event.setActorFaction(actorFaction);
@@ -50,7 +49,15 @@ public class CombatReplayEventAppender {
         event.setPayloadJson(payloadSerializer.write(payload));
         candidateEventRepository.save(event);
 
-        freshCandidate.setNextEventSequence(freshCandidate.getNextEventSequence() + 1);
+        freshCandidate.setNextEventSequence(sequenceNumber + 1);
         candidateRepository.save(freshCandidate);
+    }
+
+    private int nextSequenceNumber(CombatCandidateEntity candidate) {
+        int nextFromEvents = candidateEventRepository
+                        .findMaxSequenceNumberByCandidateId(candidate.getId())
+                        .orElse(0)
+                + 1;
+        return Math.max(candidate.getNextEventSequence(), nextFromEvents);
     }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -18,7 +18,6 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayChannels;
 import ti4.contest.replay.entities.CombatCandidateEntity;
@@ -101,10 +100,9 @@ public class CombatReplayLeaderboardService {
         replayPredictionRepository.save(lockedPrediction);
     }
 
-    @Transactional
     public void clearLockedPredictions(Long replayContestId) {
         if (replayContestId == null) return;
-        replayPredictionRepository.deleteByContestId(replayContestId);
+        replayPredictionRepository.findByContestId(replayContestId).ifPresent(replayPredictionRepository::delete);
     }
 
     public void finalizeReplayLeaderboardContest(
@@ -113,12 +111,7 @@ public class CombatReplayLeaderboardService {
         if (replayContest.getId() == null) return;
         if (replayContest.getLeaderboardPostedAt() != null) return;
 
-        CombatReplayPredictionEntity lockedPrediction = replayPredictionRepository
-                .findByContestId(replayContest.getId())
-                .orElse(null);
-        ScoredContestResult result = lockedPrediction == null
-                ? scoreSideBetOnlyContest(candidate, replayContest)
-                : scoreContest(candidate, replayContest, lockedPrediction);
+        ScoredContestResult result = scoreReplayContest(candidate, replayContest);
         MessageChannel threadOrChannel = getContestThreadOrChannel(replayContest);
         if (threadOrChannel != null) {
             postPredictionResultsSummary(game, threadOrChannel, candidate, result, () -> {
@@ -229,6 +222,16 @@ public class CombatReplayLeaderboardService {
             CombatCandidateEntity candidate, CombatReplayContestEntity replayContest) {
         SideBetResolution sideBetResolution = sideBetService.resolveSideBets(candidate, replayContest);
         return new ScoredContestResult(0, List.of(), sideBetResolution.resolvedSideBets());
+    }
+
+    private synchronized ScoredContestResult scoreReplayContest(
+            CombatCandidateEntity candidate, CombatReplayContestEntity replayContest) {
+        CombatReplayPredictionEntity lockedPrediction = replayPredictionRepository
+                .findByContestId(replayContest.getId())
+                .orElse(null);
+        return lockedPrediction == null
+                ? scoreSideBetOnlyContest(candidate, replayContest)
+                : scoreContest(candidate, replayContest, lockedPrediction);
     }
 
     private ScoredContestResult scoreContest(

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -1,10 +1,11 @@
 package ti4.contest.replay.service;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -41,12 +42,35 @@ public class CombatReplayService {
     private final CombatCandidateEventRepository candidateEventRepository;
     private final CombatReplayEventAppender eventAppender;
     private final CombatReplaySideBetTriggerService sideBetTriggerService;
+    private final ThreadLocal<PreInteractionSnapshot> preInteractionSnapshot = new ThreadLocal<>();
     private CombatReplaySelection selection;
 
     @PostConstruct
     void initializeSelectionSnapshot() {
         selection = new CombatReplaySelection(settings);
         refreshSelectionSnapshot();
+    }
+
+    public PreInteractionSnapshot capturePreInteractionSnapshot(Game game) {
+        if (game == null) return PreInteractionSnapshot.empty();
+
+        Map<Long, CandidateInitialSnapshot> snapshots = new HashMap<>();
+        for (CombatCandidateEntity candidate : getTrackingCandidates(game)) {
+            if (isInitialSnapshotCaptured(candidate)) continue;
+            CandidateInitialSnapshot snapshot = captureCandidateInitialSnapshot(game, candidate);
+            if (snapshot != null) {
+                snapshots.put(candidate.getId(), snapshot);
+            }
+        }
+        return new PreInteractionSnapshot(snapshots);
+    }
+
+    public void setPreInteractionSnapshot(PreInteractionSnapshot snapshot) {
+        preInteractionSnapshot.set(snapshot);
+    }
+
+    public void clearPreInteractionSnapshot() {
+        preInteractionSnapshot.remove();
     }
 
     public void onSpaceCombatStarted(Game game, Player attacker, Player defender, Tile tile) {
@@ -68,25 +92,17 @@ public class CombatReplayService {
 
         if (!eligible) return;
 
-        CombatCandidateEntity candidate = buildCandidate(
-                observation,
-                attacker,
-                defender,
-                tile,
-                CombatReplayTileRenderer.captureInitialSnapshot(game, tile.getPosition()));
+        CombatCandidateEntity candidate = buildCandidate(observation, attacker, defender, tile);
         candidateRepository.save(candidate);
-
-        appendDiscordEvent(candidate, CombatCandidateEventType.START, null, null, snapshot.replaySummaryText());
     }
 
     public void onButtonInteractionSettled(Game game, Player player, ButtonInteractionEvent event) {
         for (CombatCandidateEntity candidate : getTrackingCandidates(game)) {
-            if (evaluateCandidateCompletion(game, candidate)) continue;
             trackHitAssignments(game, player, event, candidate);
+            evaluateCandidateCompletion(game, candidate);
         }
     }
 
-    @Transactional
     public void mirrorCombatRoll(
             Game game,
             Player player,
@@ -101,6 +117,7 @@ public class CombatReplayService {
         if (candidate == null || !matchesParticipants(candidate, player, opponent)) return;
         if (!isSpaceCombatRoll(rollType)) return;
 
+        ensureInitialSnapshot(candidate, game);
         int round = getCurrentRound(game, candidate);
         updateCandidateRollTracking(candidate, player, rollType, whiff, slam, round);
         appendDiscordEvent(
@@ -118,13 +135,11 @@ public class CombatReplayService {
         return rollType == CombatRollType.combatround || rollType == CombatRollType.AFB;
     }
 
-    @Transactional
     public void mirrorCombatEvent(
             Game game, Player player, String header, String name, MessageEmbed embed, String sourceChannelName) {
         mirrorCombatEvent(game, player, header, name, embed, sourceChannelName, CombatReplayTrackedEvent.NONE);
     }
 
-    @Transactional
     public void mirrorCombatEvent(
             Game game,
             Player player,
@@ -135,6 +150,7 @@ public class CombatReplayService {
             CombatReplayTrackedEvent trackedEvent) {
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
+        ensureInitialSnapshot(candidate, game);
         updateCandidateEventTracking(candidate, player, trackedEvent);
 
         String message = "## " + header + "\n" + player.getRepresentation() + " " + name;
@@ -142,10 +158,10 @@ public class CombatReplayService {
         appendSideBetTriggerEvents(candidate, sideBetTriggerService.fromTrackedEvent(candidate, player, trackedEvent));
     }
 
-    @Transactional
     public void mirrorLeaderPlayed(Game game, Player player, String leaderId, String sourceChannelName) {
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
+        ensureInitialSnapshot(candidate, game);
 
         appendStructuredEvent(
                 candidate,
@@ -156,7 +172,6 @@ public class CombatReplayService {
                 ReplayDispatchPayload.leaderPlayed(leaderId));
     }
 
-    @Transactional
     public void mirrorActionCardPlayed(
             Game game,
             Player player,
@@ -165,6 +180,7 @@ public class CombatReplayService {
             CombatReplayTrackedEvent trackedEvent) {
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
+        ensureInitialSnapshot(candidate, game);
         updateCandidateEventTracking(candidate, player, trackedEvent);
 
         appendStructuredEvent(
@@ -180,6 +196,7 @@ public class CombatReplayService {
     public void mirrorRetreatDeclared(Game game, Player player, String sourceChannelName) {
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
+        ensureInitialSnapshot(candidate, game);
 
         appendStructuredEvent(
                 candidate,
@@ -193,6 +210,7 @@ public class CombatReplayService {
     public void mirrorRetreatResolved(Game game, Player player, String destination, String sourceChannelName) {
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
+        ensureInitialSnapshot(candidate, game);
 
         appendStructuredEvent(
                 candidate,
@@ -206,6 +224,7 @@ public class CombatReplayService {
     public void mirrorAssaultCannonAssigned(Game game, Player player, String sourceChannelName) {
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
+        ensureInitialSnapshot(candidate, game);
 
         appendStructuredEvent(
                 candidate,
@@ -219,6 +238,7 @@ public class CombatReplayService {
     public void mirrorGravitonExhausted(Game game, Player player, String sourceChannelName) {
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
+        ensureInitialSnapshot(candidate, game);
 
         appendStructuredEvent(
                 candidate,
@@ -357,6 +377,7 @@ public class CombatReplayService {
                 .equals(getTilePosition(event.getButton().getCustomId()))) return;
         if (!matchesParticipant(candidate, player)) return;
 
+        ensureInitialSnapshot(candidate, game);
         int round = getCurrentRound(game, candidate);
         if (candidateEventRepository.existsByCandidateIdAndEventTypeAndActorFactionAndRoundNumber(
                 candidate.getId(), CombatCandidateEventType.HIT_ASSIGN, player.getFaction(), round)) {
@@ -376,6 +397,58 @@ public class CombatReplayService {
                 ReplayDispatchPayload.hitAssign(
                         candidate.getTilePosition(),
                         CombatReplayTileRenderer.captureUnitStateSnapshot(game, candidate.getTilePosition())));
+    }
+
+    private void ensureInitialSnapshot(CombatCandidateEntity candidate, Game fallbackGame) {
+        if (isInitialSnapshotCaptured(candidate)) return;
+
+        CandidateInitialSnapshot snapshot = null;
+        PreInteractionSnapshot currentSnapshot = preInteractionSnapshot.get();
+        if (currentSnapshot != null) {
+            snapshot = currentSnapshot.forCandidate(candidate.getId());
+        }
+        if (snapshot == null) {
+            snapshot = captureCandidateInitialSnapshot(fallbackGame, candidate);
+        }
+        if (snapshot == null) return;
+
+        candidate.setPreReplayContextText(snapshot.preReplayContextText());
+        candidate.setInitialRenderSnapshotJson(snapshot.initialRenderSnapshotJson());
+        candidate.setReplayAbilitiesJson(snapshot.replayAbilitiesJson());
+        candidate.setAttackerDestroyerCount(snapshot.attackerDestroyerCount());
+        candidate.setDefenderDestroyerCount(snapshot.defenderDestroyerCount());
+        candidate.setAttackerHasAssaultCannon(snapshot.attackerHasAssaultCannon());
+        candidate.setDefenderHasAssaultCannon(snapshot.defenderHasAssaultCannon());
+        candidate.setAttackerHp(snapshot.attackerHp());
+        candidate.setDefenderHp(snapshot.defenderHp());
+        candidateRepository.save(candidate);
+    }
+
+    private boolean isInitialSnapshotCaptured(CombatCandidateEntity candidate) {
+        return candidate.getInitialRenderSnapshotJson() != null
+                && !candidate.getInitialRenderSnapshotJson().isBlank();
+    }
+
+    private CandidateInitialSnapshot captureCandidateInitialSnapshot(Game game, CombatCandidateEntity candidate) {
+        if (game == null) return null;
+        Tile tile = game.getTileByPosition(candidate.getTilePosition());
+        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        if (tile == null || attacker == null || defender == null) return null;
+
+        LazaxCombatSupport.SpaceCombatSnapshot combatSnapshot =
+                LazaxCombatSupport.buildSpaceCombatSnapshot(game, attacker, defender, tile);
+        if (combatSnapshot == null) return null;
+        return new CandidateInitialSnapshot(
+                LazaxCombatSupport.formatCombatTechSummary(tile, attacker, defender),
+                CombatReplayTileRenderer.captureInitialSnapshot(game, tile.getPosition()),
+                CombatReplayDecoys.buildJson(attacker, defender, tile),
+                countDestroyersInCombat(tile, attacker),
+                countDestroyersInCombat(tile, defender),
+                hasAssaultCannon(attacker),
+                hasAssaultCannon(defender),
+                combatSnapshot.attackerHp(),
+                combatSnapshot.defenderHp());
     }
 
     private ResolutionState buildResolutionState(Game game, CombatCandidateEntity candidate, Tile tile) {
@@ -565,11 +638,7 @@ public class CombatReplayService {
     }
 
     private CombatCandidateEntity buildCandidate(
-            CombatObservationEntity observation,
-            Player attacker,
-            Player defender,
-            Tile tile,
-            String initialRenderSnapshotJson) {
+            CombatObservationEntity observation, Player attacker, Player defender, Tile tile) {
         CombatCandidateEntity candidate = new CombatCandidateEntity();
         candidate.setObservationId(observation.getId());
         candidate.setStatus(CombatCandidateStatus.TRACKING);
@@ -580,10 +649,6 @@ public class CombatReplayService {
         candidate.setTilePosition(observation.getTilePosition());
         candidate.setAttackerFaction(attacker.getFaction());
         candidate.setDefenderFaction(defender.getFaction());
-        candidate.setPreReplayContextText(LazaxCombatSupport.formatCombatTechSummary(
-                attacker.getGame().getTileByPosition(observation.getTilePosition()), attacker, defender));
-        candidate.setInitialRenderSnapshotJson(initialRenderSnapshotJson);
-        candidate.setReplayAbilitiesJson(CombatReplayDecoys.buildJson(attacker, defender, tile));
         candidate.setSideBetCompatible(true);
         candidate.setAttackerDestroyerCount(countDestroyersInCombat(tile, attacker));
         candidate.setDefenderDestroyerCount(countDestroyersInCombat(tile, defender));
@@ -734,6 +799,32 @@ public class CombatReplayService {
     private String firstNonBlank(String first, String fallback) {
         return first == null || first.isBlank() ? fallback : first;
     }
+
+    public record PreInteractionSnapshot(Map<Long, CandidateInitialSnapshot> snapshotsByCandidateId) {
+
+        public PreInteractionSnapshot {
+            snapshotsByCandidateId = Map.copyOf(snapshotsByCandidateId);
+        }
+
+        public static PreInteractionSnapshot empty() {
+            return new PreInteractionSnapshot(Map.of());
+        }
+
+        private CandidateInitialSnapshot forCandidate(Long candidateId) {
+            return snapshotsByCandidateId.get(candidateId);
+        }
+    }
+
+    public record CandidateInitialSnapshot(
+            String preReplayContextText,
+            String initialRenderSnapshotJson,
+            String replayAbilitiesJson,
+            int attackerDestroyerCount,
+            int defenderDestroyerCount,
+            boolean attackerHasAssaultCannon,
+            boolean defenderHasAssaultCannon,
+            double attackerHp,
+            double defenderHp) {}
 
     private record SelectionSnapshot(
             int windowSize,

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
@@ -78,6 +78,12 @@ public class CombatReplaySideBetPayoutService {
         return offeredProfitPoints == null ? sideBet.getBetType().profitPoints() : offeredProfitPoints;
     }
 
+    public boolean hasAfbUnits(CombatCandidateEntity candidate, String targetFaction) {
+        InitialSnapshotCombatContext context = initialSnapshotCombatContext(candidate, targetFaction);
+        return context != null
+                && !collectAfbUnits(context.tile(), context.player()).isEmpty();
+    }
+
     private int fixedPayout(CombatSideBetType betType) {
         return betType.profitPoints();
     }
@@ -152,6 +158,7 @@ public class CombatReplaySideBetPayoutService {
         if (context == null) return null;
 
         Map<UnitModel, Integer> playerUnits = collectAfbUnits(context.tile(), context.player());
+        if (playerUnits.isEmpty()) return null;
         Map<UnitModel, Integer> opponentUnits =
                 CombatUnitSelectionHelper.collectCombatRoundUnits(context.tile(), context.space(), context.opponent());
         TileModel tileModel = TileHelper.getTileById(context.tile().getTileID());

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
@@ -1,34 +1,29 @@
 package ti4.contest.replay.service;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatContestSettings;
-import ti4.contest.replay.core.CombatRollPayload;
-import ti4.contest.replay.core.CombatRollPayload.RollSegmentType;
 import ti4.contest.replay.core.CombatSideBetType;
+import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
-import ti4.contest.replay.dispatch.ReplayDispatchPayload;
-import ti4.contest.replay.dispatch.ReplayDispatchSerializer;
 import ti4.contest.replay.entities.CombatCandidateEntity;
-import ti4.contest.replay.entities.CombatCandidateEventEntity;
 import ti4.contest.replay.entities.CombatContestSideBetEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
-import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.helpers.CombatModHelper;
 import ti4.helpers.Constants;
+import ti4.image.Mapper;
 import ti4.image.TileHelper;
 import ti4.model.NamedCombatModifierModel;
 import ti4.model.TileModel;
 import ti4.model.UnitModel;
+import ti4.service.combat.CombatRollService;
 import ti4.service.combat.CombatRollType;
 import ti4.service.combat.CombatStatsService;
 import ti4.service.combat.CombatUnitSelectionHelper;
@@ -42,16 +37,7 @@ public class CombatReplaySideBetPayoutService {
 
     public static final String ODDS_V1 = "ODDS_V1";
 
-    private static final EnumSet<RollSegmentType> OPENING_ROLL_SEGMENTS = EnumSet.of(
-            RollSegmentType.PRIMARY,
-            RollSegmentType.SUPERCHARGE_SELECTED_UNIT,
-            RollSegmentType.SUPERCHARGE_REST,
-            RollSegmentType.GRAVLEASH_SELECTED_UNIT,
-            RollSegmentType.GRAVLEASH_REST);
-
     private final CombatContestSettings settings;
-    private final CombatCandidateEventRepository candidateEventRepository;
-    private final ReplayDispatchSerializer payloadSerializer;
 
     public int offeredPayout(
             CombatReplayContestEntity contest,
@@ -59,25 +45,30 @@ public class CombatReplaySideBetPayoutService {
             CombatSideBetType betType,
             String targetFaction) {
         if (!ODDS_V1.equalsIgnoreCase(contest.getSideBetPayoutModel())
-                || (betType != CombatSideBetType.ROUND_ONE_WHIFF
+                || (betType != CombatSideBetType.AFB_WHIFF
+                        && betType != CombatSideBetType.ROUND_ONE_WHIFF
                         && betType != CombatSideBetType.ROUND_ONE_SLAM
                         && betType != CombatSideBetType.WINNER_ONE_HP)) {
             return fixedPayout(betType);
         }
 
         if (betType == CombatSideBetType.WINNER_ONE_HP) {
-            return candidate.getAttackerHp() == null || candidate.getDefenderHp() == null
+            InitialSnapshotCombatContext context = initialSnapshotCombatContext(candidate, null);
+            return context == null
                     ? fixedPayout(betType)
-                    : hpPayout(candidate.getAttackerHp(), candidate.getDefenderHp());
+                    : hpPayout(
+                            context.snapshot().attackerHp(), context.snapshot().defenderHp());
+        }
+
+        if (betType == CombatSideBetType.AFB_WHIFF) {
+            Double probability = afbWhiffProbabilityFromInitialSnapshot(candidate, targetFaction);
+            if (probability == null) return fixedPayout(betType);
+            return probability <= 0.0 ? maxDynamicPayout() : dynamicPayout(probability);
         }
 
         boolean slam = betType == CombatSideBetType.ROUND_ONE_SLAM;
         Double probability = openingRoundProbabilityFromInitialSnapshot(candidate, targetFaction, slam);
-        if (probability == null) {
-            CombatRollPayload payload = roundOnePayload(candidate, targetFaction);
-            if (payload == null) return fixedPayout(betType);
-            probability = eventProbability(payload.unitRolls(), slam);
-        }
+        if (probability == null) return fixedPayout(betType);
 
         return probability <= 0.0 ? maxDynamicPayout() : dynamicPayout(probability);
     }
@@ -111,48 +102,139 @@ public class CombatReplaySideBetPayoutService {
         double x = Math.max(0.0, totalHp - 8.0) / 52.0;
         int profitPoints = (int) Math.round(3.0 + Math.pow(x, 1.35) * (64.0 + 8.0 * Math.sqrt(balance)));
         profitPoints = Math.max(3, profitPoints);
-        return Math.min(settings.getSideBets().getDynamicPayoutCap(), profitPoints);
+        return Math.min(settings.getSideBets().getDynamicPayoutCap(), profitPoints * 2);
     }
 
     private Double openingRoundProbabilityFromInitialSnapshot(
             CombatCandidateEntity candidate, String targetFaction, boolean slam) {
+        InitialSnapshotCombatContext context = initialSnapshotCombatContext(candidate, targetFaction);
+        if (context == null) return null;
+
+        Map<UnitModel, Integer> playerUnits =
+                CombatUnitSelectionHelper.collectCombatRoundUnits(context.tile(), context.space(), context.player());
+        Map<UnitModel, Integer> opponentUnits =
+                CombatUnitSelectionHelper.collectCombatRoundUnits(context.tile(), context.space(), context.opponent());
+        TileModel tileModel = TileHelper.getTileById(context.tile().getTileID());
+        List<NamedCombatModifierModel> hitModifiers = CombatModHelper.getModifiers(
+                context.player(),
+                context.opponent(),
+                playerUnits,
+                opponentUnits,
+                tileModel,
+                context.game(),
+                CombatRollType.combatround,
+                Constants.COMBAT_MODIFIERS);
+        List<NamedCombatModifierModel> extraRollModifiers = CombatModHelper.getModifiers(
+                context.player(),
+                context.opponent(),
+                playerUnits,
+                opponentUnits,
+                tileModel,
+                context.game(),
+                CombatRollType.combatround,
+                Constants.COMBAT_EXTRA_ROLLS);
+
+        return eventProbability(
+                playerUnits,
+                context.player(),
+                context.opponent(),
+                context.game(),
+                context.tile(),
+                context.space(),
+                hitModifiers,
+                extraRollModifiers,
+                CombatRollType.combatround,
+                slam);
+    }
+
+    private Double afbWhiffProbabilityFromInitialSnapshot(CombatCandidateEntity candidate, String targetFaction) {
+        InitialSnapshotCombatContext context = initialSnapshotCombatContext(candidate, targetFaction);
+        if (context == null) return null;
+
+        Map<UnitModel, Integer> playerUnits = collectAfbUnits(context.tile(), context.player());
+        Map<UnitModel, Integer> opponentUnits =
+                CombatUnitSelectionHelper.collectCombatRoundUnits(context.tile(), context.space(), context.opponent());
+        TileModel tileModel = TileHelper.getTileById(context.tile().getTileID());
+        List<NamedCombatModifierModel> hitModifiers = CombatModHelper.getModifiers(
+                context.player(),
+                context.opponent(),
+                playerUnits,
+                opponentUnits,
+                tileModel,
+                context.game(),
+                CombatRollType.AFB,
+                Constants.COMBAT_MODIFIERS);
+        List<NamedCombatModifierModel> extraRollModifiers = CombatModHelper.getModifiers(
+                context.player(),
+                context.opponent(),
+                playerUnits,
+                opponentUnits,
+                tileModel,
+                context.game(),
+                CombatRollType.AFB,
+                Constants.COMBAT_EXTRA_ROLLS);
+
+        return eventProbability(
+                playerUnits,
+                context.player(),
+                context.opponent(),
+                context.game(),
+                context.tile(),
+                context.space(),
+                hitModifiers,
+                extraRollModifiers,
+                CombatRollType.AFB,
+                false);
+    }
+
+    private Map<UnitModel, Integer> collectAfbUnits(Tile tile, Player player) {
+        Map<String, Integer> unitsByAsyncId = new java.util.HashMap<>();
+        String colorId = Mapper.getColorID(player.getColor());
+        for (UnitHolder holder : tile.getUnitHolders().values()) {
+            for (Map.Entry<String, Integer> entry :
+                    holder.getUnitAsyncIdsOnHolder(colorId).entrySet()) {
+                unitsByAsyncId.merge(entry.getKey(), entry.getValue(), Integer::sum);
+            }
+        }
+
+        Map<UnitModel, Integer> afbUnits = new java.util.HashMap<>();
+        for (Map.Entry<String, Integer> entry : unitsByAsyncId.entrySet()) {
+            UnitModel unit = player.getPriorityUnitByAsyncID(entry.getKey(), null);
+            if (unit != null && unit.getAfbDieCount(player) > 0) {
+                afbUnits.put(unit, entry.getValue());
+            }
+        }
+        if (player.hasRelic("metalivoidarmaments")) {
+            afbUnits.put(CombatRollService.getMetaliAFBUnit(player), 1);
+        }
+        return afbUnits;
+    }
+
+    private InitialSnapshotCombatContext initialSnapshotCombatContext(
+            CombatCandidateEntity candidate, String targetFaction) {
         String snapshotJson = candidate.getInitialRenderSnapshotJson();
         if (snapshotJson == null || snapshotJson.isBlank()) return null;
 
         Game game = CombatReplayTileRenderer.render(snapshotJson, snapshotJson);
         if (game == null) return null;
         Tile tile = game.getTileByPosition(candidate.getTilePosition());
-        if (tile == null) tile = game.getTileByPosition(game.getActiveSystem());
-        Player player = game.getPlayerFromColorOrFaction(targetFaction);
-        Player opponent = opponentFor(game, candidate, targetFaction);
+        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        Player player = targetFaction == null ? attacker : game.getPlayerFromColorOrFaction(targetFaction);
+        Player opponent = targetFaction == null ? defender : opponentFor(game, candidate, targetFaction);
         UnitHolder space = tile == null ? null : tile.getUnitHolders().get(Constants.SPACE);
-        if (tile == null || player == null || opponent == null || space == null) return null;
-
-        Map<UnitModel, Integer> playerUnits = CombatUnitSelectionHelper.collectCombatRoundUnits(tile, space, player);
-        Map<UnitModel, Integer> opponentUnits =
-                CombatUnitSelectionHelper.collectCombatRoundUnits(tile, space, opponent);
-        TileModel tileModel = TileHelper.getTileById(tile.getTileID());
-        List<NamedCombatModifierModel> hitModifiers = CombatModHelper.getModifiers(
-                player,
-                opponent,
-                playerUnits,
-                opponentUnits,
-                tileModel,
-                game,
-                CombatRollType.combatround,
-                Constants.COMBAT_MODIFIERS);
-        List<NamedCombatModifierModel> extraRollModifiers = CombatModHelper.getModifiers(
-                player,
-                opponent,
-                playerUnits,
-                opponentUnits,
-                tileModel,
-                game,
-                CombatRollType.combatround,
-                Constants.COMBAT_EXTRA_ROLLS);
-
-        return eventProbability(
-                playerUnits, player, opponent, game, tile, space, hitModifiers, extraRollModifiers, slam);
+        if (tile == null
+                || attacker == null
+                || defender == null
+                || player == null
+                || opponent == null
+                || space == null) {
+            return null;
+        }
+        LazaxCombatSupport.SpaceCombatSnapshot snapshot =
+                LazaxCombatSupport.buildSpaceCombatSnapshot(game, attacker, defender, tile);
+        if (snapshot == null) return null;
+        return new InitialSnapshotCombatContext(game, tile, space, player, opponent, snapshot);
     }
 
     private Player opponentFor(Game game, CombatCandidateEntity candidate, String targetFaction) {
@@ -171,6 +253,7 @@ public class CombatReplaySideBetPayoutService {
             UnitHolder space,
             List<NamedCombatModifierModel> hitModifiers,
             List<NamedCombatModifierModel> extraRollModifiers,
+            CombatRollType rollType,
             boolean slam) {
         double probability = 1.0;
         int dice = 0;
@@ -178,90 +261,40 @@ public class CombatReplaySideBetPayoutService {
         for (Map.Entry<UnitModel, Integer> entry : unitCounts.entrySet()) {
             UnitModel unit = entry.getKey();
             int quantity = entry.getValue();
-            CombatStatsService.CombatRoundProfile profile =
-                    CombatStatsService.getCombatRoundProfile(true, unit, player, tile, opponent, false);
-            int modifier = CombatModHelper.getCombinedModifierForUnit(
-                    unit,
-                    quantity,
-                    hitModifiers,
-                    player,
-                    opponent,
-                    game,
-                    playerUnitTypes,
-                    CombatRollType.combatround,
-                    tile,
-                    space);
-            int extraDice = CombatModHelper.getCombinedModifierForUnit(
-                    unit,
-                    quantity,
-                    extraRollModifiers,
-                    player,
-                    opponent,
-                    game,
-                    playerUnitTypes,
-                    CombatRollType.combatround,
-                    tile,
-                    space);
-            int diceCount = Math.max(0, quantity * profile.diceCount() + extraDice);
-            if (diceCount == 0) continue;
-            double hitChance = hitChance(profile.hitsOn() - modifier);
-            probability *= Math.pow(slam ? hitChance : 1.0 - hitChance, diceCount);
-            dice += diceCount;
-        }
-        return dice == 0 ? 0.0 : probability;
-    }
-
-    private CombatRollPayload roundOnePayload(CombatCandidateEntity candidate, String targetFaction) {
-        for (CombatCandidateEventEntity event :
-                candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId())) {
-            if (event.getEventType() != CombatCandidateEventType.ROLL) continue;
-            if (!Integer.valueOf(1).equals(event.getRoundNumber())) continue;
-            if (!targetFaction.equalsIgnoreCase(event.getActorFaction())) continue;
-
-            CombatRollPayload payload = readCombatRollPayload(event);
-            if (isRoundOneCombatPayload(payload)) {
-                return payload;
+            int dicePerUnit;
+            int hitsOn;
+            if (rollType == CombatRollType.combatround) {
+                CombatStatsService.CombatRoundProfile profile =
+                        CombatStatsService.getCombatRoundProfile(true, unit, player, tile, opponent, false);
+                dicePerUnit = profile.diceCount();
+                hitsOn = profile.hitsOn();
+            } else {
+                dicePerUnit = unit.getCombatDieCountForAbility(rollType, player);
+                hitsOn = unit.getCombatDieHitsOnForAbility(rollType, player);
             }
-        }
-        return null;
-    }
-
-    private CombatRollPayload readCombatRollPayload(CombatCandidateEventEntity event) {
-        ReplayDispatchPayload payload = payloadSerializer.read(event);
-        if (payload instanceof ReplayDispatchPayload.CombatRollDispatch combatRoll) {
-            return combatRoll.payload();
-        }
-        return null;
-    }
-
-    private boolean isRoundOneCombatPayload(CombatRollPayload payload) {
-        if (payload == null) return false;
-        CombatRollPayload.RollHeader header = payload.header();
-        return header != null && header.rollType() == CombatRollType.combatround;
-    }
-
-    private double eventProbability(List<CombatRollPayload.UnitRoll> unitRolls, boolean slam) {
-        double probability = 1.0;
-        int dice = 0;
-        for (CombatRollPayload.UnitRoll unitRoll : unitRolls) {
-            int diceCount = openingDiceCount(unitRoll);
-            if (diceCount <= 0) continue;
-            double hitChance = hitChance(unitRoll.effectiveThreshold());
+            int modifier = CombatModHelper.getCombinedModifierForUnit(
+                    unit, quantity, hitModifiers, player, opponent, game, playerUnitTypes, rollType, tile, space);
+            int extraDice = CombatModHelper.getCombinedModifierForUnit(
+                    unit, quantity, extraRollModifiers, player, opponent, game, playerUnitTypes, rollType, tile, space);
+            int diceCount = Math.max(0, quantity * dicePerUnit + extraDice);
+            if (diceCount == 0) continue;
+            double hitChance = hitChance(hitsOn - modifier);
             probability *= Math.pow(slam ? hitChance : 1.0 - hitChance, diceCount);
             dice += diceCount;
         }
         return dice == 0 ? 0.0 : probability;
-    }
-
-    private int openingDiceCount(CombatRollPayload.UnitRoll unitRoll) {
-        if (!OPENING_ROLL_SEGMENTS.contains(unitRoll.segmentType())) return 0;
-        int recordedDice = unitRoll.dice().size();
-        if (recordedDice > 0) return recordedDice;
-        return Math.max(0, unitRoll.quantity() * unitRoll.dicePerUnit() + unitRoll.extraDice());
     }
 
     private double hitChance(int effectiveThreshold) {
         int boundedThreshold = Math.max(1, Math.min(11, effectiveThreshold));
         return Math.max(0.0, Math.min(1.0, (11 - boundedThreshold) / 10.0));
     }
+
+    private record InitialSnapshotCombatContext(
+            Game game,
+            Tile tile,
+            UnitHolder space,
+            Player player,
+            Player opponent,
+            LazaxCombatSupport.SpaceCombatSnapshot snapshot) {}
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -1,6 +1,5 @@
 package ti4.contest.replay.service;
 
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,51 +48,68 @@ public class CombatReplaySideBetService {
         sideBetUiService.postSideBetButtonsIfNeeded(channel, game, contest, candidate);
     }
 
-    @Transactional
     public PlacementResult placeSideBet(
             ButtonInteractionEvent event, Long contestId, CombatSideBetType betType, String targetFaction) {
         if (contestId == null || event == null || event.getUser() == null) {
             return PlacementResult.rejected("Side bet context is incomplete.");
         }
 
+        String userId = event.getUser().getId();
+        String userName = event.getUser().getEffectiveName();
+        PlacementPersistenceResult persisted = persistSideBet(contestId, betType, targetFaction, userId, userName);
+        if (!persisted.result().accepted()) return persisted.result();
+
+        sideBetUiService.refreshSummaryMessage(event.getMessageChannel(), persisted.contest(), persisted.candidate());
+        String personalSummary = sideBetUiService.renderUserSummary(
+                persisted.contest(),
+                persisted.candidate(),
+                userId,
+                persisted.result().totalPoints());
+        return PlacementResult.accepted(personalSummary, persisted.result().totalPoints());
+    }
+
+    private synchronized PlacementPersistenceResult persistSideBet(
+            Long contestId, CombatSideBetType betType, String targetFaction, String userId, String userName) {
         CombatReplayContestEntity contest =
                 replayContestRepository.findById(contestId).orElse(null);
-        if (contest == null) return PlacementResult.rejected("This combat contest is no longer available.");
-        if (!settings.getSideBets().isEnableSideBets()) return PlacementResult.rejected("Side bets are disabled.");
+        if (contest == null) {
+            return PlacementPersistenceResult.rejected("This combat contest is no longer available.");
+        }
+        if (!settings.getSideBets().isEnableSideBets()) {
+            return PlacementPersistenceResult.rejected("Side bets are disabled.");
+        }
         if (contest.getReplayStartAt() == null || !LocalDateTime.now().isBefore(contest.getReplayStartAt())) {
-            return PlacementResult.rejected("The side-bet window is closed.");
+            return PlacementPersistenceResult.rejected("The side-bet window is closed.");
         }
 
         CombatCandidateEntity candidate =
                 candidateRepository.findById(contest.getCandidateId()).orElse(null);
         if (candidate == null || !Boolean.TRUE.equals(candidate.getSideBetCompatible())) {
-            return PlacementResult.rejected("This combat does not support side bets.");
+            return PlacementPersistenceResult.rejected("This combat does not support side bets.");
         }
         if (!isValidBet(candidate, betType, targetFaction)) {
-            return PlacementResult.rejected("That side bet is not available for this combat.");
+            return PlacementPersistenceResult.rejected("That side bet is not available for this combat.");
         }
 
-        String userId = event.getUser().getId();
-        String userName = event.getUser().getEffectiveName();
-
         CombatReplayLeaderboardEntryEntity entry =
-                leaderboardEntryRepository.findByDiscordUserIdForUpdate(userId).orElse(null);
+                leaderboardEntryRepository.findByDiscordUserId(userId).orElse(null);
         if (entry == null) {
-            return PlacementResult.rejected("You do not have any points to bet.");
+            return PlacementPersistenceResult.rejected("You do not have any points to bet.");
         }
 
         int existingCount = sideBetRepository.countByContestIdAndDiscordUserId(contestId, userId);
         if (existingCount >= settings.getSideBets().getMaxBetsPerUser()) {
-            return PlacementResult.rejected("You have already placed the maximum number of side bets for this combat.");
+            return PlacementPersistenceResult.rejected(
+                    "You have already placed the maximum number of side bets for this combat.");
         }
 
         int costPoints = settings.getSideBets().getCostPoints();
         int currentPoints = safeInt(entry.getTotalPoints());
         if (currentPoints <= 0) {
-            return PlacementResult.rejected("You do not have any points to bet.");
+            return PlacementPersistenceResult.rejected("You do not have any points to bet.");
         }
         if (currentPoints < costPoints) {
-            return PlacementResult.rejected("You do not have enough points to place that side bet.");
+            return PlacementPersistenceResult.rejected("You do not have enough points to place that side bet.");
         }
 
         entry.setDiscordUserName(userName);
@@ -111,12 +127,11 @@ public class CombatReplaySideBetService {
         sideBet.setPlacedAt(LocalDateTime.now());
         sideBetRepository.save(sideBet);
 
-        sideBetUiService.refreshSummaryMessage(event.getMessageChannel(), contest, candidate);
-        String personalSummary = sideBetUiService.renderUserSummary(contest, candidate, userId, entry.getTotalPoints());
-        return PlacementResult.accepted(personalSummary, entry.getTotalPoints());
+        return new PlacementPersistenceResult(PlacementResult.accepted("", entry.getTotalPoints()), contest, candidate);
     }
 
-    public SideBetResolution resolveSideBets(CombatCandidateEntity candidate, CombatReplayContestEntity replayContest) {
+    public synchronized SideBetResolution resolveSideBets(
+            CombatCandidateEntity candidate, CombatReplayContestEntity replayContest) {
         if (candidate == null || replayContest == null || replayContest.getId() == null) {
             return SideBetResolution.empty();
         }
@@ -182,6 +197,13 @@ public class CombatReplaySideBetService {
     }
 
     public record ResolvedSideBet(String discordUserId, String discordUserName, String label, int profitPoints) {}
+
+    private record PlacementPersistenceResult(
+            PlacementResult result, CombatReplayContestEntity contest, CombatCandidateEntity candidate) {
+        static PlacementPersistenceResult rejected(String message) {
+            return new PlacementPersistenceResult(PlacementResult.rejected(message), null, null);
+        }
+    }
 
     public record SideBetResolution(
             List<ResolvedSideBet> resolvedSideBets, List<CombatReplayLeaderboardEntryEntity> leaderboardEntries) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -215,6 +215,7 @@ public class CombatReplaySideBetService {
     private boolean isValidBet(CombatCandidateEntity candidate, CombatSideBetType betType, String targetFaction) {
         CombatSideState state = CombatSideState.forFaction(candidate, targetFaction);
         if (state == null || !betType.isAvailable(state.destroyerCount())) return false;
+        if (betType == CombatSideBetType.AFB_WHIFF) return payoutService.hasAfbUnits(candidate, targetFaction);
         return betType != CombatSideBetType.AFB_SKIPPED || isAfbSkippedAvailable(candidate, targetFaction);
     }
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
@@ -96,6 +96,7 @@ public class CombatReplaySideBetUiService {
     private boolean isAvailableForFaction(
             CombatSideBetType type, CombatCandidateEntity candidate, String faction, CombatSideState state) {
         if (!type.isAvailable(state.destroyerCount())) return false;
+        if (type == CombatSideBetType.AFB_WHIFF) return payoutService.hasAfbUnits(candidate, faction);
         if (type != CombatSideBetType.AFB_SKIPPED) return true;
         return !(state.destroyerCount() == 1 && opponentHasAssaultCannon(candidate, faction));
     }

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -91,17 +91,24 @@ public class ButtonProcessor {
             RollbarManager.put("game_name", GameNameService.getGameNameFromChannel(event));
 
             if (context.isValid()) {
+                CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
+                CombatReplayService.PreInteractionSnapshot preInteractionSnapshot =
+                        combatReplayService.capturePreInteractionSnapshot(context.getGame());
+                combatReplayService.setPreInteractionSnapshot(preInteractionSnapshot);
                 long beforeTime = System.currentTimeMillis();
-                resolveButtonInteractionEvent(context);
-                resolveRuntime = System.currentTimeMillis() - beforeTime;
+                try {
+                    resolveButtonInteractionEvent(context);
+                    resolveRuntime = System.currentTimeMillis() - beforeTime;
 
-                beforeTime = System.currentTimeMillis();
-                context.save();
-                if (context.getGame() != null) {
-                    SpringContext.getBean(CombatReplayService.class)
-                            .onButtonInteractionSettled(context.getGame(), context.getPlayer(), event);
+                    beforeTime = System.currentTimeMillis();
+                    context.save();
+                    if (context.getGame() != null) {
+                        combatReplayService.onButtonInteractionSettled(context.getGame(), context.getPlayer(), event);
+                    }
+                    saveRuntime = System.currentTimeMillis() - beforeTime;
+                } finally {
+                    combatReplayService.clearPreInteractionSnapshot();
                 }
-                saveRuntime = System.currentTimeMillis() - beforeTime;
             }
         } catch (Exception e) {
             LogOrigin origin = new LogOrigin(event, context);

--- a/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.listeners.context.ModalContext;
 import ti4.discord.interactions.routing.AnnotationHandler;
@@ -18,6 +19,7 @@ import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.logging.RollbarManager;
 import ti4.service.game.GameNameService;
+import ti4.spring.context.SpringContext;
 import ti4.spring.service.deploy.ActiveLeaseService;
 
 public final class ModalListener extends ListenerAdapter {
@@ -75,8 +77,15 @@ public final class ModalListener extends ListenerAdapter {
             RollbarManager.put("modal_id", event.getModalId());
             RollbarManager.put("game_name", GameNameService.getGameNameFromChannel(event));
             if (context.isValid()) {
-                resolveModalInteractionEvent(context);
-                context.save();
+                CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
+                combatReplayService.setPreInteractionSnapshot(
+                        combatReplayService.capturePreInteractionSnapshot(context.getGame()));
+                try {
+                    resolveModalInteractionEvent(context);
+                    context.save();
+                } finally {
+                    combatReplayService.clearPreInteractionSnapshot();
+                }
             }
         } catch (Exception e) {
             String message = "Modal issue in event: " + event.getModalId() + "\n> Channel: "

--- a/src/main/java/ti4/discord/interactions/listeners/SlashCommandListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/SlashCommandListener.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionE
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.interactions.commands.Command;
 import ti4.discord.interactions.commands.GameStateContainer;
 import ti4.discord.interactions.commands.ParentCommand;
@@ -19,6 +20,7 @@ import ti4.logging.BotLogger;
 import ti4.logging.RollbarManager;
 import ti4.service.SusSlashCommandService;
 import ti4.service.game.GameNameService;
+import ti4.spring.context.SpringContext;
 
 class SlashCommandListener extends ListenerAdapter implements CommandListenerInterface {
 
@@ -67,9 +69,17 @@ class SlashCommandListener extends ListenerAdapter implements CommandListenerInt
         RollbarManager.put("game_name", GameNameService.getGameName(event));
 
         ParentCommand command = SlashCommandManager.getCommand(event.getName());
+        Command<SlashCommandInteractionEvent> resolvedCommand = getCommand(event);
+        boolean combatReplaySnapshotBound = false;
+        CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
         try {
             if (command.accept(event)) {
                 command.preExecute(event);
+                if (resolvedCommand instanceof GameStateContainer gameStateContainer) {
+                    combatReplayService.setPreInteractionSnapshot(
+                            combatReplayService.capturePreInteractionSnapshot(gameStateContainer.getGame()));
+                    combatReplaySnapshotBound = true;
+                }
                 logSlashCommand(event);
                 command.execute(event);
                 command.postExecute(event);
@@ -80,6 +90,9 @@ class SlashCommandListener extends ListenerAdapter implements CommandListenerInt
         } catch (Exception e) {
             command.onException(event, e);
         } finally {
+            if (combatReplaySnapshotBound) {
+                combatReplayService.clearPreInteractionSnapshot();
+            }
             RollbarManager.clear();
         }
 

--- a/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
+++ b/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.interactions.listeners.context.SelectionMenuContext;
 import ti4.discord.interactions.routing.AnnotationHandler;
 import ti4.discord.interactions.routing.SelectionHandler;
@@ -15,6 +16,7 @@ import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.logging.RollbarManager;
 import ti4.service.game.GameNameService;
+import ti4.spring.context.SpringContext;
 
 @UtilityClass
 public final class SelectionMenuProcessor {
@@ -50,8 +52,15 @@ public final class SelectionMenuProcessor {
             RollbarManager.put("game_name", GameNameService.getGameNameFromChannel(event));
 
             if (context.isValid()) {
-                resolveSelectionMenu(context);
-                context.save();
+                CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
+                combatReplayService.setPreInteractionSnapshot(
+                        combatReplayService.capturePreInteractionSnapshot(context.getGame()));
+                try {
+                    resolveSelectionMenu(context);
+                    context.save();
+                } finally {
+                    combatReplayService.clearPreInteractionSnapshot();
+                }
             }
         } catch (Exception e) {
             String message = "Selection Menu issue in event: " + event.getComponentId() + "\n> Channel: "

--- a/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
@@ -2,32 +2,34 @@ package ti4.contest.replay.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
 
-import java.util.List;
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
-import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatContestSettings;
-import ti4.contest.replay.core.CombatRollPayload;
-import ti4.contest.replay.core.CombatRollPayload.DieRollSource;
-import ti4.contest.replay.core.CombatRollPayload.RollSegmentType;
 import ti4.contest.replay.core.CombatSideBetType;
-import ti4.contest.replay.dispatch.ReplayDispatchPayload;
-import ti4.contest.replay.dispatch.ReplayDispatchSerializer;
+import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
 import ti4.contest.replay.entities.CombatCandidateEntity;
-import ti4.contest.replay.entities.CombatCandidateEventEntity;
 import ti4.contest.replay.entities.CombatContestSideBetEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
-import ti4.service.combat.CombatRollType;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.helpers.Constants;
+import ti4.helpers.Units;
+import ti4.helpers.Units.UnitType;
+import ti4.image.Mapper;
+import ti4.image.PositionMapper;
+import ti4.model.FactionModel;
+import ti4.service.player.PlayerColorService;
+import ti4.testUtils.BaseTi4Test;
 
-class CombatReplaySideBetPayoutServiceTest {
+class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
 
     private final CombatContestSettings settings = new CombatContestSettings();
     private final CombatCandidateEventRepository eventRepository = mock(CombatCandidateEventRepository.class);
-    private final ReplayDispatchSerializer serializer = new ReplayDispatchSerializer();
-    private final CombatReplaySideBetPayoutService service =
-            new CombatReplaySideBetPayoutService(settings, eventRepository, serializer);
+    private final CombatReplaySideBetPayoutService service = new CombatReplaySideBetPayoutService(settings);
 
     @Test
     void usesFixedPayoutForExistingContestWithoutOddsModel() {
@@ -39,52 +41,59 @@ class CombatReplaySideBetPayoutServiceTest {
     }
 
     @Test
-    void pricesRoundOneWhiffFromCapturedOpeningRollOdds() {
+    void pricesRoundOneWhiffFromInitialSnapshotOnly() {
         CombatReplayContestEntity contest = oddsContest();
-        CombatCandidateEntity candidate = candidate();
-        when(eventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId()))
-                .thenReturn(List.of(rollEvent(candidate, "sol", payload(List.of(unitRoll(6, 2))))));
+        CombatCandidateEntity candidate = snapshotCandidate(4, 1);
 
         int payout = service.offeredPayout(contest, candidate, CombatSideBetType.ROUND_ONE_WHIFF, "sol");
 
         assertEquals(4, payout);
+        verifyNoInteractions(eventRepository);
     }
 
     @Test
-    void capsVeryLowOddsRoundOneSlamAtMaxPayout() {
+    void capsVeryLowOddsRoundOneSlamFromInitialSnapshotAtMaxPayout() {
         CombatReplayContestEntity contest = oddsContest();
-        CombatCandidateEntity candidate = candidate();
-        when(eventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId()))
-                .thenReturn(List.of(rollEvent(candidate, "sol", payload(List.of(unitRoll(9, 4))))));
+        CombatCandidateEntity candidate = snapshotCandidate(4, 1);
 
         int payout = service.offeredPayout(contest, candidate, CombatSideBetType.ROUND_ONE_SLAM, "sol");
 
         assertEquals(100, payout);
+        verifyNoInteractions(eventRepository);
     }
 
     @Test
-    void zeroProbabilityRoundOneSideBetUsesMaxPayout() {
+    void pricesAfbWhiffFromInitialSnapshotAfbUnitsOnly() {
+        CombatReplayContestEntity contest = oddsContest();
+        CombatCandidateEntity candidate = afbSnapshotCandidate();
+
+        int payout = service.offeredPayout(contest, candidate, CombatSideBetType.AFB_WHIFF, "sol");
+
+        assertEquals(6, payout);
+        verifyNoInteractions(eventRepository);
+    }
+
+    @Test
+    void roundOneSideBetsUseFixedPayoutWhenInitialSnapshotIsMissing() {
         CombatReplayContestEntity contest = oddsContest();
         CombatCandidateEntity candidate = candidate();
-        when(eventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId()))
-                .thenReturn(List.of(rollEvent(candidate, "sol", payload(List.of(unitRoll(1, 1))))));
 
         int payout = service.offeredPayout(contest, candidate, CombatSideBetType.ROUND_ONE_WHIFF, "sol");
 
-        assertEquals(100, payout);
+        assertEquals(10, payout);
+        verifyNoInteractions(eventRepository);
     }
 
     @Test
-    void pricesOneHpFromTotalInitialFightHp() {
-        int smallFight = service.offeredPayout(oddsContest(), candidate(4, 4), CombatSideBetType.WINNER_ONE_HP, "sol");
-        int largeFight =
-                service.offeredPayout(oddsContest(), candidate(30, 30), CombatSideBetType.WINNER_ONE_HP, "sol");
-        int hugeBlowout =
-                service.offeredPayout(oddsContest(), candidate(60, 4), CombatSideBetType.WINNER_ONE_HP, "sol");
+    void pricesOneHpFromInitialSnapshotAndIgnoresCandidateHpFields() {
+        CombatCandidateEntity candidate = snapshotCandidate(1, 1);
+        candidate.setAttackerHp(30.0);
+        candidate.setDefenderHp(30.0);
 
-        assertEquals(3, smallFight);
-        assertEquals(75, largeFight);
-        assertEquals(76, hugeBlowout);
+        int payout = service.offeredPayout(oddsContest(), candidate, CombatSideBetType.WINNER_ONE_HP, "sol");
+
+        assertEquals(6, payout);
+        verifyNoInteractions(eventRepository);
     }
 
     @Test
@@ -114,64 +123,72 @@ class CombatReplaySideBetPayoutServiceTest {
         return candidate;
     }
 
+    private CombatCandidateEntity snapshotCandidate(int solCarriers, int yinCarriers) {
+        Game game = new Game();
+        game.newGameSetup();
+        game.setName("pbd-side-bet-snapshot");
+        Player sol = player(game, "sol");
+        Player yin = player(game, "yin");
+        Tile tile = tile(game, "18");
+        tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Carrier, sol.getColorID()), solCarriers);
+        tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Carrier, yin.getColorID()), yinCarriers);
+
+        CombatCandidateEntity candidate = candidate(null, null);
+        candidate.setTilePosition(tile.getPosition());
+        candidate.setInitialRenderSnapshotJson(
+                CombatReplayTileRenderer.captureInitialSnapshot(game, tile.getPosition()));
+        return candidate;
+    }
+
+    private CombatCandidateEntity afbSnapshotCandidate() {
+        Game game = new Game();
+        game.newGameSetup();
+        game.setName("pbd-side-bet-afb-snapshot");
+        Player sol = player(game, "sol");
+        sol.removeOwnedUnitByID("destroyer");
+        sol.addOwnedUnitByID("destroyer2");
+        Player yin = player(game, "yin");
+        Tile tile = tile(game, "18");
+        tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Destroyer, sol.getColorID()), 1);
+        tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Carrier, sol.getColorID()), 3);
+        tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Carrier, yin.getColorID()), 1);
+
+        CombatCandidateEntity candidate = candidate(null, null);
+        candidate.setTilePosition(tile.getPosition());
+        candidate.setInitialRenderSnapshotJson(
+                CombatReplayTileRenderer.captureInitialSnapshot(game, tile.getPosition()));
+        return candidate;
+    }
+
     private CombatReplayContestEntity oddsContest() {
         CombatReplayContestEntity contest = new CombatReplayContestEntity();
         contest.setSideBetPayoutModel(CombatReplaySideBetPayoutService.ODDS_V1);
         return contest;
     }
 
-    private CombatCandidateEventEntity rollEvent(
-            CombatCandidateEntity candidate, String actorFaction, CombatRollPayload payload) {
-        CombatCandidateEventEntity event = new CombatCandidateEventEntity();
-        event.setCandidateId(candidate.getId());
-        event.setEventType(CombatCandidateEventType.ROLL);
-        event.setActorFaction(actorFaction);
-        event.setRoundNumber(1);
-        event.setPayloadJson(serializer.write(ReplayDispatchPayload.combatRoll("roll", payload)));
-        return event;
+    private Player player(Game game, String faction) {
+        FactionModel model = Mapper.getFaction(faction);
+        Player player = game.addPlayer(model.getAlias(), model.getFactionName());
+        player.setFaction(game, faction);
+        player.setFactionEmoji("<" + faction + ">");
+        player.setColor(PlayerColorService.getPreferredColor(player));
+        player.setUnitsOwned(new HashSet<>(model.getUnits()));
+        player.setCommoditiesBase(model.getCommodities());
+        player.setFactionTechs(model.getFactionTech());
+        return player;
     }
 
-    private CombatRollPayload payload(List<CombatRollPayload.UnitRoll> unitRolls) {
-        return new CombatRollPayload(
-                new CombatRollPayload.RollHeader(
-                        "sol",
-                        "blue",
-                        "",
-                        "yin",
-                        "red",
-                        "101",
-                        "18",
-                        "space",
-                        "space combat",
-                        CombatRollType.combatround,
-                        1,
-                        false,
-                        false),
-                List.of(),
-                List.of(),
-                unitRolls,
-                new CombatRollPayload.RollTotal(
-                        unitRolls.stream().mapToInt(unit -> unit.dice().size()).sum(), 0, 0, 0));
+    private Tile tile(Game game, String tileId) {
+        Tile tile = new Tile(tileId, getNextPosition(game));
+        game.setTile(tile);
+        game.setActiveSystem(tile.getPosition());
+        return tile;
     }
 
-    private CombatRollPayload.UnitRoll unitRoll(int threshold, int diceCount) {
-        return new CombatRollPayload.UnitRoll(
-                "fighter",
-                "ff",
-                "fighter",
-                "Fighter",
-                "",
-                "",
-                diceCount,
-                1,
-                0,
-                threshold,
-                0,
-                threshold,
-                RollSegmentType.PRIMARY,
-                java.util.stream.IntStream.range(0, diceCount)
-                        .mapToObj(i -> new CombatRollPayload.DieRoll(1, threshold, false, DieRollSource.PRIMARY))
-                        .toList(),
-                0);
+    private String getNextPosition(Game game) {
+        for (String position : PositionMapper.getTilePositions()) {
+            if (game.getTileByPosition(position) == null) return position;
+        }
+        return null;
     }
 }

--- a/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
@@ -69,7 +69,20 @@ class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
 
         int payout = service.offeredPayout(contest, candidate, CombatSideBetType.AFB_WHIFF, "sol");
 
+        assertEquals(true, service.hasAfbUnits(candidate, "sol"));
         assertEquals(6, payout);
+        verifyNoInteractions(eventRepository);
+    }
+
+    @Test
+    void afbWhiffIsUnavailableWithoutInitialSnapshotAfbUnits() {
+        CombatReplayContestEntity contest = oddsContest();
+        CombatCandidateEntity candidate = snapshotCandidate(4, 1);
+
+        int payout = service.offeredPayout(contest, candidate, CombatSideBetType.AFB_WHIFF, "sol");
+
+        assertEquals(false, service.hasAfbUnits(candidate, "sol"));
+        assertEquals(4, payout);
         verifyNoInteractions(eventRepository);
     }
 


### PR DESCRIPTION
## Summary
- capture the initial combat replay snapshot from the pre-interaction game state on the first tracked interaction, without a start-event snapshot fallback
- simplify single-instance replay sequencing, side-bet placement, and leaderboard scoring with synchronized sections instead of pessimistic transaction locks
- update side-bet payout behavior and availability, including snapshot-based AFB/1HP math, hiding AFB Whiff when no AFB units exist, 15-minute betting windows, and two-hour contest cadence

## Test Plan
- mvn -Dtest=CombatReplayServiceTest,CombatReplaySideBetServiceTest,CombatReplaySideBetPayoutServiceTest,CombatReplayContestLifecycleServiceTest,CombatSideBetTypeTest test