### PR TITLE
Remove defender promotion score bonus

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -637,8 +637,7 @@ public class CombatReplayService {
         double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
         double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
         double endingTensionScore = winnerRemainingHp <= 0 ? 0.0 : 5.0 * Math.exp(-6.0 * winnerSurvivalRatio);
-        double defenderWinBonus = winnerFaction.equalsIgnoreCase(candidate.getDefenderFaction()) ? 0.5 : 0.0;
-        return roundScore + openingBalanceScore + endingTensionScore + defenderWinBonus;
+        return roundScore + openingBalanceScore + endingTensionScore;
     }
 
     public static double computeDrawPromotionScore(InitialCombatStats initialStats, int roundsObserved) {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -65,13 +65,13 @@ class CombatReplayServiceTest {
                 "muaat",
                 4);
 
-        assertEquals(2.7033, blowoutScore, 0.0001);
-        assertEquals(4.1705, squeakerScore, 0.0001);
+        assertEquals(2.2033, blowoutScore, 0.0001);
+        assertEquals(3.6705, squeakerScore, 0.0001);
         assertTrue(squeakerScore > blowoutScore);
     }
 
     @Test
-    void promotionScoreAddsHalfPointBonusWhenDefenderWins() {
+    void promotionScoreDoesNotDependOnAttackerOrDefenderRole() {
         CombatCandidateEntity candidate = candidate("sol", "yin");
         CombatReplayService.InitialCombatStats initialStats = initialStats(12, 12, 8, 8);
 
@@ -82,7 +82,7 @@ class CombatReplayServiceTest {
         double defenderWinScore = CombatReplayService.computePromotionScore(
                 candidate, initialStats, attackerRemaining, defenderRemaining, "yin", 2);
 
-        assertEquals(attackerWinScore + 0.5, defenderWinScore, 0.0001);
+        assertEquals(attackerWinScore, defenderWinScore, 0.0001);
     }
 
     @Test
@@ -107,8 +107,8 @@ class CombatReplayServiceTest {
         double snapshotScore = CombatReplayService.computePromotionScore(
                 candidate, replaySnapshotStats, attackerRemaining, defenderRemaining, "hacan", 3);
 
-        assertEquals(2.7074, staleScore, 0.0001);
-        assertEquals(1.4888, snapshotScore, 0.0001);
+        assertEquals(2.2074, staleScore, 0.0001);
+        assertEquals(0.9888, snapshotScore, 0.0001);
         assertTrue(snapshotScore < staleScore);
     }
 


### PR DESCRIPTION
## Summary
- Remove the flat +0.5 defender-win bonus from combat replay promotion scoring
- Update promotion score tests to assert attacker/defender role neutrality
- Confirm the promotion score backfill cron recomputes winner outcomes through the shared scorer, so historical scores pick up this formula change

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayServiceTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests compile