### PR TITLE
Hide usernames in Naalu foresight reveals

### DIFF
--- a/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
+++ b/src/main/java/ti4/contest/replay/house/naalu/CombatReplayNaaluAbilityService.java
@@ -36,8 +36,6 @@ import ti4.contest.replay.service.CombatReplayInteractionResult;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.game.Game;
-import ti4.game.Player;
-import ti4.game.persistence.GameManager;
 import ti4.image.Mapper;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
@@ -210,7 +208,6 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         CombatCandidateEntity candidate = loadCandidate(contest);
         if (candidate == null) return "Could not find that combat archive.";
 
-        Game game = loadGame(candidate.getGameName());
         List<String> lines = new ArrayList<>();
         for (CombatCandidateEventEntity event : orderedEvents(candidate)) {
             ReplayDispatchPayload payload = payloadSerializer.read(event);
@@ -218,7 +215,7 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
 
             ActionCardModel actionCard = Mapper.getActionCard(actionCardId);
             String cardName = actionCard == null ? actionCardId : actionCard.getName();
-            lines.add("- " + actor(game, event.getActorFaction()) + ": _" + cardName + "_");
+            lines.add("- " + actor(event.getActorFaction()) + ": _" + cardName + "_");
         }
 
         if (lines.isEmpty()) {
@@ -232,7 +229,6 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         CombatCandidateEntity candidate = loadCandidate(contest);
         if (candidate == null) return "Could not find that combat archive.";
 
-        Game game = loadGame(candidate.getGameName());
         CombatReplayDecoys.Abilities abilities = CombatReplayDecoys.read(candidate.getReplayAbilitiesJson());
         List<String> rolls = new ArrayList<>();
         for (CombatCandidateEventEntity event : orderedEvents(candidate)) {
@@ -247,7 +243,7 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
             CombatRollPayload payloadWithDecoys = CombatReplayDecoys.applyToRoll(combatRoll.payload(), abilities);
             String rendered = renderRoundOneRollSummary(payloadWithDecoys);
             if (StringUtils.isBlank(rendered)) continue;
-            rolls.add("### " + actor(game, event.getActorFaction()) + "\n" + rendered.strip());
+            rolls.add("### " + actor(event.getActorFaction()) + "\n" + rendered.strip());
         }
 
         if (rolls.isEmpty()) {
@@ -267,7 +263,6 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         CombatCandidateEntity candidate = loadCandidate(contest);
         if (candidate == null) return "Could not find that combat archive.";
 
-        Game game = loadGame(candidate.getGameName());
         LuckAccumulator overall = new LuckAccumulator();
         Map<String, LuckAccumulator> actorLuck = new LinkedHashMap<>();
         for (CombatCandidateEventEntity event : orderedEvents(candidate)) {
@@ -298,7 +293,7 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         for (Map.Entry<String, LuckAccumulator> entry : actorLuck.entrySet()) {
             LuckAccumulator actorAccumulator = entry.getValue();
             if (actorAccumulator.diceRolled() == 0) continue;
-            lines.add(actor(game, entry.getKey()) + ": **" + luckLabel(actorAccumulator.delta()) + "**");
+            lines.add(actor(entry.getKey()) + ": **" + luckLabel(actorAccumulator.delta()) + "**");
         }
         return "## Gift of Foresight: Omens\n" + String.join("\n", lines);
     }
@@ -454,10 +449,9 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
         return payload != null && payload.header() != null && payload.header().rollType() == CombatRollType.combatround;
     }
 
-    private String actor(Game game, String actorFaction) {
-        Player player = game == null ? null : game.getPlayerFromColorOrFaction(actorFaction);
-        if (player != null) return player.getRepresentationNoPing();
-        return StringUtils.defaultIfBlank(actorFaction, "Unknown player");
+    private String actor(String actorFaction) {
+        if (StringUtils.isBlank(actorFaction)) return "Unknown faction";
+        return factionLabel(actorFaction);
     }
 
     private String factionLabel(String faction) {
@@ -471,15 +465,6 @@ public class CombatReplayNaaluAbilityService implements CombatReplayHouseAbility
     private CombatCandidateEntity loadCandidate(CombatReplayContestEntity contest) {
         if (contest == null) return null;
         return candidateRepository.findById(contest.getCandidateId()).orElse(null);
-    }
-
-    private Game loadGame(String gameName) {
-        try {
-            var managedGame = GameManager.getManagedGame(gameName);
-            return managedGame == null ? null : managedGame.getGame();
-        } catch (Exception e) {
-            return null;
-        }
     }
 
     private TextChannel houseChannel() {

--- a/src/test/java/ti4/contest/replay/service/CombatReplayNaaluAbilityServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayNaaluAbilityServiceTest.java
@@ -51,7 +51,7 @@ class CombatReplayNaaluAbilityServiceTest {
             serializer);
 
     @Test
-    void actionCardPeekAttributesCardsToActors() {
+    void actionCardPeekAttributesCardsToFactions() {
         CombatCandidateEntity candidate = candidate();
         CombatReplayContestEntity contest = contest(candidate);
         CombatCandidateEventEntity event =
@@ -63,7 +63,8 @@ class CombatReplayNaaluAbilityServiceTest {
 
         String peek = service.renderActionCardPeek(1L);
 
-        assertTrue(peek.contains("naalu: _Ancient Burial Sites_") || peek.contains("naalu: _abs_"));
+        assertTrue(peek.contains("Naalu: _Ancient Burial Sites_") || peek.contains("Naalu: _abs_"));
+        assertFalse(peek.contains("user-name"));
     }
 
     @Test
@@ -83,8 +84,10 @@ class CombatReplayNaaluAbilityServiceTest {
 
         String peek = service.renderRoundOneRollPeek(1L);
 
-        assertTrue(peek.contains("### naalu"));
+        assertTrue(peek.contains("###"));
+        assertTrue(peek.contains("Naalu"));
         assertTrue(peek.contains("**Total hits 0**"));
+        assertFalse(peek.contains("user-name"));
         assertFalse(peek.contains("`2x`"));
         assertFalse(peek.contains("Destroyer"));
         assertFalse(peek.contains("hits on"));
@@ -114,8 +117,9 @@ class CombatReplayNaaluAbilityServiceTest {
         String omens = service.renderLuckOmens(1L);
 
         assertTrue(omens.contains("Overall: **Lucky**"));
-        assertTrue(omens.contains("naalu: **Lucky**"));
-        assertTrue(omens.contains("hacan: **Unlucky**"));
+        assertTrue(omens.contains("Naalu: **Lucky**"));
+        assertTrue(omens.contains("Hacan: **Unlucky**"));
+        assertFalse(omens.contains("user-name"));
         assertFalse(omens.contains("Expected"));
         assertFalse(omens.contains("EV"));
     }
@@ -137,7 +141,8 @@ class CombatReplayNaaluAbilityServiceTest {
         String omens = service.renderLuckOmens(1L);
 
         assertTrue(omens.contains("Overall: **Average**"));
-        assertTrue(omens.contains("naalu: **Average**"));
+        assertTrue(omens.contains("Naalu: **Average**"));
+        assertFalse(omens.contains("user-name"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Render Naalu Gift of Foresight actor labels with faction icons/names instead of player representations.
- Cover action card, round 1 roll, and luck omen reveals with faction-only assertions.

## Test Plan
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=ti4.contest.replay.service.CombatReplayNaaluAbilityServiceTest test