### PR TITLE
Add Tyris Non-Linear Time Progression breakthrough

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/tyris/TyrisBreakthroughButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/tyris/TyrisBreakthroughButtonHandler.java
@@ -1,0 +1,161 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.tyris;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.ButtonHelper;
+import ti4.image.Mapper;
+import ti4.message.MessageHelper;
+import ti4.model.TechnologyModel;
+
+@UtilityClass
+public class TyrisBreakthroughButtonHandler {
+
+    private static final String STORED_KEY_SUFFIX = "tyrisBTTechs";
+
+    public static List<String> getTyrisBTTechs(Player player, Game game) {
+        List<String> result = new ArrayList<>();
+        for (String tech :
+                game.getStoredValue(player.getFaction() + STORED_KEY_SUFFIX).split(",")) {
+            if (!tech.isEmpty() && Mapper.getTech(tech) != null) {
+                result.add(tech);
+            }
+        }
+        return result;
+    }
+
+    public static void addTyrisBTTech(Player player, Game game, String techID) {
+        if (getTyrisBTTechs(player, game).contains(techID)) return;
+        String prev = game.getStoredValue(player.getFaction() + STORED_KEY_SUFFIX);
+        game.setStoredValue(player.getFaction() + STORED_KEY_SUFFIX, prev.isEmpty() ? techID : prev + "," + techID);
+    }
+
+    public static String removeTyrisBTTech(Player player, Game game) {
+        List<String> techs = getTyrisBTTechs(player, game);
+        if (techs.isEmpty()) return null;
+        String removed = techs.getFirst();
+        removeTechByID(player, game, removed);
+        return removed;
+    }
+
+    private static void removeTechByID(Player player, Game game, String techID) {
+        String stored = game.getStoredValue(player.getFaction() + STORED_KEY_SUFFIX);
+        stored = stored.replace("," + techID, "").replace(techID + ",", "").replace(techID, "");
+        game.setStoredValue(player.getFaction() + STORED_KEY_SUFFIX, stored);
+    }
+
+    public static Optional<Button> getPlaceButton(Player player, Game game) {
+        List<String> onCard = getTyrisBTTechs(player, game);
+        boolean hasEligible = player.getTechs().stream()
+                .filter(t -> !onCard.contains(t))
+                .map(Mapper::getTech)
+                .anyMatch(m -> m != null && !m.isUnitUpgrade());
+        if (!hasEligible) return Optional.empty();
+        int current = onCard.size();
+        String label =
+                "Place Tech on Non-Linear Time Progression" + (current > 0 ? " (currently -" + current + ")" : "");
+        return Optional.of(Buttons.green(player.factionButtonChecker() + "tyrisBTSelectTech", label));
+    }
+
+    @ButtonHandler("tyrisBTSelectTech")
+    public static void selectTech(ButtonInteractionEvent event, Game game, Player player) {
+        List<String> onCard = getTyrisBTTechs(player, game);
+        List<Button> buttons = new ArrayList<>();
+        for (String techID : player.getTechs()) {
+            if (onCard.contains(techID)) continue;
+            TechnologyModel m = Mapper.getTech(techID);
+            if (m == null || m.isUnitUpgrade()) continue;
+            buttons.add(Buttons.green(player.factionButtonChecker() + "tyrisBTPlaceTech_" + techID, m.getName()));
+        }
+        if (buttons.isEmpty()) {
+            MessageHelper.sendMessageToChannel(
+                    event.getMessageChannel(),
+                    player.getRepresentation()
+                            + " has no eligible technologies to place on _Non-Linear Time Progression_.");
+            return;
+        }
+        MessageHelper.sendMessageToChannelWithButtons(
+                event.getMessageChannel(),
+                player.getRepresentationUnfogged()
+                        + ", choose a non-unit-upgrade technology to place on _Non-Linear Time Progression_:",
+                buttons);
+    }
+
+    @ButtonHandler("tyrisBTPlaceTech_")
+    public static void placeTech(String buttonID, ButtonInteractionEvent event, Game game, Player player) {
+        String techID = buttonID.replace("tyrisBTPlaceTech_", "");
+        TechnologyModel m = Mapper.getTech(techID);
+        if (m == null) return;
+        addTyrisBTTech(player, game, techID);
+        player.addSpentThing("tyrisbt");
+        int count = getTyrisBTTechs(player, game).size();
+        MessageHelper.sendMessageToChannel(
+                player.getCorrectChannel(),
+                player.getRepresentation() + " placed _" + m.getName()
+                        + "_ on _Non-Linear Time Progression_ (cost reduced by "
+                        + count + " resource" + (count == 1 ? "" : "s") + " total).");
+        ButtonHelper.deleteMessage(event);
+    }
+
+    @ButtonHandler("tyrisBTRemoveTech_")
+    public static void removeTech(String buttonID, ButtonInteractionEvent event, Game game, Player player) {
+        String techID = buttonID.replace("tyrisBTRemoveTech_", "");
+        if (!getTyrisBTTechs(player, game).contains(techID)) return;
+        removeTechByID(player, game, techID);
+        TechnologyModel m = Mapper.getTech(techID);
+        String name = m != null ? "_" + m.getName() + "_" : techID;
+        MessageHelper.sendMessageToChannel(
+                player.getCorrectChannel(),
+                player.getRepresentation() + " removed " + name + " from _Non-Linear Time Progression_.");
+        ButtonHelper.deleteMessage(event);
+    }
+
+    public static void sendNonLinearTimeProgressionInfo(Game game, Player tyris, Player caller) {
+        List<String> techs = getTyrisBTTechs(tyris, game);
+        String techList = techs.isEmpty()
+                ? "_(none)_"
+                : techs.stream()
+                        .map(id -> {
+                            TechnologyModel m = Mapper.getTech(id);
+                            return m != null ? "_" + m.getName() + "_" : id;
+                        })
+                        .collect(java.util.stream.Collectors.joining(", "));
+
+        String msg = tyris.getRepresentation() + "'s _Non-Linear Time Progression_ (-" + techs.size() + " resource"
+                + (techs.size() == 1 ? "" : "s") + " to spend): " + techList;
+        MessageHelper.sendMessageToChannel(caller.getCardsInfoThread(), msg);
+    }
+
+    public static void handlePlayerPassed(Game game, Player p) {
+        List<String> techs = getTyrisBTTechs(p, game);
+        if (techs.isEmpty()) return;
+        if (techs.size() == 1) {
+            String removed = removeTyrisBTTech(p, game);
+            TechnologyModel m = Mapper.getTech(removed);
+            String name = m != null ? "_" + m.getName() + "_" : removed;
+            MessageHelper.sendMessageToChannel(
+                    p.getCardsInfoThread(),
+                    p.getRepresentation() + "'s " + name
+                            + " was removed from _Non-Linear Time Progression_ because a player passed.");
+        } else {
+            List<Button> buttons = new ArrayList<>();
+            for (String techID : techs) {
+                TechnologyModel m = Mapper.getTech(techID);
+                String label = m != null ? m.getName() : techID;
+                buttons.add(Buttons.red(p.factionButtonChecker() + "tyrisBTRemoveTech_" + techID, label));
+            }
+            MessageHelper.sendMessageToChannelWithButtons(
+                    p.getCardsInfoThread(),
+                    p.getRepresentation()
+                            + ", a player passed — choose 1 technology to remove from _Non-Linear Time Progression_:",
+                    buttons);
+        }
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/breakthrough/BreakthroughInfo.java
+++ b/src/main/java/ti4/discord/interactions/commands/breakthrough/BreakthroughInfo.java
@@ -2,6 +2,7 @@ package ti4.discord.interactions.commands.breakthrough;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.tyris.TyrisBreakthroughButtonHandler;
 import ti4.discord.interactions.commands.CommandHelper;
 import ti4.discord.interactions.commands.GameStateSubcommand;
 import ti4.game.Player;
@@ -17,6 +18,10 @@ class BreakthroughInfo extends GameStateSubcommand {
 
     public void execute(SlashCommandInteractionEvent event) {
         Player p2 = CommandHelper.getOtherPlayerFromEvent(getGame(), event);
+        if (p2 == null) p2 = getPlayer();
         BreakthroughCommandHelper.sendBreakthroughInfo(event, getGame(), getPlayer(), p2);
+        if (p2.hasUnlockedBreakthrough("tyrisbt")) {
+            TyrisBreakthroughButtonHandler.sendNonLinearTimeProgressionInfo(getGame(), p2, getPlayer());
+        }
     }
 }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -59,6 +59,7 @@ import ti4.ResourceHelper;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.buttons.handlers.agenda.VoteButtonHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.tyris.PhantomEnergyHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.tyris.TyrisBreakthroughButtonHandler;
 import ti4.discord.interactions.commands.tokens.AddTokenCommand;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.discord.interactions.selections.selectmenus.SelectFaction;
@@ -719,6 +720,10 @@ public class ButtonHelper {
         if (player.hasAbility("diplomats")
                 && !ButtonHelperAbilities.getDiplomatButtons(game, player).isEmpty()) {
             buttons.add(Buttons.gray("getDiplomatsButtons", "Use Diplomats Ability", FactionEmojis.freesystems));
+        }
+        if ((whatIsItFor.contains("res") || whatIsItFor.contains("both"))
+                && player.hasUnlockedBreakthrough("tyrisbt")) {
+            TyrisBreakthroughButtonHandler.getPlaceButton(player, game).ifPresent(buttons::add);
         }
         buttons.add(Buttons.gray("resetSpend_" + whatIsItFor, "Reset Spent Planets and Trade Goods"));
         return buttons;

--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -1299,6 +1299,7 @@ public final class Helper {
                     && !thing.contains("warmachine")
                     && !thing.contains("manifest")
                     && !thing.contains("ghostbt")
+                    && !thing.contains("tyrisbt")
                     && !thing.contains("dwsDiscount")
                     && !thing.contains("aida")
                     && !thing.contains("commander")
@@ -1426,6 +1427,10 @@ public final class Helper {
                             .append(CardEmojis.getACEmoji(game))
                             .append('\n');
                     res += 3;
+                }
+                if ("tyrisbt".equals(thing)) {
+                    res += 1;
+                    msg.append("> Used _Non-Linear Time Progression_ for 1 resource discount\n");
                 }
                 if (thing.contains("ghostbt")) {
                     int wormholes =

--- a/src/main/java/ti4/service/turn/PassService.java
+++ b/src/main/java/ti4/service/turn/PassService.java
@@ -7,6 +7,7 @@ import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.tyris.TyrisBreakthroughButtonHandler;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.ButtonHelper;
@@ -131,6 +132,11 @@ public class PassService {
             }
         }
 
+        Player tyris =
+                game.getPlayersFromBreakthrough("tyrisbt").stream().findFirst().orElse(null);
+        if (tyris != null && tyris.hasUnlockedBreakthrough("tyrisbt")) {
+            TyrisBreakthroughButtonHandler.handlePlayerPassed(game, tyris);
+        }
         EndTurnService.pingNextPlayer(event, game, player, true);
         if (!autoPass) {
             StatusHelper.offerPreScoringButtons(game, player);


### PR DESCRIPTION
- New TyrisBreakthroughButtonHandler: place/remove non-unit-upgrade techs on the card during resource spending; each tech reduces cost by 1 via addSpentThing
- PassService: trigger tech removal when any player passes
- ButtonHelper: show place-tech button during resource spending
- Helper: count tyrisbt spent things as resource discount in spend summary
- BreakthroughInfo: show card state when /breakthrough info run for Tyris