### PR TITLE
feat: add Lazax leaderboard commands

### DIFF
--- a/src/main/java/ti4/contest/replay/repository/CombatReplayLeaderboardEntryRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayLeaderboardEntryRepository.java
@@ -14,4 +14,10 @@ public interface CombatReplayLeaderboardEntryRepository
 
     List<CombatReplayLeaderboardEntryEntity>
             findTop10ByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc();
+
+    List<CombatReplayLeaderboardEntryEntity>
+            findTop100ByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc();
+
+    List<CombatReplayLeaderboardEntryEntity>
+            findAllByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc();
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -143,6 +143,46 @@ public class CombatReplayLeaderboardService {
         TextChannel contestChannel = getContestPublicChannelByName();
         if (contestChannel == null) return false;
 
+        MessageHelper.sendMessageToChannel(contestChannel, buildLeaderboardMessage(topEntries));
+        return true;
+    }
+
+    public String buildTop100LeaderboardMessage() {
+        List<CombatReplayLeaderboardEntryEntity> topEntries =
+                leaderboardEntryRepository
+                        .findTop100ByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc();
+        if (topEntries.isEmpty()) return "No Lazax War Archives leaderboard entries have been recorded yet.";
+        return buildLeaderboardMessage(topEntries);
+    }
+
+    public String buildUserPointsMessage(String discordUserId) {
+        CombatReplayLeaderboardEntryEntity userEntry =
+                leaderboardEntryRepository.findByDiscordUserId(discordUserId).orElse(null);
+        if (userEntry == null) {
+            return "You do not have any Lazax War Archives points yet.";
+        }
+
+        List<CombatReplayLeaderboardEntryEntity> entries =
+                leaderboardEntryRepository
+                        .findAllByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc();
+        int rank = 0;
+        for (int index = 0; index < entries.size(); index++) {
+            if (discordUserId.equals(entries.get(index).getDiscordUserId())) {
+                rank = index + 1;
+                break;
+            }
+        }
+
+        int predictions = safeInt(userEntry.getPredictionCount());
+        int correctPredictions = safeInt(userEntry.getCorrectPredictions());
+        int accuracy = predictions == 0 ? 0 : Math.round((100.0f * correctPredictions) / predictions);
+        return "## Your Lazax War Archives Points\n"
+                + "Rank: **" + (rank == 0 ? "Unranked" : "#" + rank) + "**\n"
+                + "Points: **" + safeInt(userEntry.getTotalPoints()) + "**\n"
+                + "Correct predictions: `" + correctPredictions + "/" + predictions + "` (" + accuracy + "%)";
+    }
+
+    private String buildLeaderboardMessage(List<CombatReplayLeaderboardEntryEntity> topEntries) {
         StringBuilder message = new StringBuilder("## Lazax War Archives Leaderboard\n");
         for (int index = 0; index < topEntries.size(); index++) {
             CombatReplayLeaderboardEntryEntity entry = topEntries.get(index);
@@ -166,8 +206,7 @@ public class CombatReplayLeaderboardService {
                 message.append("\n");
             }
         }
-        MessageHelper.sendMessageToChannel(contestChannel, message.toString());
-        return true;
+        return message.toString();
     }
 
     private CombatReplayPredictionEntity buildLockedPredictionSnapshot(

--- a/src/main/java/ti4/discord/interactions/commands/SlashCommandManager.java
+++ b/src/main/java/ti4/discord/interactions/commands/SlashCommandManager.java
@@ -27,6 +27,7 @@ import ti4.discord.interactions.commands.franken.FrankenCommand;
 import ti4.discord.interactions.commands.game.GameCommand;
 import ti4.discord.interactions.commands.help.HelpCommand;
 import ti4.discord.interactions.commands.installation.InstallationCommand;
+import ti4.discord.interactions.commands.lazax.LazaxCommand;
 import ti4.discord.interactions.commands.leaders.LeaderCommand;
 import ti4.discord.interactions.commands.map.MapCommand;
 import ti4.discord.interactions.commands.milty.MiltyCommand;
@@ -134,6 +135,7 @@ public class SlashCommandManager {
                     new PlanetCommand(),
                     new SelectionBoxDemoCommand(),
                     new UserCommand(),
+                    new LazaxCommand(),
                     new TiglCommand(),
                     new AsyncCommand(),
                     new OmegaPhaseCommand(),

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
@@ -1,0 +1,29 @@
+package ti4.discord.interactions.commands.lazax;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import ti4.discord.interactions.commands.ParentCommand;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.helpers.Constants;
+
+public class LazaxCommand implements ParentCommand {
+
+    private final Map<String, Subcommand> subcommands = Stream.of(new LazaxMyPoints(), new LazaxTop100())
+            .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
+
+    @Override
+    public String getName() {
+        return Constants.LAZAX;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Lazax War Archives";
+    }
+
+    @Override
+    public Map<String, Subcommand> getSubcommands() {
+        return subcommands;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxMyPoints.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxMyPoints.java
@@ -1,0 +1,21 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.contest.replay.service.CombatReplayLeaderboardService;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.helpers.Constants;
+import ti4.spring.context.SpringContext;
+
+class LazaxMyPoints extends Subcommand {
+
+    LazaxMyPoints() {
+        super(Constants.LAZAX_MY_POINTS, "Show your Lazax War Archives leaderboard points.");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        String message = SpringContext.getBean(CombatReplayLeaderboardService.class)
+                .buildUserPointsMessage(event.getUser().getId());
+        LazaxReplyHelper.replyEphemeral(event, message);
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxReplyHelper.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxReplyHelper.java
@@ -1,0 +1,36 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.logging.BotLogger;
+
+final class LazaxReplyHelper {
+
+    private static final int MAX_MESSAGE_LENGTH = 1900;
+
+    private LazaxReplyHelper() {}
+
+    static void replyEphemeral(SlashCommandInteractionEvent event, String message) {
+        for (String chunk : splitByLine(message)) {
+            event.getHook().sendMessage(chunk).setEphemeral(true).queue(null, BotLogger::catchRestError);
+        }
+    }
+
+    private static Iterable<String> splitByLine(String message) {
+        java.util.List<String> chunks = new java.util.ArrayList<>();
+        StringBuilder chunk = new StringBuilder();
+        for (String line : message.split("\\R", -1)) {
+            if (!chunk.isEmpty() && chunk.length() + line.length() + 1 > MAX_MESSAGE_LENGTH) {
+                chunks.add(chunk.toString());
+                chunk.setLength(0);
+            }
+            if (!chunk.isEmpty()) {
+                chunk.append('\n');
+            }
+            chunk.append(line);
+        }
+        if (!chunk.isEmpty()) {
+            chunks.add(chunk.toString());
+        }
+        return chunks;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxTop100.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxTop100.java
@@ -1,0 +1,32 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.contest.replay.service.CombatReplayLeaderboardService;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+import ti4.spring.context.SpringContext;
+
+class LazaxTop100 extends Subcommand {
+
+    LazaxTop100() {
+        super(Constants.LAZAX_TOP_100, "Show the top 100 Lazax War Archives leaderboard.");
+        addOptions(new OptionData(
+                OptionType.BOOLEAN, Constants.PUBLIC, "True to post in the channel. Default false sends only to you."));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        boolean publicMessage = event.getOption(Constants.PUBLIC, Boolean.FALSE, OptionMapping::getAsBoolean);
+        String message =
+                SpringContext.getBean(CombatReplayLeaderboardService.class).buildTop100LeaderboardMessage();
+        if (publicMessage) {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
+            return;
+        }
+        LazaxReplyHelper.replyEphemeral(event, message);
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1541,6 +1541,10 @@ public final class Constants {
     public static final String TIGL_CHANGE_NICKNAME = "change_nickname";
     public static final String TIGL_NICKNAME = "nickname";
     public static final String TIGL_FRACTURED_TAG = "TIGL Fractured";
+    public static final String LAZAX = "lazax";
+    public static final String LAZAX_MY_POINTS = "my_points";
+    public static final String LAZAX_TOP_100 = "top_100";
+    public static final String PUBLIC = "public";
     public static final String IS_FRACTURED = "is_fractured";
     public static final String SHOW_GAME_IDS = "show_game_ids";
     public static final String SEARCH_NAMES = "search_names";

--- a/src/test/java/ti4/contest/replay/service/CombatReplayLeaderboardServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayLeaderboardServiceTest.java
@@ -2,8 +2,12 @@ package ti4.contest.replay.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
@@ -15,12 +19,7 @@ class CombatReplayLeaderboardServiceTest {
 
     @Test
     void newLeaderboardEntriesStartWithInitialPoints() throws Exception {
-        CombatReplayLeaderboardService service = new CombatReplayLeaderboardService(
-                new CombatContestSettings(),
-                mock(CombatReplayContestRepository.class),
-                mock(CombatReplayPredictionRepository.class),
-                mock(CombatReplayLeaderboardEntryRepository.class),
-                mock(CombatReplaySideBetService.class));
+        CombatReplayLeaderboardService service = newService(mock(CombatReplayLeaderboardEntryRepository.class));
         Method method = CombatReplayLeaderboardService.class.getDeclaredMethod(
                 "newLeaderboardEntry", String.class, String.class);
         method.setAccessible(true);
@@ -31,5 +30,59 @@ class CombatReplayLeaderboardServiceTest {
         assertEquals(CombatReplayLeaderboardService.STARTING_POINTS, entry.getTotalPoints());
         assertEquals(0, entry.getPredictionCount());
         assertEquals(0, entry.getCorrectPredictions());
+    }
+
+    @Test
+    void userPointsMessageIncludesRankPointsAndAccuracy() {
+        CombatReplayLeaderboardEntryRepository repository = mock(CombatReplayLeaderboardEntryRepository.class);
+        CombatReplayLeaderboardEntryEntity first = leaderboardEntry("1", "First", 140, 10, 7);
+        CombatReplayLeaderboardEntryEntity user = leaderboardEntry("2", "Player", 120, 5, 3);
+        when(repository.findByDiscordUserId("2")).thenReturn(Optional.of(user));
+        when(repository.findAllByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc())
+                .thenReturn(List.of(first, user));
+        CombatReplayLeaderboardService service = newService(repository);
+
+        String message = service.buildUserPointsMessage("2");
+
+        assertEquals(
+                "## Your Lazax War Archives Points\n"
+                        + "Rank: **#2**\n"
+                        + "Points: **120**\n"
+                        + "Correct predictions: `3/5` (60%)",
+                message);
+    }
+
+    @Test
+    void top100MessageUsesLeaderboardFormatting() {
+        CombatReplayLeaderboardEntryRepository repository = mock(CombatReplayLeaderboardEntryRepository.class);
+        when(repository.findTop100ByOrderByTotalPointsDescCorrectPredictionsDescPredictionCountDescDiscordUserNameAsc())
+                .thenReturn(List.of(leaderboardEntry("1", "Player", 120, 5, 3)));
+        CombatReplayLeaderboardService service = newService(repository);
+
+        String message = service.buildTop100LeaderboardMessage();
+
+        assertEquals(
+                "## Lazax War Archives Leaderboard\n" + "`1.` Player - **120** points (`3/5` correct, 60%)", message);
+    }
+
+    private static CombatReplayLeaderboardService newService(CombatReplayLeaderboardEntryRepository repository) {
+        return new CombatReplayLeaderboardService(
+                new CombatContestSettings(),
+                mock(CombatReplayContestRepository.class),
+                mock(CombatReplayPredictionRepository.class),
+                repository,
+                mock(CombatReplaySideBetService.class));
+    }
+
+    private static CombatReplayLeaderboardEntryEntity leaderboardEntry(
+            String userId, String userName, int totalPoints, int predictionCount, int correctPredictions) {
+        CombatReplayLeaderboardEntryEntity entry = new CombatReplayLeaderboardEntryEntity();
+        entry.setDiscordUserId(userId);
+        entry.setDiscordUserName(userName);
+        entry.setTotalPoints(totalPoints);
+        entry.setPredictionCount(predictionCount);
+        entry.setCorrectPredictions(correctPredictions);
+        entry.setUpdatedAt(LocalDateTime.now());
+        return entry;
     }
 }


### PR DESCRIPTION
## Summary
- Add /lazax my_points for ephemeral user leaderboard points.
- Add /lazax top_100 with optional public posting.
- Reuse leaderboard formatting and cover the new message builders with focused tests.

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:apply test -Dtest=CombatReplayLeaderboardServiceTest