### PR TITLE
Add twilightkart filter and autocomplete

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/statistics/GameStatisticsFilterer.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/GameStatisticsFilterer.java
@@ -197,6 +197,7 @@ public class GameStatisticsFilterer {
             case "tf" -> game.isTwilightsFallMode();
             case "tedemo" -> game.isThundersEdgeDemo();
             case "noswap" -> game.isNoSwapMode();
+            case "twilightkart" -> game.isTwilightKart();
             default -> false;
         };
     }

--- a/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
+++ b/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
@@ -479,6 +479,7 @@ class AutoCompleteProvider {
                         "ordinian",
                         "te",
                         "tf",
+                        "twilightkart",
                         "tedemo",
                         "noswap");
                 List<Command.Choice> options = mapTo25ChoicesThatContain(tokens, enteredValue);


### PR DESCRIPTION
Support filtering by the 'twilightkart' game mode: add a case in GameStatisticsFilterer that checks game.isTwilightKart(), and include 'twilightkart' in the AutoCompleteProvider token list so it appears in autocomplete suggestions.