### PR TITLE
Increase Hacan Market Compact favor gain

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -149,6 +149,18 @@ public class CombatContestSettings {
         require(
                 houseAbilities.hacan.highTradeConvoysPredictionBonus >= 0,
                 "houseAbilities.hacan.highTradeConvoysPredictionBonus must be >= 0.");
+        require(
+                houseAbilities.hacan.veryHighTradeConvoysFavorCost >= 0,
+                "houseAbilities.hacan.veryHighTradeConvoysFavorCost must be >= 0.");
+        require(
+                houseAbilities.hacan.veryHighTradeConvoysPredictionBonus >= 0,
+                "houseAbilities.hacan.veryHighTradeConvoysPredictionBonus must be >= 0.");
+        require(
+                houseAbilities.hacan.maximumTradeConvoysFavorCost >= 0,
+                "houseAbilities.hacan.maximumTradeConvoysFavorCost must be >= 0.");
+        require(
+                houseAbilities.hacan.maximumTradeConvoysPredictionBonus >= 0,
+                "houseAbilities.hacan.maximumTradeConvoysPredictionBonus must be >= 0.");
     }
 
     private void require(boolean condition, String message) {
@@ -282,13 +294,17 @@ public class CombatContestSettings {
     @Setter
     public static class Hacan {
         private int maxSubsidiesPerContest = 2;
-        private int subsidyFavorOnHit = 10;
+        private int subsidyFavorOnHit = 20;
         private int marketMakerPointsPerBet = 1;
         private int lowTradeConvoysFavorCost = 10;
-        private int lowTradeConvoysPredictionBonus = 5;
+        private int lowTradeConvoysPredictionBonus = 10;
         private int mediumTradeConvoysFavorCost = 20;
-        private int mediumTradeConvoysPredictionBonus = 10;
+        private int mediumTradeConvoysPredictionBonus = 16;
         private int highTradeConvoysFavorCost = 30;
-        private int highTradeConvoysPredictionBonus = 15;
+        private int highTradeConvoysPredictionBonus = 22;
+        private int veryHighTradeConvoysFavorCost = 40;
+        private int veryHighTradeConvoysPredictionBonus = 29;
+        private int maximumTradeConvoysFavorCost = 50;
+        private int maximumTradeConvoysPredictionBonus = 36;
     }
 }

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -129,6 +129,9 @@ public class CombatContestSettings {
                 "houseAbilities.hacan.maxSubsidiesPerContest must be >= 0.");
         require(houseAbilities.hacan.subsidyFavorOnHit >= 0, "houseAbilities.hacan.subsidyFavorOnHit must be >= 0.");
         require(
+                houseAbilities.hacan.baseCombatFavorGain >= 0,
+                "houseAbilities.hacan.baseCombatFavorGain must be >= 0.");
+        require(
                 houseAbilities.hacan.marketMakerPointsPerBet >= 0,
                 "houseAbilities.hacan.marketMakerPointsPerBet must be >= 0.");
         require(
@@ -294,8 +297,9 @@ public class CombatContestSettings {
     @Setter
     public static class Hacan {
         private int maxSubsidiesPerContest = 2;
-        private int subsidyFavorOnHit = 20;
-        private int marketMakerPointsPerBet = 1;
+        private int subsidyFavorOnHit = 10;
+        private int baseCombatFavorGain = 20;
+        private int marketMakerPointsPerBet = 2;
         private int lowTradeConvoysFavorCost = 10;
         private int lowTradeConvoysPredictionBonus = 10;
         private int mediumTradeConvoysFavorCost = 20;

--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
@@ -222,11 +222,6 @@ public class CombatReplayHacanTradeConvoysService {
 
         List<CombatReplayHacanTradeConvoysVoteEntity> votes =
                 tradeConvoysVoteRepository.findByContestId(contest.getId());
-        if (!voteService.meetsMinimumVoterThreshold(votes, CombatReplayHacanTradeConvoysVoteEntity::getDiscordUserId)) {
-            return lockNoTradeConvoys(
-                    contest,
-                    voteService.distinctVoterCount(votes, CombatReplayHacanTradeConvoysVoteEntity::getDiscordUserId));
-        }
 
         TradeConvoysTally winning = winningTally(votes);
         if (winning == null || winning.targetHouse() == null || winning.bonusPercent() <= 0) {
@@ -385,7 +380,11 @@ public class CombatReplayHacanTradeConvoysService {
                 new TradeConvoysTier(hacan.getLowTradeConvoysFavorCost(), hacan.getLowTradeConvoysPredictionBonus()),
                 new TradeConvoysTier(
                         hacan.getMediumTradeConvoysFavorCost(), hacan.getMediumTradeConvoysPredictionBonus()),
-                new TradeConvoysTier(hacan.getHighTradeConvoysFavorCost(), hacan.getHighTradeConvoysPredictionBonus()));
+                new TradeConvoysTier(hacan.getHighTradeConvoysFavorCost(), hacan.getHighTradeConvoysPredictionBonus()),
+                new TradeConvoysTier(
+                        hacan.getVeryHighTradeConvoysFavorCost(), hacan.getVeryHighTradeConvoysPredictionBonus()),
+                new TradeConvoysTier(
+                        hacan.getMaximumTradeConvoysFavorCost(), hacan.getMaximumTradeConvoysPredictionBonus()));
     }
 
     private TradeConvoysTally winningTally(List<CombatReplayHacanTradeConvoysVoteEntity> votes) {
@@ -401,7 +400,7 @@ public class CombatReplayHacanTradeConvoysService {
                                                                 CombatReplayHacanTradeConvoysVoteEntity,
                                                                 TradeConvoysOption>
                                                         tally) -> tally.voteCount())
-                                .thenComparingInt(tally -> tally.option().bonusPercent())
+                                .thenComparingInt(tally -> tradeConvoysFavorTieRank(tally.option()))
                                 .thenComparing(tally -> tally.option().targetHouse() == null
                                         ? ""
                                         : tally.option().targetHouse().displayName()))
@@ -452,8 +451,12 @@ public class CombatReplayHacanTradeConvoysService {
     private String voteSummary(Long contestId) {
         List<CombatReplayHacanTradeConvoysVoteEntity> votes = tradeConvoysVoteRepository.findByContestId(contestId);
         if (votes.isEmpty()) return "No Hacan Trade Convoys votes recorded.";
-        return voteService.voteSummary(votes, this::optionLabel) + "\nVotes needed to resolve: `"
-                + voteService.minimumAbilityVotesToResolve() + "`";
+        return voteService.voteSummary(votes, this::optionLabel);
+    }
+
+    private int tradeConvoysFavorTieRank(TradeConvoysOption option) {
+        if (option.targetHouse() == null || option.bonusPercent() <= 0) return Integer.MIN_VALUE;
+        return -option.favorCost();
     }
 
     private String optionLabel(CombatReplayHacanTradeConvoysVoteEntity vote) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayCustodianFavorScoringRule.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayCustodianFavorScoringRule.java
@@ -27,19 +27,30 @@ public class CombatReplayCustodianFavorScoringRule implements CombatReplayHouseS
 
         for (CombatReplayHouse house : CombatReplayHouse.assignmentOrder()) {
             int pointsBehind = Math.max(0, leaderPoints - seasonPointsByHouse.getOrDefault(house, 0));
-            int favor = combatFavorGain(pointsBehind);
+            int favor = combatFavorGain(house, pointsBehind);
             context.totals(house).favorPoints += favor;
             context.addFavorSummary(house, "the Custodians sealing this combat's ledger", favor, true);
         }
     }
 
     public int combatFavorGain(int pointsBehindLeader) {
+        return combatFavorGain(null, pointsBehindLeader);
+    }
+
+    public int combatFavorGain(CombatReplayHouse house, int pointsBehindLeader) {
         CombatContestSettings.HouseAbilities houseAbilities = settings.getHouseAbilities();
         int catchupBonus = Math.min(
                 houseAbilities.getMaxCatchupFavorBonus(),
                 (Math.max(0, pointsBehindLeader) / houseAbilities.getCatchupFavorPointsPerBonus())
                         * houseAbilities.getCatchupFavorBonusStep());
-        return houseAbilities.getBaseCombatFavorGain() + catchupBonus;
+        return baseCombatFavorGain(house, houseAbilities) + catchupBonus;
+    }
+
+    private int baseCombatFavorGain(CombatReplayHouse house, CombatContestSettings.HouseAbilities houseAbilities) {
+        if (house == CombatReplayHouse.HACAN) {
+            return houseAbilities.getHacan().getBaseCombatFavorGain();
+        }
+        return houseAbilities.getBaseCombatFavorGain();
     }
 
     private EnumMap<CombatReplayHouse, Integer> currentSeasonPointsByHouse(CombatReplayHouseScoringContext context) {

--- a/src/main/java/ti4/contest/replay/service/LazaxSeasonService.java
+++ b/src/main/java/ti4/contest/replay/service/LazaxSeasonService.java
@@ -288,7 +288,7 @@ public class LazaxSeasonService {
                         "Market Compact and Hacan Trade Convoys",
                         """
                         **Market Compact**
-                        Mark up to 2 side bets during discussion. Hacan gains `+1 point` for each non-Hacan player who takes this side bet. If a marked side bet hits, the Hacan also gain `+10 Favor`.
+                        Mark up to 2 side bets during discussion. Hacan gains `+1 point` for each non-Hacan player who takes this side bet. If a marked side bet hits, the Hacan also gain `+20 Favor`.
 
                         **Hacan Trade Convoys**
                         At the end of a combat, send `10`, `20`, or `30` favor to one of the other delegations. If you do so, get `5/10/15%` of their earned points in the next combat as a bonus.

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -66,7 +66,7 @@ houseAbilities:
     warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
-    subsidyFavorOnHit: 10
+    subsidyFavorOnHit: 20
     marketMakerPointsPerBet: 1
     lowTradeConvoysFavorCost: 10
     lowTradeConvoysPredictionBonus: 5

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -69,8 +69,12 @@ houseAbilities:
     subsidyFavorOnHit: 20
     marketMakerPointsPerBet: 1
     lowTradeConvoysFavorCost: 10
-    lowTradeConvoysPredictionBonus: 5
+    lowTradeConvoysPredictionBonus: 10
     mediumTradeConvoysFavorCost: 20
-    mediumTradeConvoysPredictionBonus: 10
+    mediumTradeConvoysPredictionBonus: 16
     highTradeConvoysFavorCost: 30
-    highTradeConvoysPredictionBonus: 15
+    highTradeConvoysPredictionBonus: 22
+    veryHighTradeConvoysFavorCost: 40
+    veryHighTradeConvoysPredictionBonus: 29
+    maximumTradeConvoysFavorCost: 50
+    maximumTradeConvoysPredictionBonus: 36

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -66,8 +66,9 @@ houseAbilities:
     warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
-    subsidyFavorOnHit: 20
-    marketMakerPointsPerBet: 1
+    subsidyFavorOnHit: 10
+    baseCombatFavorGain: 20
+    marketMakerPointsPerBet: 2
     lowTradeConvoysFavorCost: 10
     lowTradeConvoysPredictionBonus: 10
     mediumTradeConvoysFavorCost: 20

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -60,8 +60,9 @@ houseAbilities:
     warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
-    subsidyFavorOnHit: 20
-    marketMakerPointsPerBet: 1
+    subsidyFavorOnHit: 10
+    baseCombatFavorGain: 20
+    marketMakerPointsPerBet: 2
     lowTradeConvoysFavorCost: 10
     lowTradeConvoysPredictionBonus: 10
     mediumTradeConvoysFavorCost: 20

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -63,8 +63,12 @@ houseAbilities:
     subsidyFavorOnHit: 20
     marketMakerPointsPerBet: 1
     lowTradeConvoysFavorCost: 10
-    lowTradeConvoysPredictionBonus: 5
+    lowTradeConvoysPredictionBonus: 10
     mediumTradeConvoysFavorCost: 20
-    mediumTradeConvoysPredictionBonus: 10
+    mediumTradeConvoysPredictionBonus: 16
     highTradeConvoysFavorCost: 30
-    highTradeConvoysPredictionBonus: 15
+    highTradeConvoysPredictionBonus: 22
+    veryHighTradeConvoysFavorCost: 40
+    veryHighTradeConvoysPredictionBonus: 29
+    maximumTradeConvoysFavorCost: 50
+    maximumTradeConvoysPredictionBonus: 36

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -60,7 +60,7 @@ houseAbilities:
     warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
-    subsidyFavorOnHit: 10
+    subsidyFavorOnHit: 20
     marketMakerPointsPerBet: 1
     lowTradeConvoysFavorCost: 10
     lowTradeConvoysPredictionBonus: 5

--- a/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
@@ -16,17 +16,17 @@ class CombatSideBetTypeTest {
     }
 
     @Test
-    void hacanMarketMakerDefaultsToOnePointPerTakenMarkedBet() {
+    void hacanMarketMakerDefaultsToTwoPointsPerTakenMarkedBet() {
         CombatContestSettings settings = new CombatContestSettings();
 
-        assertEquals(1, settings.getHouseAbilities().getHacan().getMarketMakerPointsPerBet());
+        assertEquals(2, settings.getHouseAbilities().getHacan().getMarketMakerPointsPerBet());
     }
 
     @Test
     void hacanMarkedBetsGrantFavorOnHit() {
         CombatContestSettings settings = new CombatContestSettings();
 
-        assertEquals(20, settings.getHouseAbilities().getHacan().getSubsidyFavorOnHit());
+        assertEquals(10, settings.getHouseAbilities().getHacan().getSubsidyFavorOnHit());
     }
 
     @Test

--- a/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
@@ -26,7 +26,7 @@ class CombatSideBetTypeTest {
     void hacanMarkedBetsGrantFavorOnHit() {
         CombatContestSettings settings = new CombatContestSettings();
 
-        assertEquals(10, settings.getHouseAbilities().getHacan().getSubsidyFavorOnHit());
+        assertEquals(20, settings.getHouseAbilities().getHacan().getSubsidyFavorOnHit());
     }
 
     @Test

--- a/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
+++ b/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
@@ -4,23 +4,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayHacanTradeConvoysEntity;
+import ti4.contest.replay.entities.CombatReplayHacanTradeConvoysVoteEntity;
 import ti4.contest.replay.entities.CombatReplayHouseScoreEntity;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
 import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysRepository;
 import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysVoteRepository;
 import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
+import ti4.contest.replay.repository.CombatReplayHouseAbilityVoteRepository;
 import ti4.contest.replay.repository.CombatReplayHouseScoreRepository;
 import ti4.contest.replay.service.CombatReplayHouseAbilityVoteService;
 import ti4.contest.replay.service.CombatReplayHouseFavorService;
@@ -34,18 +38,27 @@ class CombatReplayHacanTradeConvoysServiceTest {
     private final CombatReplayContestRepository contestRepository = mock(CombatReplayContestRepository.class);
     private final CombatReplayHouseScoreRepository houseScoreRepository = mock(CombatReplayHouseScoreRepository.class);
     private final CombatReplayHouseFavorService houseFavorService = mock(CombatReplayHouseFavorService.class);
+    private final CombatReplayHouseAbilityUseRepository abilityUseRepository =
+            mock(CombatReplayHouseAbilityUseRepository.class);
+    private final CombatReplayHacanTradeConvoysVoteRepository tradeConvoysVoteRepository =
+            mock(CombatReplayHacanTradeConvoysVoteRepository.class);
     private final CombatContestSettings settings = new CombatContestSettings();
+    private final CombatReplayHouseAbilityVoteService voteService = new CombatReplayHouseAbilityVoteService(
+            settings,
+            mock(CombatReplayHouseAbilityUseRepository.class),
+            mock(CombatReplayHouseAbilityVoteRepository.class),
+            houseFavorService);
     private final CombatReplayHacanTradeConvoysService service = new CombatReplayHacanTradeConvoysService(
             settings,
             mock(CombatReplayHouseService.class),
             new CombatReplayHousePhaseService(settings, contestRepository),
-            mock(CombatReplayHouseAbilityVoteService.class),
+            voteService,
             houseFavorService,
             mock(CombatCandidateRepository.class),
             contestRepository,
-            mock(CombatReplayHouseAbilityUseRepository.class),
+            abilityUseRepository,
             tradeConvoysRepository,
-            mock(CombatReplayHacanTradeConvoysVoteRepository.class),
+            tradeConvoysVoteRepository,
             houseScoreRepository);
 
     @Test
@@ -99,10 +112,51 @@ class CombatReplayHacanTradeConvoysServiceTest {
         List<net.dv8tion.jda.api.components.buttons.Button> buttons =
                 service.tradeConvoysButtonsForHouse(contest, CombatReplayHouse.NAALU);
 
-        assertEquals(3, buttons.size());
+        assertEquals(5, buttons.size());
+        assertTrue(buttons.get(4).getLabel().startsWith("50 Favor: 36%"));
         assertFalse(buttons.get(0).isDisabled());
         assertTrue(buttons.get(1).isDisabled());
         assertTrue(buttons.get(2).isDisabled());
+        assertTrue(buttons.get(3).isDisabled());
+        assertTrue(buttons.get(4).isDisabled());
+    }
+
+    @Test
+    void tradeConvoysLocksWithSingleVote() {
+        CombatReplayContestEntity contest = contest(3L, 7L);
+        CombatCandidateEntity candidate = candidate(7L);
+        when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
+        when(tradeConvoysVoteRepository.findByContestId(contest.getId()))
+                .thenReturn(List.of(vote(CombatReplayHouse.NAALU, 10, 10, "user-1")));
+        when(houseFavorService.canAfford(CombatReplayHouse.HACAN, 10)).thenReturn(true);
+
+        CombatReplayHacanTradeConvoysService.TradeConvoys tradeConvoys =
+                service.lockTradeConvoysIfNeeded(contest, candidate);
+
+        assertTrue(tradeConvoys.active());
+        assertEquals(CombatReplayHouse.NAALU, tradeConvoys.targetHouse());
+        assertEquals(10, tradeConvoys.favorCost());
+        assertEquals(10, tradeConvoys.bonusPercent());
+    }
+
+    @Test
+    void tradeConvoysTieBetweenFavorOptionsLocksLowerFavorValue() {
+        CombatReplayContestEntity contest = contest(3L, 7L);
+        CombatCandidateEntity candidate = candidate(7L);
+        when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
+        when(tradeConvoysVoteRepository.findByContestId(contest.getId()))
+                .thenReturn(List.of(
+                        vote(CombatReplayHouse.NAALU, 50, 36, "user-1"),
+                        vote(CombatReplayHouse.MENTAK, 10, 10, "user-2")));
+        when(houseFavorService.canAfford(CombatReplayHouse.HACAN, 10)).thenReturn(true);
+
+        service.lockTradeConvoysIfNeeded(contest, candidate);
+
+        ArgumentCaptor<CombatReplayHacanTradeConvoysEntity> savedTradeConvoys =
+                ArgumentCaptor.forClass(CombatReplayHacanTradeConvoysEntity.class);
+        verify(tradeConvoysRepository).save(savedTradeConvoys.capture());
+        assertEquals(10, savedTradeConvoys.getValue().getFavorCost());
+        assertEquals(10, savedTradeConvoys.getValue().getPredictionBonus());
     }
 
     @Test
@@ -128,6 +182,32 @@ class CombatReplayHacanTradeConvoysServiceTest {
         convoy.setPredictionBonus(bonusPercent);
         convoy.setVoteCount(1);
         return convoy;
+    }
+
+    private CombatReplayContestEntity contest(Long contestId, Long candidateId) {
+        CombatReplayContestEntity contest = new CombatReplayContestEntity();
+        contest.setId(contestId);
+        contest.setCandidateId(candidateId);
+        return contest;
+    }
+
+    private CombatCandidateEntity candidate(Long candidateId) {
+        CombatCandidateEntity candidate = new CombatCandidateEntity();
+        candidate.setId(candidateId);
+        return candidate;
+    }
+
+    private CombatReplayHacanTradeConvoysVoteEntity vote(
+            CombatReplayHouse targetHouse, int favorCost, int bonusPercent, String discordUserId) {
+        CombatReplayHacanTradeConvoysVoteEntity vote = new CombatReplayHacanTradeConvoysVoteEntity();
+        vote.setContestId(3L);
+        vote.setTargetHouse(targetHouse);
+        vote.setFavorCost(favorCost);
+        vote.setPredictionBonus(bonusPercent);
+        vote.setDiscordUserId(discordUserId);
+        vote.setDiscordUserName(discordUserId);
+        vote.setVotedAt(LocalDateTime.now());
+        return vote;
     }
 
     private CombatReplayHouseScoreEntity score(Long contestId) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayHacanMarketCompactServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayHacanMarketCompactServiceTest.java
@@ -51,7 +51,7 @@ class CombatReplayHacanMarketCompactServiceTest {
                         sideBet("mentak-user", CombatSideBetType.ROUND_ONE_WHIFF, "sol"),
                         sideBet("mentak-user", CombatSideBetType.ROUND_ONE_SLAM, "sol")));
 
-        assertEquals(3, points);
+        assertEquals(6, points);
     }
 
     private CombatReplayHacanSubsidyEntity markedBet() {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayHouseLedgerServiceFavorTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayHouseLedgerServiceFavorTest.java
@@ -42,6 +42,12 @@ class CombatReplayHouseLedgerServiceFavorTest {
     }
 
     @Test
+    void hacanGetsHigherBaseCombatFavorGain() {
+        assertEquals(10, custodianFavorScoringRule.combatFavorGain(CombatReplayHouse.NAALU, 0));
+        assertEquals(20, custodianFavorScoringRule.combatFavorGain(CombatReplayHouse.HACAN, 0));
+    }
+
+    @Test
     void catchupFavorCanBeConfiguredBackOn() {
         settings.getHouseAbilities().setCatchupFavorBonusStep(10);
         settings.getHouseAbilities().setMaxCatchupFavorBonus(30);


### PR DESCRIPTION
## Summary
- Increase Hacan Market Compact favor gained on marked side-bet hits from 10 to 20 in dev and prod config.
- Update the Lazax season help text to match the new favor amount.

## Test Plan
- mvn -q spotless:apply
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayHacanMarketCompactServiceTest,CombatReplayHacanTradeConvoysServiceTest,CombatReplayHouseLedgerServiceFavorTest test