### PR TITLE
Update Lazax house replay abilities

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -109,6 +109,7 @@ public class CombatContestSettings {
         require(
                 houseAbilities.naalu.roundOneRollPeekFavorCost >= 0,
                 "houseAbilities.naalu.roundOneRollPeekFavorCost must be >= 0.");
+        require(houseAbilities.naalu.luckOmensFavorCost >= 0, "houseAbilities.naalu.luckOmensFavorCost must be >= 0.");
         require(
                 houseAbilities.mentak.previewLeadSeconds >= 0,
                 "houseAbilities.mentak.previewLeadSeconds must be >= 0.");
@@ -266,6 +267,7 @@ public class CombatContestSettings {
     public static class Naalu {
         private int actionCardPeekFavorCost = 30;
         private int roundOneRollPeekFavorCost = 50;
+        private int luckOmensFavorCost = 40;
     }
 
     @Getter

--- a/src/main/java/ti4/contest/replay/core/CombatReplayDecoys.java
+++ b/src/main/java/ti4/contest/replay/core/CombatReplayDecoys.java
@@ -184,7 +184,7 @@ public class CombatReplayDecoys {
 
         String vanished = renderVanishedUnits(abilities.decoy().units());
         return "## False Colors Revealed\n"
-                + "As the battle ends, "
+                + "As the replay begins, "
                 + vanished
                 + " drop their false colors and vanish from the formation. No wreckage remains.";
     }

--- a/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityButtonHandler.java
+++ b/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityButtonHandler.java
@@ -38,6 +38,13 @@ public class CombatReplayNaaluAbilityButtonHandler {
                             contestId, event.getUser().getId(), event.getUser().getName()));
             return;
         }
+        if (buttonId.startsWith(CombatReplayNaaluAbilityService.NAALU_LUCK_OMENS)) {
+            sendVoteResult(
+                    event,
+                    service.voteLuckOmens(
+                            contestId, event.getUser().getId(), event.getUser().getName()));
+            return;
+        }
         if (buttonId.startsWith(CombatReplayNaaluAbilityService.NAALU_DO_NOT_USE)) {
             sendVoteResult(
                     event,

--- a/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
+++ b/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
@@ -1,7 +1,9 @@
 package ti4.contest.replay.house.naalu;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
@@ -42,7 +44,6 @@ import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.model.ActionCardModel;
 import ti4.service.combat.CombatRollType;
-import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.DiceEmojis;
 import ti4.service.emoji.FactionEmojis;
 
@@ -54,13 +55,17 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
     public static final String NAALU_PEEK_PREFIX = "combatReplayNaaluPeek_";
     public static final String NAALU_ACTION_CARDS = NAALU_PEEK_PREFIX + "actionCards_";
     public static final String NAALU_ROUND_ONE_ROLLS = NAALU_PEEK_PREFIX + "roundOneRolls_";
+    public static final String NAALU_LUCK_OMENS = NAALU_PEEK_PREFIX + "luckOmens_";
     public static final String NAALU_DO_NOT_USE = NAALU_PEEK_PREFIX + "doNotUse_";
 
     private static final String NAALU_ACTION_CARDS_ABILITY = "NAALU_ACTION_CARDS";
     private static final String NAALU_ROUND_ONE_ROLLS_ABILITY = "NAALU_ROUND_ONE_ROLLS";
+    private static final String NAALU_LUCK_OMENS_ABILITY = "NAALU_LUCK_OMENS";
     private static final String DO_NOT_USE_ABILITY = "DO_NOT_USE";
     private static final String SYSTEM_USER_ID = "0";
     private static final String SYSTEM_USER_NAME = "Naalu Delegation";
+    private static final double AVERAGE_DELTA_LIMIT = 0.5;
+    private static final double STRONG_LUCK_DELTA_LIMIT = 1.5;
 
     private final CombatContestSettings settings;
     private final CombatReplayContestRepository replayContestRepository;
@@ -105,7 +110,7 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
                         + CombatReplayAbilityWindowText.votesLockLine(discussionWindowSeconds())
                         + "\n"
                         + favorBalanceLine()
-                        + "\n-# Gift of Foresight: choose one vision to reveal when discussion ends. Predictions and side bets remain open afterward.",
+                        + "\n-# Gift of Foresight: choose whether to read the combat's omens when discussion ends. Predictions and side bets remain open afterward.",
                 peekButtons(contest.getId()));
     }
 
@@ -142,6 +147,10 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         return vote(contestId, NAALU_ROUND_ONE_ROLLS_ABILITY, "Round 1 Rolls", discordUserId, discordUserName);
     }
 
+    public CombatReplayInteractionResult voteLuckOmens(long contestId, String discordUserId, String discordUserName) {
+        return vote(contestId, NAALU_LUCK_OMENS_ABILITY, "Omens", discordUserId, discordUserName);
+    }
+
     public CombatReplayInteractionResult voteDoNotUse(long contestId, String discordUserId, String discordUserName) {
         return vote(contestId, DO_NOT_USE_ABILITY, "Do Not Use", discordUserId, discordUserName);
     }
@@ -176,6 +185,8 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
             reveal = renderActionCardPeek(contest.getId());
         } else if (NAALU_ROUND_ONE_ROLLS_ABILITY.equals(winningVote.optionKey())) {
             reveal = renderRoundOneRollPeek(contest.getId());
+        } else if (NAALU_LUCK_OMENS_ABILITY.equals(winningVote.optionKey())) {
+            reveal = renderLuckOmens(contest.getId());
         } else {
             return;
         }
@@ -246,6 +257,59 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         return "## Gift of Foresight: Round 1 Rolls\n" + String.join("\n\n", rolls);
     }
 
+    public String renderLuckOmens(long contestId) {
+        CombatReplayContestEntity contest = loadContest(contestId);
+        CombatCandidateEntity candidate = loadCandidate(contest);
+        if (candidate == null) return "Could not find that combat archive.";
+
+        Game game = loadGame(candidate.getGameName());
+        LuckAccumulator overall = new LuckAccumulator();
+        Map<String, LuckAccumulator> actorLuck = new LinkedHashMap<>();
+        for (CombatCandidateEventEntity event : orderedEvents(candidate)) {
+            if (event.getEventType() != CombatCandidateEventType.ROLL) continue;
+            ReplayDispatchPayload payload = payloadSerializer.read(event);
+            if (!(payload instanceof ReplayDispatchPayload.CombatRollDispatch combatRoll)) continue;
+            if (combatRoll.payload() == null) continue;
+
+            String actorFaction = actorFaction(event, combatRoll.payload());
+            LuckAccumulator actorAccumulator =
+                    actorLuck.computeIfAbsent(actorFaction, ignored -> new LuckAccumulator());
+            for (CombatRollPayload.UnitRoll unitRoll : combatRoll.payload().unitRolls()) {
+                for (CombatRollPayload.DieRoll die : unitRoll.dice()) {
+                    double expectedHits = hitProbability(die.threshold());
+                    int actualHits = die.success() ? 1 : 0;
+                    overall.record(actualHits, expectedHits);
+                    actorAccumulator.record(actualHits, expectedHits);
+                }
+            }
+        }
+
+        if (overall.diceRolled() == 0) {
+            return "## Gift of Foresight: Omens\nNo combat rolls have surfaced yet.";
+        }
+
+        List<String> lines = new ArrayList<>();
+        lines.add("Overall: **" + luckLabel(overall.delta()) + "**");
+        for (Map.Entry<String, LuckAccumulator> entry : actorLuck.entrySet()) {
+            LuckAccumulator actorAccumulator = entry.getValue();
+            if (actorAccumulator.diceRolled() == 0) continue;
+            lines.add(actor(game, entry.getKey()) + ": **" + luckLabel(actorAccumulator.delta()) + "**");
+        }
+        return "## Gift of Foresight: Omens\n" + String.join("\n", lines);
+    }
+
+    private double hitProbability(int threshold) {
+        return Math.max(0.0, Math.min(1.0, (11 - threshold) / 10.0));
+    }
+
+    private String luckLabel(double delta) {
+        if (delta <= -STRONG_LUCK_DELTA_LIMIT) return "Unlucky";
+        if (delta < -AVERAGE_DELTA_LIMIT) return "Slightly Unlucky";
+        if (delta <= AVERAGE_DELTA_LIMIT) return "Average";
+        if (delta < STRONG_LUCK_DELTA_LIMIT) return "Slightly Lucky";
+        return "Lucky";
+    }
+
     private CombatReplayInteractionResult recordVote(
             long candidateId, String optionKey, String optionLabel, String discordUserId, String discordUserName) {
         return voteService.recordVote(
@@ -301,24 +365,22 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
     }
 
     private String activeResolutionMessage(CombatReplayHouseAbilityVoteService.WinningVote winningVote, String reveal) {
-        String action =
-                NAALU_ACTION_CARDS_ABILITY.equals(winningVote.optionKey()) ? "action cards" : "first-round rolls";
-        return "## Naalu Gift of Foresight\nNaalu Delegation used Gift of Foresight to view "
-                + action
+        return "## Naalu Gift of Foresight\nNaalu Delegation used Gift of Foresight: "
+                + optionLabel(winningVote.optionKey())
                 + " for this combat (`"
                 + winningVote.voteCount()
                 + "` votes).\n\n"
                 + reveal;
     }
 
-    private List<Button> peekButtons(Long contestId) {
+    List<Button> peekButtons(Long contestId) {
         return List.of(
                 abilityButton(
                         Buttons.blue(
-                                NAALU_ACTION_CARDS + contestId,
-                                "Vote: Action Cards" + favorCostSuffix(actionCardPeekFavorCost()),
-                                CardEmojis.ActionCard),
-                        actionCardPeekFavorCost()),
+                                NAALU_LUCK_OMENS + contestId,
+                                "Vote: Omens" + favorCostSuffix(luckOmensFavorCost()),
+                                FactionEmojis.Naalu),
+                        luckOmensFavorCost()),
                 abilityButton(
                         Buttons.blue(
                                 NAALU_ROUND_ONE_ROLLS + contestId,
@@ -339,6 +401,7 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
     private int favorCost(String optionKey) {
         if (NAALU_ACTION_CARDS_ABILITY.equals(optionKey)) return actionCardPeekFavorCost();
         if (NAALU_ROUND_ONE_ROLLS_ABILITY.equals(optionKey)) return roundOneRollPeekFavorCost();
+        if (NAALU_LUCK_OMENS_ABILITY.equals(optionKey)) return luckOmensFavorCost();
         return 0;
     }
 
@@ -348,6 +411,10 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
 
     private int roundOneRollPeekFavorCost() {
         return settings.getHouseAbilities().getNaalu().getRoundOneRollPeekFavorCost();
+    }
+
+    private int luckOmensFavorCost() {
+        return settings.getHouseAbilities().getNaalu().getLuckOmensFavorCost();
     }
 
     private int minimumAbilityVotesToResolve() {
@@ -364,11 +431,18 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         if (DO_NOT_USE_ABILITY.equals(optionKey)) return "Do Not Use";
         if (NAALU_ACTION_CARDS_ABILITY.equals(optionKey)) return "Action Cards";
         if (NAALU_ROUND_ONE_ROLLS_ABILITY.equals(optionKey)) return "Round 1 Rolls";
+        if (NAALU_LUCK_OMENS_ABILITY.equals(optionKey)) return "Omens";
         return optionKey;
     }
 
     private List<CombatCandidateEventEntity> orderedEvents(CombatCandidateEntity candidate) {
         return candidateEventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId());
+    }
+
+    private String actorFaction(CombatCandidateEventEntity event, CombatRollPayload payload) {
+        if (StringUtils.isNotBlank(event.getActorFaction())) return event.getActorFaction();
+        if (payload != null && payload.header() != null) return payload.header().actorFaction();
+        return null;
     }
 
     private boolean isCombatRoundRoll(CombatRollPayload payload) {
@@ -413,5 +487,25 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
             BotLogger.warning("Lazax house channel not found: " + CombatReplayHouse.NAALU.channelName());
         }
         return channel;
+    }
+
+    private static class LuckAccumulator {
+        private int actualHits;
+        private double expectedHits;
+        private int diceRolled;
+
+        private void record(int actualHits, double expectedHits) {
+            this.actualHits += actualHits;
+            this.expectedHits += expectedHits;
+            diceRolled++;
+        }
+
+        private double delta() {
+            return actualHits - expectedHits;
+        }
+
+        private int diceRolled() {
+            return diceRolled;
+        }
     }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatContestReplayStatus;
 import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatCandidateEventEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
@@ -150,6 +151,8 @@ public class CombatReplayExecutionService {
             }
             if (contest.getReplayStatus() == CombatContestReplayStatus.PENDING && candidate != null && game != null) {
                 announcePreReplayContextIfNeeded(channel, contest, candidate);
+                announceFalseColorsRevealAtReplayStart(channel, candidate);
+                replaySideBetService.refreshSideBetSummary(channel, contest, candidate);
                 replayLeaderboardService.lockPredictionsAtReplayStart(game, contest, candidate);
                 replayLeaderboardService.announceLockedPredictionsIfNeeded(channel, game, contest, candidate);
             }
@@ -184,6 +187,14 @@ public class CombatReplayExecutionService {
         }
         contest.setPreReplayContextPostedAt(LocalDateTime.now());
         replayContestRepository.save(contest);
+    }
+
+    private void announceFalseColorsRevealAtReplayStart(MessageChannel channel, CombatCandidateEntity candidate) {
+        String message = CombatReplayDecoys.renderDisappearanceMessage(
+                CombatReplayDecoys.read(candidate.getReplayAbilitiesJson()));
+        if (message != null && !message.isBlank()) {
+            MessageHelper.sendMessageToChannel(channel, message);
+        }
     }
 
     private void announcePredictionLockCountdown(MessageChannel channel) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -449,7 +449,6 @@ public class CombatReplayService {
                 roundsObserved));
         candidateRepository.save(candidate);
 
-        appendFalseColorsRevealedEvent(candidate, roundsObserved);
         appendTileRenderEvent(
                 candidate,
                 CombatCandidateEventType.RESOLVED,
@@ -484,7 +483,6 @@ public class CombatReplayService {
         }
         candidateRepository.save(candidate);
 
-        appendFalseColorsRevealedEvent(candidate, roundsObserved);
         appendTileRenderEvent(
                 candidate,
                 CombatCandidateEventType.RESOLVED,
@@ -506,14 +504,6 @@ public class CombatReplayService {
         candidateRepository.save(candidate);
 
         appendDiscordEvent(candidate, CombatCandidateEventType.CANCELLED, null, null, "## Contest Closed\n" + reason);
-    }
-
-    private void appendFalseColorsRevealedEvent(CombatCandidateEntity candidate, int roundsObserved) {
-        String message = CombatReplayDecoys.renderDisappearanceMessage(
-                CombatReplayDecoys.read(candidate.getReplayAbilitiesJson()));
-        if (message == null || message.isBlank()) return;
-
-        appendDiscordEvent(candidate, CombatCandidateEventType.RESOLVED, roundsObserved, null, message);
     }
 
     private boolean trackHitAssignments(

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetService.java
@@ -51,6 +51,11 @@ public class CombatReplaySideBetService {
         sideBetUiService.postSideBetButtonsIfNeeded(channel, game, contest, candidate);
     }
 
+    public void refreshSideBetSummary(
+            MessageChannel channel, CombatReplayContestEntity contest, CombatCandidateEntity candidate) {
+        sideBetUiService.refreshSummaryMessage(channel, contest, candidate);
+    }
+
     public PlacementResult placeSideBet(
             ButtonInteractionEvent event, Long contestId, CombatSideBetType betType, String targetFaction) {
         if (contestId == null || event == null) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
@@ -1,5 +1,6 @@
 package ti4.contest.replay.service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -144,22 +145,38 @@ class CombatReplaySideBetUiService {
     private String renderSummaryMessage(Game game, CombatReplayContestEntity contest) {
         List<CombatContestSideBetEntity> sideBets = sideBetRepository.findByContestId(contest.getId());
         sideBets.sort(sideBetOrder());
+        boolean sideBetWindowClosed = sideBetWindowClosed(contest);
         StringBuilder message = new StringBuilder();
         if (sideBets.isEmpty()) {
             message.append("```text\n");
-            message.append(String.format("%-3s | %s%n", "Qty", "Bet"));
-            message.append("----+------------------------------\n");
-            message.append(" -  | Waiting for the first bet\n");
+            if (sideBetWindowClosed) {
+                message.append(String.format("%-3s | %s%n", "Qty", "Bet"));
+                message.append("----+------------------------------\n");
+                message.append(" -  | No side bets placed\n");
+            } else {
+                message.append("Bet\n");
+                message.append("------------------------------\n");
+                message.append("Waiting for the first bet\n");
+            }
             message.append("```");
             return message.toString();
         }
 
         Map<String, Long> countsByBet = summarizeBetCounts(sideBets, game);
         message.append("```text\n");
-        message.append(String.format("%-3s | %s%n", "Qty", "Bet"));
-        message.append("----+------------------------------\n");
-        for (Map.Entry<String, Long> entry : countsByBet.entrySet()) {
-            message.append(String.format("%-3s | %s%n", entry.getValue() + "x", entry.getKey()));
+        if (sideBetWindowClosed) {
+            message.append(String.format("%-3s | %s%n", "Qty", "Bet"));
+            message.append("----+------------------------------\n");
+            for (Map.Entry<String, Long> entry :
+                    sortBetCountsByQuantityDesc(countsByBet).entrySet()) {
+                message.append(String.format("%-3s | %s%n", entry.getValue() + "x", entry.getKey()));
+            }
+        } else {
+            message.append("Bet\n");
+            message.append("------------------------------\n");
+            for (String label : sortBetLabelsAlphabetically(countsByBet.keySet())) {
+                message.append(label).append("\n");
+            }
         }
         message.append("```");
         return message.toString();
@@ -203,7 +220,7 @@ class CombatReplaySideBetUiService {
             String label = formatFriendlyBetLabel(game, sideBet, true);
             countsByBet.merge(label, 1L, Long::sum);
         }
-        return sortBetCountsByQuantityDesc(countsByBet);
+        return countsByBet;
     }
 
     private Map<String, Long> summarizeUserBetCounts(List<CombatContestSideBetEntity> sideBets, Game game) {
@@ -225,6 +242,19 @@ class CombatReplaySideBetUiService {
             sorted.put(entry.getKey(), entry.getValue());
         }
         return sorted;
+    }
+
+    private List<String> sortBetLabelsAlphabetically(Iterable<String> labels) {
+        List<String> sorted = new ArrayList<>();
+        for (String label : labels) {
+            sorted.add(label);
+        }
+        sorted.sort(String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder()));
+        return sorted;
+    }
+
+    private boolean sideBetWindowClosed(CombatReplayContestEntity contest) {
+        return contest.getReplayStartAt() != null && !LocalDateTime.now().isBefore(contest.getReplayStartAt());
     }
 
     private String formatFriendlyBetLabel(Game game, CombatContestSideBetEntity sideBet, boolean useShortFactionId) {

--- a/src/main/java/ti4/contest/replay/service/ReplayPayloadRenderer.java
+++ b/src/main/java/ti4/contest/replay/service/ReplayPayloadRenderer.java
@@ -8,9 +8,7 @@ import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
-import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatReplayDecoys;
-import ti4.contest.replay.core.CombatRollPayload;
 import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
 import ti4.contest.replay.core.renderers.CombatRollPayloadRenderer;
 import ti4.contest.replay.dispatch.ReplayDispatchPayload;
@@ -127,12 +125,7 @@ public class ReplayPayloadRenderer {
                 : firstNonBlank(replayMessage.content(), context.event().getSummaryText());
         List<MessageEmbed> embeds =
                 replayMessage == null ? List.of() : ReplayDispatchSerializer.toMessageEmbeds(replayMessage.embeds());
-        return tileRender(
-                content,
-                embeds,
-                payload.tilePosition(),
-                payload.combatStateSnapshotJson(),
-                context.event().getEventType() != CombatCandidateEventType.RESOLVED);
+        return tileRender(content, embeds, payload.tilePosition(), payload.combatStateSnapshotJson(), false);
     }
 
     private RenderedReplayEvent renderGenericMessage(
@@ -142,9 +135,7 @@ public class ReplayPayloadRenderer {
 
     private RenderedReplayEvent renderCombatRoll(
             RenderContext context, ReplayDispatchPayload.CombatRollDispatch rollDispatch) {
-        CombatRollPayload payloadWithAbilities =
-                CombatReplayDecoys.applyToRoll(rollDispatch.payload(), readReplayAbilities(context.candidate()));
-        String rendered = CombatRollPayloadRenderer.render(payloadWithAbilities);
+        String rendered = CombatRollPayloadRenderer.render(rollDispatch.payload());
         String renderedWithHeader = StringUtils.isBlank(rendered) ? null : "## Roll Update\n" + rendered;
         String content = firstNonBlank(
                 renderedWithHeader,
@@ -252,7 +243,7 @@ public class ReplayPayloadRenderer {
 
     private TileRenderResult tileRender(
             String content, List<MessageEmbed> embeds, String tilePosition, String snapshotJson) {
-        return tileRender(content, embeds, tilePosition, snapshotJson, true);
+        return tileRender(content, embeds, tilePosition, snapshotJson, false);
     }
 
     private TileRenderResult tileRender(
@@ -276,10 +267,10 @@ public class ReplayPayloadRenderer {
         String previousSnapshotJson = previousTileSnapshotJson(context, payload.tilePosition());
         if (StringUtils.isBlank(previousSnapshotJson)) return null;
 
-        Game previous =
-                restoreReplayGame(previousSnapshotJson, context.game(), context.candidate(), payload.tilePosition());
+        Game previous = restoreReplayGame(
+                previousSnapshotJson, context.game(), context.candidate(), payload.tilePosition(), false);
         Game current = restoreReplayGame(
-                payload.combatStateSnapshotJson(), context.game(), context.candidate(), payload.tilePosition());
+                payload.combatStateSnapshotJson(), context.game(), context.candidate(), payload.tilePosition(), false);
         if (previous == null || current == null) return null;
 
         List<String> changes = hitAssignmentChanges(previous, current, payload.tilePosition());

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -54,6 +54,8 @@ houseAbilities:
     actionCardPeekFavorCost: 20
     # roundOneRollPeekFavorCost: 0
     roundOneRollPeekFavorCost: 40
+    # luckOmensFavorCost: 0
+    luckOmensFavorCost: 20
   mentak:
     previewLeadSeconds: 15
     # destroyerDecoyFavorCost: 0
@@ -69,8 +71,8 @@ houseAbilities:
     subsidyFavorOnHit: 10
     marketMakerPointsPerBet: 1
     lowTradeConvoysFavorCost: 10
-    lowTradeConvoysPredictionBonus: 5
+    lowTradeConvoysPredictionBonus: 10
     mediumTradeConvoysFavorCost: 20
-    mediumTradeConvoysPredictionBonus: 10
+    mediumTradeConvoysPredictionBonus: 15
     highTradeConvoysFavorCost: 30
-    highTradeConvoysPredictionBonus: 15
+    highTradeConvoysPredictionBonus: 20

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -52,6 +52,7 @@ houseAbilities:
   naalu:
     actionCardPeekFavorCost: 20
     roundOneRollPeekFavorCost: 40
+    luckOmensFavorCost: 20
   mentak:
     previewLeadSeconds: 900
     destroyerDecoyFavorCost: 20
@@ -63,8 +64,8 @@ houseAbilities:
     subsidyFavorOnHit: 10
     marketMakerPointsPerBet: 1
     lowTradeConvoysFavorCost: 10
-    lowTradeConvoysPredictionBonus: 5
+    lowTradeConvoysPredictionBonus: 10
     mediumTradeConvoysFavorCost: 20
-    mediumTradeConvoysPredictionBonus: 10
+    mediumTradeConvoysPredictionBonus: 15
     highTradeConvoysFavorCost: 30
-    highTradeConvoysPredictionBonus: 15
+    highTradeConvoysPredictionBonus: 20

--- a/src/test/java/ti4/contest/replay/core/CombatReplayDecoysTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatReplayDecoysTest.java
@@ -263,6 +263,7 @@ class CombatReplayDecoysTest extends BaseTi4Test {
         String message = CombatReplayDecoys.renderDisappearanceMessage(abilities);
 
         assertTrue(message.contains("## False Colors Revealed"));
+        assertTrue(message.contains("As the replay begins"));
         assertTrue(message.contains("<ghost> 2 cruisers"));
         assertTrue(message.contains("<yin> 1 destroyer"));
     }

--- a/src/test/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityServiceButtonTest.java
+++ b/src/test/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityServiceButtonTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import net.dv8tion.jda.api.components.buttons.Button;
 import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatContestSettings;
@@ -45,5 +46,19 @@ class CombatReplayNaaluAbilityServiceButtonTest {
 
         assertFalse(affordable.isDisabled());
         assertTrue(unaffordable.isDisabled());
+    }
+
+    @Test
+    void normalWindowHidesActionCardsButKeepsRollOptions() {
+        when(houseFavorService.canAfford(CombatReplayHouse.NAALU, 20)).thenReturn(true);
+        when(houseFavorService.canAfford(CombatReplayHouse.NAALU, 40)).thenReturn(true);
+
+        List<String> labels =
+                service.peekButtons(1L).stream().map(Button::getLabel).toList();
+
+        assertTrue(labels.stream().anyMatch(label -> label.contains("Vote: Omens")));
+        assertTrue(labels.stream().anyMatch(label -> label.contains("Round 1 Rolls")));
+        assertTrue(labels.stream().anyMatch(label -> label.contains("Vote: Do Not Use")));
+        assertFalse(labels.stream().anyMatch(label -> label.contains("Action Cards")));
     }
 }

--- a/src/test/java/ti4/contest/replay/service/CombatReplayNaaluAbilityServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayNaaluAbilityServiceTest.java
@@ -72,7 +72,7 @@ class CombatReplayNaaluAbilityServiceTest {
         candidate.setReplayAbilitiesJson(JsonMapperManager.basic()
                 .writeValueAsString(new CombatReplayDecoys.Abilities(
                         new CombatReplayDecoys.Decoy(List.of(new CombatReplayDecoys.DecoyUnit(
-                                "naalu", ":naalu:", "blu", UnitType.Destroyer, Constants.SPACE, 1))))));
+                                "naalu", ":naalu:", "blue", UnitType.Destroyer, Constants.SPACE, 1))))));
         CombatReplayContestEntity contest = contest(candidate);
         CombatCandidateEventEntity event =
                 event(CombatCandidateEventType.ROLL, 1, "naalu", ReplayDispatchPayload.combatRoll("", rollPayload()));
@@ -84,6 +84,56 @@ class CombatReplayNaaluAbilityServiceTest {
         String peek = service.renderRoundOneRollPeek(1L);
 
         assertTrue(peek.contains("`2x`"));
+    }
+
+    @Test
+    void luckOmensBucketAllRollsWithoutExposingExpectedValues() {
+        CombatCandidateEntity candidate = candidate();
+        CombatReplayContestEntity contest = contest(candidate);
+        CombatCandidateEventEntity attackerRoll = event(
+                CombatCandidateEventType.ROLL,
+                1,
+                "naalu",
+                ReplayDispatchPayload.combatRoll("", luckPayload("naalu", true, true, true, true, true)));
+        CombatCandidateEventEntity defenderRoll = event(
+                CombatCandidateEventType.ROLL,
+                1,
+                "hacan",
+                ReplayDispatchPayload.combatRoll(
+                        "",
+                        luckPayload("hacan", false, false, false, false, false, false, false, false, false, false)));
+        when(contestRepository.findById(1L)).thenReturn(Optional.of(contest));
+        when(candidateRepository.findById(candidate.getId())).thenReturn(Optional.of(candidate));
+        when(eventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId()))
+                .thenReturn(List.of(attackerRoll, defenderRoll));
+
+        String omens = service.renderLuckOmens(1L);
+
+        assertTrue(omens.contains("Overall: **Lucky**"));
+        assertTrue(omens.contains("naalu: **Lucky**"));
+        assertTrue(omens.contains("hacan: **Unlucky**"));
+        assertFalse(omens.contains("Expected"));
+        assertFalse(omens.contains("EV"));
+    }
+
+    @Test
+    void luckOmensUsesAverageBand() {
+        CombatCandidateEntity candidate = candidate();
+        CombatReplayContestEntity contest = contest(candidate);
+        CombatCandidateEventEntity event = event(
+                CombatCandidateEventType.ROLL,
+                1,
+                "naalu",
+                ReplayDispatchPayload.combatRoll("", luckPayload("naalu", true, false, false, false, false)));
+        when(contestRepository.findById(1L)).thenReturn(Optional.of(contest));
+        when(candidateRepository.findById(candidate.getId())).thenReturn(Optional.of(candidate));
+        when(eventRepository.findByCandidateIdOrderBySequenceNumberAsc(candidate.getId()))
+                .thenReturn(List.of(event));
+
+        String omens = service.renderLuckOmens(1L);
+
+        assertTrue(omens.contains("Overall: **Average**"));
+        assertTrue(omens.contains("naalu: **Average**"));
     }
 
     @Test
@@ -165,5 +215,49 @@ class CombatReplayNaaluAbilityServiceTest {
                         List.of(new CombatRollPayload.DieRoll(4, 9, false, CombatRollPayload.DieRollSource.PRIMARY)),
                         0)),
                 new CombatRollPayload.RollTotal(1, 0, 1, 1));
+    }
+
+    private CombatRollPayload luckPayload(String actorFaction, boolean... successes) {
+        List<CombatRollPayload.DieRoll> dice = new java.util.ArrayList<>();
+        for (boolean success : successes) {
+            dice.add(new CombatRollPayload.DieRoll(
+                    success ? 9 : 4, 9, success, CombatRollPayload.DieRollSource.PRIMARY));
+        }
+        return new CombatRollPayload(
+                new CombatRollPayload.RollHeader(
+                        actorFaction,
+                        "blue",
+                        ":" + actorFaction + ":",
+                        "opponent",
+                        "red",
+                        "101",
+                        "18",
+                        Constants.SPACE,
+                        "space combat",
+                        CombatRollType.combatround,
+                        1,
+                        false,
+                        false),
+                List.of(),
+                List.of(),
+                List.of(new CombatRollPayload.UnitRoll(
+                        "destroyer",
+                        "dd",
+                        "destroyer",
+                        "Destroyer",
+                        "Destroyer",
+                        ":destroyer:",
+                        1,
+                        successes.length,
+                        0,
+                        9,
+                        0,
+                        9,
+                        CombatRollPayload.RollSegmentType.PRIMARY,
+                        dice,
+                        (int) dice.stream()
+                                .filter(CombatRollPayload.DieRoll::success)
+                                .count())),
+                new CombatRollPayload.RollTotal(successes.length, 0, successes.length, successes.length));
     }
 }

--- a/src/test/java/ti4/contest/replay/service/ReplayPayloadRendererTest.java
+++ b/src/test/java/ti4/contest/replay/service/ReplayPayloadRendererTest.java
@@ -45,7 +45,7 @@ class ReplayPayloadRendererTest {
     }
 
     @Test
-    void nonResolvedTileRenderKeepsReplayDecoys() {
+    void nonResolvedTileRenderSkipsReplayDecoysAfterReplayStarts() {
         CombatCandidateEventEntity event = event(
                 CombatCandidateEventType.HIT_ASSIGN,
                 ReplayDispatchPayload.tileRenderMessage("000", "{}", "## Combat Update"));
@@ -53,7 +53,7 @@ class ReplayPayloadRendererTest {
         ReplayPayloadRenderer.RenderedReplayEvent rendered = renderer.render(null, new CombatCandidateEntity(), event);
 
         ReplayPayloadRenderer.TileRenderResult tileRender = (ReplayPayloadRenderer.TileRenderResult) rendered;
-        assertTrue(tileRender.applyReplayDecoys());
+        assertFalse(tileRender.applyReplayDecoys());
     }
 
     private CombatCandidateEventEntity event(CombatCandidateEventType eventType, ReplayDispatchPayload payload) {


### PR DESCRIPTION
## Summary
- Replace Naalu action-card peek in the normal window with Omens while keeping Round 1 Rolls available.
- Hide public side-bet popularity until the replay starts, then reveal count-sorted totals.
- Move Mentak False Colors reveal to replay start and remove decoys from downstream replay rendering.
- Increase Hacan Trade Convoys prediction bonuses by 5 per tier.

## Test Plan
- mvn -q spotless:apply
- mvn -q spotless:check
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn test