### PR TITLE
Fix delayed Mentak preview public promotion

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -244,7 +244,7 @@ public class CombatReplayPromotionService {
         LocalDateTime publicPromotionWindow = mentakPublicPromotionWindow(now);
         if (!canPublicPromoteAt(publicPromotionWindow)) return;
         List<CombatCandidateEntity> candidates = rankPromotionCandidates(findPromotionCandidates(now).stream()
-                .filter(candidate -> isMentakPreviewReadyForPublicPromotion(candidate, publicPromotionWindow))
+                .filter(candidate -> isMentakPreviewReadyForPublicPromotion(candidate, now))
                 .toList());
         for (CombatCandidateEntity candidate : candidates) {
             if (promoteCandidate(candidate) != null) return;

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -3,7 +3,6 @@ package ti4.contest.replay.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -186,7 +185,7 @@ class CombatReplayContestLifecycleServiceTest {
     }
 
     @Test
-    void promoteBestCandidateIfDueWaitsForNextHourlySlotWhenPreviewBecomesReadyMidHour() {
+    void promoteBestCandidateIfDueUsesActualTimeWhenPreviewBecomesReadyMidHour() {
         CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
         CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
         CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
@@ -205,7 +204,7 @@ class CombatReplayContestLifecycleServiceTest {
                         CombatCandidatePromotionStatus.PENDING,
                         LocalDateTime.parse("2026-04-27T00:25:00")))
                 .thenReturn(List.of(candidate));
-        when(observationRepository.findAllById(List.of())).thenReturn(List.of());
+        when(observationRepository.findAllById(List.of(1L))).thenReturn(List.of());
 
         service.promoteBestCandidateIfDue();
 
@@ -214,7 +213,7 @@ class CombatReplayContestLifecycleServiceTest {
                         CombatCandidateStatus.RESOLVED,
                         CombatCandidatePromotionStatus.PENDING,
                         LocalDateTime.parse("2026-04-27T00:25:00"));
-        verify(observationRepository, never()).findById(1L);
+        verify(observationRepository).findById(1L);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Check Mentak preview readiness against actual current time instead of the start of the current hour.
- Keep hourly promotion quota/cooldown logic on the current promotion window.
- Update the lifecycle test so a preview that becomes ready mid-hour is attempted immediately.

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayContestLifecycleServiceTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests test-compile`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:check`
- `git diff --check`