### PR TITLE
fix: preserve ephemeral Lazax replies

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/Command.java
+++ b/src/main/java/ti4/discord/interactions/commands/Command.java
@@ -34,6 +34,10 @@ public interface Command<T extends GenericInteractionCreateEvent> {
         return false;
     }
 
+    default boolean isEphemeral(T event) {
+        return false;
+    }
+
     default void register(CommandListUpdateAction update) {}
 
     default void registerSearchCommands(CommandListUpdateAction update) {}

--- a/src/main/java/ti4/discord/interactions/commands/ParentCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/ParentCommand.java
@@ -58,6 +58,12 @@ public interface ParentCommand extends Command<SlashCommandInteractionEvent> {
         return subcommand != null && subcommand.isSuspicious(event);
     }
 
+    @Override
+    default boolean isEphemeral(SlashCommandInteractionEvent event) {
+        Command<SlashCommandInteractionEvent> subcommand = getSubcommand(event);
+        return subcommand != null && subcommand.isEphemeral(event);
+    }
+
     default void register(CommandListUpdateAction commands) {
         var command = Commands.slash(getName(), getDescription())
                 .addSubcommands(getSubcommands().values())

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxMyPoints.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxMyPoints.java
@@ -18,4 +18,9 @@ class LazaxMyPoints extends Subcommand {
                 .buildUserPointsMessage(event.getUser().getId());
         LazaxReplyHelper.replyEphemeral(event, message);
     }
+
+    @Override
+    public boolean isEphemeral(SlashCommandInteractionEvent event) {
+        return true;
+    }
 }

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxReplyHelper.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxReplyHelper.java
@@ -10,7 +10,13 @@ final class LazaxReplyHelper {
     private LazaxReplyHelper() {}
 
     static void replyEphemeral(SlashCommandInteractionEvent event, String message) {
+        boolean firstChunk = true;
         for (String chunk : splitByLine(message)) {
+            if (firstChunk) {
+                event.getHook().editOriginal(chunk).queue(null, BotLogger::catchRestError);
+                firstChunk = false;
+                continue;
+            }
             event.getHook().sendMessage(chunk).setEphemeral(true).queue(null, BotLogger::catchRestError);
         }
     }

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxTop100.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxTop100.java
@@ -29,4 +29,9 @@ class LazaxTop100 extends Subcommand {
         }
         LazaxReplyHelper.replyEphemeral(event, message);
     }
+
+    @Override
+    public boolean isEphemeral(SlashCommandInteractionEvent event) {
+        return !event.getOption(Constants.PUBLIC, Boolean.FALSE, OptionMapping::getAsBoolean);
+    }
 }

--- a/src/main/java/ti4/discord/interactions/listeners/SlashCommandListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/SlashCommandListener.java
@@ -35,7 +35,10 @@ class SlashCommandListener extends ListenerAdapter implements CommandListener {
         if (!canReceiveCommands(event)) return;
 
         if (!isModalCommand(event)) {
-            event.getInteraction().deferReply().queue(Consumers.nop(), BotLogger::catchRestError);
+            Command<SlashCommandInteractionEvent> command = getCommand(event);
+            event.getInteraction()
+                    .deferReply(command.isEphemeral(event))
+                    .queue(Consumers.nop(), BotLogger::catchRestError);
         }
 
         queue(event);
@@ -81,7 +84,7 @@ class SlashCommandListener extends ListenerAdapter implements CommandListener {
                 logSlashCommand(event);
                 command.execute(event);
                 command.postExecute(event);
-                if (!isModalCommand(event)) {
+                if (!isModalCommand(event) && !resolvedCommand.isEphemeral(event)) {
                     event.getHook().deleteOriginal().queue(Consumers.nop(), BotLogger::catchRestError);
                 }
             }


### PR DESCRIPTION
## Summary
- Defer slash commands as ephemeral when the resolved command requests it.
- Skip the global deleteOriginal cleanup for commands that own their ephemeral response.
- Make Lazax private leaderboard replies edit the original ephemeral response instead of sending a follow-up that gets cleared.

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:apply test -Dtest=CombatReplayLeaderboardServiceTest
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests compile