### PR TITLE
Fix Mentak preview fallback and Trade Convoys privacy

### DIFF
--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
@@ -476,23 +476,37 @@ public class CombatReplayHacanTradeConvoysService {
                             + " Hacan Delegation brokered no Trade Convoys for this combat.");
             return;
         }
-        String message = "## "
-                + FactionEmojis.getFactionIcon(CombatReplayHouse.HACAN.displayName())
-                + " Hacan Delegation Trade Convoys Locked\n"
-                + FactionEmojis.getFactionIcon(tradeConvoys.getTargetHouse().displayName())
-                + " Hacan sends `"
-                + safeInt(tradeConvoys.getFavorCost())
-                + " Favor` to " + tradeConvoys.getTargetHouse().displayName()
-                + " Delegation and will gain `"
-                + safeInt(tradeConvoys.getPredictionBonus())
-                + "%` of that Delegation's earned points in the next combat.";
-        sendTradeConvoysLockedMessage(CombatReplayHouse.HACAN, message);
-        sendTradeConvoysLockedMessage(tradeConvoys.getTargetHouse(), message);
+        sendTradeConvoysLockedMessage(CombatReplayHouse.HACAN, hacanLockedTradeConvoysMessage(tradeConvoys));
+        sendTradeConvoysLockedMessage(tradeConvoys.getTargetHouse(), targetLockedTradeConvoysMessage(tradeConvoys));
     }
 
     private void sendTradeConvoysLockedMessage(CombatReplayHouse house, String message) {
         TextChannel channel = houseChannel(house);
         if (channel != null) MessageHelper.sendMessageToChannel(channel, message);
+    }
+
+    String hacanLockedTradeConvoysMessage(CombatReplayHacanTradeConvoysEntity tradeConvoys) {
+        return lockedTradeConvoysHeader()
+                + "\n"
+                + lockedTradeConvoysFavorTransferLine(tradeConvoys)
+                + " and will gain `"
+                + safeInt(tradeConvoys.getPredictionBonus())
+                + "%` of that Delegation's earned points in the next combat.";
+    }
+
+    String targetLockedTradeConvoysMessage(CombatReplayHacanTradeConvoysEntity tradeConvoys) {
+        return lockedTradeConvoysHeader() + "\n" + lockedTradeConvoysFavorTransferLine(tradeConvoys) + ".";
+    }
+
+    private String lockedTradeConvoysHeader() {
+        return "## " + FactionEmojis.getFactionIcon(CombatReplayHouse.HACAN.displayName())
+                + " Hacan Delegation Trade Convoys Locked";
+    }
+
+    private String lockedTradeConvoysFavorTransferLine(CombatReplayHacanTradeConvoysEntity tradeConvoys) {
+        return FactionEmojis.getFactionIcon(tradeConvoys.getTargetHouse().displayName()) + " Hacan sends `"
+                + safeInt(tradeConvoys.getFavorCost()) + " Favor` to "
+                + tradeConvoys.getTargetHouse().displayName() + " Delegation";
     }
 
     private TradeConvoys toTradeConvoys(CombatReplayHacanTradeConvoysEntity entity) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -219,9 +219,10 @@ public class CombatReplayPromotionService {
     private void postMentakPreviewIfDue(LocalDateTime now) {
         List<CombatCandidateEntity> candidates = findPromotionCandidates(now);
         if (candidates.stream().anyMatch(candidate -> candidate.getMentakPreviewPostedAt() != null)) return;
-        CombatCandidateEntity winner = selectPromotionWinner(candidates);
-        if (winner == null) return;
-        postMentakPreview(winner);
+        for (CombatCandidateEntity candidate : rankPromotionCandidates(candidates)) {
+            if (postMentakPreview(candidate) != null) return;
+            BotLogger.error("Mentak preview skipped for candidate " + candidate.getId() + " because posting failed.");
+        }
     }
 
     private void postProductionMentakPreviewIfDue(LocalDateTime now) {
@@ -286,19 +287,22 @@ public class CombatReplayPromotionService {
     }
 
     private CombatReplayContestEntity postMentakPreview(CombatCandidateEntity candidate) {
-        CombatObservationEntity observation =
-                observationRepository.findById(candidate.getObservationId()).orElse(null);
-        Game game = loadGame(candidate.getGameName());
-        TextChannel channel = discordPostService.houseChannel(CombatReplayHouse.MENTAK);
-        if (observation == null || game == null || channel == null) return null;
-
-        CombatReplayContestEntity previewContest = createPreviewContest(candidate);
-        lockPreviousContestTradeConvoys(previewContest);
-
-        String startSummaryText = snapshotStartSummaryText(candidate);
-        String message = LazaxCombatSupport.formatReplayAnnouncement(
-                game, candidate, discordPostService.getHouseRoleMention(CombatReplayHouse.MENTAK), startSummaryText);
         try {
+            CombatObservationEntity observation =
+                    observationRepository.findById(candidate.getObservationId()).orElse(null);
+            Game game = loadGame(candidate.getGameName());
+            TextChannel channel = discordPostService.houseChannel(CombatReplayHouse.MENTAK);
+            if (observation == null || game == null || channel == null) return null;
+
+            CombatReplayContestEntity previewContest = createPreviewContest(candidate);
+            lockPreviousContestTradeConvoys(previewContest);
+
+            String startSummaryText = snapshotStartSummaryText(candidate);
+            String message = LazaxCombatSupport.formatReplayAnnouncement(
+                    game,
+                    candidate,
+                    discordPostService.getHouseRoleMention(CombatReplayHouse.MENTAK),
+                    startSummaryText);
             discordPostService.postPromotionMessage(channel, message, game, candidate);
             mentakAbilityService.postDecoyButtons(channel, candidate);
             candidate.setMentakPreviewPostedAt(LocalDateTime.now(clock));

--- a/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
+++ b/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
@@ -105,6 +105,20 @@ class CombatReplayHacanTradeConvoysServiceTest {
         assertTrue(buttons.get(2).isDisabled());
     }
 
+    @Test
+    void tradeConvoysLockedTargetMessageDoesNotRevealHacanPayout() {
+        CombatReplayHacanTradeConvoysEntity convoy = convoy(1L, CombatReplayHouse.NAALU, 30, 15);
+
+        String hacanMessage = service.hacanLockedTradeConvoysMessage(convoy);
+        String targetMessage = service.targetLockedTradeConvoysMessage(convoy);
+
+        assertTrue(hacanMessage.contains("will gain `15%`"));
+        assertTrue(targetMessage.contains("Hacan sends `30 Favor` to Naalu Delegation"));
+        assertFalse(targetMessage.contains("15%"));
+        assertFalse(targetMessage.contains("earned points"));
+        assertFalse(targetMessage.contains("will gain"));
+    }
+
     private CombatReplayHacanTradeConvoysEntity convoy(
             Long contestId, CombatReplayHouse targetHouse, int favorCost, int bonusPercent) {
         CombatReplayHacanTradeConvoysEntity convoy = new CombatReplayHacanTradeConvoysEntity();

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -218,6 +218,37 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
+    void promoteBestCandidateIfDueFallsBackWhenMentakPreviewPostingFails() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.getRuntime().setDevMode(false);
+        settings.setHousesEnabled(true);
+        settings.getHouseAbilities().getMentak().setPreviewLeadSeconds(900);
+        CombatReplayContestLifecycleService service =
+                service(settings, candidateRepository, observationRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:50:00"));
+        CombatCandidateEntity first = promotionCandidate(1L, LocalDateTime.parse("2026-04-27T12:20:00"), 10.0);
+        CombatCandidateEntity second = promotionCandidate(2L, LocalDateTime.parse("2026-04-27T12:25:00"), 5.0);
+
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        CombatCandidateStatus.RESOLVED,
+                        CombatCandidatePromotionStatus.PENDING,
+                        LocalDateTime.parse("2026-04-27T00:50:00")))
+                .thenReturn(List.of(first, second));
+        when(observationRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of());
+        when(observationRepository.findById(1L)).thenReturn(java.util.Optional.empty());
+        when(observationRepository.findById(2L)).thenReturn(java.util.Optional.empty());
+
+        service.promoteBestCandidateIfDue();
+
+        verify(observationRepository).findById(1L);
+        verify(observationRepository).findById(2L);
+    }
+
+    @Test
     void promoteBestCandidateIfDueFallsBackWhenReadyMentakPreviewPromotionFails() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
@@ -296,6 +327,12 @@ class CombatReplayContestLifecycleServiceTest {
         candidate.setMentakPreviewPostedAt(previewedAt);
         candidate.setPromotionScore(promotionScore);
         candidate.setInitialRenderSnapshotJson("{\"context\":{}}");
+        return candidate;
+    }
+
+    private CombatCandidateEntity promotionCandidate(Long id, LocalDateTime resolvedAt, Double promotionScore) {
+        CombatCandidateEntity candidate = previewedCandidate(id, resolvedAt, promotionScore);
+        candidate.setMentakPreviewPostedAt(null);
         return candidate;
     }
 


### PR DESCRIPTION
## Summary
- Try ranked Mentak preview candidates until one successfully posts instead of stopping on the top candidate.
- Catch failures across the full preview posting path so game-load or setup failures do not kill the cron.
- Keep Hacan Trade Convoys payout details private to Hacan when locked messages are sent to the target delegation.
- Add regression tests for preview fallback and recipient-facing Trade Convoys text.

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayContestLifecycleServiceTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayHacanTradeConvoysServiceTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests test-compile`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:check`
- `git diff --check`