### PR TITLE
Change ReactionService to use COMPLETE over QUEUE

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/info/CardsInfoButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/info/CardsInfoButtonHandler.java
@@ -22,9 +22,7 @@ class CardsInfoButtonHandler {
         if (!game.isFowMode()) {
             ThreadChannel channel = player.getCardsInfoThread();
             // archiving it to combat a common bug that is solved via archiving
-            channel.getManager()
-                    .setArchived(true)
-                    .queue(Consumers.nop(), BotLogger::catchRestError);
+            channel.getManager().setArchived(true).queue(Consumers.nop(), BotLogger::catchRestError);
         }
         CardsInfoService.sendCardsInfo(game, player, event);
         EidolonMaximumService.sendEidolonMaximumFlipButtons(game, player);

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/info/CardsInfoButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/info/CardsInfoButtonHandler.java
@@ -21,12 +21,10 @@ class CardsInfoButtonHandler {
         }
         if (!game.isFowMode()) {
             ThreadChannel channel = player.getCardsInfoThread();
+            // archiving it to combat a common bug that is solved via archiving
             channel.getManager()
                     .setArchived(true)
-                    .queue(
-                            Consumers.nop(),
-                            BotLogger::catchRestError); // archiving it to combat a common bug that is solved via
-            // archiving
+                    .queue(Consumers.nop(), BotLogger::catchRestError);
         }
         CardsInfoService.sendCardsInfo(game, player, event);
         EidolonMaximumService.sendEidolonMaximumFlipButtons(game, player);

--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -1874,7 +1874,6 @@ public final class AgendaHelper {
             return;
         }
         if (game.getCurrentAgendaInfo() != null) {
-
             Player nextInLine = null;
             try {
                 nextInLine = getNextInLine(null, getVotingOrder(game), game);

--- a/src/main/java/ti4/service/button/ReactionService.java
+++ b/src/main/java/ti4/service/button/ReactionService.java
@@ -192,7 +192,9 @@ public class ReactionService {
             return;
         }
 
-        var message = game.getMainGameChannel().retrieveMessageById(gameMessage.messageId()).complete();
+        var message = game.getMainGameChannel()
+                .retrieveMessageById(gameMessage.messageId())
+                .complete();
         if (gameMessage.type() == GameMessageType.AGENDA_AFTER) {
             handleAllPlayersReactingNoAfters(message, game);
         } else if (gameMessage.type() == GameMessageType.AGENDA_WHEN) {

--- a/src/main/java/ti4/service/button/ReactionService.java
+++ b/src/main/java/ti4/service/button/ReactionService.java
@@ -1,6 +1,7 @@
 package ti4.service.button;
 
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -191,15 +192,14 @@ public class ReactionService {
             return;
         }
 
-        game.getMainGameChannel().retrieveMessageById(gameMessage.messageId()).queue(message -> {
-            if (gameMessage.type() == GameMessageType.AGENDA_AFTER) {
-                handleAllPlayersReactingNoAfters(message, game);
-            } else if (gameMessage.type() == GameMessageType.AGENDA_WHEN) {
-                handleAllPlayersReactingNoWhens(message, game);
-            } else {
-                handleAllPlayersReactingNoSabotage(message, game, gameMessage);
-            }
-        });
+        var message = game.getMainGameChannel().retrieveMessageById(gameMessage.messageId()).complete();
+        if (gameMessage.type() == GameMessageType.AGENDA_AFTER) {
+            handleAllPlayersReactingNoAfters(message, game);
+        } else if (gameMessage.type() == GameMessageType.AGENDA_WHEN) {
+            handleAllPlayersReactingNoWhens(message, game);
+        } else {
+            handleAllPlayersReactingNoSabotage(message, game, gameMessage);
+        }
     }
 
     public static void handleAllPlayersReactingNoAfters(Message message, Game game) {


### PR DESCRIPTION
Replace async .queue callback with a blocking .complete() in ReactionService to simplify control flow and handle message processing synchronously. Also tighten StringUtils imports to specific static methods (isBlank, isNotBlank). Minor non-functional cleanups: reflowed an archival comment in CardsInfoButtonHandler and removed an extraneous blank line in AgendaHelper.