### PR TITLE
Fix Hacan Trade Convoys repost command

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatReplayHouse.java
+++ b/src/main/java/ti4/contest/replay/core/CombatReplayHouse.java
@@ -23,7 +23,7 @@ public enum CombatReplayHouse {
     }
 
     public String roleName() {
-        return displayName + " Delegation";
+        return displayName + "Delegation";
     }
 
     public String channelName() {

--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
@@ -86,14 +86,15 @@ public class CombatReplayHacanTradeConvoysService {
     }
 
     public boolean repostOpenTradeConvoysVotingButtons() {
-        CombatReplayContestEntity contest =
-                contestRepository.findFirstByOrderByIdDesc().orElse(null);
-        CombatCandidateEntity candidate = contest == null || contest.getCandidateId() == null
-                ? null
-                : candidateRepository.findById(contest.getCandidateId()).orElse(null);
-        if (!shouldOfferVoting(contest, candidate)) return false;
-        postTradeConvoysVotingButtons(contest);
-        return true;
+        for (CombatReplayContestEntity contest : contestRepository.findAllByOrderByIdDesc()) {
+            CombatCandidateEntity candidate = contest == null || contest.getCandidateId() == null
+                    ? null
+                    : candidateRepository.findById(contest.getCandidateId()).orElse(null);
+            if (!shouldOfferVoting(contest, candidate)) continue;
+            postTradeConvoysVotingButtons(contest);
+            return true;
+        }
+        return false;
     }
 
     private void postTradeConvoysVotingButtons(CombatReplayContestEntity contest) {

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
@@ -20,6 +20,8 @@ public interface CombatReplayContestRepository extends JpaRepository<CombatRepla
 
     Optional<CombatReplayContestEntity> findFirstByOrderByIdDesc();
 
+    List<CombatReplayContestEntity> findAllByOrderByIdDesc();
+
     boolean existsByIdGreaterThan(Long id);
 
     boolean existsByIdGreaterThanAndReplayCompletedAtIsNotNull(Long id);

--- a/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayHouseService.java
@@ -293,16 +293,16 @@ public class CombatReplayHouseService {
         if (guild == null || member == null) return "Could not update your Lazax delegation role.";
 
         Role role = findRole(guild, assignment.getHouse());
-        if (role == null) return "Could not find the " + assignment.getHouse().displayName() + " Delegation role.";
+        if (role == null) return "Could not find the " + assignment.getHouse().roleName() + " role.";
 
         if (member.getRoles().contains(role)) {
             guild.removeRoleFromMember(member, role).queue(null, BotLogger::catchRestError);
-            return "Removed your **" + assignment.getHouse().displayName()
-                    + " Delegation** role. Your delegation assignment is unchanged.";
+            return "Removed your **" + assignment.getHouse().roleName()
+                    + "** role. Your delegation assignment is unchanged.";
         }
 
         grantHouseRole(guild, member, assignment.getHouse(), null);
-        return "Added your **" + assignment.getHouse().displayName() + " Delegation** role.";
+        return "Added your **" + assignment.getHouse().roleName() + "** role.";
     }
 
     public synchronized String toggleHouseOptIn(Guild guild, Member member, User user) {
@@ -375,9 +375,9 @@ public class CombatReplayHouseService {
     }
 
     private String houseRoleMention(Guild guild, CombatReplayHouse house) {
-        if (guild == null) return "**" + house.displayName() + " Delegation**";
+        if (guild == null) return "**" + house.roleName() + "**";
         Role role = findRole(guild, house);
-        return role == null ? "**" + house.displayName() + " Delegation**" : role.getAsMention();
+        return role == null ? "**" + house.roleName() + "**" : role.getAsMention();
     }
 
     public List<CombatReplayHouseEntity> allHouseAssignments() {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -116,6 +116,10 @@ public class CombatReplayPromotionService {
             return CombatReplayContestLifecycleService.ForcePromoteResult.rejected(
                     "Candidate uses the old replay snapshot format");
         }
+        if (expireIfDiscordantStars(candidate)) {
+            return CombatReplayContestLifecycleService.ForcePromoteResult.rejected(
+                    "Discordant Stars games are not eligible for promotion.");
+        }
 
         CombatReplayContestEntity existingContest =
                 replayContestRepository.findByCandidateId(candidateId).orElse(null);
@@ -169,6 +173,7 @@ public class CombatReplayPromotionService {
                     CombatCandidatePromotionStatus.PENDING,
                     now.minusHours(lookbackHours));
             candidates = candidates.stream()
+                    .filter(candidate -> !expireIfDiscordantStars(candidate))
                     .filter(this::usesCurrentReplaySnapshotFormat)
                     .toList();
             if (!candidates.isEmpty()) return candidates;
@@ -184,6 +189,8 @@ public class CombatReplayPromotionService {
 
     private CombatReplayContestEntity promoteCandidate(
             CombatCandidateEntity winner, CombatReplayContestEntity existingContest) {
+        if (expireIfDiscordantStars(winner)) return null;
+
         CombatObservationEntity observation =
                 observationRepository.findById(winner.getObservationId()).orElse(null);
         if (observation == null) return null;
@@ -288,6 +295,8 @@ public class CombatReplayPromotionService {
 
     private CombatReplayContestEntity postMentakPreview(CombatCandidateEntity candidate) {
         try {
+            if (expireIfDiscordantStars(candidate)) return null;
+
             CombatObservationEntity observation =
                     observationRepository.findById(candidate.getObservationId()).orElse(null);
             Game game = loadGame(candidate.getGameName());
@@ -353,6 +362,16 @@ public class CombatReplayPromotionService {
 
     private boolean usesCurrentReplaySnapshotFormat(CombatCandidateEntity candidate) {
         return candidate != null && CombatReplayTileRenderer.canRender(candidate.getInitialRenderSnapshotJson());
+    }
+
+    private boolean expireIfDiscordantStars(CombatCandidateEntity candidate) {
+        if (candidate == null || candidate.getPromotionStatus() != CombatCandidatePromotionStatus.PENDING) return false;
+        Game game = loadGame(candidate.getGameName());
+        if (game == null || !game.isDiscordantStarsMode()) return false;
+        candidate.setPromotionStatus(CombatCandidatePromotionStatus.EXPIRED);
+        candidate.setCancellationReason("Ineligible for promotion because Discordant Stars games are excluded.");
+        candidateRepository.save(candidate);
+        return true;
     }
 
     private CombatCandidateEntity selectPromotionWinner(List<CombatCandidateEntity> candidates) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -91,6 +91,8 @@ public class CombatReplayService {
     }
 
     public void onSpaceCombatStarted(Game game, Player attacker, Player defender, Tile tile) {
+        if (isDiscordantStarsGame(game)) return;
+
         boolean trackAllCombatsAsCandidates = settings.getRuntime().isTrackAllCombatsAsCandidates();
         if (!trackAllCombatsAsCandidates
                 && (!LazaxCombatSupport.isEligibleGame(game)
@@ -828,12 +830,17 @@ public class CombatReplayService {
 
     private boolean isEligibleCandidate(
             Game game, Player attacker, Player defender, Tile tile, CombatReplaySelection.Evaluation evaluation) {
+        if (isDiscordantStarsGame(game)) return false;
         if (settings.getRuntime().isTrackAllCombatsAsCandidates()) {
             return getOpenCandidate(game, tile.getPosition()) == null;
         }
         return evaluation.eligible()
                 && !LazaxCombatSupport.hasExcludedFlagship(attacker, defender)
                 && getOpenCandidate(game, tile.getPosition()) == null;
+    }
+
+    private boolean isDiscordantStarsGame(Game game) {
+        return game != null && game.isDiscordantStarsMode();
     }
 
     private CombatReplaySelection selection() {

--- a/src/test/java/ti4/contest/replay/core/CombatReplayHouseTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatReplayHouseTest.java
@@ -8,8 +8,8 @@ class CombatReplayHouseTest {
 
     @Test
     void roleNamesMatchDiscordDelegationRoles() {
-        assertEquals("Naalu Delegation", CombatReplayHouse.NAALU.roleName());
-        assertEquals("Mentak Delegation", CombatReplayHouse.MENTAK.roleName());
-        assertEquals("Hacan Delegation", CombatReplayHouse.HACAN.roleName());
+        assertEquals("NaaluDelegation", CombatReplayHouse.NAALU.roleName());
+        assertEquals("MentakDelegation", CombatReplayHouse.MENTAK.roleName());
+        assertEquals("HacanDelegation", CombatReplayHouse.HACAN.roleName());
     }
 }

--- a/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
+++ b/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
@@ -109,6 +109,27 @@ class CombatReplayHacanTradeConvoysServiceTest {
     }
 
     @Test
+    void repostOpenTradeConvoysUsesPreviousWindowDuringCurrentPreview() {
+        CombatReplayContestEntity previewContest = contest(4L, 8L);
+        CombatCandidateEntity previewCandidate = candidate(8L);
+        CombatReplayContestEntity previousContest = contest(3L, 7L);
+        previousContest.setReplayCompletedAt(LocalDateTime.now().minusMinutes(10));
+        CombatCandidateEntity previousCandidate = candidate(7L);
+
+        when(contestRepository.findAllByOrderByIdDesc()).thenReturn(List.of(previewContest, previousContest));
+        when(candidateRepository.findById(previewContest.getCandidateId())).thenReturn(Optional.of(previewCandidate));
+        when(candidateRepository.findById(previousContest.getCandidateId())).thenReturn(Optional.of(previousCandidate));
+        when(tradeConvoysRepository.findByContestId(previewContest.getId())).thenReturn(Optional.empty());
+        when(tradeConvoysRepository.findByContestId(previousContest.getId())).thenReturn(Optional.empty());
+        when(contestRepository.existsByIdGreaterThanAndReplayCompletedAtIsNotNull(previousContest.getId()))
+                .thenReturn(false);
+
+        assertTrue(service.repostOpenTradeConvoysVotingButtons());
+
+        verify(tradeConvoysRepository).findByContestId(previousContest.getId());
+    }
+
+    @Test
     void tradeConvoysButtonsStayVisibleButDisableUnaffordableFavorCosts() {
         CombatReplayContestEntity contest = new CombatReplayContestEntity();
         contest.setId(3L);

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -2,6 +2,8 @@ package ti4.contest.replay.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -11,7 +13,9 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import ti4.contest.replay.core.CombatCandidatePromotionStatus;
 import ti4.contest.replay.core.CombatCandidateStatus;
 import ti4.contest.replay.core.CombatContestReplayStatus;
@@ -22,6 +26,9 @@ import ti4.contest.replay.house.mentak.CombatReplayMentakAbilityService;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatObservationRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
+import ti4.game.Game;
+import ti4.game.persistence.GameManager;
+import ti4.game.persistence.ManagedGame;
 
 class CombatReplayContestLifecycleServiceTest {
 
@@ -278,6 +285,50 @@ class CombatReplayContestLifecycleServiceTest {
         verify(observationRepository).findById(2L);
     }
 
+    @Test
+    void promoteBestCandidateIfDueExpiresDiscordantStarsCandidateAndContinues() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.setHousesEnabled(false);
+        settings.getRuntime().setDevMode(false);
+        CombatReplayContestLifecycleService service =
+                service(settings, candidateRepository, observationRepository, replayContestRepository);
+        service.setClock(fixedClock("2026-04-27T12:00:00"));
+        CombatCandidateEntity discordantStarsCandidate =
+                promotionCandidate(1L, LocalDateTime.parse("2026-04-27T11:30:00"), 10.0);
+        discordantStarsCandidate.setGameName("pbd-ds");
+        CombatCandidateEntity nextBestCandidate =
+                promotionCandidate(2L, LocalDateTime.parse("2026-04-27T11:35:00"), 5.0);
+        nextBestCandidate.setGameName("pbd-pok");
+        Game discordantStarsGame = game("pbd-ds", true);
+        Game normalGame = game("pbd-pok", false);
+        ManagedGame discordantStarsManagedGame = mock(ManagedGame.class);
+        ManagedGame normalManagedGame = mock(ManagedGame.class);
+
+        when(replayContestRepository.countByPostedAtGreaterThanEqual(any())).thenReturn(0L);
+        when(candidateRepository.findResolvedPromotionCandidates(
+                        eq(CombatCandidateStatus.RESOLVED), eq(CombatCandidatePromotionStatus.PENDING), any()))
+                .thenReturn(List.of(discordantStarsCandidate, nextBestCandidate));
+        when(observationRepository.findAllById(List.of(2L))).thenReturn(List.of());
+        when(observationRepository.findById(2L)).thenReturn(java.util.Optional.empty());
+        when(discordantStarsManagedGame.getGame()).thenReturn(discordantStarsGame);
+        when(normalManagedGame.getGame()).thenReturn(normalGame);
+
+        try (MockedStatic<GameManager> gameManager = org.mockito.Mockito.mockStatic(GameManager.class)) {
+            gameManager.when(() -> GameManager.getManagedGame("pbd-ds")).thenReturn(discordantStarsManagedGame);
+            gameManager.when(() -> GameManager.getManagedGame("pbd-pok")).thenReturn(normalManagedGame);
+
+            service.promoteBestCandidateIfDue();
+        }
+
+        Assertions.assertEquals(CombatCandidatePromotionStatus.EXPIRED, discordantStarsCandidate.getPromotionStatus());
+        verify(candidateRepository).save(discordantStarsCandidate);
+        verify(observationRepository).findById(2L);
+    }
+
     private CombatReplayContestLifecycleService service(
             CombatContestSettings settings,
             CombatCandidateRepository candidateRepository,
@@ -339,5 +390,12 @@ class CombatReplayContestLifecycleServiceTest {
         CombatReplayContestEntity contest = new CombatReplayContestEntity();
         contest.setReplayStatus(CombatContestReplayStatus.PREVIEW);
         return contest;
+    }
+
+    private Game game(String name, boolean discordantStarsMode) {
+        Game game = new Game();
+        game.setName(name);
+        game.setDiscordantStarsMode(discordantStarsMode);
+        return game;
     }
 }

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -199,6 +200,28 @@ class CombatReplayServiceTest {
 
         assertFalse(service.isTrackedCandidateRoll(game, attacker, defender, tile, CombatRollType.bombardment));
         assertFalse(service.isTrackedCandidateRoll(game, attacker, outsider, tile, CombatRollType.combatround));
+    }
+
+    @Test
+    void doesNotTrackDiscordantStarsCombatsEvenWhenTrackAllIsEnabled() {
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getRuntime().setTrackAllCombatsAsCandidates(true);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayService service = new CombatReplayService(
+                settings,
+                observationRepository,
+                candidateRepository,
+                mock(CombatCandidateEventRepository.class),
+                mock(CombatReplayEventAppender.class),
+                mock(CombatReplaySideBetTriggerService.class),
+                mock(CombatSideBetAvailabilityService.class));
+        Game game = game("pbd-discordant-stars");
+        game.setDiscordantStarsMode(true);
+
+        service.onSpaceCombatStarted(game, player(game, "rohdhna"), player(game, "khrask"), new Tile("d31", "317"));
+
+        verifyNoInteractions(observationRepository, candidateRepository);
     }
 
     private CombatReplayService service(CombatCandidateRepository candidateRepository) {


### PR DESCRIPTION
## Summary
- Make `/lazax hacan_trade_convoys` search for the newest actually open Trade Convoys window instead of only checking the latest contest
- Add coverage for reposting the previous post-combat window while the current combat is in Mentak preview
- Change Lazax house role lookup/mentions/role toggles to use `HacanDelegation`, `NaaluDelegation`, and `MentakDelegation`
- Exclude Discordant Stars games from new replay tracking, and expire existing DS candidates when promotion selection encounters them

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayHacanTradeConvoysServiceTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayHouseTest,CombatReplayHacanTradeConvoysServiceTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayContestLifecycleServiceTest#promoteBestCandidateIfDueExpiresDiscordantStarsCandidateAndContinues test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest=CombatReplayServiceTest#doesNotTrackDiscordantStarsCombatsEvenWhenTrackAllIsEnabled test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests compile

## Note
- The combined `CombatReplayServiceTest,CombatReplayContestLifecycleServiceTest` run hung in Surefire locally after the individual focused tests passed, so it was interrupted and not counted as passing.