### PR TITLE
Lower prod house ability costs

### DIFF
--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -54,10 +54,10 @@ houseAbilities:
     roundOneRollPeekFavorCost: 40
   mentak:
     previewLeadSeconds: 900
-    destroyerDecoyFavorCost: 30
-    cruiserDecoyFavorCost: 40
-    dreadnoughtDecoyFavorCost: 60
-    warSunDecoyFavorCost: 80
+    destroyerDecoyFavorCost: 20
+    cruiserDecoyFavorCost: 30
+    dreadnoughtDecoyFavorCost: 40
+    warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
     subsidyFavorOnHit: 10

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -50,8 +50,8 @@ houseAbilities:
   catchupFavorBonusStep: 0
   maxCatchupFavorBonus: 0
   naalu:
-    actionCardPeekFavorCost: 30
-    roundOneRollPeekFavorCost: 50
+    actionCardPeekFavorCost: 20
+    roundOneRollPeekFavorCost: 40
   mentak:
     previewLeadSeconds: 900
     destroyerDecoyFavorCost: 30


### PR DESCRIPTION
## Summary
- Set prod Naalu Action Cards peek cost to 20 Favor
- Set prod Naalu Round 1 Rolls peek cost to 40 Favor
- Set prod Mentak decoy costs to 20/30/40/70 Favor

## Test Plan
- mvn -DskipTests process-resources
- git diff --check