### PR TITLE
Add Mentak preview context threads

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
@@ -87,6 +87,15 @@ public class CombatReplayExecutionService {
         }
     }
 
+    public void postPreviewContext(
+            MessageChannel replayChannel, CombatReplayContestEntity contest, CombatCandidateEntity winner) {
+        try {
+            announcePreReplayContextIfNeeded(replayChannel, contest, winner);
+        } catch (Exception e) {
+            BotLogger.error("Failed to post replay context for preview.", e);
+        }
+    }
+
     private void postSideBetMarketsIfDue() {
         if (!settings.isHousesEnabled()) return;
         if (!settings.getSideBets().isEnableSideBets()) return;

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -312,7 +312,13 @@ public class CombatReplayPromotionService {
                     candidate,
                     discordPostService.getHouseRoleMention(CombatReplayHouse.MENTAK),
                     startSummaryText);
-            discordPostService.postPromotionMessage(channel, message, game, candidate);
+            Message posted = discordPostService.postPromotionMessage(channel, message, game, candidate);
+            ThreadChannel thread = discordPostService.createReplayThread(posted, candidate);
+            previewContest.setPublicChannelId(channel.getIdLong());
+            previewContest.setPublicMessageId(posted.getIdLong());
+            previewContest.setPublicThreadId(thread == null ? null : thread.getIdLong());
+            replayContestRepository.save(previewContest);
+            replayExecutionService.postPreviewContext(thread != null ? thread : channel, previewContest, candidate);
             mentakAbilityService.postDecoyButtons(channel, candidate);
             candidate.setMentakPreviewPostedAt(LocalDateTime.now(clock));
             candidateRepository.save(candidate);
@@ -366,6 +372,7 @@ public class CombatReplayPromotionService {
 
     private boolean expireIfDiscordantStars(CombatCandidateEntity candidate) {
         if (candidate == null || candidate.getPromotionStatus() != CombatCandidatePromotionStatus.PENDING) return false;
+        if (StringUtils.isBlank(candidate.getGameName())) return false;
         Game game = loadGame(candidate.getGameName());
         if (game == null || !game.isDiscordantStarsMode()) return false;
         candidate.setPromotionStatus(CombatCandidatePromotionStatus.EXPIRED);

--- a/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayContestLifecycleServiceTest.java
@@ -13,6 +13,10 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -20,7 +24,10 @@ import ti4.contest.replay.core.CombatCandidatePromotionStatus;
 import ti4.contest.replay.core.CombatCandidateStatus;
 import ti4.contest.replay.core.CombatContestReplayStatus;
 import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
 import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatObservationEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.house.mentak.CombatReplayMentakAbilityService;
 import ti4.contest.replay.repository.CombatCandidateRepository;
@@ -157,6 +164,76 @@ class CombatReplayContestLifecycleServiceTest {
         assertFalse(result.promoted());
         assertEquals("Promotion failed", result.reason());
         verify(observationRepository).findById(1L);
+    }
+
+    @Test
+    void forcePromoteCandidatePostsMentakPreviewContextInReplayThread() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatObservationRepository observationRepository = mock(CombatObservationRepository.class);
+        CombatReplayContestRepository replayContestRepository = mock(CombatReplayContestRepository.class);
+        CombatReplayExecutionService replayExecutionService = mock(CombatReplayExecutionService.class);
+        CombatReplayDiscordPostService discordPostService = mock(CombatReplayDiscordPostService.class);
+        CombatReplayMentakAbilityService mentakAbilityService = mock(CombatReplayMentakAbilityService.class);
+        CombatContestSettings settings = new CombatContestSettings();
+        settings.getPromotion().setEnabled(true);
+        settings.setHousesEnabled(true);
+        settings.getHouseAbilities().getMentak().setPreviewLeadSeconds(900);
+        CombatReplayContestLifecycleService service = service(
+                settings,
+                candidateRepository,
+                observationRepository,
+                replayContestRepository,
+                replayExecutionService,
+                discordPostService,
+                mentakAbilityService);
+        service.setClock(fixedClock("2026-04-27T12:00:00"));
+        CombatCandidateEntity candidate = promotionCandidate(1L, LocalDateTime.parse("2026-04-27T11:55:00"), 10.0);
+        candidate.setGameName("pbd-preview");
+        candidate.setTilePosition("306");
+        candidate.setAttackerFaction("mentak");
+        candidate.setDefenderFaction("hacan");
+        CombatReplayContestEntity previewContest = previewContest();
+        TextChannel channel = mock(TextChannel.class);
+        Message posted = mock(Message.class);
+        ThreadChannel thread = mock(ThreadChannel.class);
+        ManagedGame managedGame = mock(ManagedGame.class);
+        Game game = game("pbd-preview", false);
+
+        when(candidateRepository.findById(1L)).thenReturn(Optional.of(candidate));
+        when(replayContestRepository.findByCandidateId(1L)).thenReturn(Optional.empty());
+        when(replayContestRepository.saveAndFlush(any(CombatReplayContestEntity.class)))
+                .thenReturn(previewContest);
+        when(observationRepository.findById(1L)).thenReturn(Optional.of(new CombatObservationEntity()));
+        when(discordPostService.houseChannel(CombatReplayHouse.MENTAK)).thenReturn(channel);
+        when(discordPostService.postPromotionMessage(eq(channel), any(), eq(game), eq(candidate)))
+                .thenReturn(posted);
+        when(discordPostService.createReplayThread(posted, candidate)).thenReturn(thread);
+        when(channel.getIdLong()).thenReturn(10L);
+        when(posted.getIdLong()).thenReturn(20L);
+        when(thread.getIdLong()).thenReturn(30L);
+        when(managedGame.getGame()).thenReturn(game);
+
+        try (MockedStatic<GameManager> gameManager = org.mockito.Mockito.mockStatic(GameManager.class);
+                MockedStatic<CombatReplayTileRenderer> tileRenderer =
+                        org.mockito.Mockito.mockStatic(CombatReplayTileRenderer.class)) {
+            gameManager.when(() -> GameManager.getManagedGame("pbd-preview")).thenReturn(managedGame);
+            tileRenderer.when(() -> CombatReplayTileRenderer.canRender(any())).thenReturn(true);
+            tileRenderer
+                    .when(() -> CombatReplayTileRenderer.render(any(), any()))
+                    .thenReturn(game);
+
+            CombatReplayContestLifecycleService.ForcePromoteResult result = service.forcePromoteCandidate(1L);
+
+            assertFalse(result.promoted());
+            assertEquals(
+                    "Mentak preview posted. Public promotion will be available after the preview window.",
+                    result.reason());
+            assertEquals(10L, previewContest.getPublicChannelId());
+            assertEquals(20L, previewContest.getPublicMessageId());
+            assertEquals(30L, previewContest.getPublicThreadId());
+            verify(replayExecutionService).postPreviewContext(thread, previewContest, candidate);
+            verify(mentakAbilityService).postDecoyButtons(channel, candidate);
+        }
     }
 
     @Test
@@ -353,6 +430,28 @@ class CombatReplayContestLifecycleServiceTest {
                 mock(CombatReplayExecutionService.class),
                 mock(CombatReplayDiscordPostService.class));
         return new CombatReplayContestLifecycleService(promotionService, mock(CombatReplayExecutionService.class));
+    }
+
+    private CombatReplayContestLifecycleService service(
+            CombatContestSettings settings,
+            CombatCandidateRepository candidateRepository,
+            CombatObservationRepository observationRepository,
+            CombatReplayContestRepository replayContestRepository,
+            CombatReplayExecutionService replayExecutionService,
+            CombatReplayDiscordPostService discordPostService,
+            CombatReplayMentakAbilityService mentakAbilityService) {
+        CombatReplayPromotionService promotionService = new CombatReplayPromotionService(
+                settings,
+                candidateRepository,
+                observationRepository,
+                replayContestRepository,
+                mock(CombatReplayLeaderboardService.class),
+                mock(ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService.class),
+                mentakAbilityService,
+                mock(CombatReplayHouseService.class),
+                replayExecutionService,
+                discordPostService);
+        return new CombatReplayContestLifecycleService(promotionService, replayExecutionService);
     }
 
     private Clock fixedClock(String localDateTime) {


### PR DESCRIPTION
## Summary
- Create a replay thread for Mentak preview posts and persist the preview channel/message/thread IDs.
- Post the existing pre-replay combat context into the Mentak preview thread so tech, relic, law, action-card count, and leader summaries are available during False Colors preview.
- Avoid Discordant Stars expiry lookups for synthetic candidates without a game name.

## Test Plan
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=CombatReplayContestLifecycleServiceTest#forcePromoteCandidatePostsMentakPreviewContextInReplayThread test
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn spotless:check

Note: Running the full CombatReplayContestLifecycleServiceTest class still hits existing GameManager warmup waits in other synthetic Mentak preview-failure tests.