### PR TITLE
Tune Lazax delegation channel pings

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
@@ -42,6 +42,8 @@ import ti4.service.emoji.TI4Emoji;
 @RequiredArgsConstructor
 public class CombatReplayHouseService {
 
+    private static final List<String> HOUSE_REACTION_CHANNEL_NAMES = List.of("lazax-hacan-mentak", "lazax-hacan-naalu");
+
     private final CombatContestSettings settings;
     private final CombatReplayHouseRepository houseRepository;
     private final CombatReplayContestRepository replayContestRepository;
@@ -291,9 +293,8 @@ public class CombatReplayHouseService {
         }
         return CombatReplayChannels.contestChannelName(settings).equalsIgnoreCase(channelName)
                 || channelName.toLowerCase().startsWith("lazax-war-archives")
-                || CombatReplayHouse.assignmentOrder().stream()
-                        .map(CombatReplayHouse::channelName)
-                        .anyMatch(houseChannelName -> houseChannelName.equalsIgnoreCase(channelName));
+                || HOUSE_REACTION_CHANNEL_NAMES.stream()
+                        .anyMatch(reactionChannelName -> reactionChannelName.equalsIgnoreCase(channelName));
     }
 
     private boolean isContestThread(ThreadChannel thread) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
@@ -39,6 +39,7 @@ class CombatReplaySideBetUiService {
     private final CombatContestSideBetRepository sideBetRepository;
     private final CombatReplaySideBetPayoutService payoutService;
     private final CombatSideBetAvailabilityService availabilityService;
+    private final CombatReplayDiscordPostService discordPostService;
 
     public boolean shouldShowButtons(CombatCandidateEntity candidate) {
         return candidate != null
@@ -60,7 +61,9 @@ class CombatReplaySideBetUiService {
         if (!settings.isHousesEnabled()) {
             return "## Side Bets\nPlace up to " + maxBets + " side bets before the replay begins.";
         }
-        return "## Side-Bet Market\nThe battle market is open. Place up to " + maxBets
+        return "## Side-Bet Market\n"
+                + discordPostService.getHouseRoleMentions()
+                + "\nThe battle market is open. Place up to " + maxBets
                 + " side bets before the replay begins.";
     }
 


### PR DESCRIPTION
## Summary
- Disable Lazax house emoji reactions in single-delegation channels (`lazax-hacan`, `lazax-naalu`, `lazax-mentak`)
- Enable Lazax house emoji reactions in cross-delegation channels (`lazax-hacan-mentak`, `lazax-hacan-naalu`)
- Ping all delegation roles when the side-bet market opens

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -DskipTests compile
- git diff --check