### PR TITLE
Fix Quietus combat effect board check

### DIFF
--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -20,6 +20,7 @@ import ti4.helpers.ButtonHelper;
 import ti4.helpers.Constants;
 import ti4.helpers.Helper;
 import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitType;
 import ti4.image.Mapper;
 import ti4.json.JsonMapperManager;
 import ti4.model.LeaderModel;
@@ -421,7 +422,13 @@ public class LazaxCombatSupport {
         Player quietusOwner = Helper.getPlayerFromUnit(game, "crimson_flagship");
         if (quietusOwner == null) return false;
         UnitHolder combatSpace = combatTile.getSpaceUnitHolder();
-        return combatSpace != null && combatSpace.getTokenList().contains(Constants.TOKEN_BREACH_ACTIVE);
+        if (combatSpace == null || !combatSpace.getTokenList().contains(Constants.TOKEN_BREACH_ACTIVE)) {
+            return false;
+        }
+        return ButtonHelper.getTilesOfPlayersSpecificUnits(game, quietusOwner, UnitType.Flagship).stream()
+                .map(Tile::getSpaceUnitHolder)
+                .filter(unitHolder -> unitHolder != null)
+                .anyMatch(unitHolder -> unitHolder.getTokenList().contains(Constants.TOKEN_BREACH_ACTIVE));
     }
 
     private String formatPlayerSummaryLine(Player player, String summary) {

--- a/src/test/java/ti4/contest/replay/core/LazaxCombatSupportTest.java
+++ b/src/test/java/ti4/contest/replay/core/LazaxCombatSupportTest.java
@@ -1,0 +1,85 @@
+package ti4.contest.replay.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.helpers.Constants;
+import ti4.helpers.Units;
+import ti4.helpers.Units.UnitType;
+import ti4.image.Mapper;
+import ti4.image.PositionMapper;
+import ti4.model.FactionModel;
+import ti4.testUtils.BaseTi4Test;
+
+class LazaxCombatSupportTest extends BaseTi4Test {
+
+    @Test
+    void combatSummaryDoesNotRenderQuietusEffectWhenQuietusIsOnlyOwned() {
+        Harness harness = new Harness();
+        Player attacker = harness.player("sol", "blue");
+        Player defender = harness.player("sardakk", "green");
+        harness.player("crimson", "red");
+
+        Tile combatTile = harness.tile("112");
+        combatTile.addToken(Constants.TOKEN_BREACH_ACTIVE, Constants.SPACE);
+
+        String summary = LazaxCombatSupport.formatCombatTechSummary(combatTile, attacker, defender);
+
+        assertFalse(summary.contains("Quietus"));
+    }
+
+    @Test
+    void combatSummaryRendersQuietusEffectWhenQuietusIsOnAnActiveBreach() {
+        Harness harness = new Harness();
+        Player attacker = harness.player("sol", "blue");
+        Player defender = harness.player("sardakk", "green");
+        Player crimson = harness.player("crimson", "red");
+
+        Tile combatTile = harness.tile("112");
+        combatTile.addToken(Constants.TOKEN_BREACH_ACTIVE, Constants.SPACE);
+        Tile quietusTile = harness.tile("94");
+        quietusTile.addToken(Constants.TOKEN_BREACH_ACTIVE, Constants.SPACE);
+        quietusTile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Flagship, crimson.getColorID()), 1);
+
+        String summary = LazaxCombatSupport.formatCombatTechSummary(combatTile, attacker, defender);
+
+        assertTrue(summary.contains("Quietus: active Breach in play"));
+    }
+
+    private static final class Harness {
+        private final Game game = new Game();
+
+        private Harness() {
+            game.newGameSetup();
+            game.setName("Lazax Combat Support Test");
+        }
+
+        private Player player(String faction, String color) {
+            FactionModel model = Mapper.getFaction(faction);
+            Player player = game.addPlayer(model.getAlias(), model.getFactionName());
+            player.setFaction(game, faction);
+            player.setFactionEmoji("<" + faction + ">");
+            player.setColor(color);
+            player.setUnitsOwned(new HashSet<>(model.getUnits()));
+            return player;
+        }
+
+        private Tile tile(String tileId) {
+            Tile tile = new Tile(tileId, getNextPosition());
+            game.setTile(tile);
+            return tile;
+        }
+
+        private String getNextPosition() {
+            for (String position : PositionMapper.getTilePositions()) {
+                if (game.getTileByPosition(position) == null) return position;
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Require the Quietus owner to actually have a flagship on the board in an active Breach before showing the combat effect summary.
- Add regression coverage for the owned-but-not-placed Quietus case and the active-board case.

## Test Plan
- mvn -Dtest=LazaxCombatSupportTest test