### PR TITLE
Add Mentak decoy quantity voting

### DIFF
--- a/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityButtonHandler.java
+++ b/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityButtonHandler.java
@@ -49,23 +49,36 @@ public class CombatReplayMentakAbilityButtonHandler {
             return;
         }
 
+        if (request.count() == null) {
+            service.sendEphemeralQuantityControls(
+                    event, request.candidateId(), request.targetFaction(), request.unitType());
+            return;
+        }
+
         CombatReplayInteractionResult result = service.voteDecoy(
                 request.candidateId(),
                 request.targetFaction(),
                 request.unitType(),
+                request.count(),
                 event.getUser().getId(),
                 event.getUser().getName());
         MessageHelper.sendEphemeralMessageToEventChannel(event, result.message());
     }
 
     private static DecoyRequest parse(String buttonId) {
-        String request = buttonId.replace(CombatReplayMentakAbilityService.MENTAK_DECOY_PREFIX, "");
-        String[] parts = request.split("_", 3);
-        if (parts.length != 3) return null;
+        boolean quantityRequest = buttonId.startsWith(CombatReplayMentakAbilityService.MENTAK_DECOY_QUANTITY_PREFIX);
+        String request = buttonId.replace(
+                quantityRequest
+                        ? CombatReplayMentakAbilityService.MENTAK_DECOY_QUANTITY_PREFIX
+                        : CombatReplayMentakAbilityService.MENTAK_DECOY_PREFIX,
+                "");
+        String[] parts = request.split("_", quantityRequest ? 4 : 3);
+        if (parts.length != (quantityRequest ? 4 : 3)) return null;
         try {
             UnitType unitType = Units.findUnitType(parts[2]);
             if (unitType == null) return null;
-            return new DecoyRequest(Long.parseLong(parts[0]), parts[1], unitType);
+            Integer count = quantityRequest ? Integer.parseInt(parts[3]) : null;
+            return new DecoyRequest(Long.parseLong(parts[0]), parts[1], unitType, count);
         } catch (NumberFormatException e) {
             return null;
         }
@@ -80,5 +93,5 @@ public class CombatReplayMentakAbilityButtonHandler {
         }
     }
 
-    private record DecoyRequest(long candidateId, String targetFaction, UnitType unitType) {}
+    private record DecoyRequest(long candidateId, String targetFaction, UnitType unitType, Integer count) {}
 }

--- a/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityService.java
+++ b/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityService.java
@@ -2,7 +2,9 @@ package ti4.contest.replay.house.mentak;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
@@ -17,6 +19,7 @@ import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatReplayHouseAbilityVoteEntity;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
 import ti4.contest.replay.service.CombatReplayAbilityWindowText;
@@ -42,10 +45,13 @@ import ti4.service.emoji.FactionEmojis;
 public class CombatReplayMentakAbilityService {
 
     public static final String MENTAK_DECOY_PREFIX = "combatReplayMentakDecoy_";
+    public static final String MENTAK_DECOY_QUANTITY_PREFIX = MENTAK_DECOY_PREFIX + "quantity_";
     public static final String MENTAK_MANAGE_VOTE_PREFIX = "combatReplayMentakManageVote_";
     public static final String MENTAK_DO_NOT_USE = MENTAK_DECOY_PREFIX + "doNotUse_";
 
     private static final String DO_NOT_USE_ABILITY = "DO_NOT_USE";
+    private static final int MAX_DECOY_COUNT = 5;
+    private static final int MINIMUM_UNIT_TYPE_VOTES_TO_RESOLVE = 2;
     private static final String SYSTEM_USER_ID = "0";
     private static final String SYSTEM_USER_NAME = "Mentak Delegation";
 
@@ -112,7 +118,7 @@ public class CombatReplayMentakAbilityService {
     }
 
     public String falseColorsSummaryLine() {
-        return "-# False Colors: choose one decoy ship. The winning choice appears in the opening formation, then vanishes when combat ends.";
+        return "-# False Colors: choose one decoy ship type and count. Ship type votes are pooled; tied ship types choose the most expensive ship, tied counts choose the lowest count.";
     }
 
     private String favorBalanceLine() {
@@ -137,7 +143,7 @@ public class CombatReplayMentakAbilityService {
             return;
         }
 
-        MessageHelper.sendEphemeralMessageToEventChannel(event, "Choose one False Colors option.");
+        MessageHelper.sendEphemeralMessageToEventChannel(event, "Choose a side and ship type for False Colors.");
         Game game = loadGame(candidate.getGameName());
         sendEphemeralDecoyButtonsForFaction(event, game, candidate, candidate.getAttackerFaction());
         sendEphemeralDecoyButtonsForFaction(event, game, candidate, candidate.getDefenderFaction());
@@ -149,13 +155,21 @@ public class CombatReplayMentakAbilityService {
     }
 
     public CombatReplayInteractionResult voteDecoy(
-            long candidateId, String targetFaction, UnitType unitType, String discordUserId, String discordUserName) {
+            long candidateId,
+            String targetFaction,
+            UnitType unitType,
+            int count,
+            String discordUserId,
+            String discordUserName) {
         CombatCandidateEntity candidate = loadCandidateForVote(candidateId);
         if (candidate == null)
             return CombatReplayInteractionResult.rejected(
                     "Could not find an open false-colors window for that combat.");
         if (!isDecoyUnit(unitType)) {
             return CombatReplayInteractionResult.rejected("Mentak Delegation cannot fly false colors with that ship.");
+        }
+        if (count < 1 || count > MAX_DECOY_COUNT) {
+            return CombatReplayInteractionResult.rejected("Mentak Delegation can deploy between 1 and 5 decoy ships.");
         }
 
         Game game = loadGame(candidate.getGameName());
@@ -165,10 +179,38 @@ public class CombatReplayMentakAbilityService {
 
         return recordVote(
                 candidate.getId(),
-                optionKey(target.getFaction(), unitType),
-                target.getFaction() + " " + unitType.humanReadableName() + " Decoy",
+                optionKey(target.getFaction(), unitType, count),
+                optionLabel(target.getFaction(), unitType, count),
                 discordUserId,
                 discordUserName);
+    }
+
+    public void sendEphemeralQuantityControls(
+            ButtonInteractionEvent event, long candidateId, String targetFaction, UnitType unitType) {
+        CombatCandidateEntity candidate = loadCandidateForVote(candidateId);
+        if (candidate == null) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "Could not find an open false-colors window for that combat.");
+            return;
+        }
+        if (!isDecoyUnit(unitType)) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "Mentak Delegation cannot fly false colors with that ship.");
+            return;
+        }
+
+        Game game = loadGame(candidate.getGameName());
+        Player target = game == null ? null : game.getPlayerFromColorOrFaction(targetFaction);
+        if (target == null) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "Could not find the target faction for that decoy.");
+            return;
+        }
+
+        String message = target.getRepresentationNoPing() + " " + unitType.humanReadableName()
+                + " decoys\nMentak Favor: `" + houseFavorService.balance(CombatReplayHouse.MENTAK) + "`";
+        MessageHelper.sendMessageToEventChannelWithEphemeralButtons(
+                event, message, quantityButtons(candidate, target.getFaction(), unitType));
     }
 
     public CombatReplayInteractionResult voteDoNotUse(long candidateId, String discordUserId, String discordUserName) {
@@ -182,8 +224,7 @@ public class CombatReplayMentakAbilityService {
     public void resolveVoteIfNeeded(CombatCandidateEntity candidate) {
         if (houseAbilityUseRepository.existsByCandidateIdAndHouse(candidate.getId(), CombatReplayHouse.MENTAK)) return;
 
-        CombatReplayHouseAbilityVoteService.WinningVote winningVote =
-                voteService.winningVote(candidate.getId(), CombatReplayHouse.MENTAK, this::optionLabel);
+        CombatReplayHouseAbilityVoteService.WinningVote winningVote = winningMentakVote(candidate.getId());
         if (winningVote == null) {
             resolveNoSelection(candidate.getId());
             return;
@@ -201,7 +242,7 @@ public class CombatReplayMentakAbilityService {
 
         if (!claimUse(
                 candidate.getId(),
-                decoyFavorCost(option.unitType()),
+                decoyFavorCost(option.unitType(), option.count()),
                 winningVote.discordUserId(),
                 winningVote.discordUserName())) {
             resolveInsufficientFavor(candidate.getId(), winningVote.optionKey());
@@ -215,7 +256,7 @@ public class CombatReplayMentakAbilityService {
                         target.getColorID(),
                         option.unitType(),
                         Constants.SPACE,
-                        1));
+                        option.count()));
         candidate.setReplayAbilitiesJson(replayAbilitiesJson);
         refreshWarSunDecoyTechSummary(candidate, game, replayAbilitiesJson, option.unitType());
         candidateRepository.save(candidate);
@@ -225,7 +266,8 @@ public class CombatReplayMentakAbilityService {
             MessageHelper.sendMessageToChannel(
                     channel,
                     "## False Colors\nMentak Delegation flew false colors. A "
-                            + option.unitType().humanReadableName() + " decoy was placed with "
+                            + option.count() + "x " + option.unitType().humanReadableName()
+                            + " decoy stack was placed with "
                             + target.getRepresentationNoPing() + " (`" + winningVote.voteCount() + "` votes).");
         }
     }
@@ -321,12 +363,32 @@ public class CombatReplayMentakAbilityService {
     }
 
     Button decoyButton(CombatCandidateEntity candidate, String faction, UnitType unitType) {
-        int favorCost = decoyFavorCost(unitType);
-        Button button = Buttons.blue(
+        return Buttons.blue(
                 MENTAK_DECOY_PREFIX + candidate.getId() + "_" + faction + "_" + unitType.name(),
-                unitType.humanReadableName() + " Decoy" + favorCostSuffix(favorCost),
+                unitType.humanReadableName() + " Decoys",
                 unitType.getUnitTypeEmoji());
-        return houseFavorService.canAfford(CombatReplayHouse.MENTAK, favorCost) ? button : button.asDisabled();
+    }
+
+    List<Button> quantityButtons(CombatCandidateEntity candidate, String faction, UnitType unitType) {
+        List<Button> buttons = new ArrayList<>();
+        if (StringUtils.isBlank(faction)) return buttons;
+        for (int count = 1; count <= MAX_DECOY_COUNT; count++) {
+            int favorCost = decoyFavorCost(unitType, count);
+            Button button = Buttons.blue(
+                    MENTAK_DECOY_QUANTITY_PREFIX
+                            + candidate.getId()
+                            + "_"
+                            + faction
+                            + "_"
+                            + unitType.name()
+                            + "_"
+                            + count,
+                    count + "x" + favorCostSuffix(favorCost),
+                    unitType.getUnitTypeEmoji());
+            buttons.add(
+                    houseFavorService.canAfford(CombatReplayHouse.MENTAK, favorCost) ? button : button.asDisabled());
+        }
+        return buttons;
     }
 
     private String favorCostSuffix(int cost) {
@@ -336,7 +398,17 @@ public class CombatReplayMentakAbilityService {
     private int favorCost(String optionKey) {
         if (DO_NOT_USE_ABILITY.equals(optionKey)) return 0;
         MentakOption option = parseOption(optionKey);
-        return option == null ? 0 : decoyFavorCost(option.unitType());
+        return option == null ? 0 : decoyFavorCost(option.unitType(), option.count());
+    }
+
+    private int decoyFavorCost(UnitType unitType, int count) {
+        if (count <= 0) return 0;
+        int baseCost = decoyFavorCost(unitType);
+        return baseCost + ((count - 1) * additionalDecoyFavorCost(baseCost));
+    }
+
+    private int additionalDecoyFavorCost(int baseCost) {
+        return (baseCost * 3 + 3) / 4;
     }
 
     private int decoyFavorCost(UnitType unitType) {
@@ -373,37 +445,129 @@ public class CombatReplayMentakAbilityService {
     }
 
     private int minimumAbilityVotesToResolve() {
-        return voteService.minimumAbilityVotesToResolve();
+        return MINIMUM_UNIT_TYPE_VOTES_TO_RESOLVE;
     }
 
     private String voteSummary(Long candidateId) {
-        return voteService.voteSummary(candidateId, CombatReplayHouse.MENTAK, this::optionLabel);
+        return voteService.voteSummary(candidateId, CombatReplayHouse.MENTAK, this::optionLabel)
+                + "\n-# Ship type threshold: `"
+                + minimumAbilityVotesToResolve()
+                + "` pooled votes. Quantity ties choose the lower count.";
     }
 
     private String optionLabel(String optionKey) {
         if (DO_NOT_USE_ABILITY.equals(optionKey)) return "Do Not Use";
         MentakOption option = parseOption(optionKey);
         if (option != null) {
-            return StringUtils.capitalize(option.targetFaction()) + " "
-                    + option.unitType().humanReadableName() + " Decoy";
+            return optionLabel(option.targetFaction(), option.unitType(), option.count());
         }
         return optionKey;
     }
 
-    private String optionKey(String targetFaction, UnitType unitType) {
-        return targetFaction + "_" + unitType.name();
+    private String optionLabel(String targetFaction, UnitType unitType, int count) {
+        return StringUtils.capitalize(targetFaction) + " "
+                + count
+                + "x "
+                + unitType.humanReadableName()
+                + " Decoy"
+                + (count == 1 ? "" : "s");
+    }
+
+    private String optionKey(String targetFaction, UnitType unitType, int count) {
+        return targetFaction + "_" + unitType.name() + "_" + count;
     }
 
     private MentakOption parseOption(String optionKey) {
         if (StringUtils.isBlank(optionKey)) return null;
-        String[] parts = optionKey.split("_", 2);
-        if (parts.length != 2) return null;
+        String[] parts = optionKey.split("_", 3);
+        if (parts.length != 3) return null;
         try {
             UnitType unitType = UnitType.valueOf(parts[1]);
-            return isDecoyUnit(unitType) ? new MentakOption(parts[0], unitType) : null;
+            int count = Integer.parseInt(parts[2]);
+            return isDecoyUnit(unitType) && count >= 1 && count <= MAX_DECOY_COUNT
+                    ? new MentakOption(parts[0], unitType, count)
+                    : null;
         } catch (IllegalArgumentException e) {
             return null;
         }
+    }
+
+    CombatReplayHouseAbilityVoteService.WinningVote winningMentakVote(Long candidateId) {
+        List<CombatReplayHouseAbilityVoteEntity> votes = voteService.votesFor(candidateId, CombatReplayHouse.MENTAK);
+        if (votes.isEmpty()) return null;
+
+        Map<MentakUnitChoice, List<CombatReplayHouseAbilityVoteEntity>> votesByUnitChoice = new HashMap<>();
+        List<CombatReplayHouseAbilityVoteEntity> doNotUseVotes = new ArrayList<>();
+        for (CombatReplayHouseAbilityVoteEntity vote : votes) {
+            if (DO_NOT_USE_ABILITY.equals(vote.getOptionKey())) {
+                doNotUseVotes.add(vote);
+                continue;
+            }
+            MentakOption option = parseOption(vote.getOptionKey());
+            if (option == null) continue;
+            votesByUnitChoice
+                    .computeIfAbsent(
+                            new MentakUnitChoice(option.targetFaction(), option.unitType()),
+                            ignored -> new ArrayList<>())
+                    .add(vote);
+        }
+
+        int threshold = minimumAbilityVotesToResolve();
+        MentakUnitChoice winningUnitChoice = votesByUnitChoice.entrySet().stream()
+                .filter(entry -> entry.getValue().size() >= threshold)
+                .max(Comparator.comparingInt(
+                                (Map.Entry<MentakUnitChoice, List<CombatReplayHouseAbilityVoteEntity>> entry) ->
+                                        entry.getValue().size())
+                        .thenComparing(entry -> decoyFavorCost(entry.getKey().unitType())))
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
+        if (winningUnitChoice == null) {
+            return doNotUseVotes.size() >= threshold ? doNotUseWinningVote(doNotUseVotes) : null;
+        }
+
+        List<CombatReplayHouseAbilityVoteEntity> winningUnitVotes = votesByUnitChoice.get(winningUnitChoice);
+        if (doNotUseVotes.size() > winningUnitVotes.size()) {
+            return doNotUseWinningVote(doNotUseVotes);
+        }
+
+        Map<Integer, List<CombatReplayHouseAbilityVoteEntity>> votesByCount = new HashMap<>();
+        for (CombatReplayHouseAbilityVoteEntity vote : winningUnitVotes) {
+            MentakOption option = parseOption(vote.getOptionKey());
+            if (option == null) continue;
+            votesByCount
+                    .computeIfAbsent(option.count(), ignored -> new ArrayList<>())
+                    .add(vote);
+        }
+
+        Map.Entry<Integer, List<CombatReplayHouseAbilityVoteEntity>> winningCount = votesByCount.entrySet().stream()
+                .max(Comparator.comparingInt((Map.Entry<Integer, List<CombatReplayHouseAbilityVoteEntity>> entry) ->
+                                entry.getValue().size())
+                        .thenComparing(Map.Entry.<Integer, List<CombatReplayHouseAbilityVoteEntity>>comparingByKey()
+                                .reversed()))
+                .orElse(null);
+        if (winningCount == null) return null;
+
+        CombatReplayHouseAbilityVoteEntity firstVote = winningCount.getValue().getFirst();
+        String optionKey =
+                optionKey(winningUnitChoice.targetFaction(), winningUnitChoice.unitType(), winningCount.getKey());
+        return new CombatReplayHouseAbilityVoteService.WinningVote(
+                optionKey,
+                optionLabel(optionKey),
+                firstVote.getDiscordUserId(),
+                firstVote.getDiscordUserName(),
+                winningUnitVotes.size());
+    }
+
+    private CombatReplayHouseAbilityVoteService.WinningVote doNotUseWinningVote(
+            List<CombatReplayHouseAbilityVoteEntity> votes) {
+        CombatReplayHouseAbilityVoteEntity firstVote = votes.getFirst();
+        return new CombatReplayHouseAbilityVoteService.WinningVote(
+                DO_NOT_USE_ABILITY,
+                optionLabel(DO_NOT_USE_ABILITY),
+                firstVote.getDiscordUserId(),
+                firstVote.getDiscordUserName(),
+                votes.size());
     }
 
     private String factionSectionTitle(Game game, String faction) {
@@ -438,5 +602,7 @@ public class CombatReplayMentakAbilityService {
         return channel;
     }
 
-    private record MentakOption(String targetFaction, UnitType unitType) {}
+    private record MentakOption(String targetFaction, UnitType unitType, int count) {}
+
+    private record MentakUnitChoice(String targetFaction, UnitType unitType) {}
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayHouseAbilityVoteService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayHouseAbilityVoteService.java
@@ -119,6 +119,10 @@ public class CombatReplayHouseAbilityVoteService {
                 .orElse(null);
     }
 
+    public List<CombatReplayHouseAbilityVoteEntity> votesFor(Long candidateId, CombatReplayHouse house) {
+        return voteRepository.findByCandidateIdAndHouse(candidateId, house);
+    }
+
     public String voteSummary(Long candidateId, CombatReplayHouse house, Function<String, String> optionLabel) {
         List<CombatReplayHouseAbilityVoteEntity> votes = voteRepository.findByCandidateIdAndHouse(candidateId, house);
         if (votes.isEmpty()) return "No votes recorded.";

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -59,13 +59,13 @@ houseAbilities:
   mentak:
     previewLeadSeconds: 15
     # destroyerDecoyFavorCost: 0
-    destroyerDecoyFavorCost: 20
+    destroyerDecoyFavorCost: 15
     # cruiserDecoyFavorCost: 0
-    cruiserDecoyFavorCost: 30
+    cruiserDecoyFavorCost: 25
     # dreadnoughtDecoyFavorCost: 0
-    dreadnoughtDecoyFavorCost: 40
+    dreadnoughtDecoyFavorCost: 35
     # warSunDecoyFavorCost: 0
-    warSunDecoyFavorCost: 70
+    warSunDecoyFavorCost: 65
   hacan:
     maxSubsidiesPerContest: 2
     subsidyFavorOnHit: 10

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -55,10 +55,10 @@ houseAbilities:
     luckOmensFavorCost: 30
   mentak:
     previewLeadSeconds: 900
-    destroyerDecoyFavorCost: 20
-    cruiserDecoyFavorCost: 30
-    dreadnoughtDecoyFavorCost: 40
-    warSunDecoyFavorCost: 70
+    destroyerDecoyFavorCost: 15
+    cruiserDecoyFavorCost: 25
+    dreadnoughtDecoyFavorCost: 35
+    warSunDecoyFavorCost: 65
   hacan:
     maxSubsidiesPerContest: 2
     subsidyFavorOnHit: 10

--- a/src/test/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityServiceButtonTest.java
+++ b/src/test/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityServiceButtonTest.java
@@ -1,17 +1,19 @@
 package ti4.contest.replay.house.mentak;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import net.dv8tion.jda.api.components.buttons.Button;
 import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatReplayHouseAbilityVoteEntity;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
 import ti4.contest.replay.service.CombatReplayHouseAbilityVoteService;
@@ -24,27 +26,85 @@ class CombatReplayMentakAbilityServiceButtonTest {
 
     private final CombatContestSettings settings = new CombatContestSettings();
     private final CombatReplayHouseFavorService houseFavorService = mock(CombatReplayHouseFavorService.class);
+    private final CombatReplayHouseAbilityVoteService voteService = mock(CombatReplayHouseAbilityVoteService.class);
     private final CombatReplayMentakAbilityService service = new CombatReplayMentakAbilityService(
             settings,
             mock(CombatCandidateRepository.class),
             mock(CombatReplayHouseAbilityUseRepository.class),
             houseFavorService,
-            mock(CombatReplayHouseAbilityVoteService.class),
+            voteService,
             mock(CombatReplayHousePhaseService.class),
             mock(CombatReplayHouseService.class));
 
     @Test
-    void decoyButtonsStayVisibleButDisableUnaffordableFavorCosts() {
+    void quantityButtonsShowTotalCostAndDisableUnaffordableCounts() {
         CombatCandidateEntity candidate = new CombatCandidateEntity();
         candidate.setId(7L);
-        int warSunCost = settings.getHouseAbilities().getMentak().getWarSunDecoyFavorCost();
-        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), anyInt()))
-                .thenReturn(true);
-        when(houseFavorService.canAfford(CombatReplayHouse.MENTAK, warSunCost)).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(25))).thenReturn(true);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(44))).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(63))).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(82))).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(101))).thenReturn(false);
 
-        Button unaffordable = service.decoyButton(candidate, "naalu", UnitType.Warsun);
+        List<Button> buttons = service.quantityButtons(candidate, "naalu", UnitType.Cruiser);
 
-        assertNotNull(unaffordable);
-        assertTrue(unaffordable.isDisabled());
+        assertEquals("1x (-25 Favor)", buttons.getFirst().getLabel());
+        assertFalse(buttons.getFirst().isDisabled());
+        assertEquals("2x (-44 Favor)", buttons.get(1).getLabel());
+        assertTrue(buttons.get(1).isDisabled());
+    }
+
+    @Test
+    void mentakVoteThresholdPoolsCountsThenLowestTiedCountWins() {
+        when(voteService.votesFor(7L, CombatReplayHouse.MENTAK))
+                .thenReturn(List.of(
+                        vote("mentak_Destroyer_1", "1"),
+                        vote("mentak_Destroyer_1", "2"),
+                        vote("mentak_Destroyer_2", "3"),
+                        vote("mentak_Destroyer_2", "4"),
+                        vote("mentak_Destroyer_3", "5")));
+
+        CombatReplayHouseAbilityVoteService.WinningVote winningVote = service.winningMentakVote(7L);
+
+        assertEquals("mentak_Destroyer_1", winningVote.optionKey());
+        assertEquals(5, winningVote.voteCount());
+    }
+
+    @Test
+    void mentakVoteTiedUnitTypesChooseMostExpensiveUnit() {
+        when(voteService.votesFor(7L, CombatReplayHouse.MENTAK))
+                .thenReturn(List.of(
+                        vote("mentak_Destroyer_1", "1"),
+                        vote("mentak_Destroyer_2", "2"),
+                        vote("mentak_Destroyer_3", "3"),
+                        vote("mentak_Warsun_1", "4"),
+                        vote("mentak_Warsun_2", "5"),
+                        vote("mentak_Warsun_3", "6")));
+
+        CombatReplayHouseAbilityVoteService.WinningVote winningVote = service.winningMentakVote(7L);
+
+        assertEquals("mentak_Warsun_1", winningVote.optionKey());
+        assertEquals(3, winningVote.voteCount());
+    }
+
+    @Test
+    void mentakVoteThresholdRequiresOnlyTwoPooledUnitTypeVotes() {
+        when(voteService.votesFor(7L, CombatReplayHouse.MENTAK))
+                .thenReturn(List.of(vote("mentak_Cruiser_1", "1"), vote("mentak_Cruiser_2", "2")));
+
+        CombatReplayHouseAbilityVoteService.WinningVote winningVote = service.winningMentakVote(7L);
+
+        assertEquals("mentak_Cruiser_1", winningVote.optionKey());
+        assertEquals(2, winningVote.voteCount());
+    }
+
+    private CombatReplayHouseAbilityVoteEntity vote(String optionKey, String voterId) {
+        CombatReplayHouseAbilityVoteEntity vote = new CombatReplayHouseAbilityVoteEntity();
+        vote.setCandidateId(7L);
+        vote.setHouse(CombatReplayHouse.MENTAK);
+        vote.setOptionKey(optionKey);
+        vote.setDiscordUserId(voterId);
+        vote.setDiscordUserName("Voter " + voterId);
+        return vote;
     }
 }


### PR DESCRIPTION
## Summary
- Add Mentak False Colors quantity selection for 1-5 decoy ships after choosing side and unit type.
- Resolve Mentak votes by pooling ship-type votes, preferring higher-cost unit types on ties, then choosing the most-voted count with lowest-count tie break.
- Reduce Mentak decoy base costs by 5 in dev and prod configs.

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn test