### PR TITLE
Stop delegation assignment welcome pings

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
@@ -464,7 +464,7 @@ public class CombatReplayHouseService {
         }
 
         MessageHelper.sendMessageToChannel(
-                channel, houseRoleMention(guild, house) + " welcomes <@" + discordUserId + ">.");
+                channel, "**" + house.displayName() + " Delegation** welcomes <@" + discordUserId + ">.");
     }
 
     private Role findRole(Guild guild, CombatReplayHouse house) {


### PR DESCRIPTION
## Summary
- Change Lazax delegation assignment welcome messages to use plain delegation text instead of the delegation role mention
- Keeps welcoming the assigned user without pinging every member of the delegation

## Test Plan
- mvn spotless:check
- git diff --check