### PR TITLE
Fix replay side bet odds without active player

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -171,6 +171,16 @@ public class CombatReplayService {
                 candidate, sideBetTriggerService.fromRoll(candidate, player, rollType, whiff, slam, round));
     }
 
+    public boolean isTrackedCandidateRoll(
+            Game game, Player player, Player opponent, Tile tile, CombatRollType rollType) {
+        if (game == null || player == null || opponent == null || tile == null || !isReplayRoll(rollType)) {
+            return false;
+        }
+        CombatCandidateEntity candidate = getTrackingCandidate(game, tile.getPosition());
+        if (candidate == null) return false;
+        return rollType == CombatRollType.SpaceCannonOffence || matchesParticipants(candidate, player, opponent);
+    }
+
     private boolean isReplayRoll(CombatRollType rollType) {
         return rollType == CombatRollType.combatround
                 || rollType == CombatRollType.AFB

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
@@ -238,6 +238,7 @@ public class CombatReplaySideBetPayoutService {
                 || space == null) {
             return null;
         }
+        game.setActivePlayerID(attacker.getUserID());
         LazaxCombatSupport.SpaceCombatSnapshot snapshot =
                 LazaxCombatSupport.buildSpaceCombatSnapshot(game, attacker, defender, tile);
         if (snapshot == null) return null;

--- a/src/main/java/ti4/helpers/CombatModHelper.java
+++ b/src/main/java/ti4/helpers/CombatModHelper.java
@@ -406,20 +406,24 @@ public class CombatModHelper {
                 }
             }
             case Constants.MOD_NEBULA_DEFENDER -> {
+                Player activePlayer = game.getActivePlayer();
                 if (onTile != null
                         && (onTile.isNebula() || tile.isNebula(game))
-                        && !game.getActivePlayerID().equals(player.getUserID())
-                        && !game.getActivePlayer().getAllianceMembers().contains(player.getFaction())
+                        && activePlayer != null
+                        && !activePlayer.getUserID().equals(player.getUserID())
+                        && !activePlayer.getAllianceMembers().contains(player.getFaction())
                         && !game.getStoredValue("mahactHeroTarget").equalsIgnoreCase(player.getFaction())) {
                     meetsCondition = true;
                 }
             }
             case "nebula_cosmic_defender" -> {
+                Player activePlayer = game.getActivePlayer();
                 if (game.isCosmicPhenomenaeMode()
                         && onTile != null
                         && (onTile.isNebula() || tile.isNebula(game))
-                        && !game.getActivePlayerID().equals(player.getUserID())
-                        && !game.getActivePlayer().getAllianceMembers().contains(player.getFaction())
+                        && activePlayer != null
+                        && !activePlayer.getUserID().equals(player.getUserID())
+                        && !activePlayer.getAllianceMembers().contains(player.getFaction())
                         && !game.getStoredValue("mahactHeroTarget").equalsIgnoreCase(player.getFaction())) {
                     meetsCondition = true;
                 }

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -348,17 +348,11 @@ public class CombatRollService {
             message = message.substring(0, message.length() - 2);
         }
         MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
-        SpringContext.getBean(CombatReplayService.class)
-                .mirrorCombatRoll(
-                        game,
-                        player,
-                        opponent,
-                        tile,
-                        message,
-                        rollType,
-                        rollResult.whiff(),
-                        rollResult.slam(),
-                        payload);
+        CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
+        boolean trackedCandidateRoll =
+                combatReplayService.isTrackedCandidateRoll(game, player, opponent, tile, rollType);
+        combatReplayService.mirrorCombatRoll(
+                game, player, opponent, tile, message, rollType, rollResult.whiff(), rollResult.slam(), payload);
         if (message.contains("adding +1, at the risk of your")) {
             Button thalnosButton = Buttons.green(
                     "startThalnos_" + tile.getPosition() + "_" + unitHolderName, "Roll Thalnos", ExploreEmojis.Relic);
@@ -370,7 +364,7 @@ public class CombatRollService {
         }
 
         if (!game.isFowMode()) {
-            if (!"none".equals(game.getStoredValue("surprisingDiceRoll"))) {
+            if (!trackedCandidateRoll && !"none".equals(game.getStoredValue("surprisingDiceRoll"))) {
                 StringBuilder disaster;
                 if ("hits".equals(game.getStoredValue("surprisingDiceRoll"))) {
                     disaster = new StringBuilder(player.getRepresentation() + " has rolled grievously against "

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -1,6 +1,7 @@
 package ti4.contest.replay.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatCandidateStatus;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplaySelection;
 import ti4.contest.replay.core.LazaxCombatSupport;
@@ -17,6 +19,10 @@ import ti4.contest.replay.entities.CombatObservationEntity;
 import ti4.contest.replay.repository.CombatCandidateEventRepository;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatObservationRepository;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.service.combat.CombatRollType;
 
 class CombatReplayServiceTest {
 
@@ -144,6 +150,57 @@ class CombatReplayServiceTest {
         assertTrue(lastObservation.eligibleAsCandidate());
     }
 
+    @Test
+    void identifiesTrackedCandidateRollForMatchingSpaceCombatParticipants() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayService service = service(candidateRepository);
+        Game game = game("pbd-tracked-roll");
+        Tile tile = new Tile("18", "305");
+        Player attacker = player(game, "sol");
+        Player defender = player(game, "yin");
+        CombatCandidateEntity candidate = candidate("sol", "yin");
+        candidate.setStatus(CombatCandidateStatus.TRACKING);
+        candidate.setGameName(game.getName());
+        candidate.setTilePosition(tile.getPosition());
+        when(candidateRepository.findFirstByGameNameAndTilePositionAndStatus(
+                        game.getName(), tile.getPosition(), CombatCandidateStatus.TRACKING))
+                .thenReturn(candidate);
+
+        assertTrue(service.isTrackedCandidateRoll(game, attacker, defender, tile, CombatRollType.combatround));
+        assertTrue(service.isTrackedCandidateRoll(game, defender, attacker, tile, CombatRollType.AFB));
+    }
+
+    @Test
+    void rejectsTrackedCandidateRollForNonReplayRollsAndUnmatchedParticipants() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayService service = service(candidateRepository);
+        Game game = game("pbd-untracked-roll");
+        Tile tile = new Tile("18", "305");
+        Player attacker = player(game, "sol");
+        Player defender = player(game, "yin");
+        Player outsider = player(game, "hacan");
+        CombatCandidateEntity candidate = candidate("sol", "yin");
+        candidate.setStatus(CombatCandidateStatus.TRACKING);
+        candidate.setGameName(game.getName());
+        candidate.setTilePosition(tile.getPosition());
+        when(candidateRepository.findFirstByGameNameAndTilePositionAndStatus(
+                        game.getName(), tile.getPosition(), CombatCandidateStatus.TRACKING))
+                .thenReturn(candidate);
+
+        assertFalse(service.isTrackedCandidateRoll(game, attacker, defender, tile, CombatRollType.bombardment));
+        assertFalse(service.isTrackedCandidateRoll(game, attacker, outsider, tile, CombatRollType.combatround));
+    }
+
+    private CombatReplayService service(CombatCandidateRepository candidateRepository) {
+        return new CombatReplayService(
+                new CombatContestSettings(),
+                mock(CombatObservationRepository.class),
+                candidateRepository,
+                mock(CombatCandidateEventRepository.class),
+                mock(CombatReplayEventAppender.class),
+                mock(CombatReplaySideBetTriggerService.class));
+    }
+
     private CombatObservationEntity observation(
             Long id,
             LocalDateTime startedAt,
@@ -179,6 +236,18 @@ class CombatReplayServiceTest {
         candidate.setAttackerFaction(attackerFaction);
         candidate.setDefenderFaction(defenderFaction);
         return candidate;
+    }
+
+    private Game game(String name) {
+        Game game = new Game();
+        game.setName(name);
+        return game;
+    }
+
+    private Player player(Game game, String faction) {
+        Player player = new Player(faction + "-user", faction, game);
+        player.setFaction(faction);
+        return player;
     }
 
     private CombatReplayService.InitialCombatStats initialStats(

--- a/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
@@ -54,6 +54,17 @@ class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
     }
 
     @Test
+    void pricesRoundOneSideBetInNebulaSnapshotWithoutActivePlayer() {
+        CombatReplayContestEntity contest = oddsContest();
+        CombatCandidateEntity candidate = snapshotCandidate("92", 1, 1);
+
+        int payout = service.offeredPayout(contest, candidate, CombatSideBetType.ROUND_ONE_WHIFF, "yin");
+
+        assertEquals(4, payout);
+        verifyNoInteractions(eventRepository);
+    }
+
+    @Test
     void capsVeryLowOddsRoundOneSlamFromInitialSnapshotAtMaxPayout() {
         CombatReplayContestEntity contest = oddsContest();
         CombatCandidateEntity candidate = snapshotCandidate(4, 1);
@@ -139,12 +150,16 @@ class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
     }
 
     private CombatCandidateEntity snapshotCandidate(int solCarriers, int yinCarriers) {
+        return snapshotCandidate("18", solCarriers, yinCarriers);
+    }
+
+    private CombatCandidateEntity snapshotCandidate(String tileId, int solCarriers, int yinCarriers) {
         Game game = new Game();
         game.newGameSetup();
         game.setName("pbd-side-bet-snapshot");
         Player sol = player(game, "sol");
         Player yin = player(game, "yin");
-        Tile tile = tile(game, "18");
+        Tile tile = tile(game, tileId);
         tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Carrier, sol.getColorID()), solCarriers);
         tile.addUnit(Constants.SPACE, Units.getUnitKey(UnitType.Carrier, yin.getColorID()), yinCarriers);
 


### PR DESCRIPTION
## Summary
- Restore the attacker as active player when pricing side bets from a replay initial snapshot.
- Guard nebula defender combat modifier checks when active player state is absent.
- Suppress disaster-watch posts for tracked replay candidate rolls when the roll is all blanks or all hits.
- Add regression coverage for nebula side-bet pricing and tracked-candidate roll detection.

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayServiceTest,CombatReplaySideBetPayoutServiceTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:check`