### PR TITLE
Add Mentak Promise of Protection scoring

### DIFF
--- a/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakScoringRule.java
+++ b/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakScoringRule.java
@@ -1,17 +1,29 @@
 package ti4.contest.replay.house.mentak;
 
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
+import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatReplayHouseAbilityUseEntity;
+import ti4.contest.replay.repository.CombatCandidateRepository;
+import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
 import ti4.contest.replay.service.CombatReplayHouseScoringContext;
 import ti4.contest.replay.service.CombatReplayHouseScoringContext.HousePrediction;
 import ti4.contest.replay.service.CombatReplayHouseScoringRule;
 
 @Service
 @Order(20)
+@RequiredArgsConstructor
 public class CombatReplayMentakScoringRule implements CombatReplayHouseScoringRule {
 
     private static final int PILLAGE_POINTS_PER_OTHER_DELEGATION_MISS = 4;
+    private static final int PROMISE_OF_PROTECTION_MULTIPLIER = 5;
+
+    private final CombatCandidateRepository candidateRepository;
+    private final CombatReplayHouseAbilityUseRepository abilityUseRepository;
 
     @Override
     public void apply(CombatReplayHouseScoringContext context) {
@@ -23,5 +35,33 @@ public class CombatReplayMentakScoringRule implements CombatReplayHouseScoringRu
             }
         }
         context.addAbilitySummary(CombatReplayHouse.MENTAK, "Pillage", points, true);
+        applyPromiseOfProtection(context);
+    }
+
+    private void applyPromiseOfProtection(CombatReplayHouseScoringContext context) {
+        if (context.contest() == null || context.contest().getCandidateId() == null) return;
+
+        CombatCandidateEntity candidate =
+                candidateRepository.findById(context.contest().getCandidateId()).orElse(null);
+        if (candidate == null || candidate.getWinnerFaction() == null) return;
+
+        CombatReplayDecoys.Abilities abilities = CombatReplayDecoys.read(candidate.getReplayAbilitiesJson());
+        if (!abilities.hasDecoys()) return;
+        boolean decoyedWinner = abilities.decoy().units().stream()
+                .anyMatch(unit -> context.normalizeFaction(unit.faction())
+                        .equals(context.normalizeFaction(candidate.getWinnerFaction())));
+        if (!decoyedWinner) return;
+
+        List<CombatReplayHouseAbilityUseEntity> uses =
+                abilityUseRepository.findByCandidateIdAndHouse(candidate.getId(), CombatReplayHouse.MENTAK);
+        int favorCost = uses.stream()
+                .map(CombatReplayHouseAbilityUseEntity::getFavorCost)
+                .filter(cost -> cost != null && cost > 0)
+                .findFirst()
+                .orElse(0);
+        if (favorCost <= 0) return;
+
+        context.addAbilitySummary(
+                CombatReplayHouse.MENTAK, "Promise of Protection", favorCost * PROMISE_OF_PROTECTION_MULTIPLIER);
     }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -162,7 +162,7 @@ public class CombatReplayLeaderboardService {
 
     public boolean postLeaderboard() {
         if (settings.isHousesEnabled()) {
-            return postHouseLeaderboard();
+            return postDelegationLeaderboard();
         }
 
         List<CombatReplayLeaderboardEntryEntity> topEntries =
@@ -248,7 +248,7 @@ public class CombatReplayLeaderboardService {
         return "You have **" + points + "** Lazax " + label + ".";
     }
 
-    private boolean postHouseLeaderboard() {
+    public boolean postDelegationLeaderboard() {
         List<HouseLeaderboardSummary> summaries = houseLedgerService.leaderboardSummaries();
         if (summaries.isEmpty()) return false;
 

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxCommand.java
@@ -12,6 +12,7 @@ public class LazaxCommand implements ParentCommand {
     private final Map<String, Subcommand> subcommands = Stream.of(
                     new LazaxMyPoints(),
                     new LazaxTop100(),
+                    new LazaxDelegationLeaderboard(),
                     new LazaxStartSeason1(),
                     new LazaxGrantFavor(),
                     new LazaxHacanTradeConvoys(),

--- a/src/main/java/ti4/discord/interactions/commands/lazax/LazaxDelegationLeaderboard.java
+++ b/src/main/java/ti4/discord/interactions/commands/lazax/LazaxDelegationLeaderboard.java
@@ -1,0 +1,35 @@
+package ti4.discord.interactions.commands.lazax;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.contest.replay.service.CombatReplayLeaderboardService;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.helpers.Constants;
+import ti4.spring.context.SpringContext;
+
+class LazaxDelegationLeaderboard extends Subcommand {
+
+    LazaxDelegationLeaderboard() {
+        super(Constants.LAZAX_DELEGATION_LEADERBOARD, "Repost the public Lazax delegation leaderboard.");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        if (!LazaxCommandAuthorization.isSeasonAdmin(event)) {
+            LazaxReplyHelper.replyEphemeral(event, "You are not authorized to repost the delegation leaderboard.");
+            return;
+        }
+
+        boolean posted =
+                SpringContext.getBean(CombatReplayLeaderboardService.class).postDelegationLeaderboard();
+        LazaxReplyHelper.replyEphemeral(
+                event,
+                posted
+                        ? "Reposted the Lazax delegation leaderboard."
+                        : "Could not repost the Lazax delegation leaderboard.");
+    }
+
+    @Override
+    public boolean isEphemeral(SlashCommandInteractionEvent event) {
+        return true;
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1544,6 +1544,7 @@ public final class Constants {
     public static final String LAZAX = "lazax";
     public static final String LAZAX_MY_POINTS = "my_points";
     public static final String LAZAX_TOP_100 = "top_100";
+    public static final String LAZAX_DELEGATION_LEADERBOARD = "delegation_leaderboard";
     public static final String PUBLIC = "public";
     public static final String IS_FRACTURED = "is_fractured";
     public static final String SHOW_GAME_IDS = "show_game_ids";

--- a/src/test/java/ti4/contest/replay/service/CombatReplayMentakScoringRuleTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayMentakScoringRuleTest.java
@@ -1,0 +1,115 @@
+package ti4.contest.replay.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatReplayDecoys;
+import ti4.contest.replay.core.CombatReplayHouse;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatReplayContestEntity;
+import ti4.contest.replay.entities.CombatReplayHouseAbilityUseEntity;
+import ti4.contest.replay.house.mentak.CombatReplayMentakScoringRule;
+import ti4.contest.replay.repository.CombatCandidateRepository;
+import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
+import ti4.helpers.Constants;
+import ti4.helpers.Units.UnitType;
+
+class CombatReplayMentakScoringRuleTest {
+
+    private final CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+    private final CombatReplayHouseAbilityUseRepository abilityUseRepository =
+            mock(CombatReplayHouseAbilityUseRepository.class);
+    private final CombatReplayMentakScoringRule rule =
+            new CombatReplayMentakScoringRule(candidateRepository, abilityUseRepository);
+
+    @Test
+    void promiseOfProtectionPaysFiveTimesFalseColorsCostWhenDecoyedFactionWins() {
+        CombatCandidateEntity candidate = candidate("ghost", "ghost", 40);
+        when(candidateRepository.findById(candidate.getId())).thenReturn(Optional.of(candidate));
+        when(abilityUseRepository.findByCandidateIdAndHouse(candidate.getId(), CombatReplayHouse.MENTAK))
+                .thenReturn(List.of(use(40)));
+        EnumMap<CombatReplayHouse, List<CombatReplayHouseLedgerService.HouseAbilitySummary>> abilities =
+                emptyAbilities();
+
+        rule.apply(context(candidate, abilities));
+
+        assertTrue(abilities.get(CombatReplayHouse.MENTAK).stream()
+                .anyMatch(summary -> "Promise of Protection".equals(summary.label()) && summary.points() == 200));
+    }
+
+    @Test
+    void promiseOfProtectionDoesNotPayWhenDecoyedFactionLoses() {
+        CombatCandidateEntity candidate = candidate("ghost", "bastion", 40);
+        when(candidateRepository.findById(candidate.getId())).thenReturn(Optional.of(candidate));
+        when(abilityUseRepository.findByCandidateIdAndHouse(candidate.getId(), CombatReplayHouse.MENTAK))
+                .thenReturn(List.of(use(40)));
+        EnumMap<CombatReplayHouse, List<CombatReplayHouseLedgerService.HouseAbilitySummary>> abilities =
+                emptyAbilities();
+
+        rule.apply(context(candidate, abilities));
+
+        assertFalse(abilities.get(CombatReplayHouse.MENTAK).stream()
+                .anyMatch(summary -> "Promise of Protection".equals(summary.label())));
+    }
+
+    private CombatCandidateEntity candidate(String decoyFaction, String winnerFaction, int favorCost) {
+        CombatCandidateEntity candidate = new CombatCandidateEntity();
+        candidate.setId(7L);
+        candidate.setWinnerFaction(winnerFaction);
+        candidate.setReplayAbilitiesJson(CombatReplayDecoys.addDecoy(
+                null,
+                new CombatReplayDecoys.DecoyUnit(
+                        decoyFaction, ":" + decoyFaction + ":", "blue", UnitType.Dreadnought, Constants.SPACE, 1)));
+        return candidate;
+    }
+
+    private CombatReplayHouseAbilityUseEntity use(int favorCost) {
+        CombatReplayHouseAbilityUseEntity use = new CombatReplayHouseAbilityUseEntity();
+        use.setFavorCost(favorCost);
+        return use;
+    }
+
+    private CombatReplayHouseScoringContext context(
+            CombatCandidateEntity candidate,
+            EnumMap<CombatReplayHouse, List<CombatReplayHouseLedgerService.HouseAbilitySummary>> abilities) {
+        CombatReplayContestEntity contest = new CombatReplayContestEntity();
+        contest.setCandidateId(candidate.getId());
+        return new CombatReplayHouseScoringContext(
+                contest, List.of(), Set.of(), List.of(), List.of(), Map.of(), emptyTotals(), abilities, emptyFavors());
+    }
+
+    private EnumMap<CombatReplayHouse, CombatReplayHouseScoringContext.HouseTotals> emptyTotals() {
+        EnumMap<CombatReplayHouse, CombatReplayHouseScoringContext.HouseTotals> totals =
+                new EnumMap<>(CombatReplayHouse.class);
+        for (CombatReplayHouse house : CombatReplayHouse.assignmentOrder()) {
+            totals.put(house, new CombatReplayHouseScoringContext.HouseTotals());
+        }
+        return totals;
+    }
+
+    private EnumMap<CombatReplayHouse, List<CombatReplayHouseLedgerService.HouseAbilitySummary>> emptyAbilities() {
+        EnumMap<CombatReplayHouse, List<CombatReplayHouseLedgerService.HouseAbilitySummary>> abilities =
+                new EnumMap<>(CombatReplayHouse.class);
+        for (CombatReplayHouse house : CombatReplayHouse.assignmentOrder()) {
+            abilities.put(house, new java.util.ArrayList<>());
+        }
+        return abilities;
+    }
+
+    private EnumMap<CombatReplayHouse, List<CombatReplayHouseLedgerService.HouseFavorSummary>> emptyFavors() {
+        EnumMap<CombatReplayHouse, List<CombatReplayHouseLedgerService.HouseFavorSummary>> favors =
+                new EnumMap<>(CombatReplayHouse.class);
+        for (CombatReplayHouse house : CombatReplayHouse.assignmentOrder()) {
+            favors.put(house, new java.util.ArrayList<>());
+        }
+        return favors;
+    }
+}


### PR DESCRIPTION
## Summary
- Add Mentak Promise of Protection as a scoring summary line when a paid False Colors decoy lands on the eventual winner.
- Score Promise of Protection at 5x the False Colors Favor cost, without depending on Mentak prediction misses.
- Add /lazax delegation_leaderboard to repost the public delegation leaderboard after score corrections.

## Test Plan
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=ti4.contest.replay.service.CombatReplayMentakScoringRuleTest,ti4.contest.replay.service.CombatReplayHouseLedgerServiceFavorTest test

## Data correction
Apply the SQL shared in the thread to backfill Promise of Protection rows, then run /lazax delegation_leaderboard.