### PR TITLE
Update Bothelper Dashboard

### DIFF
--- a/src/main/java/ti4/service/bothelper/BothelperDashboardService.java
+++ b/src/main/java/ti4/service/bothelper/BothelperDashboardService.java
@@ -46,7 +46,7 @@ public class BothelperDashboardService {
     public static String buildDashboardContent() {
         List<Guild> servers = JdaService.serversToCreateNewGamesOn;
         Set<String> uniqueUserIds = new HashSet<>();
-        StringBuilder sb = new StringBuilder("# Bothelper Dashboard\n");
+        StringBuilder sb = new StringBuilder("# __Bothelper Dashboard__\n");
 
         StringBuilder serverBlocks = new StringBuilder();
         for (Guild guild : servers) {
@@ -54,14 +54,14 @@ public class BothelperDashboardService {
             if (bothelperRole == null) continue;
             List<Member> members = guild.getMembersWithRoles(bothelperRole);
             serverBlocks
-                    .append("## ")
+                    .append("- ")
                     .append(guild.getName())
                     .append(" (")
                     .append(members.size())
                     .append(")\n");
             for (Member member : members) {
                 uniqueUserIds.add(member.getId());
-                serverBlocks.append("- ").append(member.getEffectiveName()).append("\n");
+                //serverBlocks.append("- ").append(member.getEffectiveName()).append("\n");
             }
         }
 
@@ -84,7 +84,7 @@ public class BothelperDashboardService {
         }
         TextChannel channel = channels.getFirst();
         String content = buildDashboardContent();
-        var manageRolesButton = Buttons.blue(BUTTON_ID, "Manage Roles");
+        var manageRolesButton = Buttons.blue(BUTTON_ID, "Pick Servers to Bothelper");
 
         // Delete all existing messages then send a fresh one
         channel.getHistory()
@@ -193,7 +193,8 @@ public class BothelperDashboardService {
             }
             Member member = guild.getMember(event.getUser());
             if (member == null) {
-                // User is not in this server; skip silently
+                skipped.add(guild.getName() + " (you are not in this server)");
+                // TODO: add a server invite link 
                 continue;
             }
             boolean userWantsRole = selectedGuildIds.contains(guild.getId());

--- a/src/main/java/ti4/service/bothelper/BothelperDashboardService.java
+++ b/src/main/java/ti4/service/bothelper/BothelperDashboardService.java
@@ -61,7 +61,6 @@ public class BothelperDashboardService {
                     .append(")\n");
             for (Member member : members) {
                 uniqueUserIds.add(member.getId());
-                //serverBlocks.append("- ").append(member.getEffectiveName()).append("\n");
             }
         }
 
@@ -84,7 +83,7 @@ public class BothelperDashboardService {
         }
         TextChannel channel = channels.getFirst();
         String content = buildDashboardContent();
-        var manageRolesButton = Buttons.blue(BUTTON_ID, "Pick Servers to Bothelper");
+        var manageRolesButton = Buttons.blue(BUTTON_ID, "Manage My Bothelper Role");
 
         // Delete all existing messages then send a fresh one
         channel.getHistory()
@@ -194,7 +193,7 @@ public class BothelperDashboardService {
             Member member = guild.getMember(event.getUser());
             if (member == null) {
                 skipped.add(guild.getName() + " (you are not in this server)");
-                // TODO: add a server invite link 
+                // TODO: add a server invite link
                 continue;
             }
             boolean userWantsRole = selectedGuildIds.contains(guild.getId());


### PR DESCRIPTION
This pull request updates the `BothelperDashboardService` to improve the clarity and user experience of the dashboard and its role management features. The main changes focus on adjusting the dashboard's formatting and user-facing text, as well as improving feedback when users attempt to manage roles on servers they are not part of.

Dashboard formatting and content improvements:
* Changed the dashboard title in `buildDashboardContent` to use markdown underline for better visibility, and simplified server listings to a bullet-point format, removing the listing of individual member names for each server.

Button and UI text updates:
* Updated the label of the roles management button to "Pick Servers to Bothelper" for clearer user guidance.

User feedback enhancements:
* Added more descriptive feedback when a user tries to manage roles for a server they are not a member of, and included a TODO note to add a server invite link in the future.