### PR TITLE
Fix combat contest config packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/root/.m2 \
 
 # add sources late for better layer reuse
 # Only package classpath config; runtime assets are mounted from the host repo.
-COPY src/main/resources/config/application.yml ./src/main/resources/config/application.yml
+COPY src/main/resources/config ./src/main/resources/config
 COPY src/main/resources/logback.xml ./src/main/resources/logback.xml
 COPY src/main/java ./src/main/java
 


### PR DESCRIPTION
## Summary
- Package the full classpath config directory in the Docker image build so combat contest YAML files are included in the jar.
- Fixes startup failure when `CombatContestSettings` loads `config/combat-contest-prod.yml`.

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests compile`