### PR TITLE
Add Promise of Protection and simplify Trade Convoys

### DIFF
--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysButtonHandler.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysButtonHandler.java
@@ -1,8 +1,6 @@
 package ti4.contest.replay.house.hacan;
 
-import java.util.List;
 import lombok.experimental.UtilityClass;
-import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysService.ParsedTradeConvoysButton;
 import ti4.contest.replay.service.CombatReplayInteractionResult;
@@ -19,15 +17,10 @@ public class CombatReplayHacanTradeConvoysButtonHandler {
             ParsedTradeConvoysButton parsed = CombatReplayHacanTradeConvoysService.parseButtonId(buttonId);
             CombatReplayHacanTradeConvoysService service =
                     SpringContext.getBean(CombatReplayHacanTradeConvoysService.class);
-            CombatReplayInteractionResult result = service.recordTradeConvoysVote(event, parsed);
-            List<Button> sendNowButtons = service.sendNowButtons(parsed, event);
-            if (sendNowButtons.isEmpty()) {
-                MessageHelper.sendEphemeralMessageToEventChannel(event, result.message());
-            } else {
-                MessageHelper.sendMessageToEventChannelWithEphemeralButtons(event, result.message(), sendNowButtons);
-            }
+            CombatReplayInteractionResult result = service.sendTradeConvoysNow(event, parsed);
+            MessageHelper.sendEphemeralMessageToEventChannel(event, result.message());
         } catch (IllegalArgumentException e) {
-            MessageHelper.sendEphemeralMessageToEventChannel(event, "Could not read that Hacan Trade Convoys vote.");
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "Could not read that Hacan Trade Convoys request.");
         }
     }
 

--- a/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
+++ b/src/main/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysService.java
@@ -30,7 +30,6 @@ import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysRepository;
 import ti4.contest.replay.repository.CombatReplayHacanTradeConvoysVoteRepository;
 import ti4.contest.replay.repository.CombatReplayHouseAbilityUseRepository;
 import ti4.contest.replay.repository.CombatReplayHouseScoreRepository;
-import ti4.contest.replay.service.CombatReplayAbilityWindowText;
 import ti4.contest.replay.service.CombatReplayHouseAbilityVoteService;
 import ti4.contest.replay.service.CombatReplayHouseFavorService;
 import ti4.contest.replay.service.CombatReplayHouseLedgerService.HousePredictionSummary;
@@ -80,7 +79,6 @@ public class CombatReplayHacanTradeConvoysService {
             CombatReplayContestEntity contest,
             CombatCandidateEntity candidate,
             List<HousePredictionSummary> currentCombatSummaries) {
-        lockPreviousTradeConvoysIfCurrentCombatEnded(contest);
         if (!canOfferTradeConvoys(contest, candidate)) return;
         postTradeConvoysVotingButtons(contest, hacanFavorLedger(contest, currentCombatSummaries));
     }
@@ -111,13 +109,12 @@ public class CombatReplayHacanTradeConvoysService {
                 channel,
                 "## " + FactionEmojis.getFactionIcon(CombatReplayHouse.HACAN.displayName())
                         + " Hacan Delegation Trade Convoys\n"
-                        + CombatReplayAbilityWindowText.votesLockWhenNextCombatEndsLine()
+                        + "-# Hacan CEO may send one Trade Convoys offer while this window is open."
                         + "\n"
                         + favorBalanceLine(favorLedger)
                         + "\n"
                         + tradeConvoysSummaryLine(),
-                List.of(Buttons.red(
-                        formatButtonId(contest.getId(), CombatReplayHouse.HACAN, 0, 0), "Do Not Use Trade Convoys")));
+                List.of());
         postTradeConvoysButtonsForHouse(channel, contest, CombatReplayHouse.NAALU, favorLedger);
         postTradeConvoysButtonsForHouse(channel, contest, CombatReplayHouse.MENTAK, favorLedger);
     }
@@ -152,13 +149,12 @@ public class CombatReplayHacanTradeConvoysService {
                 "## "
                         + FactionEmojis.getFactionIcon(CombatReplayHouse.HACAN.displayName())
                         + " Hacan Delegation Trade Convoys\n"
-                        + CombatReplayAbilityWindowText.votesLockWhenNextCombatEndsLine()
+                        + "-# Hacan CEO may send one Trade Convoys offer while this window is open."
                         + "\n"
                         + favorBalanceLine(null)
                         + "\n"
-                        + voteSummary(contest.getId()),
-                List.of(Buttons.red(
-                        formatButtonId(contest.getId(), CombatReplayHouse.HACAN, 0, 0), "Do Not Use Trade Convoys")));
+                        + tradeConvoysSummaryLine(),
+                List.of());
         sendEphemeralTradeConvoysButtonsForHouse(event, contest, CombatReplayHouse.NAALU);
         sendEphemeralTradeConvoysButtonsForHouse(event, contest, CombatReplayHouse.MENTAK);
     }
@@ -273,36 +269,7 @@ public class CombatReplayHacanTradeConvoysService {
         CombatReplayHacanTradeConvoysEntity existing =
                 tradeConvoysRepository.findByContestId(contest.getId()).orElse(null);
         if (existing != null) return toTradeConvoys(existing);
-
-        List<CombatReplayHacanTradeConvoysVoteEntity> votes =
-                tradeConvoysVoteRepository.findByContestId(contest.getId());
-
-        TradeConvoysTally winning = winningTally(votes);
-        if (winning == null || winning.targetHouse() == null || winning.bonusPercent() <= 0) {
-            return lockNoTradeConvoys(contest, winning == null ? 0 : winning.voteCount());
-        }
-        if (!houseFavorService.canAfford(CombatReplayHouse.HACAN, effectiveFavorCost(winning.favorCost()))) {
-            return lockNoTradeConvoys(contest, winning.voteCount());
-        }
-        if (!claimHacanTradeConvoysUse(
-                candidate.getId(),
-                effectiveFavorCost(winning.favorCost()),
-                winning.discordUserId(),
-                winning.discordUserName())) {
-            return lockNoTradeConvoys(contest, winning.voteCount());
-        }
-
-        CombatReplayHacanTradeConvoysEntity tradeConvoys = new CombatReplayHacanTradeConvoysEntity();
-        tradeConvoys.setContestId(contest.getId());
-        tradeConvoys.setTargetHouse(winning.targetHouse());
-        tradeConvoys.setFavorCost(winning.favorCost());
-        tradeConvoys.setPredictionBonus(winning.bonusPercent());
-        tradeConvoys.setVoteCount(winning.voteCount());
-        tradeConvoys.setSelectedAt(LocalDateTime.now());
-        tradeConvoysRepository.save(tradeConvoys);
-        creditTradeConvoysFavorTransferIfScored(tradeConvoys);
-        postLockedTradeConvoysSummary(tradeConvoys);
-        return toTradeConvoys(tradeConvoys);
+        return TradeConvoys.none();
     }
 
     public TradeConvoys tradeConvoysForContest(Long contestId) {
@@ -423,18 +390,7 @@ public class CombatReplayHacanTradeConvoysService {
     public void lockPreviousTradeConvoysIfCurrentCombatEnded(CombatReplayContestEntity currentContest) {
         if (currentContest == null || currentContest.getId() == null || currentContest.getReplayCompletedAt() == null)
             return;
-        CombatReplayContestEntity previousContest = contestRepository
-                .findFirstByIdLessThanOrderByIdDesc(currentContest.getId())
-                .orElse(null);
-        if (previousContest == null
-                || previousContest.getCandidateId() == null
-                || (previousContest.getReplayCompletedAt() == null && previousContest.getLeaderboardPostedAt() == null))
-            return;
-        CombatCandidateEntity previousCandidate =
-                candidateRepository.findById(previousContest.getCandidateId()).orElse(null);
-        if (previousCandidate != null) {
-            lockTradeConvoysIfNeeded(previousContest, previousCandidate);
-        }
+        // Trade Convoys no longer auto-resolves from delegation votes. Hacan CEO must use Send Now.
     }
 
     public boolean userHasHouse(String discordUserId) {

--- a/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakScoringRule.java
+++ b/src/main/java/ti4/contest/replay/house/mentak/CombatReplayMentakScoringRule.java
@@ -20,7 +20,7 @@ import ti4.contest.replay.service.CombatReplayHouseScoringRule;
 public class CombatReplayMentakScoringRule implements CombatReplayHouseScoringRule {
 
     private static final int PILLAGE_POINTS_PER_OTHER_DELEGATION_MISS = 4;
-    private static final int PROMISE_OF_PROTECTION_MULTIPLIER = 5;
+    private static final int PROMISE_OF_PROTECTION_POINTS = 60;
 
     private final CombatCandidateRepository candidateRepository;
     private final CombatReplayHouseAbilityUseRepository abilityUseRepository;
@@ -61,7 +61,6 @@ public class CombatReplayMentakScoringRule implements CombatReplayHouseScoringRu
                 .orElse(0);
         if (favorCost <= 0) return;
 
-        context.addAbilitySummary(
-                CombatReplayHouse.MENTAK, "Promise of Protection", favorCost * PROMISE_OF_PROTECTION_MULTIPLIER);
+        context.addAbilitySummary(CombatReplayHouse.MENTAK, "Promise of Protection", PROMISE_OF_PROTECTION_POINTS);
     }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -144,7 +144,6 @@ public class CombatReplayLeaderboardService {
         if (replayContest.getId() == null) return;
         if (replayContest.getLeaderboardPostedAt() != null) return;
 
-        hacanTradeConvoysService.lockPreviousTradeConvoysIfCurrentCombatEnded(replayContest);
         ScoredContestResult result = scoreReplayContest(candidate, replayContest);
         MessageChannel threadOrChannel = getContestThreadOrChannel(replayContest);
         if (threadOrChannel != null) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -305,7 +305,6 @@ public class CombatReplayPromotionService {
             if (observation == null || game == null || channel == null) return null;
 
             CombatReplayContestEntity previewContest = createPreviewContest(candidate);
-            lockPreviousContestTradeConvoys(previewContest);
 
             String startSummaryText = snapshotStartSummaryText(candidate);
             String message = LazaxCombatSupport.formatReplayAnnouncement(
@@ -442,31 +441,10 @@ public class CombatReplayPromotionService {
                 : resetReplayContest(
                         existingContest, winner, publicChannelId, publicMessageId, publicThreadId, promotedAt);
         CombatReplayContestEntity savedContest = replayContestRepository.save(contest);
-        lockPreviousContestTradeConvoys(savedContest);
-
         winner.setPromotionStatus(CombatCandidatePromotionStatus.PROMOTED);
         winner.setPromotedAt(promotedAt);
         candidateRepository.save(winner);
         return savedContest;
-    }
-
-    private void lockPreviousContestTradeConvoys(CombatReplayContestEntity newContest) {
-        if (newContest == null || newContest.getId() == null) return;
-        if (!isPostCombat(newContest)) return;
-        CombatReplayContestEntity previousContest = replayContestRepository
-                .findFirstByIdLessThanOrderByIdDesc(newContest.getId())
-                .orElse(null);
-        if (previousContest == null || previousContest.getCandidateId() == null) return;
-        if (!isPostCombat(previousContest)) return;
-        CombatCandidateEntity previousCandidate =
-                candidateRepository.findById(previousContest.getCandidateId()).orElse(null);
-        if (previousCandidate == null) return;
-        hacanTradeConvoysService.lockTradeConvoysIfNeeded(previousContest, previousCandidate);
-        replayLeaderboardService.computeAndPersistHouseScoresFromFacts(previousCandidate, previousContest);
-    }
-
-    private boolean isPostCombat(CombatReplayContestEntity contest) {
-        return contest != null && (contest.getReplayCompletedAt() != null || contest.getLeaderboardPostedAt() != null);
     }
 
     private CombatReplayContestEntity createPreviewContest(CombatCandidateEntity candidate) {

--- a/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
+++ b/src/test/java/ti4/contest/replay/house/hacan/CombatReplayHacanTradeConvoysServiceTest.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayHouse;
 import ti4.contest.replay.entities.CombatCandidateEntity;
@@ -149,7 +148,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
     }
 
     @Test
-    void tradeConvoysLocksWithSingleVote() {
+    void tradeConvoysVotesDoNotAutoLock() {
         CombatReplayContestEntity contest = contest(3L, 7L);
         CombatCandidateEntity candidate = candidate(7L);
         when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
@@ -160,14 +159,12 @@ class CombatReplayHacanTradeConvoysServiceTest {
         CombatReplayHacanTradeConvoysService.TradeConvoys tradeConvoys =
                 service.lockTradeConvoysIfNeeded(contest, candidate);
 
-        assertTrue(tradeConvoys.active());
-        assertEquals(CombatReplayHouse.NAALU, tradeConvoys.targetHouse());
-        assertEquals(10, tradeConvoys.favorCost());
-        assertEquals(9, tradeConvoys.bonusPercent());
+        assertFalse(tradeConvoys.active());
+        verify(tradeConvoysRepository, org.mockito.Mockito.never()).save(org.mockito.Mockito.any());
     }
 
     @Test
-    void openingNewPostCombatWindowLocksPreviousTradeConvoys() {
+    void openingNewPostCombatWindowDoesNotLockPreviousTradeConvoysVotes() {
         CombatReplayContestEntity previousContest = contest(3L, 7L);
         previousContest.setReplayCompletedAt(LocalDateTime.now().minusMinutes(10));
         CombatReplayContestEntity currentContest = contest(4L, 8L);
@@ -184,15 +181,11 @@ class CombatReplayHacanTradeConvoysServiceTest {
 
         service.postPostCombatTradeConvoysButtonsIfNeeded(currentContest, currentCandidate);
 
-        ArgumentCaptor<CombatReplayHacanTradeConvoysEntity> savedTradeConvoys =
-                ArgumentCaptor.forClass(CombatReplayHacanTradeConvoysEntity.class);
-        verify(tradeConvoysRepository).save(savedTradeConvoys.capture());
-        assertEquals(previousContest.getId(), savedTradeConvoys.getValue().getContestId());
-        assertEquals(CombatReplayHouse.NAALU, savedTradeConvoys.getValue().getTargetHouse());
+        verify(tradeConvoysRepository, org.mockito.Mockito.never()).save(org.mockito.Mockito.any());
     }
 
     @Test
-    void tradeConvoysTieBetweenFavorOptionsLocksLowerFavorValue() {
+    void tradeConvoysTieBetweenFavorOptionsDoesNotAutoLock() {
         CombatReplayContestEntity contest = contest(3L, 7L);
         CombatCandidateEntity candidate = candidate(7L);
         when(tradeConvoysRepository.findByContestId(contest.getId())).thenReturn(Optional.empty());
@@ -204,11 +197,7 @@ class CombatReplayHacanTradeConvoysServiceTest {
 
         service.lockTradeConvoysIfNeeded(contest, candidate);
 
-        ArgumentCaptor<CombatReplayHacanTradeConvoysEntity> savedTradeConvoys =
-                ArgumentCaptor.forClass(CombatReplayHacanTradeConvoysEntity.class);
-        verify(tradeConvoysRepository).save(savedTradeConvoys.capture());
-        assertEquals(10, savedTradeConvoys.getValue().getFavorCost());
-        assertEquals(9, savedTradeConvoys.getValue().getPredictionBonus());
+        verify(tradeConvoysRepository, org.mockito.Mockito.never()).save(org.mockito.Mockito.any());
     }
 
     @Test

--- a/src/test/java/ti4/contest/replay/service/CombatReplayMentakScoringRuleTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayMentakScoringRuleTest.java
@@ -31,7 +31,7 @@ class CombatReplayMentakScoringRuleTest {
             new CombatReplayMentakScoringRule(candidateRepository, abilityUseRepository);
 
     @Test
-    void promiseOfProtectionPaysFiveTimesFalseColorsCostWhenDecoyedFactionWins() {
+    void promiseOfProtectionPaysFlatPointsWhenDecoyedFactionWins() {
         CombatCandidateEntity candidate = candidate("ghost", "ghost", 40);
         when(candidateRepository.findById(candidate.getId())).thenReturn(Optional.of(candidate));
         when(abilityUseRepository.findByCandidateIdAndHouse(candidate.getId(), CombatReplayHouse.MENTAK))
@@ -42,7 +42,7 @@ class CombatReplayMentakScoringRuleTest {
         rule.apply(context(candidate, abilities));
 
         assertTrue(abilities.get(CombatReplayHouse.MENTAK).stream()
-                .anyMatch(summary -> "Promise of Protection".equals(summary.label()) && summary.points() == 200));
+                .anyMatch(summary -> "Promise of Protection".equals(summary.label()) && summary.points() == 60));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add Mentak Promise of Protection scoring for paid False Colors decoys that land on the eventual winner.
- Add /lazax delegation_leaderboard to repost the public delegation leaderboard after score corrections.
- Make Hacan Trade Convoys send-now only by removing automatic vote-based sending at combat replay boundaries.

## Test Plan
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=ti4.contest.replay.service.CombatReplayMentakScoringRuleTest,ti4.contest.replay.service.CombatReplayHouseLedgerServiceFavorTest test
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -Dtest=ti4.contest.replay.house.hacan.CombatReplayHacanTradeConvoysServiceTest test