### PR TITLE
Add contest promotion cooldown grace window

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -1,5 +1,6 @@
 package ti4.contest.replay.service;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -46,6 +47,8 @@ public class CombatReplayContestLifecycleService {
 
     private static final long SHADOW_DISCORD_ID = 0L;
     private static final String PROMOTION_DISABLED_REASON = "Candidate-to-contest promotion is disabled.";
+    private static final Duration PUBLIC_PROMOTION_COOLDOWN = Duration.ofHours(2);
+    private static final Duration PUBLIC_PROMOTION_COOLDOWN_GRACE = Duration.ofMinutes(5);
     private static final List<String> PREDICTION_LOCK_TITLES = List.of(
             "The Wagers Open",
             "The Archives Open",
@@ -75,15 +78,16 @@ public class CombatReplayContestLifecycleService {
     private final CombatReplayLeaderboardService replayLeaderboardService;
     private final CombatReplaySideBetService replaySideBetService;
     private final ReplayPayloadRenderer replayPayloadRenderer;
+    private Clock clock = Clock.systemDefaultZone();
 
     public void promoteBestCandidateIfDue() {
         if (!settings.getPromotion().isEnabled()) return;
 
-        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
         if (now.getMinute() != 0) return;
         int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
         if (maxPromotionsPerHour <= 0) return;
-        if (replayContestRepository.countByPostedAtGreaterThanEqual(now.minusHours(2)) > 0) return;
+        if (replayContestRepository.countByPostedAtGreaterThanEqual(publicPromotionCooldownCutoff(now)) > 0) return;
         if (replayContestRepository.countByPostedAtGreaterThanEqual(now.truncatedTo(ChronoUnit.HOURS))
                 >= maxPromotionsPerHour) {
             return;
@@ -112,6 +116,14 @@ public class CombatReplayContestLifecycleService {
             }
         }
         return List.of();
+    }
+
+    void setClock(Clock clock) {
+        this.clock = clock == null ? Clock.systemDefaultZone() : clock;
+    }
+
+    static LocalDateTime publicPromotionCooldownCutoff(LocalDateTime now) {
+        return now.minus(PUBLIC_PROMOTION_COOLDOWN).plus(PUBLIC_PROMOTION_COOLDOWN_GRACE);
     }
 
     public ForcePromoteResult forcePromoteCandidate(Long candidateId) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -3,9 +3,17 @@ package ti4.contest.replay.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatCandidatePromotionStatus;
+import ti4.contest.replay.core.CombatCandidateStatus;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
@@ -25,6 +33,53 @@ class CombatReplayContestLifecycleServiceTest {
         service.promoteBestCandidateIfDue();
 
         verifyNoInteractions(candidateRepository, replayContestRepository);
+    }
+
+    @Test
+    void promoteBestCandidateIfDueAllowsFiveMinuteCooldownGrace() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:00:00"));
+        LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T10:05:00");
+
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(recentContestCutoff))
+                .thenReturn(0L);
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(LocalDateTime.parse("2026-04-27T12:00:00")))
+                .thenReturn(0L);
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:00:00")))
+                .thenReturn(List.of());
+
+        service.promoteBestCandidateIfDue();
+
+        verify(replayContestRepository).countByPostedAtGreaterThanEqual(recentContestCutoff);
+        verify(candidateRepository)
+                .findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:00:00"));
+    }
+
+    @Test
+    void promoteBestCandidateIfDueBlocksWhenContestExistsInsideCooldownGrace() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:00:00"));
+        LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T10:05:00");
+
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(recentContestCutoff))
+                .thenReturn(1L);
+
+        service.promoteBestCandidateIfDue();
+
+        verify(replayContestRepository).countByPostedAtGreaterThanEqual(recentContestCutoff);
+        verifyNoInteractions(candidateRepository);
     }
 
     @Test
@@ -55,5 +110,13 @@ class CombatReplayContestLifecycleServiceTest {
                 mock(CombatReplayLeaderboardService.class),
                 mock(CombatReplaySideBetService.class),
                 mock(ReplayPayloadRenderer.class));
+    }
+
+    private Clock fixedClock(String localDateTime) {
+        return Clock.fixed(
+                LocalDateTime.parse(localDateTime)
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant(),
+                ZoneId.systemDefault());
     }
 }


### PR DESCRIPTION
## Summary
- Allow public combat replay promotion after 1h55m without another contest instead of requiring the full 2h window.
- Add deterministic lifecycle tests for the 5-minute cooldown grace boundary.

## Test Plan
- mvn -Dtest=CombatReplayContestLifecycleServiceTest test