### PR TITLE
Enable combat promotion in prod

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -79,9 +79,6 @@ public class CombatReplayPromotionService {
             }
 
             postProductionMentakPreviewIfDue(now);
-            LocalDateTime publicPromotionWindow = now.truncatedTo(ChronoUnit.MINUTES);
-            if (publicPromotionWindow.getMinute() != 0) return;
-            if (!canPublicPromoteAt(publicPromotionWindow)) return;
             promoteMentakPreviewedCandidateIfDue(now);
             return;
         }
@@ -128,11 +125,37 @@ public class CombatReplayPromotionService {
                     "Candidate already has an active replay contest", existingContest);
         }
 
+        if (usesMentakPreviewFlow()) {
+            if (isMentakPreviewReadyForPublicPromotion(candidate, LocalDateTime.now(clock))) {
+                CombatReplayContestEntity contest = promoteCandidate(candidate, existingContest);
+                if (contest == null) {
+                    return CombatReplayContestLifecycleService.ForcePromoteResult.rejected("Promotion failed");
+                }
+                return CombatReplayContestLifecycleService.ForcePromoteResult.promoted(contest);
+            }
+            return forceMentakPreviewCandidate(candidate, existingContest);
+        }
+
         CombatReplayContestEntity contest = promoteCandidate(candidate, existingContest);
         if (contest == null) {
             return CombatReplayContestLifecycleService.ForcePromoteResult.rejected("Promotion failed");
         }
         return CombatReplayContestLifecycleService.ForcePromoteResult.promoted(contest);
+    }
+
+    private CombatReplayContestLifecycleService.ForcePromoteResult forceMentakPreviewCandidate(
+            CombatCandidateEntity candidate, CombatReplayContestEntity existingContest) {
+        if (candidate.getMentakPreviewPostedAt() != null) {
+            return CombatReplayContestLifecycleService.ForcePromoteResult.rejected(
+                    "Mentak preview window is still open.", existingContest);
+        }
+
+        CombatReplayContestEntity contest = postMentakPreview(candidate);
+        if (contest == null) {
+            return CombatReplayContestLifecycleService.ForcePromoteResult.rejected("Mentak preview failed.");
+        }
+        return CombatReplayContestLifecycleService.ForcePromoteResult.rejected(
+                "Mentak preview posted. Public promotion will be available after the preview window.", contest);
     }
 
     private List<CombatCandidateEntity> findPromotionCandidates(LocalDateTime now) {
@@ -215,6 +238,7 @@ public class CombatReplayPromotionService {
     }
 
     private void promoteMentakPreviewedCandidateIfDue(LocalDateTime now) {
+        if (!canPublicPromoteAt(now.truncatedTo(ChronoUnit.MINUTES))) return;
         CombatCandidateEntity winner = selectPromotionWinner(findPromotionCandidates(now).stream()
                 .filter(candidate -> isMentakPreviewReadyForPublicPromotion(candidate, now))
                 .toList());
@@ -249,12 +273,12 @@ public class CombatReplayPromotionService {
                 .isAfter(now);
     }
 
-    private void postMentakPreview(CombatCandidateEntity candidate) {
+    private CombatReplayContestEntity postMentakPreview(CombatCandidateEntity candidate) {
         CombatObservationEntity observation =
                 observationRepository.findById(candidate.getObservationId()).orElse(null);
         Game game = loadGame(candidate.getGameName());
         TextChannel channel = discordPostService.houseChannel(CombatReplayHouse.MENTAK);
-        if (observation == null || game == null || channel == null) return;
+        if (observation == null || game == null || channel == null) return null;
 
         CombatReplayContestEntity previewContest = createPreviewContest(candidate);
         lockPreviousContestTradeConvoys(previewContest);
@@ -267,8 +291,10 @@ public class CombatReplayPromotionService {
             mentakAbilityService.postDecoyButtons(channel, candidate);
             candidate.setMentakPreviewPostedAt(LocalDateTime.now(clock));
             candidateRepository.save(candidate);
+            return previewContest;
         } catch (Exception e) {
             BotLogger.error("Failed to post Mentak combat replay preview.", e);
+            return null;
         }
     }
 

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -63,7 +63,7 @@ houseAbilities:
     # dreadnoughtDecoyFavorCost: 0
     dreadnoughtDecoyFavorCost: 40
     # warSunDecoyFavorCost: 0
-    warSunDecoyFavorCost: 60
+    warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
     subsidyFavorOnHit: 10

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -51,7 +51,7 @@ houseAbilities:
   maxCatchupFavorBonus: 0
   naalu:
     # actionCardPeekFavorCost: 0
-    actionCardPeekFavorCost: 30
+    actionCardPeekFavorCost: 20
     # roundOneRollPeekFavorCost: 0
     roundOneRollPeekFavorCost: 40
   mentak:

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -53,17 +53,17 @@ houseAbilities:
     # actionCardPeekFavorCost: 0
     actionCardPeekFavorCost: 30
     # roundOneRollPeekFavorCost: 0
-    roundOneRollPeekFavorCost: 50
+    roundOneRollPeekFavorCost: 40
   mentak:
     previewLeadSeconds: 15
     # destroyerDecoyFavorCost: 0
-    destroyerDecoyFavorCost: 30
+    destroyerDecoyFavorCost: 20
     # cruiserDecoyFavorCost: 0
-    cruiserDecoyFavorCost: 40
+    cruiserDecoyFavorCost: 30
     # dreadnoughtDecoyFavorCost: 0
-    dreadnoughtDecoyFavorCost: 60
+    dreadnoughtDecoyFavorCost: 40
     # warSunDecoyFavorCost: 0
-    warSunDecoyFavorCost: 80
+    warSunDecoyFavorCost: 60
   hacan:
     maxSubsidiesPerContest: 2
     subsidyFavorOnHit: 10

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -5,7 +5,7 @@ candidateSelection:
   targetCandidatesPerHour: 4
 
 promotion:
-  enabled: false
+  enabled: true
   intervalSeconds: 60
   candidateLookbackHours: 12
   maxPromotionsPerHour: 1

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -14,7 +14,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatCandidatePromotionStatus;
 import ti4.contest.replay.core.CombatCandidateStatus;
+import ti4.contest.replay.core.CombatContestReplayStatus;
 import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.house.mentak.CombatReplayMentakAbilityService;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatObservationRepository;
@@ -101,14 +104,102 @@ class CombatReplayContestLifecycleServiceTest {
         verifyNoInteractions(candidateRepository, replayContestRepository);
     }
 
+    @Test
+    void forcePromoteCandidateDoesNotPubliclyPromoteBeforeMentakPreviewWindowExpires() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.setHousesEnabled(true);
+        settings.getHouseAbilities().getMentak().setPreviewLeadSeconds(900);
+        CombatReplayContestLifecycleService service = service(settings, candidateRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:14:59"));
+        CombatCandidateEntity candidate = previewedCandidate(LocalDateTime.parse("2026-04-27T12:00:00"));
+        CombatReplayContestEntity contest = previewContest();
+
+        when(candidateRepository.findById(1L)).thenReturn(java.util.Optional.of(candidate));
+        when(replayContestRepository.findByCandidateId(1L)).thenReturn(java.util.Optional.of(contest));
+
+        CombatReplayContestLifecycleService.ForcePromoteResult result = service.forcePromoteCandidate(1L);
+
+        assertFalse(result.promoted());
+        assertEquals("Mentak preview window is still open.", result.reason());
+        assertEquals(contest, result.contest());
+    }
+
+    @Test
+    void forcePromoteCandidateCanPubliclyPromoteAfterMentakPreviewWindowExpires() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.setHousesEnabled(true);
+        settings.getHouseAbilities().getMentak().setPreviewLeadSeconds(900);
+        CombatReplayContestLifecycleService service =
+                service(settings, candidateRepository, observationRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:15:00"));
+        CombatCandidateEntity candidate = previewedCandidate(LocalDateTime.parse("2026-04-27T12:00:00"));
+        CombatReplayContestEntity contest = previewContest();
+
+        when(candidateRepository.findById(1L)).thenReturn(java.util.Optional.of(candidate));
+        when(replayContestRepository.findByCandidateId(1L)).thenReturn(java.util.Optional.of(contest));
+
+        CombatReplayContestLifecycleService.ForcePromoteResult result = service.forcePromoteCandidate(1L);
+
+        assertFalse(result.promoted());
+        assertEquals("Promotion failed", result.reason());
+        verify(observationRepository).findById(1L);
+    }
+
+    @Test
+    void promoteBestCandidateIfDueChecksReadyMentakPreviewsAwayFromTopOfHour() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.getRuntime().setDevMode(false);
+        settings.setHousesEnabled(true);
+        settings.getHouseAbilities().getMentak().setPreviewLeadSeconds(900);
+        CombatReplayContestLifecycleService service =
+                service(settings, candidateRepository, observationRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:25:00"));
+        CombatCandidateEntity candidate = previewedCandidate(LocalDateTime.parse("2026-04-27T12:10:00"));
+
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:25:00")))
+                .thenReturn(List.of(candidate));
+        when(observationRepository.findAllById(List.of(1L))).thenReturn(List.of());
+
+        service.promoteBestCandidateIfDue();
+
+        verify(candidateRepository)
+                .findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:25:00"));
+        verify(observationRepository).findById(1L);
+    }
+
     private CombatReplayContestLifecycleService service(
             CombatContestSettings settings,
             CombatCandidateRepository candidateRepository,
             CombatReplayContestRepository replayContestRepository) {
+        return service(settings, candidateRepository, mock(CombatObservationRepository.class), replayContestRepository);
+    }
+
+    private CombatReplayContestLifecycleService service(
+            CombatContestSettings settings,
+            CombatCandidateRepository candidateRepository,
+            CombatObservationRepository observationRepository,
+            CombatReplayContestRepository replayContestRepository) {
         CombatReplayPromotionService promotionService = new CombatReplayPromotionService(
                 settings,
                 candidateRepository,
-                mock(CombatObservationRepository.class),
+                observationRepository,
                 replayContestRepository,
                 mock(CombatReplayLeaderboardService.class),
                 mock(ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService.class),
@@ -124,5 +215,23 @@ class CombatReplayContestLifecycleServiceTest {
                         .atZone(ZoneId.systemDefault())
                         .toInstant(),
                 ZoneId.systemDefault());
+    }
+
+    private CombatCandidateEntity previewedCandidate(LocalDateTime previewedAt) {
+        CombatCandidateEntity candidate = new CombatCandidateEntity();
+        candidate.setId(1L);
+        candidate.setObservationId(1L);
+        candidate.setStatus(CombatCandidateStatus.RESOLVED);
+        candidate.setPromotionStatus(CombatCandidatePromotionStatus.PENDING);
+        candidate.setResolvedAt(previewedAt);
+        candidate.setMentakPreviewPostedAt(previewedAt);
+        candidate.setInitialRenderSnapshotJson("{\"context\":{}}");
+        return candidate;
+    }
+
+    private CombatReplayContestEntity previewContest() {
+        CombatReplayContestEntity contest = new CombatReplayContestEntity();
+        contest.setReplayStatus(CombatContestReplayStatus.PREVIEW);
+        return contest;
     }
 }


### PR DESCRIPTION
## Summary
- Turn on combat contest candidate promotion in the production config
- Route forced promotion through the Mentak preview window when house previews are enabled
- Allow cron to publicly promote previewed candidates once the configured preview timer has elapsed, without waiting for the next top-of-hour slot

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -Dtest=CombatReplayContestLifecycleServiceTest test
- mvn -DskipTests process-resources
- git diff --check