### PR TITLE
Fix Planetary Stabilisation: Tactical Pool, remove unactivated restriction

### DIFF
--- a/src/main/resources/data/abilities/untangled_space.json
+++ b/src/main/resources/data/abilities/untangled_space.json
@@ -4,7 +4,7 @@
         "name": "Planetary Stabilisation",
         "faction": "neutral",
         "window": "ACTION",
-        "windowEffect": "Spend 1 Command Counter from your Strategy Pool to roll 1 die. On a result of 1–4, draw a random unused red tile; on a result of 5–10, draw a random unused blue tile. Place that tile adjacent to an unactivated system containing your ships, so that it is touching a system. If the system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then you may activate the placed system with a token from your reinforcements and continue with a tactical action. If you do, spend trade goods equal to half your trade goods (rounded down), minus 1 for each system tile adjacent to the placed system (minimum 0).",
+        "windowEffect": "Spend 1 Command Counter from your Tactical Pool to roll 1 die. On a result of 1–4, draw a random unused red tile; on a result of 5–10, draw a random unused blue tile. Place that tile adjacent to a system containing your ships, so that it is touching a system. If the system contains no planets, place a frontier token there and either gain 2 commodities or convert up to 2 commodities to trade goods. Then you may activate the placed system with a token from your reinforcements and continue with a tactical action. If you do, spend trade goods equal to half your trade goods (rounded down), minus 1 for each system tile adjacent to the placed system (minimum 0).",
         "source": "untangled_space"
     }
 ]


### PR DESCRIPTION
Two corrections to the Planetary Stabilisation ability text:

- **"Strategy Pool" → "Tactical Pool"** — the ability spends from the tactical pool, not the strategy pool
- **Drop "unactivated"** — the tile should be placeable adjacent to any system containing your ships, not only unactivated ones

No other changes.