### PR TITLE
Handle unknown sabotage window messages in auto-react cron

### DIFF
--- a/src/main/java/ti4/cron/SabotageAutoReactCron.java
+++ b/src/main/java/ti4/cron/SabotageAutoReactCron.java
@@ -10,6 +10,7 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.persistence.GameManager;
 import ti4.game.persistence.ManagedGame;
+import ti4.helpers.discord.DiscordHelper;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.message.GameMessageManager;
@@ -66,9 +67,19 @@ public class SabotageAutoReactCron {
             }
 
             for (var acMessage : acMessages) {
-                if (!ReactionService.checkForSpecificPlayerReact(acMessage.messageId(), player, game)) {
-                    String message = game.isFowMode() ? "No Sabotage" : null;
+                if (ReactionService.checkForSpecificPlayerReact(acMessage.messageId(), player, game)) {
+                    continue;
+                }
+
+                String message = game.isFowMode() ? "No Sabotage" : null;
+                try {
                     ReactionService.addReaction(player, false, message, null, acMessage.messageId(), game);
+                } catch (Exception e) {
+                    if (DiscordHelper.isUnknownMessageError(e)) {
+                        GameMessageManager.remove(game.getName(), acMessage.messageId());
+                        continue;
+                    }
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Avoid the `SabotageAutoReactCron` failing the whole run when Discord returns an "Unknown Message" error for a stale action-card message. 
- Ensure the cron continues processing other messages and players by removing message IDs that no longer exist.

### Description
- Import `DiscordHelper` and wrap `ReactionService.addReaction(...)` calls in a try/catch to detect unknown-message errors. 
- On `DiscordHelper.isUnknownMessageError(e)` the code now calls `GameMessageManager.remove(game.getName(), acMessage.messageId())` and continues processing. 
- Preserve existing behavior by rethrowing non-unknown-message exceptions and skip already-reacted messages early with an inverted check.

### Testing
- Attempted a local build with `mvn -q -DskipTests compile`, which failed due to external dependency resolution for `org.springframework.boot:spring-boot-starter-parent:4.1.0-RC1` returning HTTP 403 in this environment. 
- No automated unit tests were run in this environment due to the build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4de308200832d85de603f7a3eeab1)