### PR TITLE
fix: disable replay decoys by default

### DIFF
--- a/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
+++ b/src/main/java/ti4/contest/replay/controller/CombatReplayDebugController.java
@@ -151,7 +151,8 @@ public class CombatReplayDebugController {
                 settings.getRuntime().isDevMode(),
                 settings.getRuntime().isDiscordPostingEnabled(),
                 settings.getRuntime().isTrackAllCombatsAsCandidates(),
-                settings.getRuntime().isImmediatePromotionOnResolve());
+                settings.getRuntime().isImmediatePromotionOnResolve(),
+                settings.isDecoysEnabled());
     }
 
     private CandidateSummary toCandidateSummary(CombatCandidateEntity candidate) {
@@ -202,7 +203,8 @@ public class CombatReplayDebugController {
             boolean devMode,
             boolean discordPostingEnabled,
             boolean trackAllCombatsAsCandidates,
-            boolean immediatePromotionOnResolve) {}
+            boolean immediatePromotionOnResolve,
+            boolean decoysEnabled) {}
 
     private record CandidateListResponse(RuntimeStateResponse runtime, List<CandidateSummary> candidates) {}
 

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -25,6 +25,7 @@ public class CombatContestSettings {
     private Retention retention = new Retention();
     private Runtime runtime = new Runtime();
     private SideBets sideBets = new SideBets();
+    private boolean decoysEnabled = false;
 
     public CombatContestSettings() {
         applyEnvironmentDefaults();

--- a/src/main/java/ti4/contest/replay/core/CombatReplayDecoys.java
+++ b/src/main/java/ti4/contest/replay/core/CombatReplayDecoys.java
@@ -16,7 +16,6 @@ import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.helpers.Constants;
 import ti4.helpers.Units;
-import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
 import ti4.image.Mapper;
 import ti4.json.JsonMapperManager;
@@ -33,7 +32,14 @@ public class CombatReplayDecoys {
     private static final Map<String, List<DecoyUnit>> DEBUG_DECOY_UNITS_BY_COMBAT = new ConcurrentHashMap<>();
 
     public String buildJson(Player attacker, Player defender, Tile tile) {
-        Abilities abilities = build(attacker, defender, tile, consumeDebugDecoyUnits(attacker, defender, tile));
+        return buildJson(attacker, defender, tile, false);
+    }
+
+    public String buildJson(Player attacker, Player defender, Tile tile, boolean decoysEnabled) {
+        List<DecoyUnit> debugDecoyUnits = consumeDebugDecoyUnits(attacker, defender, tile);
+        if (!decoysEnabled) return null;
+
+        Abilities abilities = build(debugDecoyUnits);
         return abilities.hasDecoys() ? write(abilities) : null;
     }
 
@@ -146,37 +152,9 @@ public class CombatReplayDecoys {
                 + "uneasy certainty that some of those ships were never truly there.";
     }
 
-    private Abilities build(Player attacker, Player defender, Tile tile, List<DecoyUnit> debugDecoyUnits) {
-        List<DecoyUnit> decoyUnits = new ArrayList<>();
-        if (debugDecoyUnits == null) {
-            addDecoyUnits(decoyUnits, attacker, tile);
-            addDecoyUnits(decoyUnits, defender, tile);
-        } else {
-            decoyUnits.addAll(debugDecoyUnits);
-        }
+    private Abilities build(List<DecoyUnit> debugDecoyUnits) {
+        List<DecoyUnit> decoyUnits = debugDecoyUnits == null ? List.of() : debugDecoyUnits;
         return new Abilities(decoyUnits.isEmpty() ? null : new Decoy(decoyUnits));
-    }
-
-    private void addDecoyUnits(List<DecoyUnit> decoyUnits, Player player, Tile tile) {
-        UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
-        for (UnitKey unitKey : space.getUnitsByState().keySet()) {
-            if (!player.getColorID().equals(unitKey.getColorID())) continue;
-            if (!isShip(unitKey.getUnitType())) continue;
-            decoyUnits.add(new DecoyUnit(
-                    player.getFaction(),
-                    player.getFactionEmoji(),
-                    player.getColorID(),
-                    unitKey.getUnitType(),
-                    Constants.SPACE,
-                    1));
-        }
-    }
-
-    private boolean isShip(UnitType unitType) {
-        return switch (unitType) {
-            case Fighter, Destroyer, Cruiser, Carrier, Dreadnought, Flagship, Warsun, Lady, Celagrom, Cavalry -> true;
-            default -> false;
-        };
     }
 
     private List<DecoyUnit> consumeDebugDecoyUnits(Player attacker, Player defender, Tile tile) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -50,6 +50,7 @@ public class CombatReplayLeaderboardService {
     public static final String LAZAX_MINIGAME_SUBSCRIPTION_MARKER = "-# Lazax Minigame Subscription";
     public static final String LAZAX_MINIGAME_ROLE_NAME = "Lazax Minigame";
 
+    static final int STARTING_POINTS = 100;
     private static final int WRONG_PREDICTION_PENALTY = -4;
     private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
     private static final String UNSUBSCRIBE_EMOJI = "\uD83D\uDD34";
@@ -314,7 +315,7 @@ public class CombatReplayLeaderboardService {
         entry.setDiscordUserId(discordUserId);
         entry.setDiscordUserName(
                 discordUserName == null || discordUserName.isBlank() ? "Unknown User" : discordUserName);
-        entry.setTotalPoints(0);
+        entry.setTotalPoints(STARTING_POINTS);
         entry.setPredictionCount(0);
         entry.setCorrectPredictions(0);
         entry.setUpdatedAt(LocalDateTime.now());

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -442,7 +442,7 @@ public class CombatReplayService {
         return new CandidateInitialSnapshot(
                 LazaxCombatSupport.formatCombatTechSummary(tile, attacker, defender),
                 CombatReplayTileRenderer.captureInitialSnapshot(game, tile.getPosition()),
-                CombatReplayDecoys.buildJson(attacker, defender, tile),
+                CombatReplayDecoys.buildJson(attacker, defender, tile, settings.isDecoysEnabled()),
                 countDestroyersInCombat(tile, attacker),
                 countDestroyersInCombat(tile, defender),
                 hasAssaultCannon(attacker),

--- a/src/main/java/ti4/contest/replay/service/ReplayPayloadRenderer.java
+++ b/src/main/java/ti4/contest/replay/service/ReplayPayloadRenderer.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.core.CombatRollPayload;
 import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
@@ -28,6 +29,7 @@ import ti4.model.TechnologyModel;
 @RequiredArgsConstructor
 public class ReplayPayloadRenderer {
 
+    private final CombatContestSettings settings;
     private final ReplayDispatchSerializer payloadSerializer;
 
     public RenderedReplayEvent render(Game game, CombatCandidateEntity candidate, CombatCandidateEventEntity event) {
@@ -51,7 +53,7 @@ public class ReplayPayloadRenderer {
     }
 
     public CombatReplayDecoys.Abilities readReplayAbilities(CombatCandidateEntity candidate) {
-        return candidate == null
+        return candidate == null || !settings.isDecoysEnabled()
                 ? new CombatReplayDecoys.Abilities(null)
                 : CombatReplayDecoys.read(candidate.getReplayAbilitiesJson());
     }

--- a/src/test/java/ti4/contest/replay/core/CombatReplayDecoysTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatReplayDecoysTest.java
@@ -2,6 +2,7 @@ package ti4.contest.replay.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,6 +22,11 @@ import ti4.service.combat.CombatRollType;
 import ti4.testUtils.BaseTi4Test;
 
 class CombatReplayDecoysTest extends BaseTi4Test {
+
+    @Test
+    void globalDecoysFlagDefaultsOff() {
+        assertFalse(new CombatContestSettings().isDecoysEnabled());
+    }
 
     @Test
     void addsDecoyUnitsToRenderedTileOnly() {
@@ -175,6 +181,33 @@ class CombatReplayDecoysTest extends BaseTi4Test {
     }
 
     @Test
+    void doesNotCaptureImplicitDecoysFromRealUnits() {
+        Game game = new Game();
+        Tile tile = new Tile("19", "000");
+        game.setTile(tile);
+        Player ghost = player(game, "ghost", "turquoise");
+        Player yin = player(game, "yin", "sunset");
+        tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Cruiser, "tqs"), 1);
+        tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Destroyer, "sns"), 1);
+        CombatReplayDecoys.clearDebugDecoys(game, tile);
+
+        assertNull(CombatReplayDecoys.buildJson(ghost, yin, tile, true));
+    }
+
+    @Test
+    void globalFlagSuppressesDebugDecoys() {
+        Game game = new Game();
+        Tile tile = new Tile("19", "000");
+        game.setTile(tile);
+        Player ghost = player(game, "ghost", "turquoise");
+        Player yin = player(game, "yin", "sunset");
+        CombatReplayDecoys.clearDebugDecoys(game, tile);
+        CombatReplayDecoys.addDebugDecoyUnit(game, tile, ghost, UnitType.Destroyer);
+
+        assertNull(CombatReplayDecoys.buildJson(ghost, yin, tile, false));
+    }
+
+    @Test
     void debugDecoyOverrideCapturesBuiltUnitMix() {
         Game game = new Game();
         Tile tile = new Tile("19", "000");
@@ -189,7 +222,7 @@ class CombatReplayDecoysTest extends BaseTi4Test {
         CombatReplayDecoys.addDebugDecoyUnit(game, tile, ghost, UnitType.Destroyer);
         CombatReplayDecoys.addDebugDecoyUnit(game, tile, ghost, UnitType.Fighter);
         CombatReplayDecoys.Abilities abilities =
-                CombatReplayDecoys.read(CombatReplayDecoys.buildJson(ghost, yin, tile));
+                CombatReplayDecoys.read(CombatReplayDecoys.buildJson(ghost, yin, tile, true));
 
         assertTrue(abilities.hasDecoys());
         assertEquals(2, abilities.decoy().units().size());
@@ -212,7 +245,7 @@ class CombatReplayDecoysTest extends BaseTi4Test {
 
         CombatReplayDecoys.setDebugDecoyUnits(game, tile, List.of());
 
-        assertEquals(null, CombatReplayDecoys.buildJson(ghost, yin, tile));
+        assertNull(CombatReplayDecoys.buildJson(ghost, yin, tile, true));
     }
 
     @Test

--- a/src/test/java/ti4/contest/replay/service/CombatReplayLeaderboardServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayLeaderboardServiceTest.java
@@ -1,0 +1,35 @@
+package ti4.contest.replay.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
+import ti4.contest.replay.repository.CombatReplayContestRepository;
+import ti4.contest.replay.repository.CombatReplayLeaderboardEntryRepository;
+import ti4.contest.replay.repository.CombatReplayPredictionRepository;
+
+class CombatReplayLeaderboardServiceTest {
+
+    @Test
+    void newLeaderboardEntriesStartWithInitialPoints() throws Exception {
+        CombatReplayLeaderboardService service = new CombatReplayLeaderboardService(
+                new CombatContestSettings(),
+                mock(CombatReplayContestRepository.class),
+                mock(CombatReplayPredictionRepository.class),
+                mock(CombatReplayLeaderboardEntryRepository.class),
+                mock(CombatReplaySideBetService.class));
+        Method method = CombatReplayLeaderboardService.class.getDeclaredMethod(
+                "newLeaderboardEntry", String.class, String.class);
+        method.setAccessible(true);
+
+        CombatReplayLeaderboardEntryEntity entry =
+                (CombatReplayLeaderboardEntryEntity) method.invoke(service, "123", "Player");
+
+        assertEquals(CombatReplayLeaderboardService.STARTING_POINTS, entry.getTotalPoints());
+        assertEquals(0, entry.getPredictionCount());
+        assertEquals(0, entry.getCorrectPredictions());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a global decoys flag that defaults off and gate replay decoy capture/playback behind it.
- Stop implicitly generating replay decoys from real combat units.
- Start newly-created replay leaderboard entries at 100 points.

## Test Plan
- mvn -Dtest=CombatReplayLeaderboardServiceTest,CombatReplayDecoysTest test