### PR TITLE
Bump Maven base image to 3.9.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build stage ----
-FROM maven:3.9.9-eclipse-temurin-26-alpine AS build
+FROM maven:3.9.15-eclipse-temurin-26-alpine AS build
 WORKDIR /opt/app
 
 # cache dependencies


### PR DESCRIPTION
Update Dockerfile build stage to use maven:3.9.15-eclipse-temurin-26-alpine (was 3.9.9). This upgrades the Maven/Temurin patch release for potential bug fixes and security updates.