### PR TITLE
Add Lazax delegation controls

### DIFF
--- a/src/main/java/ti4/contest/replay/buttons/LazaxHousePreferenceButtonHandler.java
+++ b/src/main/java/ti4/contest/replay/buttons/LazaxHousePreferenceButtonHandler.java
@@ -1,0 +1,26 @@
+package ti4.contest.replay.buttons;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.contest.replay.service.CombatReplayHouseService;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.message.MessageHelper;
+import ti4.spring.context.SpringContext;
+
+@UtilityClass
+public class LazaxHousePreferenceButtonHandler {
+
+    @ButtonHandler(value = CombatReplayHouseService.TOGGLE_HOUSE_ROLE_BUTTON_ID, save = false)
+    public static void toggleHouseRole(ButtonInteractionEvent event) {
+        String message = SpringContext.getBean(CombatReplayHouseService.class)
+                .toggleHouseRole(event.getGuild(), event.getMember(), event.getUser());
+        MessageHelper.sendEphemeralMessageToEventChannel(event, message);
+    }
+
+    @ButtonHandler(value = CombatReplayHouseService.TOGGLE_HOUSE_OPT_IN_BUTTON_ID, save = false)
+    public static void toggleHouseOptIn(ButtonInteractionEvent event) {
+        String message = SpringContext.getBean(CombatReplayHouseService.class)
+                .toggleHouseOptIn(event.getGuild(), event.getMember(), event.getUser());
+        MessageHelper.sendEphemeralMessageToEventChannel(event, message);
+    }
+}

--- a/src/main/java/ti4/contest/replay/entities/CombatReplayHouseOptOutEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatReplayHouseOptOutEntity.java
@@ -1,0 +1,49 @@
+package ti4.contest.replay.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import ti4.contest.replay.core.CombatReplayHouse;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "combat_replay_house_opt_out",
+        indexes = @Index(name = "idx_replay_house_opt_out_house", columnList = "house"),
+        uniqueConstraints = @UniqueConstraint(name = "uk_replay_house_opt_out_user", columnNames = "discord_user_id"))
+/**
+ * Stores the previous Lazax house for users who opted out, so opting back in restores the same delegation.
+ */
+public class CombatReplayHouseOptOutEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "discord_user_id", nullable = false)
+    private String discordUserId;
+
+    @Column(name = "discord_user_name", nullable = false)
+    private String discordUserName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "house", nullable = false)
+    private CombatReplayHouse house;
+
+    @Column(name = "assigned_at", nullable = false)
+    private LocalDateTime assignedAt;
+
+    @Column(name = "opted_out_at", nullable = false)
+    private LocalDateTime optedOutAt;
+}

--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
@@ -23,6 +23,7 @@ import ti4.contest.replay.entities.CombatReplayHacanTradeConvoysEntity;
 import ti4.contest.replay.entities.CombatReplayHacanTradeConvoysVoteEntity;
 import ti4.contest.replay.entities.CombatReplayHouseAbilityUseEntity;
 import ti4.contest.replay.entities.CombatReplayHouseScoreEntity;
+import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
 import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysRepository;
 import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysVoteRepository;
@@ -54,6 +55,7 @@ public class CombatReplayHacanTradeConvoysService {
     private final CombatReplayHousePhaseService phaseService;
     private final CombatReplayHouseAbilityVoteService voteService;
     private final CombatReplayHouseFavorService houseFavorService;
+    private final CombatCandidateRepository candidateRepository;
     private final CombatReplayContestRepository contestRepository;
     private final CombatReplayHouseAbilityUseRepository abilityUseRepository;
     private final CombatReplayHacanTradeConvoysRepository tradeConvoysRepository;
@@ -77,6 +79,17 @@ public class CombatReplayHacanTradeConvoysService {
             List<HousePredictionSummary> currentCombatSummaries) {
         if (!canOfferTradeConvoys(contest, candidate)) return;
         postTradeConvoysVotingButtons(contest, hacanFavorLedger(contest, currentCombatSummaries));
+    }
+
+    public boolean repostOpenTradeConvoysVotingButtons() {
+        CombatReplayContestEntity contest =
+                contestRepository.findFirstByOrderByIdDesc().orElse(null);
+        CombatCandidateEntity candidate = contest == null || contest.getCandidateId() == null
+                ? null
+                : candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        if (!shouldOfferVoting(contest, candidate)) return false;
+        postTradeConvoysVotingButtons(contest);
+        return true;
     }
 
     private void postTradeConvoysVotingButtons(CombatReplayContestEntity contest) {
@@ -348,9 +361,13 @@ public class CombatReplayHacanTradeConvoysService {
         return phaseService.postCombatVoteOpen(contest);
     }
 
-    private boolean userHasHacan(String discordUserId) {
+    public boolean userHasHouse(String discordUserId) {
         if (settings.getRuntime().isDevMode()) return true;
         return houseService.houseForUser(discordUserId) == CombatReplayHouse.HACAN;
+    }
+
+    private boolean userHasHacan(String discordUserId) {
+        return userHasHouse(discordUserId);
     }
 
     private boolean isValidRequest(ParsedTradeConvoysButton request) {

--- a/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityService.java
+++ b/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityService.java
@@ -1,6 +1,7 @@
 package ti4.contest.replay.house.mentak;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.components.buttons.Button;
@@ -9,6 +10,8 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import ti4.contest.replay.core.CombatCandidatePromotionStatus;
+import ti4.contest.replay.core.CombatCandidateStatus;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.core.CombatReplayHouse;
@@ -70,6 +73,38 @@ public class CombatReplayMentakAbilityService {
                 List.of(
                         Buttons.blue(MENTAK_MANAGE_VOTE_PREFIX + candidate.getId(), "Manage False Colors"),
                         Buttons.red(MENTAK_DO_NOT_USE + candidate.getId(), "Do Not Use False Colors")));
+    }
+
+    public boolean repostOpenFalseColorsVotingButtons() {
+        CombatCandidateEntity candidate = candidateRepository.findByStatus(CombatCandidateStatus.RESOLVED).stream()
+                .filter(phaseService::mentakPreviewOpen)
+                .filter(candidateEntity ->
+                        candidateEntity.getPromotionStatus() == CombatCandidatePromotionStatus.PENDING)
+                .filter(candidateEntity -> candidateEntity.getMentakPreviewPostedAt() != null)
+                .max(Comparator.comparing(CombatCandidateEntity::getMentakPreviewPostedAt))
+                .orElse(null);
+        if (candidate == null) return false;
+
+        TextChannel channel = houseChannel();
+        if (channel == null) return false;
+        postDirectDecoyVotingButtons(channel, candidate);
+        return true;
+    }
+
+    private void postDirectDecoyVotingButtons(TextChannel channel, CombatCandidateEntity candidate) {
+        Game game = loadGame(candidate.getGameName());
+        MessageHelper.sendMessageToChannelWithButtons(
+                channel,
+                "## " + FactionEmojis.getFactionIcon(CombatReplayHouse.MENTAK.displayName())
+                        + " Mentak Delegation False Colors\n"
+                        + CombatReplayAbilityWindowText.votesLockLine(previewLeadSeconds())
+                        + "\n"
+                        + favorBalanceLine()
+                        + "\n"
+                        + falseColorsSummaryLine(),
+                List.of(Buttons.red(MENTAK_DO_NOT_USE + candidate.getId(), "Vote: Do Not Use False Colors")));
+        postDecoyButtonsForFaction(channel, game, candidate, candidate.getAttackerFaction());
+        postDecoyButtonsForFaction(channel, game, candidate, candidate.getDefenderFaction());
     }
 
     public boolean shouldOfferDecoyVoting(CombatCandidateEntity candidate) {
@@ -266,6 +301,13 @@ public class CombatReplayMentakAbilityService {
         List<Button> buttons = decoyButtonsForFaction(candidate, faction);
         if (buttons.isEmpty()) return;
         MessageHelper.sendMessageToEventChannelWithEphemeralButtons(event, factionSectionTitle(game, faction), buttons);
+    }
+
+    private void postDecoyButtonsForFaction(
+            TextChannel channel, Game game, CombatCandidateEntity candidate, String faction) {
+        List<Button> buttons = decoyButtonsForFaction(candidate, faction);
+        if (buttons.isEmpty()) return;
+        MessageHelper.sendMessageToChannelWithButtons(channel, factionSectionTitle(game, faction), buttons);
     }
 
     private List<Button> decoyButtonsForFaction(CombatCandidateEntity candidate, String faction) {

--- a/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
+++ b/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
@@ -109,6 +109,16 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
                 peekButtons(contest.getId()));
     }
 
+    public boolean repostOpenGiftOfForesightButtons() {
+        CombatReplayContestEntity contest =
+                replayContestRepository.findFirstByOrderByIdDesc().orElse(null);
+        if (!phaseService.discussionOpen(contest)) return false;
+        CombatCandidateEntity candidate = loadCandidate(contest);
+        if (candidate == null) return false;
+        postAbilityButtonsIfNeeded(contest, candidate);
+        return true;
+    }
+
     private String favorBalanceLine() {
         return "-# Total Favor: `" + houseFavorService.balance(CombatReplayHouse.NAALU) + "`";
     }

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
@@ -18,6 +18,8 @@ public interface CombatReplayContestRepository extends JpaRepository<CombatRepla
 
     Optional<CombatReplayContestEntity> findFirstByIdLessThanOrderByIdDesc(Long id);
 
+    Optional<CombatReplayContestEntity> findFirstByOrderByIdDesc();
+
     boolean existsByIdGreaterThan(Long id);
 
     List<CombatReplayContestEntity> findByReplayStatusInAndNextReplayAtLessThanEqualOrderByNextReplayAtAsc(

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayHouseOptOutRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayHouseOptOutRepository.java
@@ -1,0 +1,9 @@
+package ti4.contest.replay.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import ti4.contest.replay.entities.CombatReplayHouseOptOutEntity;
+
+public interface CombatReplayHouseOptOutRepository extends JpaRepository<CombatReplayHouseOptOutEntity, Long> {
+    Optional<CombatReplayHouseOptOutEntity> findByDiscordUserId(String discordUserId);
+}

--- a/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
@@ -27,12 +28,15 @@ import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayHouseEntity;
+import ti4.contest.replay.entities.CombatReplayHouseOptOutEntity;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
+import ti4.contest.replay.repository.CombatReplayHouseOptOutRepository;
 import ti4.contest.replay.repository.CombatReplayHouseRepository;
 import ti4.contest.replay.repository.CombatReplayLeaderboardEntryRepository;
 import ti4.discord.JdaService;
+import ti4.discord.interactions.buttons.Buttons;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.service.emoji.FactionEmojis;
@@ -42,13 +46,28 @@ import ti4.service.emoji.TI4Emoji;
 @RequiredArgsConstructor
 public class CombatReplayHouseService {
 
+    public static final String TOGGLE_HOUSE_ROLE_BUTTON_ID = "lazaxToggleHouseRole";
+    public static final String TOGGLE_HOUSE_OPT_IN_BUTTON_ID = "lazaxToggleHouseOptIn";
+
     private static final List<String> HOUSE_REACTION_CHANNEL_NAMES = List.of("lazax-hacan-mentak", "lazax-hacan-naalu");
 
     private final CombatContestSettings settings;
     private final CombatReplayHouseRepository houseRepository;
+    private final CombatReplayHouseOptOutRepository houseOptOutRepository;
     private final CombatReplayContestRepository replayContestRepository;
     private final CombatCandidateRepository candidateRepository;
     private final CombatReplayLeaderboardEntryRepository leaderboardEntryRepository;
+
+    public void postPublicParticipationControls(TextChannel channel) {
+        if (!settings.isHousesEnabled() || channel == null) return;
+        List<Button> buttons = List.of(
+                Buttons.gray(TOGGLE_HOUSE_ROLE_BUTTON_ID, "Toggle Role"),
+                Buttons.red(TOGGLE_HOUSE_OPT_IN_BUTTON_ID, "Opt In/Out Entirely"));
+        MessageHelper.sendMessageToChannelWithButtons(
+                channel,
+                "-# Lazax delegation controls: toggle your Discord role visibility, or opt out entirely while preserving your delegation for a future opt-in.",
+                buttons);
+    }
 
     public void addHouseEmojiReactionIfNeeded(MessageReceivedEvent event) {
         if (!settings.isHousesEnabled()) return;
@@ -145,6 +164,9 @@ public class CombatReplayHouseService {
             }
             assignment.setUpdatedAt(now);
             houseRepository.save(assignment);
+            houseOptOutRepository
+                    .findByDiscordUserId(entry.getDiscordUserId())
+                    .ifPresent(houseOptOutRepository::delete);
 
             Member member = retrieveMember(guild, entry.getDiscordUserId());
             setOnlyHouseRole(guild, member, house);
@@ -192,6 +214,9 @@ public class CombatReplayHouseService {
             }
             assignment.setUpdatedAt(now);
             houseRepository.save(assignment);
+            houseOptOutRepository
+                    .findByDiscordUserId(entry.getDiscordUserId())
+                    .ifPresent(houseOptOutRepository::delete);
 
             participationByHouse.computeIfPresent(
                     house, (ignored, participation) -> participation + safeInt(entry.getPredictionCount()));
@@ -221,6 +246,7 @@ public class CombatReplayHouseService {
         }
         assignment.setUpdatedAt(now);
         CombatReplayHouseEntity saved = houseRepository.save(assignment);
+        houseOptOutRepository.findByDiscordUserId(discordUserId).ifPresent(houseOptOutRepository::delete);
 
         setOnlyHouseRole(guild, member, house);
         return saved;
@@ -250,6 +276,79 @@ public class CombatReplayHouseService {
         houseRepository.delete(assignment);
         clearHouseRoles(guild, member);
         return true;
+    }
+
+    public synchronized String toggleHouseRole(Guild guild, Member member, User user) {
+        if (!settings.isHousesEnabled()) return "Lazax delegations are not enabled.";
+        if (user == null || user.isBot()) return "Could not identify your Lazax delegation.";
+
+        CombatReplayHouseEntity assignment =
+                houseRepository.findByDiscordUserId(user.getId()).orElse(null);
+        if (assignment == null) {
+            if (houseOptOutRepository.findByDiscordUserId(user.getId()).isPresent()) {
+                return "You are opted out of Lazax delegations. Use **Opt In/Out Entirely** to opt back in first.";
+            }
+            return "You do not have a Lazax delegation yet.";
+        }
+        if (guild == null || member == null) return "Could not update your Lazax delegation role.";
+
+        Role role = findRole(guild, assignment.getHouse());
+        if (role == null) return "Could not find the " + assignment.getHouse().displayName() + " Delegation role.";
+
+        if (member.getRoles().contains(role)) {
+            guild.removeRoleFromMember(member, role).queue(null, BotLogger::catchRestError);
+            return "Removed your **" + assignment.getHouse().displayName()
+                    + " Delegation** role. Your delegation assignment is unchanged.";
+        }
+
+        grantHouseRole(guild, member, assignment.getHouse(), null);
+        return "Added your **" + assignment.getHouse().displayName() + " Delegation** role.";
+    }
+
+    public synchronized String toggleHouseOptIn(Guild guild, Member member, User user) {
+        if (!settings.isHousesEnabled()) return "Lazax delegations are not enabled.";
+        if (user == null || user.isBot()) return "Could not identify your Lazax delegation.";
+
+        CombatReplayHouseEntity assignment =
+                houseRepository.findByDiscordUserId(user.getId()).orElse(null);
+        if (assignment != null) {
+            CombatReplayHouseOptOutEntity optOut = houseOptOutRepository
+                    .findByDiscordUserId(user.getId())
+                    .orElseGet(CombatReplayHouseOptOutEntity::new);
+            optOut.setDiscordUserId(assignment.getDiscordUserId());
+            optOut.setDiscordUserName(assignment.getDiscordUserName());
+            optOut.setHouse(assignment.getHouse());
+            optOut.setAssignedAt(assignment.getAssignedAt());
+            optOut.setOptedOutAt(LocalDateTime.now());
+            houseOptOutRepository.save(optOut);
+
+            houseRepository.delete(assignment);
+            clearHouseRoles(guild, member);
+            return "Opted out of Lazax delegations. Your **"
+                    + assignment.getHouse().displayName()
+                    + " Delegation** assignment is saved if you opt back in later.";
+        }
+
+        CombatReplayHouseOptOutEntity optOut =
+                houseOptOutRepository.findByDiscordUserId(user.getId()).orElse(null);
+        if (optOut != null) {
+            CombatReplayHouseEntity restored = new CombatReplayHouseEntity();
+            restored.setDiscordUserId(optOut.getDiscordUserId());
+            restored.setDiscordUserName(StringUtils.defaultIfBlank(user.getName(), optOut.getDiscordUserName()));
+            restored.setHouse(optOut.getHouse());
+            restored.setAssignedAt(optOut.getAssignedAt());
+            restored.setUpdatedAt(LocalDateTime.now());
+            houseRepository.save(restored);
+            houseOptOutRepository.delete(optOut);
+            ensureLeaderboardEntry(restored.getDiscordUserId(), restored.getDiscordUserName());
+            setOnlyHouseRole(guild, member, restored.getHouse());
+            return "Opted back in to **" + restored.getHouse().displayName() + " Delegation**.";
+        }
+
+        CombatReplayHouseEntity newAssignment = assignHouseIfAbsent(guild, member, user.getId(), user.getName());
+        return newAssignment == null
+                ? "Could not opt you in to Lazax delegations."
+                : "Opted in to **" + newAssignment.getHouse().displayName() + " Delegation**.";
     }
 
     public Map<String, CombatReplayHouse> housesByUserIds(Collection<String> discordUserIds) {
@@ -326,6 +425,10 @@ public class CombatReplayHouseService {
             }
             ensureHouseRole(guild, member, existing.getHouse());
             return existing;
+        }
+        if (houseOptOutRepository.findByDiscordUserId(discordUserId).isPresent()) {
+            clearHouseRoles(guild, member);
+            return null;
         }
 
         CombatReplayHouse house = houseWithFewestMembers();

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -53,6 +53,7 @@ public class CombatReplayPromotionService {
     private final CombatReplayLeaderboardService replayLeaderboardService;
     private final CombatReplayHacanTradeConvoysService hacanTradeConvoysService;
     private final CombatReplayMentakAbilityService mentakAbilityService;
+    private final CombatReplayHouseService houseService;
     private final CombatReplayExecutionService replayExecutionService;
     private final CombatReplayDiscordPostService discordPostService;
     private Clock clock = Clock.systemDefaultZone();
@@ -202,6 +203,7 @@ public class CombatReplayPromotionService {
         try {
             LocalDateTime promotedAt = LocalDateTime.now(clock);
             Message posted = discordPostService.postPromotionMessage(contestChannel, message, game, winner);
+            houseService.postPublicParticipationControls(contestChannel);
             ThreadChannel thread = discordPostService.createReplayThread(posted, winner);
             CombatReplayContestEntity contest =
                     persistPromotedReplayContest(winner, promotedAt, contestChannel, posted, thread, existingContest);

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
@@ -10,7 +10,12 @@ import ti4.helpers.Constants;
 public class LazaxCommand implements ParentCommand {
 
     private final Map<String, Subcommand> subcommands = Stream.of(
-                    new LazaxMyPoints(), new LazaxTop100(), new LazaxStartSeason1())
+                    new LazaxMyPoints(),
+                    new LazaxTop100(),
+                    new LazaxStartSeason1(),
+                    new LazaxHacanTradeConvoys(),
+                    new LazaxMentakFalseColors(),
+                    new LazaxNaaluGiftForesight())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommandAuthorization.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommandAuthorization.java
@@ -1,0 +1,28 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.service.CombatReplayHouseService;
+import ti4.spring.context.SpringContext;
+
+final class LazaxCommandAuthorization {
+
+    private static final String SEASON_ADMIN_USER_ID = "139760548471504897";
+
+    private LazaxCommandAuthorization() {}
+
+    static boolean isSeasonAdmin(SlashCommandInteractionEvent event) {
+        return event != null && SEASON_ADMIN_USER_ID.equals(event.getUser().getId());
+    }
+
+    static boolean canUseHouseCommand(SlashCommandInteractionEvent event, CombatReplayHouse house) {
+        if (isSeasonAdmin(event)) return true;
+        return SpringContext.getBean(CombatReplayHouseService.class)
+                        .houseForUser(event.getUser().getId())
+                == house;
+    }
+
+    static boolean isInHouseChannel(SlashCommandInteractionEvent event, CombatReplayHouse house) {
+        return event != null && house != null && event.getChannel().getName().equalsIgnoreCase(house.channelName());
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxHacanTradeConvoys.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxHacanTradeConvoys.java
@@ -1,0 +1,39 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.spring.context.SpringContext;
+
+class LazaxHacanTradeConvoys extends Subcommand {
+
+    LazaxHacanTradeConvoys() {
+        super("hacan_trade_convoys", "Repost open Hacan Trade Convoys voting buttons.");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        if (!LazaxCommandAuthorization.isInHouseChannel(event, CombatReplayHouse.HACAN)) {
+            LazaxReplyHelper.replyEphemeral(event, "Use this command in `#lazax-hacan`.");
+            return;
+        }
+        if (!LazaxCommandAuthorization.canUseHouseCommand(event, CombatReplayHouse.HACAN)) {
+            LazaxReplyHelper.replyEphemeral(event, "Only Hacan Delegation may repost Trade Convoys controls.");
+            return;
+        }
+
+        boolean posted = SpringContext.getBean(CombatReplayHacanTradeConvoysService.class)
+                .repostOpenTradeConvoysVotingButtons();
+        LazaxReplyHelper.replyEphemeral(
+                event,
+                posted
+                        ? "Reposted Hacan Trade Convoys voting controls."
+                        : "The Hacan Trade Convoys voting window is not open.");
+    }
+
+    @Override
+    public boolean isEphemeral(SlashCommandInteractionEvent event) {
+        return true;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxMentakFalseColors.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxMentakFalseColors.java
@@ -1,0 +1,39 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.house.mentak.CombatReplayMentakAbilityService;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.spring.context.SpringContext;
+
+class LazaxMentakFalseColors extends Subcommand {
+
+    LazaxMentakFalseColors() {
+        super("mentak_false_colors", "Repost open Mentak False Colors voting buttons.");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        if (!LazaxCommandAuthorization.isInHouseChannel(event, CombatReplayHouse.MENTAK)) {
+            LazaxReplyHelper.replyEphemeral(event, "Use this command in `#lazax-mentak`.");
+            return;
+        }
+        if (!LazaxCommandAuthorization.canUseHouseCommand(event, CombatReplayHouse.MENTAK)) {
+            LazaxReplyHelper.replyEphemeral(event, "Only Mentak Delegation may repost False Colors controls.");
+            return;
+        }
+
+        boolean posted =
+                SpringContext.getBean(CombatReplayMentakAbilityService.class).repostOpenFalseColorsVotingButtons();
+        LazaxReplyHelper.replyEphemeral(
+                event,
+                posted
+                        ? "Reposted Mentak False Colors voting controls."
+                        : "The Mentak False Colors voting window is not open.");
+    }
+
+    @Override
+    public boolean isEphemeral(SlashCommandInteractionEvent event) {
+        return true;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxNaaluGiftForesight.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxNaaluGiftForesight.java
@@ -1,0 +1,39 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.house.naalu.CombatReplayNaaluAbilityService;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.spring.context.SpringContext;
+
+class LazaxNaaluGiftForesight extends Subcommand {
+
+    LazaxNaaluGiftForesight() {
+        super("naalu_gift_foresight", "Repost open Naalu Gift of Foresight voting buttons.");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        if (!LazaxCommandAuthorization.isInHouseChannel(event, CombatReplayHouse.NAALU)) {
+            LazaxReplyHelper.replyEphemeral(event, "Use this command in `#lazax-naalu`.");
+            return;
+        }
+        if (!LazaxCommandAuthorization.canUseHouseCommand(event, CombatReplayHouse.NAALU)) {
+            LazaxReplyHelper.replyEphemeral(event, "Only Naalu Delegation may repost Gift of Foresight controls.");
+            return;
+        }
+
+        boolean posted =
+                SpringContext.getBean(CombatReplayNaaluAbilityService.class).repostOpenGiftOfForesightButtons();
+        LazaxReplyHelper.replyEphemeral(
+                event,
+                posted
+                        ? "Reposted Naalu Gift of Foresight voting controls."
+                        : "The Naalu Gift of Foresight voting window is not open.");
+    }
+
+    @Override
+    public boolean isEphemeral(SlashCommandInteractionEvent event) {
+        return true;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxStartSeason1.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxStartSeason1.java
@@ -7,15 +7,13 @@ import ti4.spring.context.SpringContext;
 
 class LazaxStartSeason1 extends Subcommand {
 
-    private static final String AUTHORIZED_USER_ID = "139760548471504897";
-
     LazaxStartSeason1() {
         super("start_season_1", "Start Lazax Season 1 with delegation setup.");
     }
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        if (!AUTHORIZED_USER_ID.equals(event.getUser().getId())) {
+        if (!LazaxCommandAuthorization.isSeasonAdmin(event)) {
             LazaxReplyHelper.replyEphemeral(event, "You are not authorized to start Lazax Season 1.");
             return;
         }

--- a/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
+++ b/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
@@ -16,6 +16,7 @@ import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayHacanTradeConvoysEntity;
 import ti4.contest.replay.entities.CombatReplayHouseScoreEntity;
+import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
 import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysRepository;
 import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysVoteRepository;
@@ -40,6 +41,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
             new CombatReplayHousePhaseService(settings, contestRepository),
             mock(CombatReplayHouseAbilityVoteService.class),
             houseFavorService,
+            mock(CombatCandidateRepository.class),
             contestRepository,
             mock(CombatReplayHouseAbilityUseRepository.class),
             tradeConvoysRepository,

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -268,6 +268,7 @@ class CombatReplayContestLifecycleServiceTest {
                 mock(CombatReplayLeaderboardService.class),
                 mock(ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService.class),
                 mock(CombatReplayMentakAbilityService.class),
+                mock(CombatReplayHouseService.class),
                 mock(CombatReplayExecutionService.class),
                 mock(CombatReplayDiscordPostService.class));
         return new CombatReplayContestLifecycleService(promotionService, mock(CombatReplayExecutionService.class));

--- a/src/test/java/ti4/contest/replay/service/CombatReplayHouseServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayHouseServiceTest.java
@@ -10,6 +10,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import ti4.contest.replay.core.CombatContestSettings;
@@ -18,20 +19,30 @@ import ti4.contest.replay.entities.CombatReplayHouseEntity;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
+import ti4.contest.replay.repository.CombatReplayHouseOptOutRepository;
 import ti4.contest.replay.repository.CombatReplayHouseRepository;
 import ti4.contest.replay.repository.CombatReplayLeaderboardEntryRepository;
 
 class CombatReplayHouseServiceTest {
 
     private final CombatReplayHouseRepository houseRepository = mock(CombatReplayHouseRepository.class);
+    private final CombatReplayHouseOptOutRepository houseOptOutRepository =
+            mock(CombatReplayHouseOptOutRepository.class);
     private final CombatReplayLeaderboardEntryRepository leaderboardEntryRepository =
             mock(CombatReplayLeaderboardEntryRepository.class);
     private final CombatReplayHouseService service = new CombatReplayHouseService(
             new CombatContestSettings(),
             houseRepository,
+            houseOptOutRepository,
             mock(CombatReplayContestRepository.class),
             mock(CombatCandidateRepository.class),
             leaderboardEntryRepository);
+
+    @BeforeEach
+    void setup() {
+        when(houseOptOutRepository.findByDiscordUserId(org.mockito.Mockito.anyString()))
+                .thenReturn(Optional.empty());
+    }
 
     @Test
     void seasonStartRandomlyAssignsLeaderboardEntriesIntoBalancedDelegations() {


### PR DESCRIPTION
## Summary
- Add house-scoped /lazax commands for reposting Hacan, Mentak, and Naalu ability voting controls only in the matching delegation channels.
- Add public Lazax participation controls after contest announcements for toggling delegation roles and opting in/out.
- Persist opt-outs with previous house assignment so opt-in restores the same delegation.

## Test Plan
- mvn -q spotless:check
- git diff --check
- mvn -q -DskipTests compile (blocked locally: active JDK is 21, project requires Java 26)