### PR TITLE
Fix replay promotion hourly cadence

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -61,7 +61,8 @@ public class CombatReplayContestLifecycleService {
     private static final long SHADOW_DISCORD_ID = 0L;
     private static final String PROMOTION_DISABLED_REASON = "Candidate-to-contest promotion is disabled.";
     private static final Duration PUBLIC_PROMOTION_COOLDOWN = Duration.ofHours(2);
-    private static final Duration PUBLIC_PROMOTION_COOLDOWN_GRACE = Duration.ofMinutes(5);
+    private static final Duration PUBLIC_PROMOTION_POSTING_WINDOW = Duration.ofMinutes(5);
+    private static final Duration PUBLIC_PROMOTION_SLOT_WIDTH = Duration.ofHours(1);
     private static final List<String> PREDICTION_LOCK_TITLES = List.of(
             "The Wagers Open",
             "The Archives Open",
@@ -99,7 +100,7 @@ public class CombatReplayContestLifecycleService {
         boolean immediatePromotion = settings.getRuntime().isImmediatePromotionOnResolve();
         LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
         if (!immediatePromotion) {
-            if (now.getMinute() != 0) return;
+            if (!isInsidePublicPromotionWindow(now)) return;
             int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
             if (maxPromotionsPerHour <= 0) return;
             if (replayContestRepository.countByPostedAtGreaterThanEqual(publicPromotionCooldownCutoff(now)) > 0) return;
@@ -139,7 +140,16 @@ public class CombatReplayContestLifecycleService {
     }
 
     static LocalDateTime publicPromotionCooldownCutoff(LocalDateTime now) {
-        return now.minus(PUBLIC_PROMOTION_COOLDOWN).plus(PUBLIC_PROMOTION_COOLDOWN_GRACE);
+        // Public cadence is slot-based: a late 10:00-slot post should not block the 12:00-slot post.
+        return publicPromotionSlot(now).minus(PUBLIC_PROMOTION_COOLDOWN).plus(PUBLIC_PROMOTION_SLOT_WIDTH);
+    }
+
+    private static LocalDateTime publicPromotionSlot(LocalDateTime now) {
+        return now.truncatedTo(ChronoUnit.HOURS);
+    }
+
+    private static boolean isInsidePublicPromotionWindow(LocalDateTime now) {
+        return Duration.between(publicPromotionSlot(now), now).compareTo(PUBLIC_PROMOTION_POSTING_WINDOW) <= 0;
     }
 
     public ForcePromoteResult forcePromoteCandidate(Long candidateId) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -36,13 +36,13 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
-    void promoteBestCandidateIfDueAllowsFiveMinuteCooldownGrace() {
+    void promoteBestCandidateIfDueAllowsPreviousPromotionSlotEvenWhenPostWasLate() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
         CombatContestSettings settings = new CombatContestSettings();
         CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
         service.setClock(fixedClock("2026-04-27T12:00:00"));
-        LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T10:05:00");
+        LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T11:00:00");
 
         when(replayContestRepository.countByPostedAtGreaterThanEqual(recentContestCutoff))
                 .thenReturn(0L);
@@ -65,13 +65,13 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
-    void promoteBestCandidateIfDueBlocksWhenContestExistsInsideCooldownGrace() {
+    void promoteBestCandidateIfDueBlocksWhenContestExistsInPreviousPromotionSlot() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
         CombatContestSettings settings = new CombatContestSettings();
         CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
         service.setClock(fixedClock("2026-04-27T12:00:00"));
-        LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T10:05:00");
+        LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T11:00:00");
 
         when(replayContestRepository.countByPostedAtGreaterThanEqual(recentContestCutoff))
                 .thenReturn(1L);
@@ -80,6 +80,48 @@ class CombatReplayContestLifecycleServiceTest {
 
         verify(replayContestRepository).countByPostedAtGreaterThanEqual(recentContestCutoff);
         verifyNoInteractions(candidateRepository);
+    }
+
+    @Test
+    void promoteBestCandidateIfDueRunsDuringTopOfHourPostingWindow() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:04:00"));
+        LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T11:00:00");
+
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(recentContestCutoff))
+                .thenReturn(0L);
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(LocalDateTime.parse("2026-04-27T12:00:00")))
+                .thenReturn(0L);
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:04:00")))
+                .thenReturn(List.of());
+
+        service.promoteBestCandidateIfDue();
+
+        verify(replayContestRepository).countByPostedAtGreaterThanEqual(recentContestCutoff);
+        verify(candidateRepository)
+                .findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:04:00"));
+    }
+
+    @Test
+    void promoteBestCandidateIfDueDoesNothingOutsideTopOfHourPostingWindow() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:06:00"));
+
+        service.promoteBestCandidateIfDue();
+
+        verifyNoInteractions(candidateRepository, replayContestRepository);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Treat public replay promotions as hourly slots instead of exact post timestamps.
- Allow the top-of-hour promotion window to recover from small cron/posting delays without skipping the next two-hour slot.
- Add unit coverage for late posts and the posting window.

## Test Plan
- `JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=ti4.contest.replay.service.CombatReplayContestLifecycleServiceTest test`