### PR TITLE
Restore Mentak preview promotion fallback

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -238,15 +238,22 @@ public class CombatReplayPromotionService {
     }
 
     private void promoteMentakPreviewedCandidateIfDue(LocalDateTime now) {
-        if (!canPublicPromoteAt(now.truncatedTo(ChronoUnit.MINUTES))) return;
+        LocalDateTime publicPromotionWindow = mentakPublicPromotionWindow(now);
+        if (!canPublicPromoteAt(publicPromotionWindow)) return;
         List<CombatCandidateEntity> candidates = rankPromotionCandidates(findPromotionCandidates(now).stream()
-                .filter(candidate -> isMentakPreviewReadyForPublicPromotion(candidate, now))
+                .filter(candidate -> isMentakPreviewReadyForPublicPromotion(candidate, publicPromotionWindow))
                 .toList());
         for (CombatCandidateEntity candidate : candidates) {
             if (promoteCandidate(candidate) != null) return;
             BotLogger.error("Mentak preview promotion skipped for candidate " + candidate.getId()
                     + " because public promotion failed.");
         }
+    }
+
+    private LocalDateTime mentakPublicPromotionWindow(LocalDateTime now) {
+        LocalDateTime truncatedNow = now.truncatedTo(ChronoUnit.MINUTES);
+        if (settings.getRuntime().isDevMode()) return truncatedNow;
+        return truncatedNow.truncatedTo(ChronoUnit.HOURS);
     }
 
     private boolean usesMentakPreviewFlow() {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -239,11 +239,14 @@ public class CombatReplayPromotionService {
 
     private void promoteMentakPreviewedCandidateIfDue(LocalDateTime now) {
         if (!canPublicPromoteAt(now.truncatedTo(ChronoUnit.MINUTES))) return;
-        CombatCandidateEntity winner = selectPromotionWinner(findPromotionCandidates(now).stream()
+        List<CombatCandidateEntity> candidates = rankPromotionCandidates(findPromotionCandidates(now).stream()
                 .filter(candidate -> isMentakPreviewReadyForPublicPromotion(candidate, now))
                 .toList());
-        if (winner == null) return;
-        promoteCandidate(winner);
+        for (CombatCandidateEntity candidate : candidates) {
+            if (promoteCandidate(candidate) != null) return;
+            BotLogger.error("Mentak preview promotion skipped for candidate " + candidate.getId()
+                    + " because public promotion failed.");
+        }
     }
 
     private boolean usesMentakPreviewFlow() {
@@ -340,18 +343,21 @@ public class CombatReplayPromotionService {
     }
 
     private CombatCandidateEntity selectPromotionWinner(List<CombatCandidateEntity> candidates) {
+        List<CombatCandidateEntity> rankedCandidates = rankPromotionCandidates(candidates);
+        return rankedCandidates.isEmpty() ? null : rankedCandidates.getFirst();
+    }
+
+    private List<CombatCandidateEntity> rankPromotionCandidates(List<CombatCandidateEntity> candidates) {
         Map<Long, Double> jointScoresByObservationId = loadJointScores(candidates);
-        CombatCandidateEntity winner = null;
         Comparator<CombatCandidateEntity> comparator = candidateComparator(jointScoresByObservationId);
         List<CombatCandidateEntity> previewedCandidates = candidates.stream()
                 .filter(candidate -> candidate.getMentakPreviewPostedAt() != null)
                 .toList();
         if (!previewedCandidates.isEmpty()) candidates = previewedCandidates;
-        for (CombatCandidateEntity candidate : candidates) {
-            if (candidate.getResolvedAt() == null) continue;
-            if (winner == null || comparator.compare(candidate, winner) > 0) winner = candidate;
-        }
-        return winner;
+        return candidates.stream()
+                .filter(candidate -> candidate.getResolvedAt() != null)
+                .sorted(comparator.reversed())
+                .toList();
     }
 
     private Map<Long, Double> loadJointScores(List<CombatCandidateEntity> candidates) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -3,6 +3,7 @@ package ti4.contest.replay.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -153,7 +154,7 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
-    void promoteBestCandidateIfDueChecksReadyMentakPreviewsAwayFromTopOfHour() {
+    void promoteBestCandidateIfDueChecksReadyMentakPreviewsWhenCronRunsLateForHourlySlot() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
         CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
@@ -165,7 +166,7 @@ class CombatReplayContestLifecycleServiceTest {
         CombatReplayContestLifecycleService service =
                 service(settings, candidateRepository, observationRepository, replayContestRepository);
         service.setClock(fixedClock("2026-04-27T12:25:00"));
-        CombatCandidateEntity candidate = previewedCandidate(LocalDateTime.parse("2026-04-27T12:10:00"));
+        CombatCandidateEntity candidate = previewedCandidate(LocalDateTime.parse("2026-04-27T11:45:00"));
 
         when(candidateRepository.findResolvedPromotionCandidates(
                         CombatCandidateStatus.RESOLVED,
@@ -185,6 +186,38 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
+    void promoteBestCandidateIfDueWaitsForNextHourlySlotWhenPreviewBecomesReadyMidHour() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.getRuntime().setDevMode(false);
+        settings.setHousesEnabled(true);
+        settings.getHouseAbilities().getMentak().setPreviewLeadSeconds(900);
+        CombatReplayContestLifecycleService service =
+                service(settings, candidateRepository, observationRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:25:00"));
+        CombatCandidateEntity candidate = previewedCandidate(LocalDateTime.parse("2026-04-27T12:10:00"));
+
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:25:00")))
+                .thenReturn(List.of(candidate));
+        when(observationRepository.findAllById(List.of())).thenReturn(List.of());
+
+        service.promoteBestCandidateIfDue();
+
+        verify(candidateRepository)
+                .findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:25:00"));
+        verify(observationRepository, never()).findById(1L);
+    }
+
+    @Test
     void promoteBestCandidateIfDueFallsBackWhenReadyMentakPreviewPromotionFails() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
@@ -197,8 +230,8 @@ class CombatReplayContestLifecycleServiceTest {
         CombatReplayContestLifecycleService service =
                 service(settings, candidateRepository, observationRepository, replayContestRepository);
         service.setClock(fixedClock("2026-04-27T12:25:00"));
-        CombatCandidateEntity first = previewedCandidate(1L, LocalDateTime.parse("2026-04-27T12:10:00"), 10.0);
-        CombatCandidateEntity second = previewedCandidate(2L, LocalDateTime.parse("2026-04-27T12:10:00"), 5.0);
+        CombatCandidateEntity first = previewedCandidate(1L, LocalDateTime.parse("2026-04-27T11:45:00"), 10.0);
+        CombatCandidateEntity second = previewedCandidate(2L, LocalDateTime.parse("2026-04-27T11:45:00"), 5.0);
 
         when(candidateRepository.findResolvedPromotionCandidates(
                         CombatCandidateStatus.RESOLVED,

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -184,6 +184,37 @@ class CombatReplayContestLifecycleServiceTest {
         verify(observationRepository).findById(1L);
     }
 
+    @Test
+    void promoteBestCandidateIfDueFallsBackWhenReadyMentakPreviewPromotionFails() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.getRuntime().setDevMode(false);
+        settings.setHousesEnabled(true);
+        settings.getHouseAbilities().getMentak().setPreviewLeadSeconds(900);
+        CombatReplayContestLifecycleService service =
+                service(settings, candidateRepository, observationRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:25:00"));
+        CombatCandidateEntity first = previewedCandidate(1L, LocalDateTime.parse("2026-04-27T12:10:00"), 10.0);
+        CombatCandidateEntity second = previewedCandidate(2L, LocalDateTime.parse("2026-04-27T12:10:00"), 5.0);
+
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:25:00")))
+                .thenReturn(List.of(first, second));
+        when(observationRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of());
+        when(observationRepository.findById(1L)).thenReturn(java.util.Optional.empty());
+        when(observationRepository.findById(2L)).thenReturn(java.util.Optional.empty());
+
+        service.promoteBestCandidateIfDue();
+
+        verify(observationRepository).findById(1L);
+        verify(observationRepository).findById(2L);
+    }
+
     private CombatReplayContestLifecycleService service(
             CombatContestSettings settings,
             CombatCandidateRepository candidateRepository,
@@ -218,13 +249,18 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     private CombatCandidateEntity previewedCandidate(LocalDateTime previewedAt) {
+        return previewedCandidate(1L, previewedAt, null);
+    }
+
+    private CombatCandidateEntity previewedCandidate(Long id, LocalDateTime previewedAt, Double promotionScore) {
         CombatCandidateEntity candidate = new CombatCandidateEntity();
-        candidate.setId(1L);
-        candidate.setObservationId(1L);
+        candidate.setId(id);
+        candidate.setObservationId(id);
         candidate.setStatus(CombatCandidateStatus.RESOLVED);
         candidate.setPromotionStatus(CombatCandidatePromotionStatus.PENDING);
         candidate.setResolvedAt(previewedAt);
         candidate.setMentakPreviewPostedAt(previewedAt);
+        candidate.setPromotionScore(promotionScore);
         candidate.setInitialRenderSnapshotJson("{\"context\":{}}");
         return candidate;
     }


### PR DESCRIPTION
## Summary
- Rank ready Mentak-previewed candidates and try each one until public promotion succeeds.
- Sync production Mentak preview promotions to hourly public slots while still allowing late cron runs for the current slot.
- Add regression coverage for fallback promotion and for waiting until the next hourly slot when a preview becomes ready mid-hour.

## Test Plan
- mvn spotless:check
- git diff --check
- mvn -Dtest=ti4.contest.replay.service.CombatReplayContestLifecycleServiceTest test *(blocked locally: current shell has JDK 21, project compiles with --release 26)*