### PR TITLE
Fix replay promotion fallback logging

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayContestLifecycleService.java
@@ -109,9 +109,13 @@ public class CombatReplayContestLifecycleService {
         }
 
         List<CombatCandidateEntity> candidates = findPromotionCandidates(now);
-        CombatCandidateEntity winner = selectPromotionWinner(candidates);
-        if (winner == null) return;
-        promoteCandidate(winner);
+        for (CombatCandidateEntity candidate : rankPromotionCandidates(candidates)) {
+            if (promoteCandidate(candidate) != null) {
+                return;
+            }
+            BotLogger.error("Replay contest promotion skipped because promotion returned no contest. "
+                    + promotionCandidateLogContext(candidate));
+        }
     }
 
     private List<CombatCandidateEntity> findPromotionCandidates(LocalDateTime now) {
@@ -176,7 +180,7 @@ public class CombatReplayContestLifecycleService {
         return ForcePromoteResult.promoted(contest);
     }
 
-    private CombatReplayContestEntity promoteCandidate(CombatCandidateEntity winner) {
+    CombatReplayContestEntity promoteCandidate(CombatCandidateEntity winner) {
         return promoteCandidate(
                 winner,
                 replayContestRepository.findByCandidateId(winner.getId()).orElse(null));
@@ -186,10 +190,18 @@ public class CombatReplayContestLifecycleService {
             CombatCandidateEntity winner, CombatReplayContestEntity existingContest) {
         CombatObservationEntity observation =
                 observationRepository.findById(winner.getObservationId()).orElse(null);
-        if (observation == null) return null;
+        if (observation == null) {
+            BotLogger.error("Replay contest promotion failed because observation was not found. "
+                    + promotionCandidateLogContext(winner));
+            return null;
+        }
 
         Game game = loadGame(winner.getGameName());
-        if (game == null) return null;
+        if (game == null) {
+            BotLogger.error("Replay contest promotion failed because game could not be loaded. "
+                    + promotionCandidateLogContext(winner));
+            return null;
+        }
 
         String startSummaryText = snapshotStartSummaryText(winner);
         String message =
@@ -199,7 +211,11 @@ public class CombatReplayContestLifecycleService {
         }
 
         TextChannel contestChannel = getContestChannel();
-        if (contestChannel == null) return null;
+        if (contestChannel == null) {
+            BotLogger.error("Replay contest promotion failed because contest channel was not found. channelName="
+                    + CombatReplayChannels.contestChannelName(settings) + " " + promotionCandidateLogContext(winner));
+            return null;
+        }
 
         try {
             LocalDateTime promotedAt = LocalDateTime.now();
@@ -211,9 +227,23 @@ public class CombatReplayContestLifecycleService {
             postPromotionContext(thread != null ? thread : contestChannel, contest, winner);
             return contest;
         } catch (Exception e) {
-            BotLogger.error("Replay contest promotion failed.", e);
+            BotLogger.error("Replay contest promotion failed. " + promotionCandidateLogContext(winner), e);
             return null;
         }
+    }
+
+    private String promotionCandidateLogContext(CombatCandidateEntity candidate) {
+        if (candidate == null) return "candidate=null";
+        return "candidateId=" + candidate.getId()
+                + ", observationId=" + candidate.getObservationId()
+                + ", game=" + candidate.getGameName()
+                + ", tile=" + candidate.getTilePosition()
+                + ", attacker=" + candidate.getAttackerFaction()
+                + ", defender=" + candidate.getDefenderFaction()
+                + ", status=" + candidate.getStatus()
+                + ", promotionStatus=" + candidate.getPromotionStatus()
+                + ", resolvedAt=" + candidate.getResolvedAt()
+                + ", promotionScore=" + candidate.getPromotionScore();
     }
 
     String snapshotStartSummaryText(CombatCandidateEntity candidate) {
@@ -407,17 +437,13 @@ public class CombatReplayContestLifecycleService {
         return candidate != null && CombatReplayTileRenderer.canRender(candidate.getInitialRenderSnapshotJson());
     }
 
-    private CombatCandidateEntity selectPromotionWinner(List<CombatCandidateEntity> candidates) {
+    private List<CombatCandidateEntity> rankPromotionCandidates(List<CombatCandidateEntity> candidates) {
         Map<Long, Double> jointScoresByObservationId = loadJointScores(candidates);
-        CombatCandidateEntity winner = null;
         Comparator<CombatCandidateEntity> comparator = candidateComparator(jointScoresByObservationId);
-        for (CombatCandidateEntity candidate : candidates) {
-            if (candidate.getResolvedAt() == null) continue;
-            if (winner == null || comparator.compare(candidate, winner) > 0) {
-                winner = candidate;
-            }
-        }
-        return winner;
+        return candidates.stream()
+                .filter(candidate -> candidate.getResolvedAt() != null)
+                .sorted(comparator.reversed())
+                .toList();
     }
 
     private Map<Long, Double> loadJointScores(List<CombatCandidateEntity> candidates) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -2,6 +2,7 @@ package ti4.contest.replay.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -10,11 +11,14 @@ import static org.mockito.Mockito.when;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatCandidatePromotionStatus;
 import ti4.contest.replay.core.CombatCandidateStatus;
 import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatObservationRepository;
@@ -112,6 +116,34 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
+    void promoteBestCandidateIfDueFallsBackWhenTopCandidatePromotionFails() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        FallbackPromotionService service = new FallbackPromotionService(
+                settings, candidateRepository, observationRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:00:00"));
+
+        CombatCandidateEntity topCandidate = candidate(1L, 10L, 5.0);
+        CombatCandidateEntity fallbackCandidate = candidate(2L, 20L, 4.0);
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(LocalDateTime.parse("2026-04-27T11:00:00")))
+                .thenReturn(0L);
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(LocalDateTime.parse("2026-04-27T12:00:00")))
+                .thenReturn(0L);
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:00:00")))
+                .thenReturn(List.of(fallbackCandidate, topCandidate));
+        when(observationRepository.findAllById(List.of(20L, 10L))).thenReturn(List.of());
+
+        service.promoteBestCandidateIfDue();
+
+        assertIterableEquals(List.of(1L, 2L), service.promotedCandidateIds);
+    }
+
+    @Test
     void forcePromoteCandidateRejectsWhenCandidatePromotionIsDisabled() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
@@ -130,15 +162,33 @@ class CombatReplayContestLifecycleServiceTest {
             CombatContestSettings settings,
             CombatCandidateRepository candidateRepository,
             CombatReplayContestRepository replayContestRepository) {
+        return service(settings, candidateRepository, mock(CombatObservationRepository.class), replayContestRepository);
+    }
+
+    private CombatReplayContestLifecycleService service(
+            CombatContestSettings settings,
+            CombatCandidateRepository candidateRepository,
+            CombatObservationRepository observationRepository,
+            CombatReplayContestRepository replayContestRepository) {
         return new CombatReplayContestLifecycleService(
                 settings,
                 candidateRepository,
-                mock(CombatObservationRepository.class),
+                observationRepository,
                 replayContestRepository,
                 mock(CombatCandidateEventRepository.class),
                 mock(CombatReplayLeaderboardService.class),
                 mock(CombatReplaySideBetService.class),
                 mock(ReplayPayloadRenderer.class));
+    }
+
+    private CombatCandidateEntity candidate(Long id, Long observationId, Double promotionScore) {
+        CombatCandidateEntity candidate = new CombatCandidateEntity();
+        candidate.setId(id);
+        candidate.setObservationId(observationId);
+        candidate.setResolvedAt(LocalDateTime.parse("2026-04-27T11:30:00"));
+        candidate.setPromotionScore(promotionScore);
+        candidate.setInitialRenderSnapshotJson("{\"context\":{}}");
+        return candidate;
     }
 
     private Clock fixedClock(String localDateTime) {
@@ -147,5 +197,32 @@ class CombatReplayContestLifecycleServiceTest {
                         .atZone(ZoneId.systemDefault())
                         .toInstant(),
                 ZoneId.systemDefault());
+    }
+
+    private static class FallbackPromotionService extends CombatReplayContestLifecycleService {
+        private final List<Long> promotedCandidateIds = new ArrayList<>();
+
+        private FallbackPromotionService(
+                CombatContestSettings settings,
+                CombatCandidateRepository candidateRepository,
+                CombatObservationRepository observationRepository,
+                CombatReplayContestRepository replayContestRepository) {
+            super(
+                    settings,
+                    candidateRepository,
+                    observationRepository,
+                    replayContestRepository,
+                    mock(CombatCandidateEventRepository.class),
+                    mock(CombatReplayLeaderboardService.class),
+                    mock(CombatReplaySideBetService.class),
+                    mock(ReplayPayloadRenderer.class));
+        }
+
+        @Override
+        CombatReplayContestEntity promoteCandidate(CombatCandidateEntity winner) {
+            promotedCandidateIds.add(winner.getId());
+            if (winner.getId() == 1L) return null;
+            return new CombatReplayContestEntity();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Continue trying ranked replay candidates when the top candidate fails to promote
- Log promotion null paths to bot-log-error with candidate context for diagnosis
- Add regression coverage for fallback promotion behavior

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayContestLifecycleServiceTest test`