### PR TITLE
Add Lazax admin Favor grant command

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayHouseFavorService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayHouseFavorService.java
@@ -115,6 +115,49 @@ public class CombatReplayHouseFavorService {
         houseScoreRepository.saveAllAndFlush(scores);
     }
 
+    public FavorLedger adjustFavorForAdmin(CombatReplayHouse house, int favorDelta) {
+        if (house == null || favorDelta == 0) return ledger(house);
+        return setAdminAdjustedBalance(house, balance(house) + favorDelta);
+    }
+
+    private FavorLedger setAdminAdjustedBalance(CombatReplayHouse house, int targetBalance) {
+        int desiredBalance = Math.max(0, targetBalance);
+        CombatReplayHouseScoreEntity adminScore = null;
+        for (CombatReplayHouseScoreEntity score :
+                houseScoreRepository.findByContestId(DEBUG_FAVOR_BALANCE_CONTEST_ID)) {
+            if (score.getHouse() == house) {
+                adminScore = score;
+                break;
+            }
+        }
+
+        int earnedOutsideAdminScore = 0;
+        for (CombatReplayHouseScoreEntity score : houseScoreRepository.findByHouse(house)) {
+            if (DEBUG_FAVOR_BALANCE_CONTEST_ID == safeLong(score.getContestId())) continue;
+            earnedOutsideAdminScore += safeInt(score.getFavorPoints());
+        }
+
+        int spent = 0;
+        for (CombatReplayHouseAbilityUseEntity use : houseAbilityUseRepository.findByHouse(house)) {
+            spent += safeInt(use.getFavorCost());
+        }
+
+        CombatReplayHouseScoreEntity score = adminScore == null ? new CombatReplayHouseScoreEntity() : adminScore;
+        score.setContestId(DEBUG_FAVOR_BALANCE_CONTEST_ID);
+        score.setHouse(house);
+        score.setPredictionPoints(safeInt(score.getPredictionPoints()));
+        score.setSideBetPoints(safeInt(score.getSideBetPoints()));
+        score.setAbilityPoints(safeInt(score.getAbilityPoints()));
+        score.setFavorPoints(desiredBalance + spent - earnedOutsideAdminScore);
+        score.setTotalPoints(safeInt(score.getTotalPoints()));
+        score.setPredictionCount(safeInt(score.getPredictionCount()));
+        score.setCorrectPredictions(safeInt(score.getCorrectPredictions()));
+        score.setAbilityBreakdownJson(score.getAbilityBreakdownJson() == null ? "[]" : score.getAbilityBreakdownJson());
+        score.setScoredAt(LocalDateTime.now());
+        houseScoreRepository.saveAndFlush(score);
+        return ledger(house);
+    }
+
     private int safeInt(Integer value) {
         return value == null ? 0 : value;
     }

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
@@ -13,6 +13,7 @@ public class LazaxCommand implements ParentCommand {
                     new LazaxMyPoints(),
                     new LazaxTop100(),
                     new LazaxStartSeason1(),
+                    new LazaxGrantFavor(),
                     new LazaxHacanTradeConvoys(),
                     new LazaxMentakFalseColors(),
                     new LazaxNaaluGiftForesight())

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxGrantFavor.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxGrantFavor.java
@@ -1,0 +1,81 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.service.CombatReplayHouseFavorService;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.message.MessageHelper;
+import ti4.spring.context.SpringContext;
+
+class LazaxGrantFavor extends Subcommand {
+
+    private static final String HOUSE = "house";
+    private static final String AMOUNT = "amount";
+
+    LazaxGrantFavor() {
+        super("grant_favor", "Adjust Favor for a Lazax delegation.");
+        addOptions(new OptionData(OptionType.STRING, HOUSE, "Delegation to receive Favor", true)
+                .addChoice(CombatReplayHouse.HACAN.displayName(), CombatReplayHouse.HACAN.name())
+                .addChoice(CombatReplayHouse.MENTAK.displayName(), CombatReplayHouse.MENTAK.name())
+                .addChoice(CombatReplayHouse.NAALU.displayName(), CombatReplayHouse.NAALU.name()));
+        addOptions(new OptionData(OptionType.INTEGER, AMOUNT, "Favor to add or remove", true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        if (!LazaxCommandAuthorization.isSeasonAdmin(event)) {
+            LazaxReplyHelper.replyEphemeral(event, "You are not authorized to grant Lazax Favor.");
+            return;
+        }
+
+        CombatReplayHouse house = CombatReplayHouse.fromName(event.getOption(HOUSE, "", OptionMapping::getAsString));
+        int amount = event.getOption(AMOUNT, 0, OptionMapping::getAsInt);
+        if (house == null || amount == 0) {
+            LazaxReplyHelper.replyEphemeral(event, "Choose a delegation and a non-zero Favor amount.");
+            return;
+        }
+
+        CombatReplayHouseFavorService.FavorLedger ledger =
+                SpringContext.getBean(CombatReplayHouseFavorService.class).adjustFavorForAdmin(house, amount);
+        MessageHelper.sendMessageToChannel(event.getMessageChannel(), grantFavorMessage(house, amount, ledger));
+        LazaxReplyHelper.replyEphemeral(
+                event,
+                "Adjusted "
+                        + house.displayName()
+                        + " Delegation Favor by `"
+                        + formatSignedAmount(amount)
+                        + "`. Available Favor is now `"
+                        + ledger.balance()
+                        + "`.");
+    }
+
+    @Override
+    public boolean isEphemeral(SlashCommandInteractionEvent event) {
+        return true;
+    }
+
+    static String grantFavorMessage(
+            CombatReplayHouse house, int amount, CombatReplayHouseFavorService.FavorLedger ledger) {
+        return "## Favor Granted\n"
+                + house.displayName()
+                + " Delegation "
+                + adjustmentVerb(amount)
+                + " `"
+                + formatSignedAmount(amount)
+                + "` Favor.\n"
+                + "**Total Favor:** `"
+                + ledger.balance()
+                + "`";
+    }
+
+    private static String adjustmentVerb(int amount) {
+        return amount < 0 ? "loses" : "receives";
+    }
+
+    private static String formatSignedAmount(int amount) {
+        return amount > 0 ? "+" + amount : Integer.toString(amount);
+    }
+}

--- a/src/test/java/ti4/contest/replay/service/CombatReplayHouseFavorServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayHouseFavorServiceTest.java
@@ -1,0 +1,79 @@
+package ti4.contest.replay.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.entities.CombatReplayHouseAbilityUseEntity;
+import ti4.contest.replay.entities.CombatReplayHouseScoreEntity;
+import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
+import ti4.contest.replay.repository.CombatReplayHouseScoreRepository;
+
+class CombatReplayHouseFavorServiceTest {
+
+    private final CombatReplayHouseScoreRepository houseScoreRepository = mock(CombatReplayHouseScoreRepository.class);
+    private final CombatReplayHouseAbilityUseRepository houseAbilityUseRepository =
+            mock(CombatReplayHouseAbilityUseRepository.class);
+    private final CombatReplayHouseFavorService service =
+            new CombatReplayHouseFavorService(houseScoreRepository, houseAbilityUseRepository);
+
+    @Test
+    void adjustFavorForAdminIncreasesAvailableBalanceWithoutChangingSpend() {
+        CombatReplayHouseScoreEntity combatScore = score(12L, CombatReplayHouse.HACAN, 20);
+        CombatReplayHouseScoreEntity adminAdjustment = score(0L, CombatReplayHouse.HACAN, 5);
+        CombatReplayHouseAbilityUseEntity spend = use(CombatReplayHouse.HACAN, 7);
+        when(houseScoreRepository.findByHouse(CombatReplayHouse.HACAN))
+                .thenReturn(List.of(combatScore, adminAdjustment));
+        when(houseScoreRepository.findByContestId(0L)).thenReturn(List.of(adminAdjustment));
+        when(houseAbilityUseRepository.findByHouse(CombatReplayHouse.HACAN)).thenReturn(List.of(spend));
+
+        CombatReplayHouseFavorService.FavorLedger ledger = service.adjustFavorForAdmin(CombatReplayHouse.HACAN, 12);
+
+        assertEquals(30, ledger.balance());
+        assertEquals(17, adminAdjustment.getFavorPoints());
+        verify(houseScoreRepository).saveAndFlush(adminAdjustment);
+    }
+
+    @Test
+    void adjustFavorForAdminCanRemoveFavorWithoutChangingSpend() {
+        CombatReplayHouseScoreEntity combatScore = score(12L, CombatReplayHouse.HACAN, 20);
+        CombatReplayHouseScoreEntity adminAdjustment = score(0L, CombatReplayHouse.HACAN, 5);
+        CombatReplayHouseAbilityUseEntity spend = use(CombatReplayHouse.HACAN, 7);
+        when(houseScoreRepository.findByHouse(CombatReplayHouse.HACAN))
+                .thenReturn(List.of(combatScore, adminAdjustment));
+        when(houseScoreRepository.findByContestId(0L)).thenReturn(List.of(adminAdjustment));
+        when(houseAbilityUseRepository.findByHouse(CombatReplayHouse.HACAN)).thenReturn(List.of(spend));
+
+        CombatReplayHouseFavorService.FavorLedger ledger = service.adjustFavorForAdmin(CombatReplayHouse.HACAN, -12);
+
+        assertEquals(6, ledger.balance());
+        assertEquals(-7, adminAdjustment.getFavorPoints());
+        verify(houseScoreRepository).saveAndFlush(adminAdjustment);
+    }
+
+    private CombatReplayHouseScoreEntity score(Long contestId, CombatReplayHouse house, int favorPoints) {
+        CombatReplayHouseScoreEntity score = new CombatReplayHouseScoreEntity();
+        score.setContestId(contestId);
+        score.setHouse(house);
+        score.setPredictionPoints(0);
+        score.setSideBetPoints(0);
+        score.setAbilityPoints(0);
+        score.setFavorPoints(favorPoints);
+        score.setTotalPoints(0);
+        score.setPredictionCount(0);
+        score.setCorrectPredictions(0);
+        score.setAbilityBreakdownJson("[]");
+        return score;
+    }
+
+    private CombatReplayHouseAbilityUseEntity use(CombatReplayHouse house, int favorCost) {
+        CombatReplayHouseAbilityUseEntity use = new CombatReplayHouseAbilityUseEntity();
+        use.setHouse(house);
+        use.setFavorCost(favorCost);
+        return use;
+    }
+}

--- a/src/test/java/ti4/discord/interactions/commands/lazax/LazaxGrantFavorTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/lazax/LazaxGrantFavorTest.java
@@ -1,0 +1,28 @@
+package ti4.discord.interactions.commands.lazax;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.service.CombatReplayHouseFavorService;
+
+class LazaxGrantFavorTest {
+
+    @Test
+    void grantFavorMessageShowsPositiveAdjustmentAndTotalFavor() {
+        String message = LazaxGrantFavor.grantFavorMessage(
+                CombatReplayHouse.MENTAK, 17, new CombatReplayHouseFavorService.FavorLedger(42, 5, 37));
+
+        assertTrue(message.contains("Mentak Delegation receives `+17` Favor."));
+        assertTrue(message.contains("**Total Favor:** `37`"));
+    }
+
+    @Test
+    void grantFavorMessageShowsNegativeAdjustmentAndTotalFavor() {
+        String message = LazaxGrantFavor.grantFavorMessage(
+                CombatReplayHouse.MENTAK, -17, new CombatReplayHouseFavorService.FavorLedger(8, 5, 3));
+
+        assertTrue(message.contains("Mentak Delegation loses `-17` Favor."));
+        assertTrue(message.contains("**Total Favor:** `3`"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `/lazax grant_favor` with delegation and signed amount options.
- Restrict the command to the same season admin user id as `/lazax start_season_1`.
- Allow positive amounts to add Favor and negative amounts to remove Favor; zero is rejected.
- Post a public channel message showing the Favor adjustment and the delegation total, while keeping command authorization/errors ephemeral.
- Add an admin Favor adjustment helper that changes available delegation Favor while preserving existing spend.

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayHouseFavorServiceTest,LazaxGrantFavorTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests test-compile`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:check`
- `git diff --check`