### PR TITLE
Keep pending combat draws promotable

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayCron.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.experimental.UtilityClass;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayContestLifecycleService;
+import ti4.contest.replay.service.CombatReplayService;
 import ti4.cron.CronManager;
 import ti4.logging.BotLogger;
 import ti4.spring.context.SpringContext;
@@ -24,6 +25,7 @@ public class CombatReplayCron {
         CombatContestSettings settings = SpringContext.getBean(CombatContestSettings.class);
         if (!shouldRun(settings.getReplayExecution().getReplayIntervalSeconds())) return;
         try {
+            SpringContext.getBean(CombatReplayService.class).finalizeExpiredPendingResolutionCandidates();
             SpringContext.getBean(CombatReplayContestLifecycleService.class).runReplayTick();
         } catch (Exception e) {
             BotLogger.error("**CombatReplayCron failed.**", e);

--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionCron.java
@@ -26,7 +26,8 @@ public class CombatReplayPromotionCron {
     private static void promoteBestCandidate() {
         if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
         CombatContestSettings settings = SpringContext.getBean(CombatContestSettings.class);
-        if (!shouldRun(settings.getPromotion().getIntervalSeconds())) return;
+        if (!settings.getRuntime().isImmediatePromotionOnResolve()
+                && !shouldRun(settings.getPromotion().getIntervalSeconds())) return;
         BotLogger.logCron("Running CombatReplayPromotionCron.");
         try {
             SpringContext.getBean(CombatReplayContestLifecycleService.class).promoteBestCandidateIfDue();

--- a/src/main/java/ti4/contest/replay/core/CombatCandidateStatus.java
+++ b/src/main/java/ti4/contest/replay/core/CombatCandidateStatus.java
@@ -6,6 +6,8 @@ package ti4.contest.replay.core;
 public enum CombatCandidateStatus {
     /** Combat is still active and accepting mirrored events. */
     TRACKING,
+    /** Combat appears complete, but remains open briefly to capture sequential hit assignment. */
+    PENDING_RESOLUTION,
     /** Combat ended and can be considered for promotion. */
     RESOLVED,
     /** Combat was abandoned, superseded, or otherwise closed before normal resolution. */

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -55,6 +55,9 @@ public class CombatContestSettings {
         require(replayExecution.startDelayMinutes >= 0, "replayExecution.startDelayMinutes must be >= 0.");
         require(replayExecution.replayIntervalSeconds > 0, "replayExecution.replayIntervalSeconds must be > 0.");
         require(replayExecution.maxEventGapSeconds >= 0, "replayExecution.maxEventGapSeconds must be >= 0.");
+        require(
+                replayExecution.pendingResolutionWindowSeconds > 0,
+                "replayExecution.pendingResolutionWindowSeconds must be > 0.");
         require(retention.observationRetentionDays > 0, "retention.observationRetentionDays must be > 0.");
         require(retention.eventRetentionDays > 0, "retention.eventRetentionDays must be > 0.");
         require(runtime.versionEnabled != null, "runtime.versionEnabled is required.");
@@ -83,6 +86,7 @@ public class CombatContestSettings {
             replayExecution.setStartDelayMinutes(15);
             replayExecution.setReplayIntervalSeconds(15);
             replayExecution.setMaxEventGapSeconds(30);
+            replayExecution.setPendingResolutionWindowSeconds(900);
             runtime.setDevMode(false);
             runtime.setTrackAllCombatsAsCandidates(false);
             runtime.setImmediatePromotionOnResolve(false);
@@ -91,6 +95,7 @@ public class CombatContestSettings {
             replayExecution.setStartDelayMinutes(0);
             replayExecution.setReplayIntervalSeconds(1);
             replayExecution.setMaxEventGapSeconds(1);
+            replayExecution.setPendingResolutionWindowSeconds(30);
             runtime.setDevMode(true);
             runtime.setTrackAllCombatsAsCandidates(true);
             runtime.setImmediatePromotionOnResolve(true);
@@ -127,6 +132,7 @@ public class CombatContestSettings {
         private int startDelayMinutes = 15;
         private int replayIntervalSeconds = 15;
         private int maxEventGapSeconds = 30;
+        private int pendingResolutionWindowSeconds = 900;
     }
 
     @Getter

--- a/src/main/java/ti4/contest/replay/core/CombatReplayTrackedEvent.java
+++ b/src/main/java/ti4/contest/replay/core/CombatReplayTrackedEvent.java
@@ -10,6 +10,10 @@ public enum CombatReplayTrackedEvent {
     MORALE_BOOST,
     /** Current tracked action-card play side bet. */
     SHIELDS_HOLDING,
+    /** Current tracked action-card play side bet. */
+    DIRECT_HIT,
+    /** Current tracked action-card play side bet. */
+    FIGHTER_PROTOTYPE,
     /** Combat-ending action card that makes the candidate ineligible for promotion. */
     ROUT
 }

--- a/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
+++ b/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
@@ -22,6 +22,10 @@ public enum CombatSideBetType {
     MORALE_BOOST("Plays Morale Boost", CardEmojis.ActionCard, 0, 8),
     /** Current tracked interaction side bet. */
     SHIELDS_HOLDING("Plays Shields Holding", CardEmojis.ActionCard, 0, 8),
+    /** Current tracked interaction side bet. */
+    DIRECT_HIT("Plays Direct Hit", CardEmojis.ActionCard, 0, 8),
+    /** Current tracked interaction side bet. */
+    FIGHTER_PROTOTYPE("Plays Fighter Prototype", CardEmojis.ActionCard, 0, 24),
     /** Current dynamic resolution side bet. */
     WINNER_ONE_HP("Wins On 1\uFE0F\u20E3 HP", "1\uFE0F\u20E3", 0, 35);
 

--- a/src/main/java/ti4/contest/replay/core/CombatSideState.java
+++ b/src/main/java/ti4/contest/replay/core/CombatSideState.java
@@ -12,7 +12,9 @@ public record CombatSideState(
         boolean roundOneWhiff,
         boolean roundOneSlam,
         boolean playedMoraleBoost,
-        boolean playedShieldsHolding) {
+        boolean playedShieldsHolding,
+        boolean playedDirectHit,
+        boolean playedFighterPrototype) {
 
     public static CombatSideState forFaction(CombatCandidateEntity candidate, String faction) {
         if (candidate == null || faction == null) return null;
@@ -21,21 +23,20 @@ public record CombatSideState(
         return null;
     }
 
-    public static boolean markRollFlags(
+    public static void markRollFlags(
             CombatCandidateEntity candidate,
             String faction,
             boolean rolledAfb,
             boolean afbWhiff,
             boolean roundOneWhiff,
             boolean roundOneSlam) {
-        if (candidate == null || faction == null) return false;
         if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
             candidate.setAttackerRolledAfb(Boolean.TRUE.equals(candidate.getAttackerRolledAfb()) || rolledAfb);
             candidate.setAttackerAfbWhiff(Boolean.TRUE.equals(candidate.getAttackerAfbWhiff()) || afbWhiff);
             candidate.setAttackerRoundOneWhiff(
                     Boolean.TRUE.equals(candidate.getAttackerRoundOneWhiff()) || roundOneWhiff);
             candidate.setAttackerRoundOneSlam(Boolean.TRUE.equals(candidate.getAttackerRoundOneSlam()) || roundOneSlam);
-            return true;
+            return;
         }
         if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
             candidate.setDefenderRolledAfb(Boolean.TRUE.equals(candidate.getDefenderRolledAfb()) || rolledAfb);
@@ -43,29 +44,32 @@ public record CombatSideState(
             candidate.setDefenderRoundOneWhiff(
                     Boolean.TRUE.equals(candidate.getDefenderRoundOneWhiff()) || roundOneWhiff);
             candidate.setDefenderRoundOneSlam(Boolean.TRUE.equals(candidate.getDefenderRoundOneSlam()) || roundOneSlam);
-            return true;
         }
-        return false;
     }
 
-    public static boolean markEventFlags(
-            CombatCandidateEntity candidate, String faction, boolean moraleBoost, boolean shieldsHolding) {
-        if (candidate == null || faction == null) return false;
-        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
-            candidate.setAttackerPlayedMoraleBoost(
-                    Boolean.TRUE.equals(candidate.getAttackerPlayedMoraleBoost()) || moraleBoost);
-            candidate.setAttackerPlayedShieldsHolding(
-                    Boolean.TRUE.equals(candidate.getAttackerPlayedShieldsHolding()) || shieldsHolding);
-            return true;
+    public static void markEventFlag(
+            CombatCandidateEntity candidate, String faction, CombatReplayTrackedEvent trackedEvent) {
+        boolean attacker = faction.equalsIgnoreCase(candidate.getAttackerFaction());
+        if (!attacker && !faction.equalsIgnoreCase(candidate.getDefenderFaction())) return;
+        switch (trackedEvent) {
+            case MORALE_BOOST -> {
+                if (attacker) candidate.setAttackerPlayedMoraleBoost(true);
+                else candidate.setDefenderPlayedMoraleBoost(true);
+            }
+            case SHIELDS_HOLDING -> {
+                if (attacker) candidate.setAttackerPlayedShieldsHolding(true);
+                else candidate.setDefenderPlayedShieldsHolding(true);
+            }
+            case DIRECT_HIT -> {
+                if (attacker) candidate.setAttackerPlayedDirectHit(true);
+                else candidate.setDefenderPlayedDirectHit(true);
+            }
+            case FIGHTER_PROTOTYPE -> {
+                if (attacker) candidate.setAttackerPlayedFighterPrototype(true);
+                else candidate.setDefenderPlayedFighterPrototype(true);
+            }
+            case ROUT, NONE -> {}
         }
-        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
-            candidate.setDefenderPlayedMoraleBoost(
-                    Boolean.TRUE.equals(candidate.getDefenderPlayedMoraleBoost()) || moraleBoost);
-            candidate.setDefenderPlayedShieldsHolding(
-                    Boolean.TRUE.equals(candidate.getDefenderPlayedShieldsHolding()) || shieldsHolding);
-            return true;
-        }
-        return false;
     }
 
     private static CombatSideState attacker(CombatCandidateEntity candidate) {
@@ -76,7 +80,9 @@ public record CombatSideState(
                 Boolean.TRUE.equals(candidate.getAttackerRoundOneWhiff()),
                 Boolean.TRUE.equals(candidate.getAttackerRoundOneSlam()),
                 Boolean.TRUE.equals(candidate.getAttackerPlayedMoraleBoost()),
-                Boolean.TRUE.equals(candidate.getAttackerPlayedShieldsHolding()));
+                Boolean.TRUE.equals(candidate.getAttackerPlayedShieldsHolding()),
+                Boolean.TRUE.equals(candidate.getAttackerPlayedDirectHit()),
+                Boolean.TRUE.equals(candidate.getAttackerPlayedFighterPrototype()));
     }
 
     private static CombatSideState defender(CombatCandidateEntity candidate) {
@@ -87,7 +93,9 @@ public record CombatSideState(
                 Boolean.TRUE.equals(candidate.getDefenderRoundOneWhiff()),
                 Boolean.TRUE.equals(candidate.getDefenderRoundOneSlam()),
                 Boolean.TRUE.equals(candidate.getDefenderPlayedMoraleBoost()),
-                Boolean.TRUE.equals(candidate.getDefenderPlayedShieldsHolding()));
+                Boolean.TRUE.equals(candidate.getDefenderPlayedShieldsHolding()),
+                Boolean.TRUE.equals(candidate.getDefenderPlayedDirectHit()),
+                Boolean.TRUE.equals(candidate.getDefenderPlayedFighterPrototype()));
     }
 
     private static int safeInt(Integer value) {

--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -22,6 +22,7 @@ import ti4.helpers.Helper;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
 import ti4.image.Mapper;
+import ti4.model.FactionModel;
 import ti4.model.LeaderModel;
 import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
@@ -177,8 +178,8 @@ public class LazaxCombatSupport {
         Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
         Tile tile = game.getTileByPosition(candidate.getTilePosition());
         String tileRepresentation = tile == null ? candidate.getTilePosition() : tile.getRepresentationForButtons();
-        String attackerLine = formatReplayLegendLine(attacker, candidate.getAttackerFaction());
-        String defenderLine = formatReplayLegendLine(defender, candidate.getDefenderFaction());
+        String attackerLine = formatReplayLegendLine(attacker, candidate.getAttackerFaction(), false);
+        String defenderLine = formatReplayLegendLine(defender, candidate.getDefenderFaction(), false);
 
         String openerText = "## A New Combat Contest Has Emerged!\n"
                 + roleMention
@@ -194,6 +195,21 @@ public class LazaxCombatSupport {
             return openerText;
         }
         return openerText + "\n\n" + boardSummary;
+    }
+
+    public String revealReplayAnnouncementPlayerNames(
+            String announcementText, Game game, CombatCandidateEntity candidate) {
+        if (announcementText == null || announcementText.isBlank()) return announcementText;
+
+        Player attacker = game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        return announcementText
+                .replace(
+                        formatReplayLegendLine(attacker, candidate.getAttackerFaction(), false),
+                        formatReplayLegendLine(attacker, candidate.getAttackerFaction(), true))
+                .replace(
+                        formatReplayLegendLine(defender, candidate.getDefenderFaction(), false),
+                        formatReplayLegendLine(defender, candidate.getDefenderFaction(), true));
     }
 
     public double computeFairnessRatio(
@@ -499,12 +515,22 @@ public class LazaxCombatSupport {
         };
     }
 
-    private String formatReplayLegendLine(Player player, String fallbackFaction) {
+    private String formatReplayLegendLine(Player player, String fallbackFaction, boolean revealPlayerName) {
         if (player == null) {
             return "- `" + fallbackFaction + "`";
         }
-        return "- " + ColorEmojis.getColorEmoji(player.getColor()) + " " + player.getFactionEmoji() + " = "
-                + player.getUserName();
+        String label = revealPlayerName ? player.getUserName() : getFactionDisplayName(player, fallbackFaction);
+        return "- " + ColorEmojis.getColorEmoji(player.getColor()) + " " + player.getFactionEmoji() + " = " + label;
+    }
+
+    private String getFactionDisplayName(Player player, String fallbackFaction) {
+        FactionModel factionModel = player.getFactionModel();
+        if (factionModel == null
+                || factionModel.getFactionName() == null
+                || factionModel.getFactionName().isBlank()) {
+            return fallbackFaction;
+        }
+        return factionModel.getFactionName();
     }
 
     private String extractRecordedBoardSummary(String summaryText) {

--- a/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
@@ -22,6 +22,9 @@ import ti4.contest.replay.core.CombatCandidateStatus;
             @Index(name = "idx_combat_candidate_status_started_at", columnList = "status, started_at"),
             @Index(name = "idx_combat_candidate_promotion_resolved_at", columnList = "promotion_status, resolved_at"),
             @Index(name = "idx_combat_candidate_game_tile_status", columnList = "game_name, tile_position, status"),
+            @Index(
+                    name = "idx_combat_candidate_status_pending_resolution",
+                    columnList = "status, pending_resolution_started_at"),
             @Index(name = "idx_combat_candidate_promoted_at", columnList = "promoted_at")
         })
 /**
@@ -50,6 +53,9 @@ public class CombatCandidateEntity {
 
     @Column(name = "resolved_at")
     private LocalDateTime resolvedAt;
+
+    @Column(name = "pending_resolution_started_at")
+    private LocalDateTime pendingResolutionStartedAt;
 
     @Column(name = "promoted_at")
     private LocalDateTime promotedAt;
@@ -146,6 +152,18 @@ public class CombatCandidateEntity {
 
     @Column(name = "defender_played_shields_holding", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean defenderPlayedShieldsHolding = false;
+
+    @Column(name = "attacker_played_direct_hit", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean attackerPlayedDirectHit = false;
+
+    @Column(name = "defender_played_direct_hit", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean defenderPlayedDirectHit = false;
+
+    @Column(name = "attacker_played_fighter_prototype", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean attackerPlayedFighterPrototype = false;
+
+    @Column(name = "defender_played_fighter_prototype", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean defenderPlayedFighterPrototype = false;
 
     @Column(name = "winner_one_hp_remaining", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean winnerOneHpRemaining = false;

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
@@ -1,6 +1,7 @@
 package ti4.contest.replay.repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,7 +16,15 @@ public interface CombatCandidateRepository extends JpaRepository<CombatCandidate
 
     List<CombatCandidateEntity> findByGameNameAndStatus(String gameName, CombatCandidateStatus status);
 
+    List<CombatCandidateEntity> findByGameNameAndStatusIn(String gameName, Collection<CombatCandidateStatus> statuses);
+
+    CombatCandidateEntity findFirstByGameNameAndTilePositionAndStatusIn(
+            String gameName, String tilePosition, Collection<CombatCandidateStatus> statuses);
+
     List<CombatCandidateEntity> findByStatus(CombatCandidateStatus status);
+
+    List<CombatCandidateEntity> findByStatusAndPendingResolutionStartedAtBefore(
+            CombatCandidateStatus status, LocalDateTime pendingResolutionStartedAt);
 
     @Query("""
             select c from CombatCandidateEntity c

--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -96,14 +96,17 @@ public class CombatReplayContestLifecycleService {
     public void promoteBestCandidateIfDue() {
         if (!settings.getPromotion().isEnabled()) return;
 
+        boolean immediatePromotion = settings.getRuntime().isImmediatePromotionOnResolve();
         LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
-        if (now.getMinute() != 0) return;
-        int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
-        if (maxPromotionsPerHour <= 0) return;
-        if (replayContestRepository.countByPostedAtGreaterThanEqual(publicPromotionCooldownCutoff(now)) > 0) return;
-        if (replayContestRepository.countByPostedAtGreaterThanEqual(now.truncatedTo(ChronoUnit.HOURS))
-                >= maxPromotionsPerHour) {
-            return;
+        if (!immediatePromotion) {
+            if (now.getMinute() != 0) return;
+            int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
+            if (maxPromotionsPerHour <= 0) return;
+            if (replayContestRepository.countByPostedAtGreaterThanEqual(publicPromotionCooldownCutoff(now)) > 0) return;
+            if (replayContestRepository.countByPostedAtGreaterThanEqual(now.truncatedTo(ChronoUnit.HOURS))
+                    >= maxPromotionsPerHour) {
+                return;
+            }
         }
 
         List<CombatCandidateEntity> candidates = findPromotionCandidates(now);

--- a/src/main/java/ti4/contest/replay/service/CombatReplayEventAppender.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayEventAppender.java
@@ -33,9 +33,12 @@ public class CombatReplayEventAppender {
         CombatCandidateEntity freshCandidate =
                 candidateRepository.findById(candidate.getId()).orElse(null);
         if (freshCandidate == null) return;
-        if (freshCandidate.getStatus() != CombatCandidateStatus.TRACKING
-                && eventType != CombatCandidateEventType.RESOLVED
-                && eventType != CombatCandidateEventType.CANCELLED) return;
+        CombatCandidateStatus status = freshCandidate.getStatus();
+        boolean pendingHitAssignment =
+                status == CombatCandidateStatus.PENDING_RESOLUTION && eventType == CombatCandidateEventType.HIT_ASSIGN;
+        boolean terminalEvent =
+                eventType == CombatCandidateEventType.RESOLVED || eventType == CombatCandidateEventType.CANCELLED;
+        if (status != CombatCandidateStatus.TRACKING && !pendingHitAssignment && !terminalEvent) return;
 
         int sequenceNumber = nextSequenceNumber(freshCandidate);
         CombatCandidateEventEntity event = new CombatCandidateEventEntity();

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.entities.emoji.Emoji;
 import org.springframework.stereotype.Service;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayChannels;
+import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
@@ -79,6 +80,14 @@ public class CombatReplayLeaderboardService {
                 .retrieveMessageById(replayContest.getPublicMessageId())
                 .complete();
         replayPredictionRepository.save(buildLockedPredictionSnapshot(game, replayContest, candidate, message));
+        revealPlayerNamesOnContestPost(message, game, candidate);
+    }
+
+    private void revealPlayerNamesOnContestPost(Message message, Game game, CombatCandidateEntity candidate) {
+        String revealedMessage =
+                LazaxCombatSupport.revealReplayAnnouncementPlayerNames(message.getContentRaw(), game, candidate);
+        if (revealedMessage == null || revealedMessage.equals(message.getContentRaw())) return;
+        message.editMessage(revealedMessage).queue(null, BotLogger::catchRestError);
     }
 
     public void announceLockedPredictionsIfNeeded(
@@ -243,11 +252,8 @@ public class CombatReplayLeaderboardService {
                 readLockedPredictions(lockedPrediction.getAttackerPredictionsJson());
         List<LockedPrediction> defenderPredictions =
                 readLockedPredictions(lockedPrediction.getDefenderPredictionsJson());
-        boolean attackerWon = candidate.getWinnerFaction() != null
-                && candidate.getWinnerFaction().equalsIgnoreCase(candidate.getAttackerFaction());
-
-        ScoredPredictions scoredPredictions =
-                CombatReplayPredictionScorer.score(attackerPredictions, defenderPredictions, attackerWon);
+        ScoredPredictions scoredPredictions = CombatReplayPredictionScorer.score(
+                attackerPredictions, defenderPredictions, candidate.getWinnerFaction(), candidate.getAttackerFaction());
 
         List<String> userIds = new ArrayList<>();
         for (LockedPrediction prediction : scoredPredictions.allPredictions()) {
@@ -328,10 +334,11 @@ public class CombatReplayLeaderboardService {
             CombatCandidateEntity candidate,
             ScoredContestResult result,
             Runnable afterPost) {
+        String resultLabel = candidate.getWinnerFaction() == null ? "Result" : "Winner";
         String winnerDisplay = getWinnerDisplay(game, candidate);
         List<WinningPredictionSummary> winningPredictions = result.winningPredictions();
         String message = "## Prediction Results\n"
-                + "Winner: " + winnerDisplay + "\n"
+                + resultLabel + ": " + winnerDisplay + "\n"
                 + "Predictions locked: **" + result.totalPredictions() + "**\n"
                 + "Correct predictions: **" + winningPredictions.size() + "**";
         if (result.totalPredictions() == 0) {
@@ -379,13 +386,14 @@ public class CombatReplayLeaderboardService {
     }
 
     private String getWinnerDisplay(Game game, CombatCandidateEntity candidate) {
-        if (game != null && candidate.getWinnerFaction() != null) {
+        if (candidate.getWinnerFaction() == null) return "**Draw**";
+        if (game != null) {
             Player winner = game.getPlayerFromColorOrFaction(candidate.getWinnerFaction());
             if (winner != null) {
                 return winner.getFactionEmoji() + " **" + getSafeLeaderboardName(winner.getUserName()) + "**";
             }
         }
-        return "**" + (candidate.getWinnerFaction() == null ? "Unknown" : candidate.getWinnerFaction()) + "**";
+        return "**" + candidate.getWinnerFaction() + "**";
     }
 
     private void postParticipantFollowup(Game game, CombatCandidateEntity candidate, MessageChannel threadOrChannel) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPredictionScorer.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPredictionScorer.java
@@ -14,8 +14,13 @@ public class CombatReplayPredictionScorer {
     static ScoredPredictions score(
             List<LockedPrediction> attackerPredictions,
             List<LockedPrediction> defenderPredictions,
-            boolean attackerWon) {
-        List<LockedPrediction> winningPredictions = attackerWon ? attackerPredictions : defenderPredictions;
+            String winnerFaction,
+            String attackerFaction) {
+        List<LockedPrediction> winningPredictions = List.of();
+        if (winnerFaction != null) {
+            winningPredictions =
+                    winnerFaction.equalsIgnoreCase(attackerFaction) ? attackerPredictions : defenderPredictions;
+        }
         List<LockedPrediction> allPredictions =
                 new ArrayList<>(attackerPredictions.size() + defenderPredictions.size());
         allPredictions.addAll(attackerPredictions);

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -3,9 +3,11 @@ package ti4.contest.replay.service;
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +35,11 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.Tile;
 import ti4.game.UnitHolder;
+import ti4.game.persistence.GameManager;
 import ti4.helpers.ButtonHelper;
 import ti4.helpers.Constants;
 import ti4.service.combat.CombatRollType;
 import ti4.service.combat.CombatUnitSelectionHelper;
-import ti4.spring.context.SpringContext;
 
 /**
  * Observes live combats, scores them against the current replay thresholds, and records replay candidates/events.
@@ -47,6 +49,8 @@ import ti4.spring.context.SpringContext;
 public class CombatReplayService {
 
     private static final Pattern SYSTEM_TILE_PATTERN = Pattern.compile("-system-([^-]+)-");
+    private static final Set<CombatCandidateStatus> OPEN_CANDIDATE_STATUSES =
+            EnumSet.of(CombatCandidateStatus.TRACKING, CombatCandidateStatus.PENDING_RESOLUTION);
     private static final ThreadLocal<PreInteractionSnapshot> preInteractionSnapshot = new ThreadLocal<>();
 
     private final CombatContestSettings settings;
@@ -67,7 +71,7 @@ public class CombatReplayService {
         if (game == null) return PreInteractionSnapshot.empty();
 
         Map<Long, CandidateInitialSnapshot> snapshots = new HashMap<>();
-        for (CombatCandidateEntity candidate : getTrackingCandidates(game)) {
+        for (CombatCandidateEntity candidate : getOpenCandidates(game)) {
             if (isInitialSnapshotCaptured(candidate)) continue;
             CandidateInitialSnapshot snapshot = captureCandidateInitialSnapshot(game, candidate);
             if (snapshot != null) {
@@ -109,9 +113,32 @@ public class CombatReplayService {
     }
 
     public void onButtonInteractionSettled(Game game, Player player, ButtonInteractionEvent event) {
-        for (CombatCandidateEntity candidate : getTrackingCandidates(game)) {
-            trackHitAssignments(game, player, event, candidate);
-            evaluateCandidateCompletion(game, candidate);
+        for (CombatCandidateEntity candidate : getOpenCandidates(game)) {
+            if (candidate.getStatus() == CombatCandidateStatus.PENDING_RESOLUTION
+                    && !candidate
+                            .getPendingResolutionStartedAt()
+                            .plusSeconds(settings.getReplayExecution().getPendingResolutionWindowSeconds())
+                            .isAfter(LocalDateTime.now())) {
+                finalizePendingResolutionCandidate(game, candidate);
+                continue;
+            }
+
+            boolean trackedHitAssignment = trackHitAssignments(game, player, event, candidate);
+            if (candidate.getStatus() == CombatCandidateStatus.TRACKING) {
+                evaluateCandidateCompletion(game, candidate);
+            } else if (trackedHitAssignment) {
+                cancelPendingResolutionIfDrawn(game, candidate);
+            }
+        }
+    }
+
+    public void finalizeExpiredPendingResolutionCandidates() {
+        LocalDateTime cutoff =
+                LocalDateTime.now().minusSeconds(settings.getReplayExecution().getPendingResolutionWindowSeconds());
+        for (CombatCandidateEntity candidate : candidateRepository.findByStatusAndPendingResolutionStartedAtBefore(
+                CombatCandidateStatus.PENDING_RESOLUTION, cutoff)) {
+            Game game = loadGame(candidate.getGameName());
+            finalizePendingResolutionCandidate(game, candidate);
         }
     }
 
@@ -126,8 +153,8 @@ public class CombatReplayService {
             boolean slam,
             CombatRollPayload payload) {
         CombatCandidateEntity candidate = getTrackingCandidate(game, tile.getPosition());
-        if (candidate == null || !matchesParticipants(candidate, player, opponent)) return;
-        if (!isSpaceCombatRoll(rollType)) return;
+        if (candidate == null || !isReplayRoll(rollType)) return;
+        if (rollType != CombatRollType.SpaceCannonOffence && !matchesParticipants(candidate, player, opponent)) return;
 
         ensureInitialSnapshot(candidate, game);
         int round = getCurrentRound(game, candidate);
@@ -143,8 +170,10 @@ public class CombatReplayService {
                 candidate, sideBetTriggerService.fromRoll(candidate, player, rollType, whiff, slam, round));
     }
 
-    private boolean isSpaceCombatRoll(CombatRollType rollType) {
-        return rollType == CombatRollType.combatround || rollType == CombatRollType.AFB;
+    private boolean isReplayRoll(CombatRollType rollType) {
+        return rollType == CombatRollType.combatround
+                || rollType == CombatRollType.AFB
+                || rollType == CombatRollType.SpaceCannonOffence;
     }
 
     public void mirrorCombatEvent(
@@ -265,12 +294,7 @@ public class CombatReplayService {
         Tile tile = game.getTileByPosition(candidate.getTilePosition());
         if (tile == null) return false;
 
-        List<Player> remainingShipPlayers = new ArrayList<>();
-        for (Player player : ButtonHelper.getPlayersWithShipsInTheSystem(game, tile)) {
-            if (player.isRealPlayer() && !player.isDummy()) {
-                remainingShipPlayers.add(player);
-            }
-        }
+        List<Player> remainingShipPlayers = remainingShipPlayers(game, tile);
         boolean hasRecordedRoll = hasRecordedRoll(candidate);
         return switch (remainingShipPlayers.size()) {
             case 0 -> {
@@ -287,8 +311,7 @@ public class CombatReplayService {
                     cancelCandidate(game, candidate, "The tracked space combat ended before any dice were rolled.");
                     yield true;
                 }
-                Player winner = remainingShipPlayers.getFirst();
-                resolveCandidate(game, candidate, tile, winner, loserFaction(candidate, winner));
+                markCandidatePendingResolution(candidate);
                 yield true;
             }
             case 2 -> {
@@ -304,6 +327,64 @@ public class CombatReplayService {
                 yield true;
             }
         };
+    }
+
+    private void markCandidatePendingResolution(CombatCandidateEntity candidate) {
+        candidate.setStatus(CombatCandidateStatus.PENDING_RESOLUTION);
+        candidate.setPendingResolutionStartedAt(LocalDateTime.now());
+        candidate.setResolutionReason("Combat pending final hit assignment.");
+        candidateRepository.save(candidate);
+    }
+
+    private void cancelPendingResolutionIfDrawn(Game game, CombatCandidateEntity candidate) {
+        Tile tile = game.getTileByPosition(candidate.getTilePosition());
+        if (tile != null && remainingShipPlayers(game, tile).isEmpty()) {
+            resolveDrawCandidate(game, candidate, tile);
+        }
+    }
+
+    private void finalizePendingResolutionCandidate(Game game, CombatCandidateEntity candidate) {
+        if (game == null) {
+            cancelCandidate(null, candidate, "The tracked space combat could not be loaded for resolution.");
+            return;
+        }
+
+        Tile tile = game.getTileByPosition(candidate.getTilePosition());
+        if (tile == null) {
+            cancelCandidate(game, candidate, "The tracked space combat tile could not be found.");
+            return;
+        }
+
+        List<Player> remainingShipPlayers = remainingShipPlayers(game, tile);
+        switch (remainingShipPlayers.size()) {
+            case 0 -> resolveDrawCandidate(game, candidate, tile);
+            case 1 -> {
+                Player winner = remainingShipPlayers.getFirst();
+                resolveCandidate(game, candidate, tile, winner, loserFaction(candidate, winner));
+            }
+            case 2 -> {
+                if (containsOnlyOriginalParticipants(candidate, remainingShipPlayers)) {
+                    cancelCandidate(
+                            game,
+                            candidate,
+                            "The tracked space combat was still unresolved after the pending-resolution window.");
+                } else {
+                    cancelCandidate(
+                            game, candidate, "The tracked space combat drifted away from the original participants.");
+                }
+            }
+            default -> cancelCandidate(game, candidate, "The tracked space combat no longer has exactly two sides.");
+        }
+    }
+
+    private List<Player> remainingShipPlayers(Game game, Tile tile) {
+        List<Player> remainingShipPlayers = new ArrayList<>();
+        for (Player player : ButtonHelper.getPlayersWithShipsInTheSystem(game, tile)) {
+            if (player.isRealPlayer() && !player.isDummy()) {
+                remainingShipPlayers.add(player);
+            }
+        }
+        return remainingShipPlayers;
     }
 
     private boolean containsOnlyOriginalParticipants(
@@ -365,10 +446,37 @@ public class CombatReplayService {
                         + ")");
         appendSideBetTriggerEvents(
                 candidate, CombatCandidateEventType.RESOLVED, sideBetTriggerService.fromResolution(candidate, winner));
+    }
 
-        if (settings.getRuntime().isImmediatePromotionOnResolve()) {
-            SpringContext.getBean(CombatReplayContestLifecycleService.class).forcePromoteCandidate(candidate.getId());
+    private void resolveDrawCandidate(Game game, CombatCandidateEntity candidate, Tile tile) {
+        int roundsObserved = candidateEventRepository
+                .findMaxRoundNumberByCandidateId(candidate.getId())
+                .orElse(0);
+        CombatObservationEntity observation =
+                observationRepository.findById(candidate.getObservationId()).orElse(null);
+
+        candidate.setStatus(CombatCandidateStatus.RESOLVED);
+        candidate.setResolvedAt(LocalDateTime.now());
+        candidate.setWinnerFaction(null);
+        candidate.setLoserFaction(null);
+        candidate.setResolutionReason("Combat ended in a draw after pending hit assignment.");
+        candidate.setWinnerOneHpRemaining(false);
+        if (observation != null) {
+            candidate.setPromotionScore(computeDrawPromotionScore(observation, roundsObserved));
         }
+        candidateRepository.save(candidate);
+
+        appendTileRenderEvent(
+                candidate,
+                CombatCandidateEventType.RESOLVED,
+                roundsObserved,
+                null,
+                tile.getPosition(),
+                CombatReplayTileRenderer.captureUnitStateSnapshot(game, tile.getPosition()),
+                "## Contest Result\nThe space combat in " + tile.getRepresentationForButtons()
+                        + " ended in a draw with no ships remaining.\n"
+                        + "Game " + game.getName() + ": [Open Game](https://asyncti4.com/game/" + game.getName()
+                        + ")");
     }
 
     private void cancelCandidate(Game game, CombatCandidateEntity candidate, String reason) {
@@ -381,19 +489,20 @@ public class CombatReplayService {
         appendDiscordEvent(candidate, CombatCandidateEventType.CANCELLED, null, null, "## Contest Closed\n" + reason);
     }
 
-    private void trackHitAssignments(
+    private boolean trackHitAssignments(
             Game game, Player player, ButtonInteractionEvent event, CombatCandidateEntity candidate) {
-        if (player == null || !isSpaceCombatHitAssignment(game, player, event)) return;
+        if (player == null || !isSpaceCombatHitAssignment(game, player, event)) return false;
         if (!candidate
                 .getTilePosition()
-                .equals(getTilePosition(event.getButton().getCustomId()))) return;
-        if (!matchesParticipant(candidate, player)) return;
+                .equals(getTilePosition(event.getButton().getCustomId()))) return false;
+        if (!matchesParticipant(candidate, player)) return false;
 
         ensureInitialSnapshot(candidate, game);
         int round = getCurrentRound(game, candidate);
-        if (candidateEventRepository.existsByCandidateIdAndEventTypeAndActorFactionAndRoundNumber(
-                candidate.getId(), CombatCandidateEventType.HIT_ASSIGN, player.getFaction(), round)) {
-            return;
+        if (candidate.getStatus() == CombatCandidateStatus.TRACKING
+                && candidateEventRepository.existsByCandidateIdAndEventTypeAndActorFactionAndRoundNumber(
+                        candidate.getId(), CombatCandidateEventType.HIT_ASSIGN, player.getFaction(), round)) {
+            return true;
         }
 
         String roundLabel = round > 0 ? "round #" + round : "the current exchange";
@@ -409,6 +518,7 @@ public class CombatReplayService {
                 ReplayDispatchPayload.hitAssign(
                         candidate.getTilePosition(),
                         CombatReplayTileRenderer.captureUnitStateSnapshot(game, candidate.getTilePosition())));
+        return true;
     }
 
     private void ensureInitialSnapshot(CombatCandidateEntity candidate, Game fallbackGame) {
@@ -507,6 +617,17 @@ public class CombatReplayService {
         return roundScore + openingBalanceScore + endingTensionScore + defenderWinBonus;
     }
 
+    private static double computeDrawPromotionScore(CombatObservationEntity observation, int roundsObserved) {
+        double weakerHp = Math.min(observation.getAttackerHp(), observation.getDefenderHp());
+        double weakerStrength = Math.min(observation.getAttackerStrength(), observation.getDefenderStrength());
+        double strongerStrength = Math.max(observation.getAttackerStrength(), observation.getDefenderStrength());
+        double sizeFactor = Math.min(1.0, weakerHp / 8.0);
+        double strengthRatio = safeRatio(weakerStrength, strongerStrength);
+        double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
+        double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
+        return roundScore + openingBalanceScore + 5.0;
+    }
+
     public CombatReplaySelection.SelectionDebugView getSelectionDebugView() {
         return selection().debugView();
     }
@@ -542,12 +663,15 @@ public class CombatReplayService {
             int round) {
         if (candidate == null || player == null) return;
         boolean rolledAfb = rollType == CombatRollType.AFB;
-        boolean afbWhiff = rolledAfb && whiff;
         boolean roundOneCombatRoll = rollType == CombatRollType.combatround && round == 1;
-        boolean roundOneWhiff = roundOneCombatRoll && whiff;
-        boolean roundOneSlam = roundOneCombatRoll && slam;
-        if (!rolledAfb && !afbWhiff && !roundOneWhiff && !roundOneSlam) return;
-        CombatSideState.markRollFlags(candidate, player.getFaction(), rolledAfb, afbWhiff, roundOneWhiff, roundOneSlam);
+        if (!rolledAfb && !roundOneCombatRoll) return;
+        CombatSideState.markRollFlags(
+                candidate,
+                player.getFaction(),
+                rolledAfb,
+                rolledAfb && whiff,
+                roundOneCombatRoll && whiff,
+                roundOneCombatRoll && slam);
         candidateRepository.save(candidate);
     }
 
@@ -572,15 +696,12 @@ public class CombatReplayService {
                 || player == null
                 || trackedEvent == null
                 || trackedEvent == CombatReplayTrackedEvent.NONE) return;
-        boolean moraleBoost = trackedEvent == CombatReplayTrackedEvent.MORALE_BOOST;
-        boolean shieldsHolding = trackedEvent == CombatReplayTrackedEvent.SHIELDS_HOLDING;
-        boolean rout = trackedEvent == CombatReplayTrackedEvent.ROUT;
-        if (rout) {
+        if (trackedEvent == CombatReplayTrackedEvent.ROUT) {
             candidate.setPromotionStatus(CombatCandidatePromotionStatus.EXPIRED);
             candidate.setCancellationReason(firstNonBlank(
                     candidate.getCancellationReason(), "Ineligible for promotion because Rout was played."));
         }
-        CombatSideState.markEventFlags(candidate, player.getFaction(), moraleBoost, shieldsHolding);
+        CombatSideState.markEventFlag(candidate, player.getFaction(), trackedEvent);
         candidateRepository.save(candidate);
     }
 
@@ -635,11 +756,11 @@ public class CombatReplayService {
     private boolean isEligibleCandidate(
             Game game, Player attacker, Player defender, Tile tile, CombatReplaySelection.Evaluation evaluation) {
         if (settings.getRuntime().isTrackAllCombatsAsCandidates()) {
-            return getTrackingCandidate(game, tile.getPosition()) == null;
+            return getOpenCandidate(game, tile.getPosition()) == null;
         }
         return evaluation.eligible()
                 && !LazaxCombatSupport.hasExcludedFlagship(attacker, defender)
-                && getTrackingCandidate(game, tile.getPosition()) == null;
+                && getOpenCandidate(game, tile.getPosition()) == null;
     }
 
     private CombatReplaySelection selection() {
@@ -675,13 +796,18 @@ public class CombatReplayService {
         return player != null && player.hasTech("asc");
     }
 
-    private List<CombatCandidateEntity> getTrackingCandidates(Game game) {
-        return candidateRepository.findByGameNameAndStatus(game.getName(), CombatCandidateStatus.TRACKING);
+    private List<CombatCandidateEntity> getOpenCandidates(Game game) {
+        return candidateRepository.findByGameNameAndStatusIn(game.getName(), OPEN_CANDIDATE_STATUSES);
     }
 
     private CombatCandidateEntity getTrackingCandidate(Game game, String tilePosition) {
         return candidateRepository.findFirstByGameNameAndTilePositionAndStatus(
                 game.getName(), tilePosition, CombatCandidateStatus.TRACKING);
+    }
+
+    private CombatCandidateEntity getOpenCandidate(Game game, String tilePosition) {
+        return candidateRepository.findFirstByGameNameAndTilePositionAndStatusIn(
+                game.getName(), tilePosition, OPEN_CANDIDATE_STATUSES);
     }
 
     private boolean hasRecordedRoll(CombatCandidateEntity candidate) {
@@ -767,12 +893,16 @@ public class CombatReplayService {
         String tilePosition = extractTilePosition(sourceChannelName);
         if (tilePosition != null) {
             CombatCandidateEntity candidate = getTrackingCandidate(game, tilePosition);
-            if (candidate != null && matchesParticipant(candidate, player)) return candidate;
+            if (candidate != null) return candidate;
         }
 
         List<CombatCandidateEntity> candidates = candidateRepository.findTrackingCandidatesForFaction(
                 game.getName(), CombatCandidateStatus.TRACKING, player.getFaction());
-        return candidates.size() == 1 ? candidates.getFirst() : null;
+        if (candidates.size() == 1) return candidates.getFirst();
+
+        List<CombatCandidateEntity> activeCandidates =
+                candidateRepository.findByGameNameAndStatus(game.getName(), CombatCandidateStatus.TRACKING);
+        return activeCandidates.size() == 1 ? activeCandidates.getFirst() : null;
     }
 
     private String extractTilePosition(String sourceChannelName) {
@@ -810,6 +940,11 @@ public class CombatReplayService {
 
     private String firstNonBlank(String first, String fallback) {
         return first == null || first.isBlank() ? fallback : first;
+    }
+
+    private Game loadGame(String gameName) {
+        var managedGame = GameManager.getManagedGame(gameName);
+        return managedGame == null ? null : managedGame.getGame();
     }
 
     public record PreInteractionSnapshot(Map<Long, CandidateInitialSnapshot> snapshotsByCandidateId) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -230,6 +230,8 @@ public class CombatReplaySideBetService {
             case ROUND_ONE_SLAM -> state.roundOneSlam();
             case MORALE_BOOST -> state.playedMoraleBoost();
             case SHIELDS_HOLDING -> state.playedShieldsHolding();
+            case DIRECT_HIT -> state.playedDirectHit();
+            case FIGHTER_PROTOTYPE -> state.playedFighterPrototype();
             case WINNER_ONE_HP ->
                 Boolean.TRUE.equals(candidate.getWinnerOneHpRemaining())
                         && sideBet.getTargetFaction() != null

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
@@ -63,6 +63,8 @@ public class CombatReplaySideBetTriggerService {
         return switch (trackedEvent) {
             case MORALE_BOOST -> List.of(announcement(player, "Morale Boost!"));
             case SHIELDS_HOLDING -> List.of(announcement(player, "Shields Holding!"));
+            case DIRECT_HIT -> List.of(announcement(player, "Direct Hit!"));
+            case FIGHTER_PROTOTYPE -> List.of(announcement(player, "Fighter Prototype!"));
             case ROUT, NONE -> List.of();
         };
     }

--- a/src/main/java/ti4/contest/replay/service/ReplayPayloadRenderer.java
+++ b/src/main/java/ti4/contest/replay/service/ReplayPayloadRenderer.java
@@ -1,6 +1,9 @@
 package ti4.contest.replay.service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.apache.commons.lang3.StringUtils;
@@ -14,9 +17,15 @@ import ti4.contest.replay.dispatch.ReplayDispatchPayload;
 import ti4.contest.replay.dispatch.ReplayDispatchSerializer;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatCandidateEventEntity;
+import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.game.UnitHolder;
 import ti4.helpers.Constants;
+import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitState;
+import ti4.helpers.Units.UnitType;
 import ti4.image.Mapper;
 import ti4.model.ActionCardModel;
 import ti4.model.LeaderModel;
@@ -31,6 +40,7 @@ public class ReplayPayloadRenderer {
 
     private final CombatContestSettings settings;
     private final ReplayDispatchSerializer payloadSerializer;
+    private final CombatCandidateEventRepository candidateEventRepository;
 
     public RenderedReplayEvent render(Game game, CombatCandidateEntity candidate, CombatCandidateEventEntity event) {
         ReplayDispatchPayload payload = payloadSerializer.read(event);
@@ -94,8 +104,9 @@ public class ReplayPayloadRenderer {
 
     private RenderedReplayEvent renderHitAssign(
             RenderContext context, ReplayDispatchPayload.HitAssignDispatch payload) {
-        return tileRender(
-                context.event().getSummaryText(), List.of(), payload.tilePosition(), payload.combatStateSnapshotJson());
+        String content = firstNonBlank(
+                renderHitAssignSummary(context, payload), context.event().getSummaryText());
+        return tileRender(content, List.of(), payload.tilePosition(), payload.combatStateSnapshotJson());
     }
 
     private RenderedReplayEvent renderTileRenderMessage(
@@ -235,6 +246,129 @@ public class ReplayPayloadRenderer {
 
     private String firstNonBlank(String value, String fallback) {
         return value != null && !value.isBlank() ? value : fallback;
+    }
+
+    private String renderHitAssignSummary(RenderContext context, ReplayDispatchPayload.HitAssignDispatch payload) {
+        String previousSnapshotJson = previousTileSnapshotJson(context, payload.tilePosition());
+        if (StringUtils.isBlank(previousSnapshotJson)) return null;
+
+        Game previous =
+                restoreReplayGame(previousSnapshotJson, context.game(), context.candidate(), payload.tilePosition());
+        Game current = restoreReplayGame(
+                payload.combatStateSnapshotJson(), context.game(), context.candidate(), payload.tilePosition());
+        if (previous == null || current == null) return null;
+
+        List<String> changes = hitAssignmentChanges(previous, current, payload.tilePosition());
+        if (changes.isEmpty()) return null;
+        return context.event().getSummaryText() + "\n" + String.join("\n", changes);
+    }
+
+    private String previousTileSnapshotJson(RenderContext context, String tilePosition) {
+        CombatCandidateEntity candidate = context.candidate();
+        if (candidate == null || candidate.getId() == null) return null;
+
+        String previousSnapshotJson = candidate.getInitialRenderSnapshotJson();
+        for (CombatCandidateEventEntity event :
+                candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId())) {
+            if (event.getSequenceNumber() == null
+                    || context.event().getSequenceNumber() == null
+                    || event.getSequenceNumber() >= context.event().getSequenceNumber()) {
+                break;
+            }
+            ReplayDispatchPayload eventPayload = payloadSerializer.read(event);
+            if (eventPayload instanceof ReplayDispatchPayload.HitAssignDispatch hitAssign
+                    && tilePosition.equals(hitAssign.tilePosition())) {
+                previousSnapshotJson = hitAssign.combatStateSnapshotJson();
+            } else if (eventPayload instanceof ReplayDispatchPayload.TileRenderMessageDispatch tileRender
+                    && tilePosition.equals(tileRender.tilePosition())) {
+                previousSnapshotJson = tileRender.combatStateSnapshotJson();
+            }
+        }
+        return previousSnapshotJson;
+    }
+
+    private List<String> hitAssignmentChanges(Game previous, Game current, String tilePosition) {
+        Map<UnitKey, Counts> before = unitCounts(previous, tilePosition);
+        Map<UnitKey, Counts> after = unitCounts(current, tilePosition);
+        List<String> changes = new ArrayList<>();
+
+        for (UnitKey key : before.keySet()) {
+            Counts previousCounts = before.get(key);
+            Counts currentCounts = after.getOrDefault(key, Counts.empty());
+            int sustained = previousCounts.sustainedBy(currentCounts);
+            int destroyed = previousCounts.total() - currentCounts.total();
+            if (sustained > 0) {
+                changes.add("- " + unitOwner(current, key.getColorID()) + " sustained "
+                        + unitPhrase(key.getUnitType(), sustained) + ".");
+            }
+            if (destroyed > 0) {
+                changes.add("- " + unitOwner(current, key.getColorID()) + " destroyed "
+                        + unitPhrase(key.getUnitType(), destroyed) + ".");
+            }
+        }
+        return changes;
+    }
+
+    private Map<UnitKey, Counts> unitCounts(Game game, String tilePosition) {
+        Tile tile = game.getTileByPosition(tilePosition);
+        if (tile == null) return Map.of();
+
+        Map<UnitKey, Counts> counts = new HashMap<>();
+        for (UnitHolder holder : tile.getUnitHolders().values()) {
+            for (UnitKey unitKey : holder.getUnitKeys()) {
+                counts.merge(unitKey, Counts.from(holder, unitKey), Counts::plus);
+            }
+        }
+        return counts;
+    }
+
+    private String unitOwner(Game game, String colorId) {
+        Player player = game.getPlayerFromColorOrFaction(colorId);
+        if (player == null) return colorId;
+        return player.getFactionEmoji();
+    }
+
+    private String unitPhrase(UnitType unitType, int count) {
+        String name = unitType.humanReadableName().toLowerCase();
+        if (count == 1 || unitType == UnitType.Infantry || unitType == UnitType.Pds) {
+            return count + " " + name;
+        }
+        return count + " " + name + "s";
+    }
+
+    private record Counts(int none, int damaged, int galvanized, int damagedGalvanized) {
+
+        private static Counts empty() {
+            return new Counts(0, 0, 0, 0);
+        }
+
+        private static Counts from(UnitHolder holder, UnitKey key) {
+            return new Counts(
+                    holder.getUnitCountForState(key, UnitState.none),
+                    holder.getUnitCountForState(key, UnitState.dmg),
+                    holder.getUnitCountForState(key, UnitState.glv),
+                    holder.getUnitCountForState(key, UnitState.dmg_glv));
+        }
+
+        private Counts plus(Counts other) {
+            return new Counts(
+                    none + other.none,
+                    damaged + other.damaged,
+                    galvanized + other.galvanized,
+                    damagedGalvanized + other.damagedGalvanized);
+        }
+
+        private int total() {
+            return none + damaged + galvanized + damagedGalvanized;
+        }
+
+        private int sustainedBy(Counts current) {
+            int standardSustains = Math.min(Math.max(0, none - current.none), Math.max(0, current.damaged - damaged));
+            int galvanizedSustains = Math.min(
+                    Math.max(0, galvanized - current.galvanized),
+                    Math.max(0, current.damagedGalvanized - damagedGalvanized));
+            return standardSustains + galvanizedSustains;
+        }
     }
 
     public sealed interface RenderedReplayEvent permits MessageResult, TileRenderResult {}

--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -2335,10 +2335,13 @@ public class ActionCardHelper {
 
     private CombatReplayTrackedEvent getCombatReplayTrackedEvent(ActionCardModel actionCard) {
         if (actionCard == null || actionCard.getAlias() == null) return CombatReplayTrackedEvent.NONE;
-        if (MORALE_BOOST_IDS.contains(actionCard.getAlias())) return CombatReplayTrackedEvent.MORALE_BOOST;
-        if (SHIELDS_HOLDING_IDS.contains(actionCard.getAlias())) return CombatReplayTrackedEvent.SHIELDS_HOLDING;
-        if ("Rout".equalsIgnoreCase(actionCard.getName())
-                || actionCard.getAlias().startsWith("rout")) {
+        String alias = actionCard.getAlias();
+        String automationId = actionCard.getAutomationID();
+        if (MORALE_BOOST_IDS.contains(alias)) return CombatReplayTrackedEvent.MORALE_BOOST;
+        if (SHIELDS_HOLDING_IDS.contains(alias)) return CombatReplayTrackedEvent.SHIELDS_HOLDING;
+        if ("direct_hit".equalsIgnoreCase(automationId)) return CombatReplayTrackedEvent.DIRECT_HIT;
+        if ("f_prototype".equalsIgnoreCase(automationId)) return CombatReplayTrackedEvent.FIGHTER_PROTOTYPE;
+        if ("Rout".equalsIgnoreCase(actionCard.getName()) || alias.startsWith("rout")) {
             return CombatReplayTrackedEvent.ROUT;
         }
         return CombatReplayTrackedEvent.NONE;


### PR DESCRIPTION
## Summary
- add pending-resolution handling so final hit assignment can resolve one-fleet wins or zero-fleet draws
- keep mutual-destruction draws eligible for promotion and score draw results without treating them as defender wins
- mirror more combat-adjacent events, add direct-hit/fighter-prototype side bets, summarize hit assignment damage, and hide player names until votes lock
- simplify the PR to production code only; no test files are changed

## Test Plan
- JAVA_HOME=/opt/homebrew/opt/openjdk@24 mvn -q -Djava.version=24 -Dtest=CombatReplayServiceTest,CombatReplayContestLifecycleServiceTest,CombatReplaySideBetServiceTest,CombatSideBetTypeTest,LazaxCombatSupportTest test
- JAVA_HOME=/opt/homebrew/opt/openjdk@24 mvn -q -Djava.version=24 spotless:check
- JAVA_HOME=/opt/homebrew/opt/openjdk@24 mvn -q -Djava.version=24 -DskipTests compile
- git diff --check