### PR TITLE
Ping delegations on public contest promotion

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayDiscordPostService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayDiscordPostService.java
@@ -127,19 +127,19 @@ public class CombatReplayDiscordPostService {
         return channels.isEmpty() ? null : channels.getFirst();
     }
 
-    public String getLazaxRoleMention() {
-        if (JdaService.guildPrimary == null) return "";
-        List<Role> roles =
-                JdaService.guildPrimary.getRolesByName(CombatReplayLeaderboardService.LAZAX_MINIGAME_ROLE_NAME, true);
-        Role role = roles.isEmpty() ? null : roles.getFirst();
-        return role == null ? "" : role.getAsMention();
-    }
-
     public String getHouseRoleMention(CombatReplayHouse house) {
         if (JdaService.guildPrimary == null || house == null) return "";
         List<Role> roles = JdaService.guildPrimary.getRolesByName(house.roleName(), true);
         Role role = roles.isEmpty() ? null : roles.getFirst();
         return role == null ? "" : role.getAsMention();
+    }
+
+    public String getHouseRoleMentions() {
+        if (JdaService.guildPrimary == null) return "";
+        return CombatReplayHouse.assignmentOrder().stream()
+                .map(this::getHouseRoleMention)
+                .filter(mention -> !mention.isBlank())
+                .collect(java.util.stream.Collectors.joining(" "));
     }
 
     private String buildReplayThreadName(CombatCandidateEntity candidate) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -194,7 +194,7 @@ public class CombatReplayPromotionService {
 
         String startSummaryText = snapshotStartSummaryText(winner);
         String message = LazaxCombatSupport.formatReplayAnnouncement(
-                game, winner, discordPostService.getLazaxRoleMention(), startSummaryText);
+                game, winner, discordPostService.getHouseRoleMentions(), startSummaryText);
 
         TextChannel contestChannel = discordPostService.getContestChannel();
         if (contestChannel == null) return null;


### PR DESCRIPTION
## Summary
- Replace the Lazax Minigame role mention in public contest promotions with all three delegation role mentions
- Remove the now-unused Lazax role mention helper from the replay Discord post service

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -DskipTests compile
- git diff --check