### PR TITLE
Add secret Mentak prediction overrides

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -303,14 +303,14 @@ public class CombatContestSettings {
         private int baseCombatFavorGain = 20;
         private int marketMakerPointsPerBet = 2;
         private int lowTradeConvoysFavorCost = 10;
-        private int lowTradeConvoysPredictionBonus = 10;
+        private int lowTradeConvoysPredictionBonus = 9;
         private int mediumTradeConvoysFavorCost = 20;
-        private int mediumTradeConvoysPredictionBonus = 16;
+        private int mediumTradeConvoysPredictionBonus = 14;
         private int highTradeConvoysFavorCost = 30;
-        private int highTradeConvoysPredictionBonus = 22;
+        private int highTradeConvoysPredictionBonus = 19;
         private int veryHighTradeConvoysFavorCost = 40;
-        private int veryHighTradeConvoysPredictionBonus = 29;
+        private int veryHighTradeConvoysPredictionBonus = 25;
         private int maximumTradeConvoysFavorCost = 50;
-        private int maximumTradeConvoysPredictionBonus = 36;
+        private int maximumTradeConvoysPredictionBonus = 31;
     }
 }

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -289,10 +289,10 @@ public class CombatContestSettings {
     @Setter
     public static class Mentak {
         private int previewLeadSeconds = 5 * 60;
-        private int destroyerDecoyFavorCost = 30;
-        private int cruiserDecoyFavorCost = 40;
-        private int dreadnoughtDecoyFavorCost = 60;
-        private int warSunDecoyFavorCost = 80;
+        private int destroyerDecoyFavorCost = 20;
+        private int cruiserDecoyFavorCost = 30;
+        private int dreadnoughtDecoyFavorCost = 40;
+        private int warSunDecoyFavorCost = 70;
     }
 
     @Getter

--- a/src/main/java/ti4/contest/replay/entities/CombatReplayPredictionEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatReplayPredictionEntity.java
@@ -46,6 +46,9 @@ public class CombatReplayPredictionEntity {
     @Column(name = "defender_prediction_count", nullable = false)
     private Integer defenderPredictionCount;
 
+    @Column(name = "mentak_prediction_override_count", nullable = false, columnDefinition = "INTEGER DEFAULT 0")
+    private Integer mentakPredictionOverrideCount = 0;
+
     @Column(name = "attacker_predictions_json", nullable = false, columnDefinition = "TEXT")
     private String attackerPredictionsJson;
 

--- a/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityButtonHandler.java
+++ b/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityButtonHandler.java
@@ -12,6 +12,28 @@ import ti4.spring.context.SpringContext;
 @UtilityClass
 public class CombatReplayMentakAbilityButtonHandler {
 
+    @ButtonHandler(CombatReplayMentakAbilityService.MENTAK_PREDICTION_PREFIX)
+    public static void handleMentakPrediction(ButtonInteractionEvent event, String buttonId) {
+        CombatReplayMentakAbilityService service = SpringContext.getBean(CombatReplayMentakAbilityService.class);
+        if (!service.userHasHouse(event.getUser().getId())) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "Only Mentak Delegation may seal pirate wagers.");
+            return;
+        }
+
+        PredictionRequest request = parsePrediction(buttonId);
+        if (request == null) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "Could not read the Mentak prediction.");
+            return;
+        }
+
+        CombatReplayInteractionResult result = service.votePredictionOverride(
+                request.contestId(),
+                request.predictedFaction(),
+                event.getUser().getId(),
+                event.getUser().getName());
+        MessageHelper.sendEphemeralMessageToEventChannel(event, result.message());
+    }
+
     @ButtonHandler(CombatReplayMentakAbilityService.MENTAK_MANAGE_VOTE_PREFIX)
     public static void handleManageMentakVote(ButtonInteractionEvent event, String buttonId) {
         CombatReplayMentakAbilityService service = SpringContext.getBean(CombatReplayMentakAbilityService.class);
@@ -93,5 +115,18 @@ public class CombatReplayMentakAbilityButtonHandler {
         }
     }
 
+    private static PredictionRequest parsePrediction(String buttonId) {
+        String request = buttonId.replace(CombatReplayMentakAbilityService.MENTAK_PREDICTION_PREFIX, "");
+        String[] parts = request.split("_", 2);
+        if (parts.length != 2) return null;
+        try {
+            return new PredictionRequest(Long.parseLong(parts[0]), parts[1]);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
     private record DecoyRequest(long candidateId, String targetFaction, UnitType unitType, Integer count) {}
+
+    private record PredictionRequest(long contestId, String predictedFaction) {}
 }

--- a/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityService.java
+++ b/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityService.java
@@ -19,6 +19,7 @@ import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayHouseAbilityVoteEntity;
 import ti4.contest.replay.repository.CombatCandidateRepository;
 import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
@@ -46,10 +47,12 @@ public class CombatReplayMentakAbilityService {
 
     public static final String MENTAK_DECOY_PREFIX = "combatReplayMentakDecoy_";
     public static final String MENTAK_DECOY_QUANTITY_PREFIX = MENTAK_DECOY_PREFIX + "quantity_";
+    public static final String MENTAK_PREDICTION_PREFIX = "combatReplayMentakPrediction_";
     public static final String MENTAK_MANAGE_VOTE_PREFIX = "combatReplayMentakManageVote_";
     public static final String MENTAK_DO_NOT_USE = MENTAK_DECOY_PREFIX + "doNotUse_";
 
     private static final String DO_NOT_USE_ABILITY = "DO_NOT_USE";
+    private static final String PREDICTION_OPTION_PREFIX = "PREDICTION_";
     private static final int MAX_DECOY_COUNT = 5;
     private static final int MINIMUM_UNIT_TYPE_VOTES_TO_RESOLVE = 2;
     private static final String SYSTEM_USER_ID = "0";
@@ -152,6 +155,54 @@ public class CombatReplayMentakAbilityService {
     public boolean userHasHouse(String discordUserId) {
         if (settings.getRuntime().isDevMode()) return true;
         return houseService.houseForUser(discordUserId) == CombatReplayHouse.MENTAK;
+    }
+
+    public void postPredictionOverrideButtons(
+            Game game, CombatReplayContestEntity contest, CombatCandidateEntity candidate) {
+        if (contest == null || contest.getId() == null || candidate == null) return;
+        TextChannel channel = houseChannel();
+        if (channel == null) return;
+
+        Player attacker = game == null ? null : game.getPlayerFromColorOrFaction(candidate.getAttackerFaction());
+        Player defender = game == null ? null : game.getPlayerFromColorOrFaction(candidate.getDefenderFaction());
+        MessageHelper.sendMessageToChannelWithButtons(
+                channel,
+                "## " + FactionEmojis.getFactionIcon(CombatReplayHouse.MENTAK.displayName())
+                        + " Mentak Delegation Hidden Wagers\n"
+                        + "-# Public reactions remain on the table. These sealed pirate marks are what the archive will count for Mentak delegates when predictions lock.",
+                List.of(
+                        predictionButton(contest.getId(), candidate.getAttackerFaction(), attacker),
+                        predictionButton(contest.getId(), candidate.getDefenderFaction(), defender)));
+    }
+
+    public CombatReplayInteractionResult votePredictionOverride(
+            long contestId, String predictedFaction, String discordUserId, String discordUserName) {
+        if (StringUtils.isBlank(predictedFaction)) {
+            return CombatReplayInteractionResult.rejected("Could not read that Mentak prediction.");
+        }
+        return voteService.recordVote(
+                predictionVoteKey(contestId),
+                CombatReplayHouse.MENTAK,
+                predictionOptionKey(predictedFaction),
+                StringUtils.capitalize(predictedFaction),
+                discordUserId,
+                discordUserName,
+                ignored -> 0,
+                this::predictionVoteSummary,
+                "Mentak Delegation has already resolved its ability for this combat.",
+                "Mentak Delegation cannot afford that prediction.");
+    }
+
+    public Map<String, String> predictionOverridesFor(Long contestId) {
+        if (contestId == null) return Map.of();
+        Map<String, String> overrides = new HashMap<>();
+        for (CombatReplayHouseAbilityVoteEntity vote :
+                voteService.votesFor(predictionVoteKey(contestId), CombatReplayHouse.MENTAK)) {
+            String faction = predictionFaction(vote.getOptionKey());
+            if (StringUtils.isBlank(faction)) continue;
+            overrides.put(vote.getDiscordUserId(), faction);
+        }
+        return overrides;
     }
 
     public CombatReplayInteractionResult voteDecoy(
@@ -369,6 +420,16 @@ public class CombatReplayMentakAbilityService {
                 unitType.getUnitTypeEmoji());
     }
 
+    private Button predictionButton(Long contestId, String faction, Player player) {
+        String label = player == null || player.getFactionModel() == null
+                ? "Predict " + StringUtils.capitalize(faction)
+                : "Predict " + player.getFactionModel().getFactionName();
+        String buttonId = MENTAK_PREDICTION_PREFIX + contestId + "_" + faction;
+        return player == null
+                ? Buttons.blue(buttonId, label, FactionEmojis.getFactionIcon(faction))
+                : Buttons.blue(buttonId, label, player.getFactionEmoji());
+    }
+
     List<Button> quantityButtons(CombatCandidateEntity candidate, String faction, UnitType unitType) {
         List<Button> buttons = new ArrayList<>();
         if (StringUtils.isBlank(faction)) return buttons;
@@ -455,6 +516,11 @@ public class CombatReplayMentakAbilityService {
                 + "` pooled votes. Quantity ties choose the lower count.";
     }
 
+    private String predictionVoteSummary(Long contestVoteKey) {
+        return voteService.voteSummary(contestVoteKey, CombatReplayHouse.MENTAK, this::predictionOptionLabel)
+                + "\n-# These are private Mentak winner predictions. Public reactions are only cover.";
+    }
+
     private String optionLabel(String optionKey) {
         if (DO_NOT_USE_ABILITY.equals(optionKey)) return "Do Not Use";
         MentakOption option = parseOption(optionKey);
@@ -462,6 +528,24 @@ public class CombatReplayMentakAbilityService {
             return optionLabel(option.targetFaction(), option.unitType(), option.count());
         }
         return optionKey;
+    }
+
+    private String predictionOptionLabel(String optionKey) {
+        String faction = predictionFaction(optionKey);
+        return StringUtils.isBlank(faction) ? optionKey : StringUtils.capitalize(faction);
+    }
+
+    private Long predictionVoteKey(long contestId) {
+        return -Math.abs(contestId);
+    }
+
+    private String predictionOptionKey(String faction) {
+        return PREDICTION_OPTION_PREFIX + faction;
+    }
+
+    private String predictionFaction(String optionKey) {
+        if (StringUtils.isBlank(optionKey) || !optionKey.startsWith(PREDICTION_OPTION_PREFIX)) return null;
+        return optionKey.substring(PREDICTION_OPTION_PREFIX.length());
     }
 
     private String optionLabel(String targetFaction, UnitType unitType, int count) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -26,6 +26,7 @@ import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
 import ti4.contest.replay.entities.CombatReplayPredictionEntity;
 import ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService;
+import ti4.contest.replay.house.mentak.CombatReplayMentakAbilityService;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
 import ti4.contest.replay.repository.CombatReplayLeaderboardEntryRepository;
 import ti4.contest.replay.repository.CombatReplayPredictionRepository;
@@ -73,6 +74,7 @@ public class CombatReplayLeaderboardService {
     private final CombatReplayHouseLedgerService houseLedgerService;
     private final CombatReplayHouseFavorService houseFavorService;
     private final CombatReplayHacanTradeConvoysService hacanTradeConvoysService;
+    private final CombatReplayMentakAbilityService mentakAbilityService;
 
     public void lockPredictionsAtReplayStart(
             Game game, CombatReplayContestEntity replayContest, CombatCandidateEntity candidate) {
@@ -294,6 +296,9 @@ public class CombatReplayLeaderboardService {
         Map<String, String> factionToEmoji = Map.of(
                 candidate.getAttackerFaction(), getFactionEmoji(game, candidate.getAttackerFaction()),
                 candidate.getDefenderFaction(), getFactionEmoji(game, candidate.getDefenderFaction()));
+        Map<String, String> mentakPredictionOverrides =
+                mentakAbilityService.predictionOverridesFor(replayContest.getId());
+        Set<String> overriddenMentakUserIds = new HashSet<>();
 
         for (MessageReaction reaction : message.getReactions()) {
             String predictedFaction = null;
@@ -307,10 +312,22 @@ public class CombatReplayLeaderboardService {
 
             for (User user : reaction.retrieveUsers().complete()) {
                 if (user.isBot()) continue;
-                houseService.assignHouseIfAbsent(user, message.getGuild());
+                CombatReplayHouse house = null;
+                var houseAssignment = houseService.assignHouseIfAbsent(user, message.getGuild());
+                if (houseAssignment != null) {
+                    house = houseAssignment.getHouse();
+                }
+                String effectivePrediction = predictedFaction;
+                String mentakOverride = mentakPredictionOverrides.get(user.getId());
+                if (house == CombatReplayHouse.MENTAK && isCombatPredictionFaction(candidate, mentakOverride)) {
+                    effectivePrediction = mentakOverride;
+                    if (!mentakOverride.equalsIgnoreCase(predictedFaction)) {
+                        overriddenMentakUserIds.add(user.getId());
+                    }
+                }
                 factionsByUser
                         .computeIfAbsent(user.getId(), key -> new HashSet<>())
-                        .add(predictedFaction);
+                        .add(effectivePrediction);
                 namesByUser.put(user.getId(), user.getName());
             }
         }
@@ -341,6 +358,7 @@ public class CombatReplayLeaderboardService {
         lockedPrediction.setScoredAt(null);
         lockedPrediction.setAttackerPredictionCount(attackerPredictions.size());
         lockedPrediction.setDefenderPredictionCount(defenderPredictions.size());
+        lockedPrediction.setMentakPredictionOverrideCount(overriddenMentakUserIds.size());
         lockedPrediction.setAttackerPredictionsJson(writeLockedPredictions(attackerPredictions));
         lockedPrediction.setDefenderPredictionsJson(writeLockedPredictions(defenderPredictions));
         return lockedPrediction;
@@ -704,14 +722,28 @@ public class CombatReplayLeaderboardService {
         return player == null ? "" : player.getFactionEmoji();
     }
 
+    private boolean isCombatPredictionFaction(CombatCandidateEntity candidate, String faction) {
+        if (candidate == null || faction == null) return false;
+        return faction.equalsIgnoreCase(candidate.getAttackerFaction())
+                || faction.equalsIgnoreCase(candidate.getDefenderFaction());
+    }
+
     private String buildLockedPredictionMessage(
             Game game, CombatCandidateEntity candidate, CombatReplayPredictionEntity lockedPrediction) {
-        return "## The Ledger Is Sealed\n"
+        String message = "## The Ledger Is Sealed\n"
                 + "Predictions are locked before the combat begins.\n"
                 + getFactionEmoji(game, candidate.getAttackerFaction()) + " " + candidate.getAttackerFaction() + ": **"
                 + safeInt(lockedPrediction.getAttackerPredictionCount()) + "**\n"
                 + getFactionEmoji(game, candidate.getDefenderFaction()) + " " + candidate.getDefenderFaction() + ": **"
                 + safeInt(lockedPrediction.getDefenderPredictionCount()) + "**";
+        if (safeInt(lockedPrediction.getMentakPredictionOverrideCount()) > 0) {
+            message += "\n\n-# Black sails crossed the ledger at the final bell. `"
+                    + safeInt(lockedPrediction.getMentakPredictionOverrideCount())
+                    + "` Mentak public prediction"
+                    + (safeInt(lockedPrediction.getMentakPredictionOverrideCount()) == 1 ? " was" : "s were")
+                    + " quietly replaced by sealed pirate marks.";
+        }
+        return message;
     }
 
     private String getSafeLeaderboardName(String userName) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -215,6 +215,7 @@ public class CombatReplayPromotionService {
             CombatReplayContestEntity contest =
                     persistPromotedReplayContest(winner, promotedAt, contestChannel, posted, thread, existingContest);
             addPredictionReactions(game, winner, posted);
+            mentakAbilityService.postPredictionOverrideButtons(game, contest, winner);
             replayExecutionService.postPromotionContext(thread != null ? thread : contestChannel, contest, winner);
             return contest;
         } catch (Exception e) {

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -72,12 +72,12 @@ houseAbilities:
     baseCombatFavorGain: 20
     marketMakerPointsPerBet: 2
     lowTradeConvoysFavorCost: 10
-    lowTradeConvoysPredictionBonus: 10
+    lowTradeConvoysPredictionBonus: 9
     mediumTradeConvoysFavorCost: 20
-    mediumTradeConvoysPredictionBonus: 16
+    mediumTradeConvoysPredictionBonus: 14
     highTradeConvoysFavorCost: 30
-    highTradeConvoysPredictionBonus: 22
+    highTradeConvoysPredictionBonus: 19
     veryHighTradeConvoysFavorCost: 40
-    veryHighTradeConvoysPredictionBonus: 29
+    veryHighTradeConvoysPredictionBonus: 25
     maximumTradeConvoysFavorCost: 50
-    maximumTradeConvoysPredictionBonus: 36
+    maximumTradeConvoysPredictionBonus: 31

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -59,13 +59,13 @@ houseAbilities:
   mentak:
     previewLeadSeconds: 15
     # destroyerDecoyFavorCost: 0
-    destroyerDecoyFavorCost: 15
+    destroyerDecoyFavorCost: 20
     # cruiserDecoyFavorCost: 0
-    cruiserDecoyFavorCost: 25
+    cruiserDecoyFavorCost: 30
     # dreadnoughtDecoyFavorCost: 0
-    dreadnoughtDecoyFavorCost: 35
+    dreadnoughtDecoyFavorCost: 40
     # warSunDecoyFavorCost: 0
-    warSunDecoyFavorCost: 65
+    warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
     subsidyFavorOnHit: 10

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -55,10 +55,10 @@ houseAbilities:
     luckOmensFavorCost: 30
   mentak:
     previewLeadSeconds: 900
-    destroyerDecoyFavorCost: 15
-    cruiserDecoyFavorCost: 25
-    dreadnoughtDecoyFavorCost: 35
-    warSunDecoyFavorCost: 65
+    destroyerDecoyFavorCost: 20
+    cruiserDecoyFavorCost: 30
+    dreadnoughtDecoyFavorCost: 40
+    warSunDecoyFavorCost: 70
   hacan:
     maxSubsidiesPerContest: 2
     subsidyFavorOnHit: 10

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -65,12 +65,12 @@ houseAbilities:
     baseCombatFavorGain: 20
     marketMakerPointsPerBet: 2
     lowTradeConvoysFavorCost: 10
-    lowTradeConvoysPredictionBonus: 10
+    lowTradeConvoysPredictionBonus: 9
     mediumTradeConvoysFavorCost: 20
-    mediumTradeConvoysPredictionBonus: 16
+    mediumTradeConvoysPredictionBonus: 14
     highTradeConvoysFavorCost: 30
-    highTradeConvoysPredictionBonus: 22
+    highTradeConvoysPredictionBonus: 19
     veryHighTradeConvoysFavorCost: 40
-    veryHighTradeConvoysPredictionBonus: 29
+    veryHighTradeConvoysPredictionBonus: 25
     maximumTradeConvoysFavorCost: 50
-    maximumTradeConvoysPredictionBonus: 36
+    maximumTradeConvoysPredictionBonus: 31

--- a/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
+++ b/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
@@ -140,7 +140,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
                 service.tradeConvoysButtonsForHouse(contest, CombatReplayHouse.NAALU);
 
         assertEquals(5, buttons.size());
-        assertTrue(buttons.get(4).getLabel().startsWith("50 Favor: 36%"));
+        assertTrue(buttons.get(4).getLabel().startsWith("50 Favor: 31%"));
         assertFalse(buttons.get(0).isDisabled());
         assertTrue(buttons.get(1).isDisabled());
         assertTrue(buttons.get(2).isDisabled());
@@ -154,7 +154,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
         CombatCandidateEntity candidate = candidate(7L);
         when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
         when(tradeConvoysVoteRepository.findByContestId(contest.getId()))
-                .thenReturn(List.of(vote(CombatReplayHouse.NAALU, 10, 10, "user-1")));
+                .thenReturn(List.of(vote(CombatReplayHouse.NAALU, 10, 9, "user-1")));
         when(houseFavorService.canAfford(CombatReplayHouse.HACAN, 10)).thenReturn(true);
 
         CombatReplayHacanTradeConvoysService.TradeConvoys tradeConvoys =
@@ -163,7 +163,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
         assertTrue(tradeConvoys.active());
         assertEquals(CombatReplayHouse.NAALU, tradeConvoys.targetHouse());
         assertEquals(10, tradeConvoys.favorCost());
-        assertEquals(10, tradeConvoys.bonusPercent());
+        assertEquals(9, tradeConvoys.bonusPercent());
     }
 
     @Test
@@ -179,7 +179,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
         when(candidateRepository.findById(previousContest.getCandidateId())).thenReturn(Optional.of(candidate(7L)));
         when(tradeConvoysRepository.findByContestId(previousContest.getId())).thenReturn(Optional.empty());
         when(tradeConvoysVoteRepository.findByContestId(previousContest.getId()))
-                .thenReturn(List.of(vote(CombatReplayHouse.NAALU, 10, 10, "user-1")));
+                .thenReturn(List.of(vote(CombatReplayHouse.NAALU, 10, 9, "user-1")));
         when(houseFavorService.canAfford(CombatReplayHouse.HACAN, 10)).thenReturn(true);
 
         service.postPostCombatTradeConvoysButtonsIfNeeded(currentContest, currentCandidate);
@@ -198,8 +198,8 @@ class CombatReplayHacanTradeConvoysServiceTest {
         when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
         when(tradeConvoysVoteRepository.findByContestId(contest.getId()))
                 .thenReturn(List.of(
-                        vote(CombatReplayHouse.NAALU, 50, 36, "user-1"),
-                        vote(CombatReplayHouse.MENTAK, 10, 10, "user-2")));
+                        vote(CombatReplayHouse.NAALU, 50, 31, "user-1"),
+                        vote(CombatReplayHouse.MENTAK, 10, 9, "user-2")));
         when(houseFavorService.canAfford(CombatReplayHouse.HACAN, 10)).thenReturn(true);
 
         service.lockTradeConvoysIfNeeded(contest, candidate);
@@ -208,7 +208,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
                 ArgumentCaptor.forClass(CombatReplayHacanTradeConvoysEntity.class);
         verify(tradeConvoysRepository).save(savedTradeConvoys.capture());
         assertEquals(10, savedTradeConvoys.getValue().getFavorCost());
-        assertEquals(10, savedTradeConvoys.getValue().getPredictionBonus());
+        assertEquals(9, savedTradeConvoys.getValue().getPredictionBonus());
     }
 
     @Test
@@ -252,7 +252,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
         CombatReplayInteractionResult result = service.sendTradeConvoysNow(
                 event,
                 new CombatReplayHacanTradeConvoysService.ParsedTradeConvoysButton(
-                        contest.getId(), CombatReplayHouse.NAALU, 10, 10));
+                        contest.getId(), CombatReplayHouse.NAALU, 10, 9));
 
         assertTrue(result.accepted());
         assertEquals(15, targetScore.getFavorPoints());

--- a/src/test/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityServiceButtonTest.java
+++ b/src/test/java/ti4/contest/replay/house/mentak/CombatReplayMentakAbilityServiceButtonTest.java
@@ -40,17 +40,17 @@ class CombatReplayMentakAbilityServiceButtonTest {
     void quantityButtonsShowTotalCostAndDisableUnaffordableCounts() {
         CombatCandidateEntity candidate = new CombatCandidateEntity();
         candidate.setId(7L);
-        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(25))).thenReturn(true);
-        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(44))).thenReturn(false);
-        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(63))).thenReturn(false);
-        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(82))).thenReturn(false);
-        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(101))).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(30))).thenReturn(true);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(53))).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(76))).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(99))).thenReturn(false);
+        when(houseFavorService.canAfford(eq(CombatReplayHouse.MENTAK), eq(122))).thenReturn(false);
 
         List<Button> buttons = service.quantityButtons(candidate, "naalu", UnitType.Cruiser);
 
-        assertEquals("1x (-25 Favor)", buttons.getFirst().getLabel());
+        assertEquals("1x (-30 Favor)", buttons.getFirst().getLabel());
         assertFalse(buttons.getFirst().isDisabled());
-        assertEquals("2x (-44 Favor)", buttons.get(1).getLabel());
+        assertEquals("2x (-53 Favor)", buttons.get(1).getLabel());
         assertTrue(buttons.get(1).isDisabled());
     }
 

--- a/src/test/java/ti4/contest/replay/service/CombatReplayLeaderboardServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayLeaderboardServiceTest.java
@@ -12,6 +12,7 @@ import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
 import ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService;
+import ti4.contest.replay.house.mentak.CombatReplayMentakAbilityService;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
 import ti4.contest.replay.repository.CombatReplayLeaderboardEntryRepository;
 import ti4.contest.replay.repository.CombatReplayPredictionRepository;
@@ -31,7 +32,8 @@ class CombatReplayLeaderboardServiceTest {
                 mock(CombatReplayHouseService.class),
                 mock(CombatReplayHouseLedgerService.class),
                 mock(CombatReplayHouseFavorService.class),
-                mock(CombatReplayHacanTradeConvoysService.class));
+                mock(CombatReplayHacanTradeConvoysService.class),
+                mock(CombatReplayMentakAbilityService.class));
         Method method = CombatReplayLeaderboardService.class.getDeclaredMethod(
                 "newLeaderboardEntry", String.class, String.class);
         method.setAccessible(true);
@@ -59,7 +61,8 @@ class CombatReplayLeaderboardServiceTest {
                 mock(CombatReplayHouseService.class),
                 mock(CombatReplayHouseLedgerService.class),
                 houseFavorService,
-                mock(CombatReplayHacanTradeConvoysService.class));
+                mock(CombatReplayHacanTradeConvoysService.class),
+                mock(CombatReplayMentakAbilityService.class));
         Method method = CombatReplayLeaderboardService.class.getDeclaredMethod(
                 "favorAwardMessage", HousePredictionSummary.class);
         method.setAccessible(true);


### PR DESCRIPTION
## Summary
- add private Mentak combat winner prediction buttons in the Mentak house channel when primary prediction reactions open
- apply Mentak private overrides while freezing public combat winner predictions, only for Mentak users who reacted publicly
- show pirate-flavored locked-ledger text when Mentak public predictions were replaced by sealed marks
- keep Mentak stacked decoys at 75% added-unit pricing, with restored base decoy costs 20/30/40/70 in dev/prod/defaults
- reduce Hacan Trade Convoys prediction bonus tiers by about 15% in dev/prod config and Java defaults: 10/16/22/29/36 -> 9/14/19/25/31

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -Dtest=CombatReplayHacanTradeConvoysServiceTest,CombatSideBetTypeTest test
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -Dtest='*Mentak*' test