### PR TITLE
Update combat replay house abilities

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -117,6 +117,19 @@ public class CombatReplayPromotionScoreBackfillCron {
         CombatReplayService.InitialCombatStats initialStats = CombatReplayService.initialCombatStats(candidate);
         if (initialStats == null) return false;
 
+        int roundsObserved = SpringContext.getBean(CombatCandidateEventRepository.class)
+                .findMaxRoundNumberByCandidateId(candidate.getId())
+                .orElse(0);
+        if (isDraw(candidate)) {
+            candidate.setPromotionScore(CombatReplayService.computeDrawPromotionScore(initialStats, roundsObserved));
+            candidate.setAttackerStrength(initialStats.attackerStrength());
+            candidate.setDefenderStrength(initialStats.defenderStrength());
+            candidate.setAttackerHp(initialStats.attackerHp());
+            candidate.setDefenderHp(initialStats.defenderHp());
+            SpringContext.getBean(CombatCandidateRepository.class).save(candidate);
+            return true;
+        }
+
         String snapshotJson = extractLatestSnapshotJson(candidate.getId());
         if (snapshotJson == null || snapshotJson.isBlank()) return false;
 
@@ -137,9 +150,6 @@ public class CombatReplayPromotionScoreBackfillCron {
                 LazaxCombatSupport.calculateFleetStrength(attacker, defender, tile, space);
         LazaxCombatSupport.FleetStrength defenderRemainingStrength =
                 LazaxCombatSupport.calculateFleetStrength(defender, attacker, tile, space);
-        int roundsObserved = SpringContext.getBean(CombatCandidateEventRepository.class)
-                .findMaxRoundNumberByCandidateId(candidate.getId())
-                .orElse(0);
         candidate.setPromotionScore(CombatReplayService.computePromotionScore(
                 candidate,
                 initialStats,
@@ -153,6 +163,10 @@ public class CombatReplayPromotionScoreBackfillCron {
         candidate.setDefenderHp(initialStats.defenderHp());
         SpringContext.getBean(CombatCandidateRepository.class).save(candidate);
         return true;
+    }
+
+    private static boolean isDraw(CombatCandidateEntity candidate) {
+        return candidate.getWinnerFaction() == null && candidate.getLoserFaction() == null;
     }
 
     private static String extractLatestSnapshotJson(Long candidateId) {

--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysButtonHandler.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysButtonHandler.java
@@ -1,6 +1,8 @@
 package ti4.contest.replay.house.hacan;
 
+import java.util.List;
 import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService.ParsedTradeConvoysButton;
 import ti4.contest.replay.service.CombatReplayInteractionResult;
@@ -15,11 +17,29 @@ public class CombatReplayHacanTradeConvoysButtonHandler {
     public static void handleHacanTradeConvoys(ButtonInteractionEvent event, String buttonId) {
         try {
             ParsedTradeConvoysButton parsed = CombatReplayHacanTradeConvoysService.parseButtonId(buttonId);
-            CombatReplayInteractionResult result = SpringContext.getBean(CombatReplayHacanTradeConvoysService.class)
-                    .recordTradeConvoysVote(event, parsed);
-            MessageHelper.sendEphemeralMessageToEventChannel(event, result.message());
+            CombatReplayHacanTradeConvoysService service =
+                    SpringContext.getBean(CombatReplayHacanTradeConvoysService.class);
+            CombatReplayInteractionResult result = service.recordTradeConvoysVote(event, parsed);
+            List<Button> sendNowButtons = service.sendNowButtons(parsed, event);
+            if (sendNowButtons.isEmpty()) {
+                MessageHelper.sendEphemeralMessageToEventChannel(event, result.message());
+            } else {
+                MessageHelper.sendMessageToEventChannelWithEphemeralButtons(event, result.message(), sendNowButtons);
+            }
         } catch (IllegalArgumentException e) {
             MessageHelper.sendEphemeralMessageToEventChannel(event, "Could not read that Hacan Trade Convoys vote.");
+        }
+    }
+
+    @ButtonHandler(CombatReplayHacanTradeConvoysService.HACAN_TRADE_CONVOYS_SEND_NOW_PREFIX)
+    public static void handleHacanTradeConvoysSendNow(ButtonInteractionEvent event, String buttonId) {
+        try {
+            ParsedTradeConvoysButton parsed = CombatReplayHacanTradeConvoysService.parseButtonId(buttonId);
+            CombatReplayInteractionResult result = SpringContext.getBean(CombatReplayHacanTradeConvoysService.class)
+                    .sendTradeConvoysNow(event, parsed);
+            MessageHelper.sendEphemeralMessageToEventChannel(event, result.message());
+        } catch (IllegalArgumentException e) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "Could not read that Hacan Trade Convoys request.");
         }
     }
 }

--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.StringUtils;
@@ -48,8 +49,10 @@ import ti4.service.emoji.FactionEmojis;
 public class CombatReplayHacanTradeConvoysService {
 
     public static final String HACAN_TRADE_CONVOYS_PREFIX = "combatReplayHacanTradeConvoys_";
+    public static final String HACAN_TRADE_CONVOYS_SEND_NOW_PREFIX = "combatReplayHacanTradeConvoysSendNow_";
 
     private static final String DELIMITER = "~";
+    private static final String HACAN_CEO_ROLE_NAME = "Hacan CEO";
     private final CombatContestSettings settings;
     private final CombatReplayHouseService houseService;
     private final CombatReplayHousePhaseService phaseService;
@@ -77,6 +80,7 @@ public class CombatReplayHacanTradeConvoysService {
             CombatReplayContestEntity contest,
             CombatCandidateEntity candidate,
             List<HousePredictionSummary> currentCombatSummaries) {
+        lockPreviousTradeConvoysIfCurrentCombatEnded(contest);
         if (!canOfferTradeConvoys(contest, candidate)) return;
         postTradeConvoysVotingButtons(contest, hacanFavorLedger(contest, currentCombatSummaries));
     }
@@ -106,7 +110,7 @@ public class CombatReplayHacanTradeConvoysService {
                 channel,
                 "## " + FactionEmojis.getFactionIcon(CombatReplayHouse.HACAN.displayName())
                         + " Hacan Delegation Trade Convoys\n"
-                        + CombatReplayAbilityWindowText.votesLockWhenNextContestPostsLine()
+                        + CombatReplayAbilityWindowText.votesLockWhenNextCombatEndsLine()
                         + "\n"
                         + favorBalanceLine(favorLedger)
                         + "\n"
@@ -126,7 +130,6 @@ public class CombatReplayHacanTradeConvoysService {
                 && contest != null
                 && contest.getId() != null
                 && candidate != null
-                && !contestRepository.existsByIdGreaterThan(contest.getId())
                 && tradeConvoysRepository.findByContestId(contest.getId()).isEmpty();
     }
 
@@ -148,7 +151,7 @@ public class CombatReplayHacanTradeConvoysService {
                 "## "
                         + FactionEmojis.getFactionIcon(CombatReplayHouse.HACAN.displayName())
                         + " Hacan Delegation Trade Convoys\n"
-                        + CombatReplayAbilityWindowText.votesLockWhenNextContestPostsLine()
+                        + CombatReplayAbilityWindowText.votesLockWhenNextCombatEndsLine()
                         + "\n"
                         + favorBalanceLine(null)
                         + "\n"
@@ -209,6 +212,56 @@ public class CombatReplayHacanTradeConvoysService {
     }
 
     @Transactional
+    public synchronized CombatReplayInteractionResult sendTradeConvoysNow(
+            ButtonInteractionEvent event, ParsedTradeConvoysButton request) {
+        if (!settings.isHousesEnabled())
+            return CombatReplayInteractionResult.rejected("Hacan Delegation Trade Convoys is disabled.");
+        if (!userCanSendTradeConvoysNow(event)) {
+            return CombatReplayInteractionResult.rejected("Only Hacan CEO may send Trade Convoys now.");
+        }
+        if (!isValidRequest(request) || isDoNotUse(request)) {
+            return CombatReplayInteractionResult.rejected("That Hacan Trade Convoys option is not available.");
+        }
+        CombatReplayContestEntity contest = tradeConvoysContest(request.contestId());
+        if (!votingOpen(contest))
+            return CombatReplayInteractionResult.rejected("The Hacan Trade Convoys window is closed.");
+        if (tradeConvoysRepository.findByContestId(request.contestId()).isPresent()) {
+            return CombatReplayInteractionResult.rejected("Hacan Trade Convoys has already resolved for this combat.");
+        }
+        CombatCandidateEntity candidate = contest == null || contest.getCandidateId() == null
+                ? null
+                : candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        if (candidate == null || candidate.getId() == null) {
+            return CombatReplayInteractionResult.rejected("Could not find the combat for that Trade Convoys option.");
+        }
+        if (!houseFavorService.canAfford(CombatReplayHouse.HACAN, request.favorCost())) {
+            return CombatReplayInteractionResult.rejected(
+                    "Hacan Delegation does not have enough Favor for that Trade Convoys option.");
+        }
+        if (!claimHacanTradeConvoysUse(
+                candidate.getId(),
+                request.favorCost(),
+                event.getUser().getId(),
+                event.getUser().getEffectiveName())) {
+            return CombatReplayInteractionResult.rejected("Hacan Trade Convoys has already resolved for this combat.");
+        }
+
+        CombatReplayHacanTradeConvoysEntity tradeConvoys = new CombatReplayHacanTradeConvoysEntity();
+        tradeConvoys.setContestId(contest.getId());
+        tradeConvoys.setTargetHouse(request.targetHouse());
+        tradeConvoys.setFavorCost(request.favorCost());
+        tradeConvoys.setPredictionBonus(request.bonusPercent());
+        tradeConvoys.setVoteCount(1);
+        tradeConvoys.setSelectedAt(LocalDateTime.now());
+        tradeConvoysRepository.save(tradeConvoys);
+        creditTradeConvoysFavorTransferIfScored(tradeConvoys);
+        postLockedTradeConvoysSummary(tradeConvoys);
+
+        return CombatReplayInteractionResult.accepted(
+                "Sent Hacan Trade Convoys now for **" + optionLabel(request) + "**.");
+    }
+
+    @Transactional
     public synchronized TradeConvoys lockTradeConvoysIfNeeded(
             CombatReplayContestEntity contest, CombatCandidateEntity candidate) {
         if (!settings.isHousesEnabled()) return TradeConvoys.none();
@@ -246,6 +299,7 @@ public class CombatReplayHacanTradeConvoysService {
         tradeConvoys.setVoteCount(winning.voteCount());
         tradeConvoys.setSelectedAt(LocalDateTime.now());
         tradeConvoysRepository.save(tradeConvoys);
+        creditTradeConvoysFavorTransferIfScored(tradeConvoys);
         postLockedTradeConvoysSummary(tradeConvoys);
         return toTradeConvoys(tradeConvoys);
     }
@@ -314,6 +368,15 @@ public class CombatReplayHacanTradeConvoysService {
         return tradeConvoysButtonsForHouse(contest, target, houseFavorService.ledger(CombatReplayHouse.HACAN));
     }
 
+    public List<Button> sendNowButtons(ParsedTradeConvoysButton request, ButtonInteractionEvent event) {
+        if (!isValidRequest(request) || isDoNotUse(request) || !userCanSendTradeConvoysNow(event)) return List.of();
+        return List.of(Buttons.green(
+                formatSendNowButtonId(
+                        request.contestId(), request.targetHouse(), request.favorCost(), request.bonusPercent()),
+                "Send Now",
+                FactionEmojis.Hacan));
+    }
+
     private List<Button> tradeConvoysButtonsForHouse(
             CombatReplayContestEntity contest,
             CombatReplayHouse target,
@@ -356,6 +419,23 @@ public class CombatReplayHacanTradeConvoysService {
         return phaseService.postCombatVoteOpen(contest);
     }
 
+    public void lockPreviousTradeConvoysIfCurrentCombatEnded(CombatReplayContestEntity currentContest) {
+        if (currentContest == null || currentContest.getId() == null || currentContest.getReplayCompletedAt() == null)
+            return;
+        CombatReplayContestEntity previousContest = contestRepository
+                .findFirstByIdLessThanOrderByIdDesc(currentContest.getId())
+                .orElse(null);
+        if (previousContest == null
+                || previousContest.getCandidateId() == null
+                || (previousContest.getReplayCompletedAt() == null && previousContest.getLeaderboardPostedAt() == null))
+            return;
+        CombatCandidateEntity previousCandidate =
+                candidateRepository.findById(previousContest.getCandidateId()).orElse(null);
+        if (previousCandidate != null) {
+            lockTradeConvoysIfNeeded(previousContest, previousCandidate);
+        }
+    }
+
     public boolean userHasHouse(String discordUserId) {
         if (settings.getRuntime().isDevMode()) return true;
         return houseService.houseForUser(discordUserId) == CombatReplayHouse.HACAN;
@@ -363,6 +443,14 @@ public class CombatReplayHacanTradeConvoysService {
 
     private boolean userHasHacan(String discordUserId) {
         return userHasHouse(discordUserId);
+    }
+
+    private boolean userCanSendTradeConvoysNow(ButtonInteractionEvent event) {
+        if (settings.getRuntime().isDevMode()) return true;
+        if (event == null) return false;
+        Member member = event.getMember();
+        return member != null
+                && member.getRoles().stream().anyMatch(role -> HACAN_CEO_ROLE_NAME.equals(role.getName()));
     }
 
     private boolean isValidRequest(ParsedTradeConvoysButton request) {
@@ -488,6 +576,22 @@ public class CombatReplayHacanTradeConvoysService {
         if (channel != null) MessageHelper.sendMessageToChannel(channel, message);
     }
 
+    private void creditTradeConvoysFavorTransferIfScored(CombatReplayHacanTradeConvoysEntity tradeConvoys) {
+        if (tradeConvoys == null
+                || tradeConvoys.getContestId() == null
+                || tradeConvoys.getTargetHouse() == null
+                || safeInt(tradeConvoys.getFavorCost()) <= 0) {
+            return;
+        }
+        houseScoreRepository
+                .findByContestIdAndHouse(tradeConvoys.getContestId(), tradeConvoys.getTargetHouse())
+                .ifPresent(score -> {
+                    score.setFavorPoints(safeInt(score.getFavorPoints()) + safeInt(tradeConvoys.getFavorCost()));
+                    score.setScoredAt(LocalDateTime.now());
+                    houseScoreRepository.saveAndFlush(score);
+                });
+    }
+
     String hacanLockedTradeConvoysMessage(CombatReplayHacanTradeConvoysEntity tradeConvoys) {
         return lockedTradeConvoysHeader()
                 + "\n"
@@ -572,11 +676,27 @@ public class CombatReplayHacanTradeConvoysService {
                 + predictionBonus;
     }
 
+    private static String formatSendNowButtonId(
+            Long contestId, CombatReplayHouse targetHouse, int favorCost, int predictionBonus) {
+        return HACAN_TRADE_CONVOYS_SEND_NOW_PREFIX
+                + contestId
+                + DELIMITER
+                + targetHouse.name()
+                + DELIMITER
+                + favorCost
+                + DELIMITER
+                + predictionBonus;
+    }
+
     public static ParsedTradeConvoysButton parseButtonId(String buttonId) {
-        if (buttonId == null || !buttonId.startsWith(HACAN_TRADE_CONVOYS_PREFIX)) {
+        if (buttonId == null
+                || (!buttonId.startsWith(HACAN_TRADE_CONVOYS_PREFIX)
+                        && !buttonId.startsWith(HACAN_TRADE_CONVOYS_SEND_NOW_PREFIX))) {
             throw new IllegalArgumentException("Unknown Hacan Trade Convoys button id: " + buttonId);
         }
-        String encoded = buttonId.substring(HACAN_TRADE_CONVOYS_PREFIX.length());
+        String encoded = buttonId.startsWith(HACAN_TRADE_CONVOYS_SEND_NOW_PREFIX)
+                ? buttonId.substring(HACAN_TRADE_CONVOYS_SEND_NOW_PREFIX.length())
+                : buttonId.substring(HACAN_TRADE_CONVOYS_PREFIX.length());
         String[] parts = encoded.split(DELIMITER, 4);
         if (parts.length != 4)
             throw new IllegalArgumentException("Malformed Hacan Trade Convoys button id: " + buttonId);

--- a/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
+++ b/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
@@ -17,7 +17,6 @@ import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.core.CombatRollPayload;
-import ti4.contest.replay.core.renderers.CombatRollPayloadRenderer;
 import ti4.contest.replay.dispatch.ReplayDispatchPayload;
 import ti4.contest.replay.dispatch.ReplayDispatchSerializer;
 import ti4.contest.replay.entities.CombatCandidateEntity;
@@ -246,7 +245,7 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
             if (!isCombatRoundRoll(combatRoll.payload())) continue;
 
             CombatRollPayload payloadWithDecoys = CombatReplayDecoys.applyToRoll(combatRoll.payload(), abilities);
-            String rendered = CombatRollPayloadRenderer.render(payloadWithDecoys);
+            String rendered = renderRoundOneRollSummary(payloadWithDecoys);
             if (StringUtils.isBlank(rendered)) continue;
             rolls.add("### " + actor(game, event.getActorFaction()) + "\n" + rendered.strip());
         }
@@ -255,6 +254,12 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
             return "## Gift of Foresight: Round 1 Rolls\nNo first-round combat rolls have surfaced yet.";
         }
         return "## Gift of Foresight: Round 1 Rolls\n" + String.join("\n\n", rolls);
+    }
+
+    private String renderRoundOneRollSummary(CombatRollPayload payload) {
+        if (payload == null || payload.total() == null) return "";
+        int totalHits = payload.total().displayedTotalHits();
+        return "**Total hits " + totalHits + "** " + ":boom:".repeat(Math.max(0, totalHits));
     }
 
     public String renderLuckOmens(long contestId) {

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
@@ -22,6 +22,8 @@ public interface CombatReplayContestRepository extends JpaRepository<CombatRepla
 
     boolean existsByIdGreaterThan(Long id);
 
+    boolean existsByIdGreaterThanAndReplayCompletedAtIsNotNull(Long id);
+
     List<CombatReplayContestEntity> findByReplayStatusInAndNextReplayAtLessThanEqualOrderByNextReplayAtAsc(
             Collection<CombatContestReplayStatus> replayStatuses, LocalDateTime nextReplayAt);
 

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayHouseScoreRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayHouseScoreRepository.java
@@ -1,12 +1,15 @@
 package ti4.contest.replay.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.entities.CombatReplayHouseScoreEntity;
 
 public interface CombatReplayHouseScoreRepository extends JpaRepository<CombatReplayHouseScoreEntity, Long> {
     List<CombatReplayHouseScoreEntity> findByContestId(Long contestId);
+
+    Optional<CombatReplayHouseScoreEntity> findByContestIdAndHouse(Long contestId, CombatReplayHouse house);
 
     List<CombatReplayHouseScoreEntity> findByHouse(CombatReplayHouse house);
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayAbilityWindowText.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayAbilityWindowText.java
@@ -13,6 +13,10 @@ public class CombatReplayAbilityWindowText {
         return "-# Votes lock when the next contest is posted.";
     }
 
+    public String votesLockWhenNextCombatEndsLine() {
+        return "-# Votes lock when the next combat ends.";
+    }
+
     private String formatDuration(int seconds) {
         if (seconds <= 0) return "0 minutes";
         if (seconds < 60) return seconds + " " + (seconds == 1 ? "second" : "seconds");

--- a/src/main/java/ti4/contest/replay/service/CombatReplayHousePhaseService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayHousePhaseService.java
@@ -42,7 +42,7 @@ public class CombatReplayHousePhaseService {
         return settings.isHousesEnabled()
                 && contest != null
                 && contest.getId() != null
-                && !contestRepository.existsByIdGreaterThan(contest.getId())
+                && !contestRepository.existsByIdGreaterThanAndReplayCompletedAtIsNotNull(contest.getId())
                 && (contest.getReplayCompletedAt() != null || contest.getLeaderboardPostedAt() != null);
     }
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -142,6 +142,7 @@ public class CombatReplayLeaderboardService {
         if (replayContest.getId() == null) return;
         if (replayContest.getLeaderboardPostedAt() != null) return;
 
+        hacanTradeConvoysService.lockPreviousTradeConvoysIfCurrentCombatEnded(replayContest);
         ScoredContestResult result = scoreReplayContest(candidate, replayContest);
         MessageChannel threadOrChannel = getContestThreadOrChannel(replayContest);
         if (threadOrChannel != null) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -425,6 +425,7 @@ public class CombatReplayPromotionService {
 
     private void lockPreviousContestTradeConvoys(CombatReplayContestEntity newContest) {
         if (newContest == null || newContest.getId() == null) return;
+        if (!isPostCombat(newContest)) return;
         CombatReplayContestEntity previousContest = replayContestRepository
                 .findFirstByIdLessThanOrderByIdDesc(newContest.getId())
                 .orElse(null);

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -641,7 +641,7 @@ public class CombatReplayService {
         return roundScore + openingBalanceScore + endingTensionScore + defenderWinBonus;
     }
 
-    private static double computeDrawPromotionScore(InitialCombatStats initialStats, int roundsObserved) {
+    public static double computeDrawPromotionScore(InitialCombatStats initialStats, int roundsObserved) {
         double weakerHp = Math.min(initialStats.attackerHp(), initialStats.defenderHp());
         double weakerStrength = Math.min(initialStats.attackerStrength(), initialStats.defenderStrength());
         double strongerStrength = Math.max(initialStats.attackerStrength(), initialStats.defenderStrength());
@@ -649,7 +649,7 @@ public class CombatReplayService {
         double strengthRatio = safeRatio(weakerStrength, strongerStrength);
         double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
         double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
-        return roundScore + openingBalanceScore + 5.0;
+        return roundScore + openingBalanceScore;
     }
 
     public static InitialCombatStats initialCombatStats(CombatCandidateEntity candidate) {

--- a/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
+++ b/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import ti4.contest.replay.core.CombatContestSettings;
@@ -30,12 +32,14 @@ import ti4.contest.replay.service.CombatReplayHouseAbilityVoteService;
 import ti4.contest.replay.service.CombatReplayHouseFavorService;
 import ti4.contest.replay.service.CombatReplayHousePhaseService;
 import ti4.contest.replay.service.CombatReplayHouseService;
+import ti4.contest.replay.service.CombatReplayInteractionResult;
 
 class CombatReplayHacanTradeConvoysServiceTest {
 
     private final CombatReplayHacanTradeConvoysRepository tradeConvoysRepository =
             mock(CombatReplayHacanTradeConvoysRepository.class);
     private final CombatReplayContestRepository contestRepository = mock(CombatReplayContestRepository.class);
+    private final CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
     private final CombatReplayHouseScoreRepository houseScoreRepository = mock(CombatReplayHouseScoreRepository.class);
     private final CombatReplayHouseFavorService houseFavorService = mock(CombatReplayHouseFavorService.class);
     private final CombatReplayHouseAbilityUseRepository abilityUseRepository =
@@ -54,7 +58,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
             new CombatReplayHousePhaseService(settings, contestRepository),
             voteService,
             houseFavorService,
-            mock(CombatCandidateRepository.class),
+            candidateRepository,
             contestRepository,
             abilityUseRepository,
             tradeConvoysRepository,
@@ -82,14 +86,15 @@ class CombatReplayHacanTradeConvoysServiceTest {
     }
 
     @Test
-    void tradeConvoysVotingOnlyOpensAfterCombatAndBeforeNextContest() {
+    void tradeConvoysVotingOnlyClosesAfterLaterCombatCompletes() {
         CombatCandidateEntity candidate = new CombatCandidateEntity();
         candidate.setId(7L);
         CombatReplayContestEntity contest = new CombatReplayContestEntity();
         contest.setId(3L);
         contest.setCandidateId(candidate.getId());
         when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
-        when(contestRepository.existsByIdGreaterThan(contest.getId())).thenReturn(false);
+        when(contestRepository.existsByIdGreaterThanAndReplayCompletedAtIsNotNull(contest.getId()))
+                .thenReturn(false);
 
         assertFalse(service.shouldOfferVoting(contest, candidate));
 
@@ -97,7 +102,8 @@ class CombatReplayHacanTradeConvoysServiceTest {
 
         assertTrue(service.shouldOfferVoting(contest, candidate));
 
-        when(contestRepository.existsByIdGreaterThan(contest.getId())).thenReturn(true);
+        when(contestRepository.existsByIdGreaterThanAndReplayCompletedAtIsNotNull(contest.getId()))
+                .thenReturn(true);
 
         assertFalse(service.shouldOfferVoting(contest, candidate));
     }
@@ -140,6 +146,31 @@ class CombatReplayHacanTradeConvoysServiceTest {
     }
 
     @Test
+    void openingNewPostCombatWindowLocksPreviousTradeConvoys() {
+        CombatReplayContestEntity previousContest = contest(3L, 7L);
+        previousContest.setReplayCompletedAt(LocalDateTime.now().minusMinutes(10));
+        CombatReplayContestEntity currentContest = contest(4L, 8L);
+        currentContest.setReplayCompletedAt(LocalDateTime.now());
+        CombatCandidateEntity currentCandidate = candidate(8L);
+
+        when(contestRepository.findFirstByIdLessThanOrderByIdDesc(currentContest.getId()))
+                .thenReturn(Optional.of(previousContest));
+        when(candidateRepository.findById(previousContest.getCandidateId())).thenReturn(Optional.of(candidate(7L)));
+        when(tradeConvoysRepository.findByContestId(previousContest.getId())).thenReturn(Optional.empty());
+        when(tradeConvoysVoteRepository.findByContestId(previousContest.getId()))
+                .thenReturn(List.of(vote(CombatReplayHouse.NAALU, 10, 10, "user-1")));
+        when(houseFavorService.canAfford(CombatReplayHouse.HACAN, 10)).thenReturn(true);
+
+        service.postPostCombatTradeConvoysButtonsIfNeeded(currentContest, currentCandidate);
+
+        ArgumentCaptor<CombatReplayHacanTradeConvoysEntity> savedTradeConvoys =
+                ArgumentCaptor.forClass(CombatReplayHacanTradeConvoysEntity.class);
+        verify(tradeConvoysRepository).save(savedTradeConvoys.capture());
+        assertEquals(previousContest.getId(), savedTradeConvoys.getValue().getContestId());
+        assertEquals(CombatReplayHouse.NAALU, savedTradeConvoys.getValue().getTargetHouse());
+    }
+
+    @Test
     void tradeConvoysTieBetweenFavorOptionsLocksLowerFavorValue() {
         CombatReplayContestEntity contest = contest(3L, 7L);
         CombatCandidateEntity candidate = candidate(7L);
@@ -171,6 +202,54 @@ class CombatReplayHacanTradeConvoysServiceTest {
         assertFalse(targetMessage.contains("15%"));
         assertFalse(targetMessage.contains("earned points"));
         assertFalse(targetMessage.contains("will gain"));
+    }
+
+    @Test
+    void sendNowImmediatelyLocksAndCreditsFavorInDevMode() {
+        settings.getRuntime().setDevMode(true);
+        CombatReplayContestEntity contest = contest(3L, 7L);
+        contest.setReplayCompletedAt(LocalDateTime.now());
+        CombatCandidateEntity candidate = candidate(7L);
+        ButtonInteractionEvent event = mock(ButtonInteractionEvent.class);
+        User user = mock(User.class);
+        CombatReplayHouseScoreEntity targetScore = score(contest.getId());
+        targetScore.setHouse(CombatReplayHouse.NAALU);
+        targetScore.setFavorPoints(5);
+
+        when(event.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn("user-1");
+        when(user.getEffectiveName()).thenReturn("User 1");
+        when(contestRepository.findById(contest.getId())).thenReturn(Optional.of(contest));
+        when(contestRepository.existsByIdGreaterThanAndReplayCompletedAtIsNotNull(contest.getId()))
+                .thenReturn(false);
+        when(candidateRepository.findById(candidate.getId())).thenReturn(Optional.of(candidate));
+        when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
+        when(houseFavorService.canAfford(CombatReplayHouse.HACAN, 10)).thenReturn(true);
+        when(houseScoreRepository.findByContestIdAndHouse(contest.getId(), CombatReplayHouse.NAALU))
+                .thenReturn(Optional.of(targetScore));
+
+        CombatReplayInteractionResult result = service.sendTradeConvoysNow(
+                event,
+                new CombatReplayHacanTradeConvoysService.ParsedTradeConvoysButton(
+                        contest.getId(), CombatReplayHouse.NAALU, 10, 10));
+
+        assertTrue(result.accepted());
+        assertEquals(15, targetScore.getFavorPoints());
+        verify(tradeConvoysRepository)
+                .save(org.mockito.ArgumentMatchers.any(CombatReplayHacanTradeConvoysEntity.class));
+        verify(houseScoreRepository).saveAndFlush(targetScore);
+    }
+
+    @Test
+    void tradeConvoysParserAcceptsSendNowButtons() {
+        CombatReplayHacanTradeConvoysService.ParsedTradeConvoysButton parsed =
+                CombatReplayHacanTradeConvoysService.parseButtonId(
+                        CombatReplayHacanTradeConvoysService.HACAN_TRADE_CONVOYS_SEND_NOW_PREFIX + "3~NAALU~10~10");
+
+        assertEquals(3L, parsed.contestId());
+        assertEquals(CombatReplayHouse.NAALU, parsed.targetHouse());
+        assertEquals(10, parsed.favorCost());
+        assertEquals(10, parsed.bonusPercent());
     }
 
     private CombatReplayHacanTradeConvoysEntity convoy(

--- a/src/test/java/ti4/contest/replay/service/CombatReplayNaaluAbilityServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayNaaluAbilityServiceTest.java
@@ -67,7 +67,7 @@ class CombatReplayNaaluAbilityServiceTest {
     }
 
     @Test
-    void roundOneRollPeekAppliesReplayDecoys() throws Exception {
+    void roundOneRollPeekOnlyShowsTotalHits() throws Exception {
         CombatCandidateEntity candidate = candidate();
         candidate.setReplayAbilitiesJson(JsonMapperManager.basic()
                 .writeValueAsString(new CombatReplayDecoys.Abilities(
@@ -83,7 +83,11 @@ class CombatReplayNaaluAbilityServiceTest {
 
         String peek = service.renderRoundOneRollPeek(1L);
 
-        assertTrue(peek.contains("`2x`"));
+        assertTrue(peek.contains("### naalu"));
+        assertTrue(peek.contains("**Total hits 0**"));
+        assertFalse(peek.contains("`2x`"));
+        assertFalse(peek.contains("Destroyer"));
+        assertFalse(peek.contains("hits on"));
     }
 
     @Test

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -86,6 +86,15 @@ class CombatReplayServiceTest {
     }
 
     @Test
+    void drawPromotionScoreHasNoFlatBonus() {
+        CombatReplayService.InitialCombatStats initialStats = initialStats(10, 10, 8, 8);
+
+        double score = CombatReplayService.computeDrawPromotionScore(initialStats, 4);
+
+        assertEquals(2.9, score, 0.0001);
+    }
+
+    @Test
     void promotionScoreUsesInitialSnapshotStatsInsteadOfObservationStats() {
         CombatCandidateEntity candidate = candidate("letnev", "hacan");
         CombatReplayService.InitialCombatStats staleObservationStats = initialStats(13.0, 11.5, 11.0, 7.0);


### PR DESCRIPTION
## Summary
- Add Hacan Trade Convoys Send Now handling and keep convoy windows open until the next combat completes
- Simplify Naalu round-one previews to private total-hit summaries
- Remove the flat draw promotion-score bump and make the backfill cron recompute draw scores

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayHacanTradeConvoysServiceTest,CombatReplayContestLifecycleServiceTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayNaaluAbilityServiceTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayServiceTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests compile