### PR TITLE
Increase luck omen favor cost

### DIFF
--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -55,7 +55,7 @@ houseAbilities:
     # roundOneRollPeekFavorCost: 0
     roundOneRollPeekFavorCost: 40
     # luckOmensFavorCost: 0
-    luckOmensFavorCost: 20
+    luckOmensFavorCost: 30
   mentak:
     previewLeadSeconds: 15
     # destroyerDecoyFavorCost: 0

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -52,7 +52,7 @@ houseAbilities:
   naalu:
     actionCardPeekFavorCost: 20
     roundOneRollPeekFavorCost: 40
-    luckOmensFavorCost: 20
+    luckOmensFavorCost: 30
   mentak:
     previewLeadSeconds: 900
     destroyerDecoyFavorCost: 20


### PR DESCRIPTION
## Summary
- Increase Naalu luck omen favor cost from 20 to 30 in dev and prod combat contest configs.

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn test`