### PR TITLE
Tune combat contest selection window

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -203,13 +203,13 @@ public class CombatContestSettings {
     @Setter
     public static class CandidateSelection {
         private Window window = new Window();
-        private int targetCandidatesPerHour = 16;
+        private int targetCandidatesPerHour = 4;
     }
 
     @Getter
     @Setter
     public static class Window {
-        private int lookbackMinutes = 1440;
+        private int lookbackMinutes = 480;
         private int refreshCronIntervalSeconds = 300;
     }
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayDiscordPostService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayDiscordPostService.java
@@ -1,6 +1,7 @@
 package ti4.contest.replay.service;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import net.dv8tion.jda.api.entities.Message;
@@ -22,6 +23,7 @@ import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.helpers.ThreadGetter;
 import ti4.image.TileGenerator;
+import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 
 @Service
@@ -98,9 +100,16 @@ public class CombatReplayDiscordPostService {
     }
 
     public ThreadChannel createReplayThread(Message posted, CombatCandidateEntity winner) {
-        return posted.createThreadChannel(buildReplayThreadName(winner))
+        ThreadChannel thread = posted.createThreadChannel(buildReplayThreadName(winner))
                 .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS)
                 .complete();
+        scheduleReplayThreadArchive(thread);
+        return thread;
+    }
+
+    private void scheduleReplayThreadArchive(ThreadChannel thread) {
+        if (thread == null) return;
+        thread.getManager().setArchived(true).queueAfter(2, TimeUnit.HOURS, ignored -> {}, BotLogger::catchRestError);
     }
 
     public MessageChannel getContestThreadOrChannel(CombatReplayContestEntity contest) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayDiscordPostService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayDiscordPostService.java
@@ -1,7 +1,6 @@
 package ti4.contest.replay.service;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import net.dv8tion.jda.api.entities.Message;
@@ -23,7 +22,6 @@ import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.helpers.ThreadGetter;
 import ti4.image.TileGenerator;
-import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 
 @Service
@@ -100,16 +98,9 @@ public class CombatReplayDiscordPostService {
     }
 
     public ThreadChannel createReplayThread(Message posted, CombatCandidateEntity winner) {
-        ThreadChannel thread = posted.createThreadChannel(buildReplayThreadName(winner))
-                .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS)
+        return posted.createThreadChannel(buildReplayThreadName(winner))
+                .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_1_HOUR)
                 .complete();
-        scheduleReplayThreadArchive(thread);
-        return thread;
-    }
-
-    private void scheduleReplayThreadArchive(ThreadChannel thread) {
-        if (thread == null) return;
-        thread.getManager().setArchived(true).queueAfter(2, TimeUnit.HOURS, ignored -> {}, BotLogger::catchRestError);
     }
 
     public MessageChannel getContestThreadOrChannel(CombatReplayContestEntity contest) {

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -1,6 +1,6 @@
 candidateSelection:
   window:
-    lookbackMinutes: 60
+    lookbackMinutes: 480
     refreshCronIntervalSeconds: 300
   targetCandidatesPerHour: 4
 

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -1,6 +1,6 @@
 candidateSelection:
   window:
-    lookbackMinutes: 60
+    lookbackMinutes: 480
     refreshCronIntervalSeconds: 300
   targetCandidatesPerHour: 4
 

--- a/src/test/java/ti4/contest/replay/service/CombatReplayDiscordPostServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayDiscordPostServiceTest.java
@@ -1,17 +1,12 @@
 package ti4.contest.replay.service;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
-import net.dv8tion.jda.api.managers.channel.concrete.ThreadChannelManager;
 import net.dv8tion.jda.api.requests.restaction.ThreadChannelAction;
 import org.junit.jupiter.api.Test;
 import ti4.contest.replay.core.CombatContestSettings;
@@ -20,11 +15,10 @@ import ti4.contest.replay.entities.CombatCandidateEntity;
 class CombatReplayDiscordPostServiceTest {
 
     @Test
-    void createReplayThreadSchedulesArchiveAfterTwoHours() {
+    void createReplayThreadUsesOneHourAutoArchiveDuration() {
         Message posted = mock(Message.class);
         ThreadChannelAction action = mock(ThreadChannelAction.class);
         ThreadChannel thread = mock(ThreadChannel.class);
-        ThreadChannelManager manager = mock(ThreadChannelManager.class);
         CombatCandidateEntity candidate = new CombatCandidateEntity();
         candidate.setId(42L);
         candidate.setTilePosition("306");
@@ -35,16 +29,13 @@ class CombatReplayDiscordPostServiceTest {
 
         when(posted.createThreadChannel("combat-archive-c42-t306-mentak-v-hacan"))
                 .thenReturn(action);
-        when(action.setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS))
+        when(action.setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_1_HOUR))
                 .thenReturn(action);
         when(action.complete()).thenReturn(thread);
-        when(thread.getManager()).thenReturn(manager);
-        when(manager.setArchived(true)).thenReturn(manager);
 
         ThreadChannel result = service.createReplayThread(posted, candidate);
 
         assertSame(thread, result);
-        verify(action).setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS);
-        verify(manager).queueAfter(eq(2L), eq(TimeUnit.HOURS), any(Consumer.class), any(Consumer.class));
+        verify(action).setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_1_HOUR);
     }
 }

--- a/src/test/java/ti4/contest/replay/service/CombatReplayDiscordPostServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayDiscordPostServiceTest.java
@@ -1,0 +1,50 @@
+package ti4.contest.replay.service;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.managers.channel.concrete.ThreadChannelManager;
+import net.dv8tion.jda.api.requests.restaction.ThreadChannelAction;
+import org.junit.jupiter.api.Test;
+import ti4.contest.replay.core.CombatContestSettings;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+
+class CombatReplayDiscordPostServiceTest {
+
+    @Test
+    void createReplayThreadSchedulesArchiveAfterTwoHours() {
+        Message posted = mock(Message.class);
+        ThreadChannelAction action = mock(ThreadChannelAction.class);
+        ThreadChannel thread = mock(ThreadChannel.class);
+        ThreadChannelManager manager = mock(ThreadChannelManager.class);
+        CombatCandidateEntity candidate = new CombatCandidateEntity();
+        candidate.setId(42L);
+        candidate.setTilePosition("306");
+        candidate.setAttackerFaction("mentak");
+        candidate.setDefenderFaction("hacan");
+        CombatReplayDiscordPostService service =
+                new CombatReplayDiscordPostService(new CombatContestSettings(), mock(ReplayPayloadRenderer.class));
+
+        when(posted.createThreadChannel("combat-archive-c42-t306-mentak-v-hacan"))
+                .thenReturn(action);
+        when(action.setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS))
+                .thenReturn(action);
+        when(action.complete()).thenReturn(thread);
+        when(thread.getManager()).thenReturn(manager);
+        when(manager.setArchived(true)).thenReturn(manager);
+
+        ThreadChannel result = service.createReplayThread(posted, candidate);
+
+        assertSame(thread, result);
+        verify(action).setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.TIME_24_HOURS);
+        verify(manager).queueAfter(eq(2L), eq(TimeUnit.HOURS), any(Consumer.class), any(Consumer.class));
+    }
+}


### PR DESCRIPTION
## Summary
- Set combat contest candidate selection to target 4 candidates per hour in Java defaults and environment config.
- Extend the observation lookback window to 8 hours (`480` minutes) for prod/dev config and defaults.
- Set Lazax combat replay threads to JDA's native 1-hour auto-archive duration.

## Test Plan
- `JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=CombatReplayServiceTest,CombatReplayDiscordPostServiceTest test`