### PR TITLE
Relax replay candidate selection

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -83,22 +83,30 @@ public class CombatReplayPromotionScoreBackfillCron {
             CombatCandidateEntity candidate =
                     candidateRepository.findById(event.getCandidateId()).orElse(null);
             if (candidate == null) continue;
-            if (markSkippedAfb(candidate, event.getActorFaction())) {
-                candidateRepository.save(candidate);
-                updated++;
-            }
+            if (hasSkippedAfbFlag(candidate, event.getActorFaction())) continue;
+            if (!markSkippedAfb(candidate, event.getActorFaction())) continue;
+            candidateRepository.save(candidate);
+            updated++;
         }
         return updated;
     }
 
+    private static boolean hasSkippedAfbFlag(CombatCandidateEntity candidate, String faction) {
+        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
+            return Boolean.TRUE.equals(candidate.getAttackerSkippedAfb());
+        }
+        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
+            return Boolean.TRUE.equals(candidate.getDefenderSkippedAfb());
+        }
+        return false;
+    }
+
     private static boolean markSkippedAfb(CombatCandidateEntity candidate, String faction) {
-        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())
-                && !Boolean.TRUE.equals(candidate.getAttackerSkippedAfb())) {
+        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
             candidate.setAttackerSkippedAfb(true);
             return true;
         }
-        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())
-                && !Boolean.TRUE.equals(candidate.getDefenderSkippedAfb())) {
+        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
             candidate.setDefenderSkippedAfb(true);
             return true;
         }

--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -11,10 +11,8 @@ import ti4.contest.replay.dispatch.ReplayDispatchPayload;
 import ti4.contest.replay.dispatch.ReplayDispatchSerializer;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatCandidateEventEntity;
-import ti4.contest.replay.entities.CombatObservationEntity;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
-import ti4.contest.replay.repository.CombatObservationRepository;
 import ti4.contest.replay.service.CombatReplayService;
 import ti4.cron.CronManager;
 import ti4.game.Game;
@@ -71,10 +69,8 @@ public class CombatReplayPromotionScoreBackfillCron {
     }
 
     private static boolean recomputePromotionScore(CombatCandidateEntity candidate) {
-        CombatObservationEntity observation = SpringContext.getBean(CombatObservationRepository.class)
-                .findById(candidate.getObservationId())
-                .orElse(null);
-        if (observation == null) return false;
+        CombatReplayService.InitialCombatStats initialStats = CombatReplayService.initialCombatStats(candidate);
+        if (initialStats == null) return false;
 
         String snapshotJson = extractLatestSnapshotJson(candidate.getId());
         if (snapshotJson == null || snapshotJson.isBlank()) return false;
@@ -100,11 +96,16 @@ public class CombatReplayPromotionScoreBackfillCron {
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
         candidate.setPromotionScore(CombatReplayService.computePromotionScore(
-                observation,
+                candidate,
+                initialStats,
                 attackerRemainingStrength,
                 defenderRemainingStrength,
                 candidate.getWinnerFaction(),
                 roundsObserved));
+        candidate.setAttackerStrength(initialStats.attackerStrength());
+        candidate.setDefenderStrength(initialStats.defenderStrength());
+        candidate.setAttackerHp(initialStats.attackerHp());
+        candidate.setDefenderHp(initialStats.defenderHp());
         SpringContext.getBean(CombatCandidateRepository.class).save(candidate);
         return true;
     }

--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.experimental.UtilityClass;
+import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatCandidateStatus;
 import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
@@ -26,6 +27,8 @@ import ti4.spring.service.deploy.ActiveLeaseService;
 
 @UtilityClass
 public class CombatReplayPromotionScoreBackfillCron {
+
+    private static final String SKIPPED_AFB_SUMMARY_TEXT = "Skipped AFB";
 
     private static final AtomicBoolean HAS_RUN = new AtomicBoolean(false);
 
@@ -55,6 +58,7 @@ public class CombatReplayPromotionScoreBackfillCron {
         }
 
         CombatCandidateRepository candidateRepository = SpringContext.getBean(CombatCandidateRepository.class);
+        int skippedAfbBackfilled = backfillSkippedAfbFlags(candidateRepository);
         int updated = 0;
         int skipped = 0;
         for (CombatCandidateEntity candidate : candidateRepository.findByStatus(CombatCandidateStatus.RESOLVED)) {
@@ -66,6 +70,39 @@ public class CombatReplayPromotionScoreBackfillCron {
         }
 
         BotLogger.info("Combat replay promotion-score backfill completed. Updated=" + updated + ", skipped=" + skipped);
+        BotLogger.info("Combat replay skipped-AFB backfill completed. Updated=" + skippedAfbBackfilled);
+    }
+
+    private static int backfillSkippedAfbFlags(CombatCandidateRepository candidateRepository) {
+        CombatCandidateEventRepository eventRepository = SpringContext.getBean(CombatCandidateEventRepository.class);
+        int updated = 0;
+        for (CombatCandidateEventEntity event : eventRepository.findByEventTypeAndSummaryTextContainingIgnoreCase(
+                CombatCandidateEventType.INFO, SKIPPED_AFB_SUMMARY_TEXT)) {
+            if (event.getActorFaction() == null) continue;
+            if (event.getCandidateId() == null) continue;
+            CombatCandidateEntity candidate =
+                    candidateRepository.findById(event.getCandidateId()).orElse(null);
+            if (candidate == null) continue;
+            if (markSkippedAfb(candidate, event.getActorFaction())) {
+                candidateRepository.save(candidate);
+                updated++;
+            }
+        }
+        return updated;
+    }
+
+    private static boolean markSkippedAfb(CombatCandidateEntity candidate, String faction) {
+        if (faction.equalsIgnoreCase(candidate.getAttackerFaction())
+                && !Boolean.TRUE.equals(candidate.getAttackerSkippedAfb())) {
+            candidate.setAttackerSkippedAfb(true);
+            return true;
+        }
+        if (faction.equalsIgnoreCase(candidate.getDefenderFaction())
+                && !Boolean.TRUE.equals(candidate.getDefenderSkippedAfb())) {
+            candidate.setDefenderSkippedAfb(true);
+            return true;
+        }
+        return false;
     }
 
     private static boolean recomputePromotionScore(CombatCandidateEntity candidate) {

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -107,13 +107,13 @@ public class CombatContestSettings {
     @Setter
     public static class CandidateSelection {
         private Window window = new Window();
-        private int targetCandidatesPerHour = 4;
+        private int targetCandidatesPerHour = 16;
     }
 
     @Getter
     @Setter
     public static class Window {
-        private int lookbackMinutes = 60;
+        private int lookbackMinutes = 1440;
         private int refreshCronIntervalSeconds = 300;
     }
 

--- a/src/main/java/ti4/contest/replay/core/CombatSideState.java
+++ b/src/main/java/ti4/contest/replay/core/CombatSideState.java
@@ -9,6 +9,7 @@ public record CombatSideState(
         int destroyerCount,
         boolean rolledAfb,
         boolean afbWhiff,
+        boolean skippedAfb,
         boolean roundOneWhiff,
         boolean roundOneSlam,
         boolean playedMoraleBoost,
@@ -28,11 +29,13 @@ public record CombatSideState(
             String faction,
             boolean rolledAfb,
             boolean afbWhiff,
+            boolean skippedAfb,
             boolean roundOneWhiff,
             boolean roundOneSlam) {
         if (faction.equalsIgnoreCase(candidate.getAttackerFaction())) {
             candidate.setAttackerRolledAfb(Boolean.TRUE.equals(candidate.getAttackerRolledAfb()) || rolledAfb);
             candidate.setAttackerAfbWhiff(Boolean.TRUE.equals(candidate.getAttackerAfbWhiff()) || afbWhiff);
+            candidate.setAttackerSkippedAfb(Boolean.TRUE.equals(candidate.getAttackerSkippedAfb()) || skippedAfb);
             candidate.setAttackerRoundOneWhiff(
                     Boolean.TRUE.equals(candidate.getAttackerRoundOneWhiff()) || roundOneWhiff);
             candidate.setAttackerRoundOneSlam(Boolean.TRUE.equals(candidate.getAttackerRoundOneSlam()) || roundOneSlam);
@@ -41,6 +44,7 @@ public record CombatSideState(
         if (faction.equalsIgnoreCase(candidate.getDefenderFaction())) {
             candidate.setDefenderRolledAfb(Boolean.TRUE.equals(candidate.getDefenderRolledAfb()) || rolledAfb);
             candidate.setDefenderAfbWhiff(Boolean.TRUE.equals(candidate.getDefenderAfbWhiff()) || afbWhiff);
+            candidate.setDefenderSkippedAfb(Boolean.TRUE.equals(candidate.getDefenderSkippedAfb()) || skippedAfb);
             candidate.setDefenderRoundOneWhiff(
                     Boolean.TRUE.equals(candidate.getDefenderRoundOneWhiff()) || roundOneWhiff);
             candidate.setDefenderRoundOneSlam(Boolean.TRUE.equals(candidate.getDefenderRoundOneSlam()) || roundOneSlam);
@@ -77,6 +81,7 @@ public record CombatSideState(
                 safeInt(candidate.getAttackerDestroyerCount()),
                 Boolean.TRUE.equals(candidate.getAttackerRolledAfb()),
                 Boolean.TRUE.equals(candidate.getAttackerAfbWhiff()),
+                Boolean.TRUE.equals(candidate.getAttackerSkippedAfb()),
                 Boolean.TRUE.equals(candidate.getAttackerRoundOneWhiff()),
                 Boolean.TRUE.equals(candidate.getAttackerRoundOneSlam()),
                 Boolean.TRUE.equals(candidate.getAttackerPlayedMoraleBoost()),
@@ -90,6 +95,7 @@ public record CombatSideState(
                 safeInt(candidate.getDefenderDestroyerCount()),
                 Boolean.TRUE.equals(candidate.getDefenderRolledAfb()),
                 Boolean.TRUE.equals(candidate.getDefenderAfbWhiff()),
+                Boolean.TRUE.equals(candidate.getDefenderSkippedAfb()),
                 Boolean.TRUE.equals(candidate.getDefenderRoundOneWhiff()),
                 Boolean.TRUE.equals(candidate.getDefenderRoundOneSlam()),
                 Boolean.TRUE.equals(candidate.getDefenderPlayedMoraleBoost()),

--- a/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
@@ -135,6 +135,12 @@ public class CombatCandidateEntity {
     @Column(name = "defender_afb_whiff", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean defenderAfbWhiff = false;
 
+    @Column(name = "attacker_skipped_afb", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean attackerSkippedAfb = false;
+
+    @Column(name = "defender_skipped_afb", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean defenderSkippedAfb = false;
+
     @Column(name = "attacker_round_one_whiff", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean attackerRoundOneWhiff = false;
 

--- a/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatCandidateEntity.java
@@ -117,6 +117,12 @@ public class CombatCandidateEntity {
     @Column(name = "defender_hp")
     private Double defenderHp;
 
+    @Column(name = "attacker_strength")
+    private Double attackerStrength;
+
+    @Column(name = "defender_strength")
+    private Double defenderStrength;
+
     @Column(name = "attacker_rolled_afb", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean attackerRolledAfb = false;
 

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateEventRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateEventRepository.java
@@ -17,8 +17,8 @@ public interface CombatCandidateEventRepository extends JpaRepository<CombatCand
     boolean existsByCandidateIdAndEventTypeAndActorFactionAndRoundNumber(
             Long candidateId, CombatCandidateEventType eventType, String actorFaction, Integer roundNumber);
 
-    boolean existsByCandidateIdAndEventTypeAndActorFactionAndSummaryTextContainingIgnoreCase(
-            Long candidateId, CombatCandidateEventType eventType, String actorFaction, String summaryText);
+    List<CombatCandidateEventEntity> findByEventTypeAndSummaryTextContainingIgnoreCase(
+            CombatCandidateEventType eventType, String summaryText);
 
     List<CombatCandidateEventEntity> findByCandidateIdOrderBySequenceNumberAsc(Long candidateId);
 

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateEventRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateEventRepository.java
@@ -17,6 +17,9 @@ public interface CombatCandidateEventRepository extends JpaRepository<CombatCand
     boolean existsByCandidateIdAndEventTypeAndActorFactionAndRoundNumber(
             Long candidateId, CombatCandidateEventType eventType, String actorFaction, Integer roundNumber);
 
+    boolean existsByCandidateIdAndEventTypeAndActorFactionAndSummaryTextContainingIgnoreCase(
+            Long candidateId, CombatCandidateEventType eventType, String actorFaction, String summaryText);
+
     List<CombatCandidateEventEntity> findByCandidateIdOrderBySequenceNumberAsc(Long candidateId);
 
     @Query("select max(e.roundNumber) from CombatCandidateEventEntity e where e.candidateId = :candidateId")

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -407,9 +407,13 @@ public class CombatReplayService {
 
     private void resolveCandidate(
             Game game, CombatCandidateEntity candidate, Tile tile, Player winner, String loserFaction) {
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        if (observation == null) return;
+        InitialCombatStats initialStats = initialCombatStats(candidate);
+        if (initialStats == null) {
+            cancelCandidate(
+                    game, candidate, "The tracked space combat initial snapshot could not be resolved cleanly.");
+            return;
+        }
+        applyInitialCombatStats(candidate, initialStats);
         ResolutionState resolution = buildResolutionState(game, candidate, tile);
         if (resolution == null) {
             cancelCandidate(game, candidate, "The tracked space combat could not be resolved cleanly.");
@@ -425,7 +429,8 @@ public class CombatReplayService {
         candidate.setResolutionReason("Winner determined from remaining fleets.");
         candidate.setWinnerOneHpRemaining(hasExactlyOneHpRemaining(resolution, candidate, winner.getFaction()));
         candidate.setPromotionScore(computePromotionScore(
-                observation,
+                candidate,
+                initialStats,
                 resolution.attackerRemainingStrength(),
                 resolution.defenderRemainingStrength(),
                 winner.getFaction(),
@@ -452,8 +457,7 @@ public class CombatReplayService {
         int roundsObserved = candidateEventRepository
                 .findMaxRoundNumberByCandidateId(candidate.getId())
                 .orElse(0);
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
+        InitialCombatStats initialStats = initialCombatStats(candidate);
 
         candidate.setStatus(CombatCandidateStatus.RESOLVED);
         candidate.setResolvedAt(LocalDateTime.now());
@@ -461,8 +465,9 @@ public class CombatReplayService {
         candidate.setLoserFaction(null);
         candidate.setResolutionReason("Combat ended in a draw after pending hit assignment.");
         candidate.setWinnerOneHpRemaining(false);
-        if (observation != null) {
-            candidate.setPromotionScore(computeDrawPromotionScore(observation, roundsObserved));
+        if (initialStats != null) {
+            applyInitialCombatStats(candidate, initialStats);
+            candidate.setPromotionScore(computeDrawPromotionScore(initialStats, roundsObserved));
         }
         candidateRepository.save(candidate);
 
@@ -543,6 +548,8 @@ public class CombatReplayService {
         candidate.setDefenderHasAssaultCannon(snapshot.defenderHasAssaultCannon());
         candidate.setAttackerHp(snapshot.attackerHp());
         candidate.setDefenderHp(snapshot.defenderHp());
+        candidate.setAttackerStrength(snapshot.attackerStrength());
+        candidate.setDefenderStrength(snapshot.defenderStrength());
         candidateRepository.save(candidate);
     }
 
@@ -569,6 +576,8 @@ public class CombatReplayService {
                 countDestroyersInCombat(tile, defender),
                 hasAssaultCannon(attacker),
                 hasAssaultCannon(defender),
+                combatSnapshot.attackerStrength(),
+                combatSnapshot.defenderStrength(),
                 combatSnapshot.attackerHp(),
                 combatSnapshot.defenderHp());
     }
@@ -593,39 +602,78 @@ public class CombatReplayService {
     }
 
     public static double computePromotionScore(
-            CombatObservationEntity observation,
+            CombatCandidateEntity candidate,
+            InitialCombatStats initialStats,
             LazaxCombatSupport.FleetStrength attackerRemainingStrength,
             LazaxCombatSupport.FleetStrength defenderRemainingStrength,
             String winnerFaction,
             int roundsObserved) {
-        double weakerHp = Math.min(observation.getAttackerHp(), observation.getDefenderHp());
-        double weakerStrength = Math.min(observation.getAttackerStrength(), observation.getDefenderStrength());
-        double strongerStrength = Math.max(observation.getAttackerStrength(), observation.getDefenderStrength());
-        double winnerRemainingHp = winnerFaction.equalsIgnoreCase(observation.getAttackerFaction())
+        double weakerHp = Math.min(initialStats.attackerHp(), initialStats.defenderHp());
+        double weakerStrength = Math.min(initialStats.attackerStrength(), initialStats.defenderStrength());
+        double strongerStrength = Math.max(initialStats.attackerStrength(), initialStats.defenderStrength());
+        double winnerRemainingHp = winnerFaction.equalsIgnoreCase(candidate.getAttackerFaction())
                 ? attackerRemainingStrength.hp()
                 : defenderRemainingStrength.hp();
-        double winnerInitialHp = winnerFaction.equalsIgnoreCase(observation.getAttackerFaction())
-                ? observation.getAttackerHp()
-                : observation.getDefenderHp();
+        double winnerInitialHp = winnerFaction.equalsIgnoreCase(candidate.getAttackerFaction())
+                ? initialStats.attackerHp()
+                : initialStats.defenderHp();
         double sizeFactor = Math.min(1.0, weakerHp / 8.0);
         double strengthRatio = safeRatio(weakerStrength, strongerStrength);
         double winnerSurvivalRatio = safeRatio(winnerRemainingHp, winnerInitialHp);
         double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
         double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
         double endingTensionScore = winnerRemainingHp <= 0 ? 0.0 : 5.0 * Math.exp(-6.0 * winnerSurvivalRatio);
-        double defenderWinBonus = winnerFaction.equalsIgnoreCase(observation.getDefenderFaction()) ? 0.5 : 0.0;
+        double defenderWinBonus = winnerFaction.equalsIgnoreCase(candidate.getDefenderFaction()) ? 0.5 : 0.0;
         return roundScore + openingBalanceScore + endingTensionScore + defenderWinBonus;
     }
 
-    private static double computeDrawPromotionScore(CombatObservationEntity observation, int roundsObserved) {
-        double weakerHp = Math.min(observation.getAttackerHp(), observation.getDefenderHp());
-        double weakerStrength = Math.min(observation.getAttackerStrength(), observation.getDefenderStrength());
-        double strongerStrength = Math.max(observation.getAttackerStrength(), observation.getDefenderStrength());
+    private static double computeDrawPromotionScore(InitialCombatStats initialStats, int roundsObserved) {
+        double weakerHp = Math.min(initialStats.attackerHp(), initialStats.defenderHp());
+        double weakerStrength = Math.min(initialStats.attackerStrength(), initialStats.defenderStrength());
+        double strongerStrength = Math.max(initialStats.attackerStrength(), initialStats.defenderStrength());
         double sizeFactor = Math.min(1.0, weakerHp / 8.0);
         double strengthRatio = safeRatio(weakerStrength, strongerStrength);
         double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
         double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
         return roundScore + openingBalanceScore + 5.0;
+    }
+
+    public static InitialCombatStats initialCombatStats(CombatCandidateEntity candidate) {
+        if (candidate == null) return null;
+        if (candidate.getAttackerStrength() != null
+                && candidate.getDefenderStrength() != null
+                && candidate.getAttackerHp() != null
+                && candidate.getDefenderHp() != null) {
+            return new InitialCombatStats(
+                    candidate.getAttackerStrength(),
+                    candidate.getDefenderStrength(),
+                    candidate.getAttackerHp(),
+                    candidate.getDefenderHp());
+        }
+        if (!CombatReplayTileRenderer.canRender(candidate.getInitialRenderSnapshotJson())) return null;
+
+        Game snapshotGame = CombatReplayTileRenderer.render(
+                candidate.getInitialRenderSnapshotJson(), candidate.getInitialRenderSnapshotJson());
+        if (snapshotGame == null) return null;
+        Tile tile = snapshotGame.getTileByPosition(candidate.getTilePosition());
+        Player attacker = snapshotGame.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = snapshotGame.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        UnitHolder space = tile == null ? null : tile.getUnitHolders().get(Constants.SPACE);
+        if (tile == null || attacker == null || defender == null || space == null) return null;
+
+        LazaxCombatSupport.FleetStrength attackerStrength =
+                LazaxCombatSupport.calculateFleetStrength(attacker, defender, tile, space);
+        LazaxCombatSupport.FleetStrength defenderStrength =
+                LazaxCombatSupport.calculateFleetStrength(defender, attacker, tile, space);
+        return new InitialCombatStats(
+                attackerStrength.value(), defenderStrength.value(), attackerStrength.hp(), defenderStrength.hp());
+    }
+
+    private void applyInitialCombatStats(CombatCandidateEntity candidate, InitialCombatStats initialStats) {
+        candidate.setAttackerStrength(initialStats.attackerStrength());
+        candidate.setDefenderStrength(initialStats.defenderStrength());
+        candidate.setAttackerHp(initialStats.attackerHp());
+        candidate.setDefenderHp(initialStats.defenderHp());
     }
 
     public CombatReplaySelection.SelectionDebugView getSelectionDebugView() {
@@ -970,8 +1018,13 @@ public class CombatReplayService {
             int defenderDestroyerCount,
             boolean attackerHasAssaultCannon,
             boolean defenderHasAssaultCannon,
+            double attackerStrength,
+            double defenderStrength,
             double attackerHp,
             double defenderHp) {}
+
+    public record InitialCombatStats(
+            double attackerStrength, double defenderStrength, double attackerHp, double defenderHp) {}
 
     private record SelectionSnapshot(
             int windowSize,

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -22,6 +22,7 @@ import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.core.CombatReplaySelection;
 import ti4.contest.replay.core.CombatReplayTrackedEvent;
 import ti4.contest.replay.core.CombatRollPayload;
+import ti4.contest.replay.core.CombatSideBetType;
 import ti4.contest.replay.core.CombatSideState;
 import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
@@ -713,14 +714,37 @@ public class CombatReplayService {
         boolean rolledAfb = rollType == CombatRollType.AFB;
         boolean roundOneCombatRoll = rollType == CombatRollType.combatround && round == 1;
         if (!rolledAfb && !roundOneCombatRoll) return;
+        CombatSideState state = CombatSideState.forFaction(candidate, player.getFaction());
+        boolean skippedAfb = roundOneCombatRoll
+                && state != null
+                && !state.rolledAfb()
+                && isAfbSkippedAvailable(candidate, player.getFaction());
         CombatSideState.markRollFlags(
                 candidate,
                 player.getFaction(),
                 rolledAfb,
                 rolledAfb && whiff,
+                skippedAfb,
                 roundOneCombatRoll && whiff,
                 roundOneCombatRoll && slam);
         candidateRepository.save(candidate);
+    }
+
+    private boolean isAfbSkippedAvailable(CombatCandidateEntity candidate, String targetFaction) {
+        if (candidate == null || targetFaction == null) return false;
+        CombatSideState state = CombatSideState.forFaction(candidate, targetFaction);
+        if (state == null || !CombatSideBetType.AFB_SKIPPED.isAvailable(state.destroyerCount())) return false;
+        return !(state.destroyerCount() == 1 && opponentHasAssaultCannon(candidate, targetFaction));
+    }
+
+    private boolean opponentHasAssaultCannon(CombatCandidateEntity candidate, String targetFaction) {
+        if (targetFaction.equalsIgnoreCase(candidate.getAttackerFaction())) {
+            return Boolean.TRUE.equals(candidate.getDefenderHasAssaultCannon());
+        }
+        if (targetFaction.equalsIgnoreCase(candidate.getDefenderFaction())) {
+            return Boolean.TRUE.equals(candidate.getAttackerHasAssaultCannon());
+        }
+        return false;
     }
 
     private void appendSideBetTriggerEvents(

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.springframework.stereotype.Service;
+import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatSideBetType;
 import ti4.contest.replay.core.CombatSideState;
@@ -18,6 +19,7 @@ import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatContestSideBetEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
+import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatContestSideBetRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
@@ -31,9 +33,12 @@ import ti4.game.Game;
 @RequiredArgsConstructor
 public class CombatReplaySideBetService {
 
+    private static final String SKIPPED_AFB_SUMMARY_TEXT = "Skipped AFB";
+
     private final CombatContestSettings settings;
     private final CombatReplayContestRepository replayContestRepository;
     private final CombatCandidateRepository candidateRepository;
+    private final CombatCandidateEventRepository candidateEventRepository;
     private final CombatContestSideBetRepository sideBetRepository;
     private final CombatReplayLeaderboardEntryRepository leaderboardEntryRepository;
     private final CombatReplaySideBetPayoutService payoutService;
@@ -224,7 +229,9 @@ public class CombatReplaySideBetService {
         if (state == null) return false;
         CombatSideBetType betType = sideBet.getBetType();
         return switch (betType) {
-            case AFB_SKIPPED -> isAfbSkippedAvailable(candidate, sideBet.getTargetFaction()) && !state.rolledAfb();
+            case AFB_SKIPPED ->
+                isAfbSkippedAvailable(candidate, sideBet.getTargetFaction())
+                        && hasSkippedAfb(candidate, sideBet.getTargetFaction(), state);
             case AFB_WHIFF -> betType.isAvailable(state.destroyerCount()) && state.afbWhiff();
             case ROUND_ONE_WHIFF -> state.roundOneWhiff();
             case ROUND_ONE_SLAM -> state.roundOneSlam();
@@ -244,6 +251,32 @@ public class CombatReplaySideBetService {
         CombatSideState state = CombatSideState.forFaction(candidate, targetFaction);
         if (state == null || !CombatSideBetType.AFB_SKIPPED.isAvailable(state.destroyerCount())) return false;
         return !(state.destroyerCount() == 1 && opponentHasAssaultCannon(candidate, targetFaction));
+    }
+
+    private boolean hasSkippedAfb(CombatCandidateEntity candidate, String targetFaction, CombatSideState state) {
+        if (state.skippedAfb()) return true;
+        if (candidate.getId() == null || targetFaction == null) return false;
+        boolean recordedSkip =
+                candidateEventRepository
+                        .existsByCandidateIdAndEventTypeAndActorFactionAndSummaryTextContainingIgnoreCase(
+                                candidate.getId(),
+                                CombatCandidateEventType.INFO,
+                                targetFaction,
+                                SKIPPED_AFB_SUMMARY_TEXT);
+        if (recordedSkip) {
+            markSkippedAfb(candidate, targetFaction);
+        }
+        return recordedSkip;
+    }
+
+    private void markSkippedAfb(CombatCandidateEntity candidate, String targetFaction) {
+        if (targetFaction.equalsIgnoreCase(candidate.getAttackerFaction())) {
+            candidate.setAttackerSkippedAfb(true);
+            candidateRepository.save(candidate);
+        } else if (targetFaction.equalsIgnoreCase(candidate.getDefenderFaction())) {
+            candidate.setDefenderSkippedAfb(true);
+            candidateRepository.save(candidate);
+        }
     }
 
     private boolean opponentHasAssaultCannon(CombatCandidateEntity candidate, String targetFaction) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.springframework.stereotype.Service;
-import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatSideBetType;
 import ti4.contest.replay.core.CombatSideState;
@@ -19,7 +18,6 @@ import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatContestSideBetEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
-import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatContestSideBetRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
@@ -33,12 +31,9 @@ import ti4.game.Game;
 @RequiredArgsConstructor
 public class CombatReplaySideBetService {
 
-    private static final String SKIPPED_AFB_SUMMARY_TEXT = "Skipped AFB";
-
     private final CombatContestSettings settings;
     private final CombatReplayContestRepository replayContestRepository;
     private final CombatCandidateRepository candidateRepository;
-    private final CombatCandidateEventRepository candidateEventRepository;
     private final CombatContestSideBetRepository sideBetRepository;
     private final CombatReplayLeaderboardEntryRepository leaderboardEntryRepository;
     private final CombatReplaySideBetPayoutService payoutService;
@@ -229,9 +224,7 @@ public class CombatReplaySideBetService {
         if (state == null) return false;
         CombatSideBetType betType = sideBet.getBetType();
         return switch (betType) {
-            case AFB_SKIPPED ->
-                isAfbSkippedAvailable(candidate, sideBet.getTargetFaction())
-                        && hasSkippedAfb(candidate, sideBet.getTargetFaction(), state);
+            case AFB_SKIPPED -> isAfbSkippedAvailable(candidate, sideBet.getTargetFaction()) && state.skippedAfb();
             case AFB_WHIFF -> betType.isAvailable(state.destroyerCount()) && state.afbWhiff();
             case ROUND_ONE_WHIFF -> state.roundOneWhiff();
             case ROUND_ONE_SLAM -> state.roundOneSlam();
@@ -251,32 +244,6 @@ public class CombatReplaySideBetService {
         CombatSideState state = CombatSideState.forFaction(candidate, targetFaction);
         if (state == null || !CombatSideBetType.AFB_SKIPPED.isAvailable(state.destroyerCount())) return false;
         return !(state.destroyerCount() == 1 && opponentHasAssaultCannon(candidate, targetFaction));
-    }
-
-    private boolean hasSkippedAfb(CombatCandidateEntity candidate, String targetFaction, CombatSideState state) {
-        if (state.skippedAfb()) return true;
-        if (candidate.getId() == null || targetFaction == null) return false;
-        boolean recordedSkip =
-                candidateEventRepository
-                        .existsByCandidateIdAndEventTypeAndActorFactionAndSummaryTextContainingIgnoreCase(
-                                candidate.getId(),
-                                CombatCandidateEventType.INFO,
-                                targetFaction,
-                                SKIPPED_AFB_SUMMARY_TEXT);
-        if (recordedSkip) {
-            markSkippedAfb(candidate, targetFaction);
-        }
-        return recordedSkip;
-    }
-
-    private void markSkippedAfb(CombatCandidateEntity candidate, String targetFaction) {
-        if (targetFaction.equalsIgnoreCase(candidate.getAttackerFaction())) {
-            candidate.setAttackerSkippedAfb(true);
-            candidateRepository.save(candidate);
-        } else if (targetFaction.equalsIgnoreCase(candidate.getDefenderFaction())) {
-            candidate.setDefenderSkippedAfb(true);
-            candidateRepository.save(candidate);
-        }
     }
 
     private boolean opponentHasAssaultCannon(CombatCandidateEntity candidate, String targetFaction) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetTriggerService.java
@@ -40,7 +40,7 @@ public class CombatReplaySideBetTriggerService {
                 && round == 1
                 && isAfbSkippedAvailable(candidate, player.getFaction())
                 && state != null
-                && !state.rolledAfb()) {
+                && state.skippedAfb()) {
             announcements.add(announcement(player, "Skipped AFB!"));
         }
         if (rollType == CombatRollType.combatround && round == 1 && whiff) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplaySelection;
 import ti4.contest.replay.core.LazaxCombatSupport;
+import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatObservationEntity;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
@@ -25,20 +26,34 @@ class CombatReplayServiceTest {
                 10L, LocalDateTime.of(2026, 4, 23, 20, 22), "pbd22333", "307", 15, 20, 9, 9, 2.2, 2.6, 0.86);
         blowout.setAttackerFaction("sol");
         blowout.setDefenderFaction("mahact");
+        CombatCandidateEntity blowoutCandidate = candidate("sol", "mahact");
+        CombatReplayService.InitialCombatStats blowoutInitialStats = initialStats(
+                blowout.getAttackerStrength(),
+                blowout.getDefenderStrength(),
+                blowout.getAttackerHp(),
+                blowout.getDefenderHp());
 
         CombatObservationEntity squeaker = observation(
                 19L, LocalDateTime.of(2026, 4, 23, 22, 41), "pbd19963f", "306", 22.5, 24.5, 16, 11, 4.5, 6.2, 0.77);
         squeaker.setAttackerFaction("naalu");
         squeaker.setDefenderFaction("muaat");
+        CombatCandidateEntity squeakerCandidate = candidate("naalu", "muaat");
+        CombatReplayService.InitialCombatStats squeakerInitialStats = initialStats(
+                squeaker.getAttackerStrength(),
+                squeaker.getDefenderStrength(),
+                squeaker.getAttackerHp(),
+                squeaker.getDefenderHp());
 
         double blowoutScore = CombatReplayService.computePromotionScore(
-                blowout,
+                blowoutCandidate,
+                blowoutInitialStats,
                 new LazaxCombatSupport.FleetStrength(3.0, 0.0, 0.0),
                 new LazaxCombatSupport.FleetStrength(10.0, 6.0, 0.0),
                 "mahact",
                 3);
         double squeakerScore = CombatReplayService.computePromotionScore(
-                squeaker,
+                squeakerCandidate,
+                squeakerInitialStats,
                 new LazaxCombatSupport.FleetStrength(0.0, 0.0, 0.0),
                 new LazaxCombatSupport.FleetStrength(8.0, 3.0, 0.0),
                 "muaat",
@@ -51,19 +66,35 @@ class CombatReplayServiceTest {
 
     @Test
     void promotionScoreAddsHalfPointBonusWhenDefenderWins() {
-        CombatObservationEntity observation =
-                observation(10L, LocalDateTime.of(2026, 4, 23, 20, 22), "pbd22333", "307", 12, 12, 8, 8, 2, 2, 1);
-        observation.setAttackerFaction("sol");
-        observation.setDefenderFaction("yin");
+        CombatCandidateEntity candidate = candidate("sol", "yin");
+        CombatReplayService.InitialCombatStats initialStats = initialStats(12, 12, 8, 8);
 
         LazaxCombatSupport.FleetStrength attackerRemaining = new LazaxCombatSupport.FleetStrength(4.0, 2.0, 0.0);
         LazaxCombatSupport.FleetStrength defenderRemaining = new LazaxCombatSupport.FleetStrength(4.0, 2.0, 0.0);
-        double attackerWinScore =
-                CombatReplayService.computePromotionScore(observation, attackerRemaining, defenderRemaining, "sol", 2);
-        double defenderWinScore =
-                CombatReplayService.computePromotionScore(observation, attackerRemaining, defenderRemaining, "yin", 2);
+        double attackerWinScore = CombatReplayService.computePromotionScore(
+                candidate, initialStats, attackerRemaining, defenderRemaining, "sol", 2);
+        double defenderWinScore = CombatReplayService.computePromotionScore(
+                candidate, initialStats, attackerRemaining, defenderRemaining, "yin", 2);
 
         assertEquals(attackerWinScore + 0.5, defenderWinScore, 0.0001);
+    }
+
+    @Test
+    void promotionScoreUsesInitialSnapshotStatsInsteadOfObservationStats() {
+        CombatCandidateEntity candidate = candidate("letnev", "hacan");
+        CombatReplayService.InitialCombatStats staleObservationStats = initialStats(13.0, 11.5, 11.0, 7.0);
+        CombatReplayService.InitialCombatStats replaySnapshotStats = initialStats(4.5, 11.5, 4.0, 7.0);
+        LazaxCombatSupport.FleetStrength attackerRemaining = new LazaxCombatSupport.FleetStrength(0.0, 0.0, 0.0);
+        LazaxCombatSupport.FleetStrength defenderRemaining = new LazaxCombatSupport.FleetStrength(7.0, 5.0, 0.0);
+
+        double staleScore = CombatReplayService.computePromotionScore(
+                candidate, staleObservationStats, attackerRemaining, defenderRemaining, "hacan", 3);
+        double snapshotScore = CombatReplayService.computePromotionScore(
+                candidate, replaySnapshotStats, attackerRemaining, defenderRemaining, "hacan", 3);
+
+        assertEquals(2.7074, staleScore, 0.0001);
+        assertEquals(1.4888, snapshotScore, 0.0001);
+        assertTrue(snapshotScore < staleScore);
     }
 
     @Test
@@ -141,5 +172,17 @@ class CombatReplayServiceTest {
         observation.setFairnessRatio(fairnessRatio);
         observation.setJointScore(0.0);
         return observation;
+    }
+
+    private CombatCandidateEntity candidate(String attackerFaction, String defenderFaction) {
+        CombatCandidateEntity candidate = new CombatCandidateEntity();
+        candidate.setAttackerFaction(attackerFaction);
+        candidate.setDefenderFaction(defenderFaction);
+        return candidate;
+    }
+
+    private CombatReplayService.InitialCombatStats initialStats(
+            double attackerStrength, double defenderStrength, double attackerHp, double defenderHp) {
+        return new CombatReplayService.InitialCombatStats(attackerStrength, defenderStrength, attackerHp, defenderHp);
     }
 }

--- a/src/test/java/ti4/contest/replay/service/CombatReplaySideBetServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplaySideBetServiceTest.java
@@ -11,14 +11,12 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatSideBetType;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatContestSideBetEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
-import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatContestSideBetRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
@@ -30,7 +28,6 @@ class CombatReplaySideBetServiceTest {
             new CombatContestSettings(),
             mock(CombatReplayContestRepository.class),
             mock(CombatCandidateRepository.class),
-            mock(CombatCandidateEventRepository.class),
             mock(CombatContestSideBetRepository.class),
             mock(CombatReplayLeaderboardEntryRepository.class),
             mock(CombatReplaySideBetPayoutService.class),
@@ -62,7 +59,6 @@ class CombatReplaySideBetServiceTest {
                 new CombatContestSettings(),
                 mock(CombatReplayContestRepository.class),
                 mock(CombatCandidateRepository.class),
-                mock(CombatCandidateEventRepository.class),
                 sideBetRepository,
                 leaderboardEntryRepository,
                 payoutService,
@@ -95,54 +91,6 @@ class CombatReplaySideBetServiceTest {
         assertEquals("Skips AFB", resolution.resolvedSideBets().getFirst().label());
         verify(sideBetRepository).saveAll(List.of(sideBet));
         verify(leaderboardEntryRepository).saveAll(any());
-    }
-
-    @Test
-    void afbSkippedBetWinsFromRecordedSkipEventForLegacyCandidates() {
-        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
-        CombatCandidateEventRepository candidateEventRepository = mock(CombatCandidateEventRepository.class);
-        CombatContestSideBetRepository sideBetRepository = mock(CombatContestSideBetRepository.class);
-        CombatReplayLeaderboardEntryRepository leaderboardEntryRepository =
-                mock(CombatReplayLeaderboardEntryRepository.class);
-        CombatReplaySideBetPayoutService payoutService = mock(CombatReplaySideBetPayoutService.class);
-        CombatReplaySideBetService resolvingService = new CombatReplaySideBetService(
-                new CombatContestSettings(),
-                mock(CombatReplayContestRepository.class),
-                candidateRepository,
-                candidateEventRepository,
-                sideBetRepository,
-                leaderboardEntryRepository,
-                payoutService,
-                mock(CombatReplaySideBetUiService.class));
-        CombatCandidateEntity candidate = candidate(0, 2, false, false);
-        candidate.setId(487L);
-        candidate.setDefenderRolledAfb(true);
-        CombatReplayContestEntity contest = new CombatReplayContestEntity();
-        contest.setId(126L);
-        CombatContestSideBetEntity sideBet = new CombatContestSideBetEntity();
-        sideBet.setContestId(126L);
-        sideBet.setDiscordUserId("user");
-        sideBet.setDiscordUserName("User");
-        sideBet.setBetType(CombatSideBetType.AFB_SKIPPED);
-        sideBet.setTargetFaction("yin");
-        CombatReplayLeaderboardEntryEntity entry = new CombatReplayLeaderboardEntryEntity();
-        entry.setDiscordUserId("user");
-        entry.setDiscordUserName("User");
-        entry.setTotalPoints(10);
-
-        when(sideBetRepository.findByContestId(126L)).thenReturn(List.of(sideBet));
-        when(leaderboardEntryRepository.findByDiscordUserIdIn(any())).thenReturn(List.of(entry));
-        when(payoutService.resolvedProfitPoints(sideBet)).thenReturn(6);
-        when(candidateEventRepository.existsByCandidateIdAndEventTypeAndActorFactionAndSummaryTextContainingIgnoreCase(
-                        487L, CombatCandidateEventType.INFO, "yin", "Skipped AFB"))
-                .thenReturn(true);
-
-        CombatReplaySideBetService.SideBetResolution resolution = resolvingService.resolveSideBets(candidate, contest);
-
-        assertEquals(16, entry.getTotalPoints());
-        assertTrue(candidate.getDefenderSkippedAfb());
-        assertEquals("Skips AFB", resolution.resolvedSideBets().getFirst().label());
-        verify(candidateRepository).save(candidate);
     }
 
     private CombatCandidateEntity candidate(

--- a/src/test/java/ti4/contest/replay/service/CombatReplaySideBetServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplaySideBetServiceTest.java
@@ -1,12 +1,24 @@
 package ti4.contest.replay.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.core.CombatSideBetType;
 import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatContestSideBetEntity;
+import ti4.contest.replay.entities.CombatReplayContestEntity;
+import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
+import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatContestSideBetRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
@@ -18,6 +30,7 @@ class CombatReplaySideBetServiceTest {
             new CombatContestSettings(),
             mock(CombatReplayContestRepository.class),
             mock(CombatCandidateRepository.class),
+            mock(CombatCandidateEventRepository.class),
             mock(CombatContestSideBetRepository.class),
             mock(CombatReplayLeaderboardEntryRepository.class),
             mock(CombatReplaySideBetPayoutService.class),
@@ -37,6 +50,99 @@ class CombatReplaySideBetServiceTest {
 
         assertFalse(service.isAfbSkippedAvailable(candidate, "sol"));
         assertTrue(service.isAfbSkippedAvailable(candidate, "yin"));
+    }
+
+    @Test
+    void afbSkippedBetWinsEvenIfAfbIsRolledLater() {
+        CombatContestSideBetRepository sideBetRepository = mock(CombatContestSideBetRepository.class);
+        CombatReplayLeaderboardEntryRepository leaderboardEntryRepository =
+                mock(CombatReplayLeaderboardEntryRepository.class);
+        CombatReplaySideBetPayoutService payoutService = mock(CombatReplaySideBetPayoutService.class);
+        CombatReplaySideBetService resolvingService = new CombatReplaySideBetService(
+                new CombatContestSettings(),
+                mock(CombatReplayContestRepository.class),
+                mock(CombatCandidateRepository.class),
+                mock(CombatCandidateEventRepository.class),
+                sideBetRepository,
+                leaderboardEntryRepository,
+                payoutService,
+                mock(CombatReplaySideBetUiService.class));
+        CombatCandidateEntity candidate = candidate(0, 2, false, false);
+        candidate.setDefenderRolledAfb(true);
+        candidate.setDefenderSkippedAfb(true);
+        CombatReplayContestEntity contest = new CombatReplayContestEntity();
+        contest.setId(126L);
+        CombatContestSideBetEntity sideBet = new CombatContestSideBetEntity();
+        sideBet.setContestId(126L);
+        sideBet.setDiscordUserId("user");
+        sideBet.setDiscordUserName("User");
+        sideBet.setBetType(CombatSideBetType.AFB_SKIPPED);
+        sideBet.setTargetFaction("yin");
+        sideBet.setPlacedAt(LocalDateTime.now());
+        CombatReplayLeaderboardEntryEntity entry = new CombatReplayLeaderboardEntryEntity();
+        entry.setDiscordUserId("user");
+        entry.setDiscordUserName("User");
+        entry.setTotalPoints(10);
+
+        when(sideBetRepository.findByContestId(126L)).thenReturn(List.of(sideBet));
+        when(leaderboardEntryRepository.findByDiscordUserIdIn(any())).thenReturn(List.of(entry));
+        when(payoutService.resolvedProfitPoints(sideBet)).thenReturn(6);
+
+        CombatReplaySideBetService.SideBetResolution resolution = resolvingService.resolveSideBets(candidate, contest);
+
+        assertEquals(16, entry.getTotalPoints());
+        assertEquals(1, resolution.resolvedSideBets().size());
+        assertEquals("Skips AFB", resolution.resolvedSideBets().getFirst().label());
+        verify(sideBetRepository).saveAll(List.of(sideBet));
+        verify(leaderboardEntryRepository).saveAll(any());
+    }
+
+    @Test
+    void afbSkippedBetWinsFromRecordedSkipEventForLegacyCandidates() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatCandidateEventRepository candidateEventRepository = mock(CombatCandidateEventRepository.class);
+        CombatContestSideBetRepository sideBetRepository = mock(CombatContestSideBetRepository.class);
+        CombatReplayLeaderboardEntryRepository leaderboardEntryRepository =
+                mock(CombatReplayLeaderboardEntryRepository.class);
+        CombatReplaySideBetPayoutService payoutService = mock(CombatReplaySideBetPayoutService.class);
+        CombatReplaySideBetService resolvingService = new CombatReplaySideBetService(
+                new CombatContestSettings(),
+                mock(CombatReplayContestRepository.class),
+                candidateRepository,
+                candidateEventRepository,
+                sideBetRepository,
+                leaderboardEntryRepository,
+                payoutService,
+                mock(CombatReplaySideBetUiService.class));
+        CombatCandidateEntity candidate = candidate(0, 2, false, false);
+        candidate.setId(487L);
+        candidate.setDefenderRolledAfb(true);
+        CombatReplayContestEntity contest = new CombatReplayContestEntity();
+        contest.setId(126L);
+        CombatContestSideBetEntity sideBet = new CombatContestSideBetEntity();
+        sideBet.setContestId(126L);
+        sideBet.setDiscordUserId("user");
+        sideBet.setDiscordUserName("User");
+        sideBet.setBetType(CombatSideBetType.AFB_SKIPPED);
+        sideBet.setTargetFaction("yin");
+        CombatReplayLeaderboardEntryEntity entry = new CombatReplayLeaderboardEntryEntity();
+        entry.setDiscordUserId("user");
+        entry.setDiscordUserName("User");
+        entry.setTotalPoints(10);
+
+        when(sideBetRepository.findByContestId(126L)).thenReturn(List.of(sideBet));
+        when(leaderboardEntryRepository.findByDiscordUserIdIn(any())).thenReturn(List.of(entry));
+        when(payoutService.resolvedProfitPoints(sideBet)).thenReturn(6);
+        when(candidateEventRepository.existsByCandidateIdAndEventTypeAndActorFactionAndSummaryTextContainingIgnoreCase(
+                        487L, CombatCandidateEventType.INFO, "yin", "Skipped AFB"))
+                .thenReturn(true);
+
+        CombatReplaySideBetService.SideBetResolution resolution = resolvingService.resolveSideBets(candidate, contest);
+
+        assertEquals(16, entry.getTotalPoints());
+        assertTrue(candidate.getDefenderSkippedAfb());
+        assertEquals("Skips AFB", resolution.resolvedSideBets().getFirst().label());
+        verify(candidateRepository).save(candidate);
     }
 
     private CombatCandidateEntity candidate(


### PR DESCRIPTION
## Summary
- Increase replay candidate tracking target from 4 to 16 candidates per hour.
- Expand the replay selection lookback window from 60 minutes to 24 hours.

## Test Plan
- `JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=ti4.contest.replay.service.CombatReplayServiceTest,ti4.contest.replay.service.CombatReplayContestLifecycleServiceTest test`