### PR TITLE
Allow delayed replay promotion ticks

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -61,7 +61,6 @@ public class CombatReplayContestLifecycleService {
     private static final long SHADOW_DISCORD_ID = 0L;
     private static final String PROMOTION_DISABLED_REASON = "Candidate-to-contest promotion is disabled.";
     private static final Duration PUBLIC_PROMOTION_COOLDOWN = Duration.ofHours(2);
-    private static final Duration PUBLIC_PROMOTION_POSTING_WINDOW = Duration.ofMinutes(5);
     private static final Duration PUBLIC_PROMOTION_SLOT_WIDTH = Duration.ofHours(1);
     private static final List<String> PREDICTION_LOCK_TITLES = List.of(
             "The Wagers Open",
@@ -100,7 +99,6 @@ public class CombatReplayContestLifecycleService {
         boolean immediatePromotion = settings.getRuntime().isImmediatePromotionOnResolve();
         LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
         if (!immediatePromotion) {
-            if (!isInsidePublicPromotionWindow(now)) return;
             int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
             if (maxPromotionsPerHour <= 0) return;
             if (replayContestRepository.countByPostedAtGreaterThanEqual(publicPromotionCooldownCutoff(now)) > 0) return;
@@ -146,10 +144,6 @@ public class CombatReplayContestLifecycleService {
 
     private static LocalDateTime publicPromotionSlot(LocalDateTime now) {
         return now.truncatedTo(ChronoUnit.HOURS);
-    }
-
-    private static boolean isInsidePublicPromotionWindow(LocalDateTime now) {
-        return Duration.between(publicPromotionSlot(now), now).compareTo(PUBLIC_PROMOTION_POSTING_WINDOW) <= 0;
     }
 
     public ForcePromoteResult forcePromoteCandidate(Long candidateId) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -83,12 +83,12 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
-    void promoteBestCandidateIfDueRunsDuringTopOfHourPostingWindow() {
+    void promoteBestCandidateIfDueRunsWhenCronIsLateForThePromotionSlot() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
         CombatContestSettings settings = new CombatContestSettings();
         CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
-        service.setClock(fixedClock("2026-04-27T12:04:00"));
+        service.setClock(fixedClock("2026-04-27T12:45:00"));
         LocalDateTime recentContestCutoff = LocalDateTime.parse("2026-04-27T11:00:00");
 
         when(replayContestRepository.countByPostedAtGreaterThanEqual(recentContestCutoff))
@@ -98,7 +98,7 @@ class CombatReplayContestLifecycleServiceTest {
         when(candidateRepository.findResolvedPromotionCandidates(
                         CombatCandidateStatus.RESOLVED,
                         CombatCandidatePromotionStatus.PENDING,
-                        LocalDateTime.parse("2026-04-27T00:04:00")))
+                        LocalDateTime.parse("2026-04-27T00:45:00")))
                 .thenReturn(List.of());
 
         service.promoteBestCandidateIfDue();
@@ -108,20 +108,7 @@ class CombatReplayContestLifecycleServiceTest {
                 .findResolvedPromotionCandidates(
                         CombatCandidateStatus.RESOLVED,
                         CombatCandidatePromotionStatus.PENDING,
-                        LocalDateTime.parse("2026-04-27T00:04:00"));
-    }
-
-    @Test
-    void promoteBestCandidateIfDueDoesNothingOutsideTopOfHourPostingWindow() {
-        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
-        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
-        CombatContestSettings settings = new CombatContestSettings();
-        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
-        service.setClock(fixedClock("2026-04-27T12:06:00"));
-
-        service.promoteBestCandidateIfDue();
-
-        verifyNoInteractions(candidateRepository, replayContestRepository);
+                        LocalDateTime.parse("2026-04-27T00:45:00"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Remove the five-minute posting window from public replay promotion.
- Keep slot-based cooldown inference so late posts still count toward their hourly slot.
- Update coverage for a delayed cron tick promoting at 45 minutes past the hour.

## Test Plan
- `JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=ti4.contest.replay.service.CombatReplayContestLifecycleServiceTest test`