### PR TITLE
Fix tibot rollout scaling

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -73,6 +73,7 @@ jobs:
             username: ${{ secrets.HOSTINGER_SSH_USER }}
             password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
             port: ${{ secrets.HOSTINGER_SSH_PORT }}
+            command_timeout: 30m
             envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_WEBHOOK_URL, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
             script: |
               set -eu
@@ -89,14 +90,6 @@ jobs:
               export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
               export IMAGE_TAG="${{ needs.buildImage.outputs.image_tag }}"
               compose_file="docker-compose.production.yml"
-              rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
-
-              if ! docker rollout --help >/dev/null 2>&1; then
-                mkdir -p "$(dirname "$rollout_plugin_path")"
-                curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/v0.13/docker-rollout -o "$rollout_plugin_path"
-                chmod +x "$rollout_plugin_path"
-                docker rollout --help >/dev/null
-              fi
 
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`PULLING DOCKER IMAGE ${IMAGE_TAG}\"}" $DISCORD_WEBHOOK_URL
@@ -108,14 +101,8 @@ jobs:
               docker compose -f "$compose_file" up -d traefik
 
               timestamp=$(date "+%F %T.%3N")
-              existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
-              if [ -n "$existing_bot_containers" ]; then
-                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ROLLING OUT NEW TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
-                docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
-              else
-                curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`STARTING INITIAL TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
-                docker compose -f "$compose_file" up -d tibot
-              fi
+              curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`ROLLING OUT ONE NEW TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL
+              COMPOSE_FILE="$compose_file" ROLLOUT_TIMEOUT_SECONDS=540 bash scripts/deploy_tibot_single_instance.sh
 
               timestamp=$(date "+%F %T.%3N")
               curl -X POST -H 'Content-Type: application/json' -d "{\"content\":\"\`$timestamp\`VERIFYING SINGLE TIBOT CONTAINER\"}" $DISCORD_WEBHOOK_URL

--- a/.github/workflows/restart-bot.yml
+++ b/.github/workflows/restart-bot.yml
@@ -30,6 +30,7 @@ jobs:
         username: ${{ secrets.HOSTINGER_SSH_USER }}
         password: ${{ secrets.HOSTINGER_SSH_PASSWORD }}
         port: ${{ secrets.HOSTINGER_SSH_PORT }}
+        command_timeout: 30m
         envs: AWS_KEY, AWS_SECRET, DISCORD_BOT_TOKEN, DISCORD_BOT_USERID, REPO_DISPATCH_TOKEN, TI4_ULTIMATE_STATISTICS_API_KEY, MANAGEMENT_ENDPOINTS_ACTUATOR_API_KEY, DISCORD_REDIRECT_URI, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, ROLLBAR_ACCESS_TOKEN, ROLLBAR_ENVIRONMENT, ROLLBAR_CODE_VERSION
         script: |
           set -eu
@@ -44,14 +45,6 @@ jobs:
           export IMAGE_REPOSITORY="${{ env.IMAGE_REPOSITORY }}"
           export IMAGE_TAG="master"
           compose_file="docker-compose.production.yml"
-          rollout_plugin_path="$HOME/.docker/cli-plugins/docker-rollout"
-
-          if ! docker rollout --help >/dev/null 2>&1; then
-            mkdir -p "$(dirname "$rollout_plugin_path")"
-            curl -fsSL https://raw.githubusercontent.com/wowu/docker-rollout/v0.13/docker-rollout -o "$rollout_plugin_path"
-            chmod +x "$rollout_plugin_path"
-            docker rollout --help >/dev/null
-          fi
           
           echo "Pulling docker image..."
           docker version
@@ -59,14 +52,8 @@ jobs:
           
           docker compose -f "$compose_file" up -d traefik
 
-          existing_bot_containers="$(docker compose -f "$compose_file" ps -q tibot || true)"
-          if [ -n "$existing_bot_containers" ]; then
-            echo "Rolling out TIBot..."
-            docker rollout -f "$compose_file" --timeout 600 --wait-after-healthy 2 --pre-stop-hook 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' tibot
-          else
-            echo "Starting initial container..."
-            docker compose -f "$compose_file" up -d tibot
-          fi
+          echo "Rolling out one new TIBot container..."
+          COMPOSE_FILE="$compose_file" ROLLOUT_TIMEOUT_SECONDS=540 bash scripts/deploy_tibot_single_instance.sh
           echo "Cleaning up docker stuff..."
           
           docker image prune --force --filter until=48h

--- a/scripts/deploy_tibot_single_instance.sh
+++ b/scripts/deploy_tibot_single_instance.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+compose_file="${COMPOSE_FILE:-docker-compose.production.yml}"
+service="${SERVICE:-tibot}"
+rollout_timeout_seconds="${ROLLOUT_TIMEOUT_SECONDS:-540}"
+wait_after_healthy_seconds="${WAIT_AFTER_HEALTHY_SECONDS:-2}"
+stop_timeout_seconds="${STOP_TIMEOUT_SECONDS:-600}"
+log_tail_lines="${ROLLBACK_LOG_TAIL_LINES:-200}"
+
+old_ids_file="$(mktemp)"
+new_ids_file="$(mktemp)"
+new_container_id=""
+
+cleanup_tmp_files() {
+  rm -f "$old_ids_file" "$new_ids_file"
+}
+
+cleanup_new_container() {
+  if [ -n "$new_container_id" ]; then
+    echo "Cleaning up new tibot container $new_container_id"
+    docker stop "$new_container_id" || true
+    docker rm "$new_container_id" || true
+  fi
+}
+
+rollback_and_exit() {
+  cleanup_new_container
+  cleanup_tmp_files
+  exit 1
+}
+
+handle_signal() {
+  echo "Rollout interrupted; rolling back new tibot container" >&2
+  cleanup_new_container
+  cleanup_tmp_files
+  exit 130
+}
+
+compose() {
+  docker compose -f "$compose_file" "$@"
+}
+
+count_lines() {
+  sed '/^$/d' | wc -l | tr -d ' '
+}
+
+health_status() {
+  docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$1"
+}
+
+trap 'cleanup_tmp_files' EXIT
+
+old_container_ids="$(compose ps -q "$service" || true)"
+printf '%s\n' "$old_container_ids" | sed '/^$/d' > "$old_ids_file"
+old_container_count="$(count_lines < "$old_ids_file")"
+target_container_count=$((old_container_count + 1))
+
+echo "Found $old_container_count existing $service container(s)."
+echo "Scaling '$service' to $target_container_count total container(s) to create exactly one rollout candidate."
+compose up --detach --scale "$service=$target_container_count" --no-recreate "$service"
+
+all_container_ids_after_scale="$(compose ps -q "$service" || true)"
+printf '%s\n' "$all_container_ids_after_scale" \
+  | sed '/^$/d' \
+  | grep -vxF -f "$old_ids_file" > "$new_ids_file" || true
+
+new_container_count="$(count_lines < "$new_ids_file")"
+if [ "$new_container_count" -ne 1 ]; then
+  echo "Expected exactly one new $service container, found $new_container_count." >&2
+  echo "Existing container ids before scale:" >&2
+  cat "$old_ids_file" >&2
+  echo "New candidate ids after scale:" >&2
+  cat "$new_ids_file" >&2
+
+  while IFS= read -r candidate_id; do
+    [ -z "$candidate_id" ] && continue
+    docker stop "$candidate_id" || true
+    docker rm "$candidate_id" || true
+  done < "$new_ids_file"
+
+  exit 1
+fi
+
+new_container_id="$(cat "$new_ids_file")"
+trap 'handle_signal' INT TERM HUP
+
+echo "Waiting for new $service container to become healthy: $new_container_id"
+for second in $(seq 1 "$rollout_timeout_seconds"); do
+  status="$(health_status "$new_container_id")"
+  if [ "$status" = "healthy" ]; then
+    break
+  fi
+
+  if [ "$second" -eq 1 ] || [ $((second % 30)) -eq 0 ]; then
+    echo "Still waiting for $new_container_id health status: $status (${second}s elapsed)"
+  fi
+
+  sleep 1
+done
+
+final_status="$(health_status "$new_container_id")"
+if [ "$final_status" != "healthy" ]; then
+  echo "New $service container did not become healthy; rolling back." >&2
+  echo "Final health status: $final_status" >&2
+  docker inspect --format='{{json .State.Health}}' "$new_container_id" || true
+  docker logs --tail "$log_tail_lines" "$new_container_id" || true
+  rollback_and_exit
+fi
+
+if [ "$wait_after_healthy_seconds" != "0" ]; then
+  echo "New $service container is healthy. Waiting ${wait_after_healthy_seconds}s before draining old containers."
+  sleep "$wait_after_healthy_seconds"
+fi
+
+trap - INT TERM HUP
+
+while IFS= read -r old_container_id; do
+  [ -z "$old_container_id" ] && continue
+
+  echo "Draining old $service container $old_container_id"
+  docker exec "$old_container_id" sh -c 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' || true
+
+  echo "Stopping and removing old $service container $old_container_id"
+  docker stop --time "$stop_timeout_seconds" "$old_container_id" || true
+  docker rm "$old_container_id" || true
+done < "$old_ids_file"
+
+active_container_ids="$(compose ps -q "$service" || true)"
+active_container_count="$(printf '%s\n' "$active_container_ids" | count_lines)"
+if [ "$active_container_count" -ne 1 ]; then
+  echo "Expected exactly one active $service container after rollout, found $active_container_count." >&2
+  compose ps "$service" || true
+  exit 1
+fi
+
+echo "Rollout complete. Active $service container: $new_container_id"


### PR DESCRIPTION
## Summary
- Replace docker-rollout with a repo-owned tibot rollout script that creates exactly one new candidate container.
- Roll back the new container on failed health checks or interrupts, then drain and remove all old containers after success.
- Keep deploy/restart workflow YAML small by calling the script directly and extending SSH command timeout.

## Test Plan
- bash -n scripts/deploy_tibot_single_instance.sh
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/deploy-to-production.yml .github/workflows/restart-bot.yml\n- actionlint not installed locally\n- shellcheck not installed locally