### PR TITLE
Add combat replay enabled flag

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatContestJanitorCron.java
+++ b/src/main/java/ti4/contest/cron/CombatContestJanitorCron.java
@@ -2,6 +2,7 @@ package ti4.contest.cron;
 
 import java.util.concurrent.TimeUnit;
 import lombok.experimental.UtilityClass;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayJanitorService;
 import ti4.cron.CronManager;
 import ti4.logging.BotLogger;
@@ -22,6 +23,7 @@ public class CombatContestJanitorCron {
 
     private static void runJanitor() {
         if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        if (!CombatContestSettings.isEnabledStatic()) return;
         BotLogger.logCron("Running CombatContestJanitorCron.");
         try {
             SpringContext.getBean(CombatReplayJanitorService.class).runJanitor();

--- a/src/main/java/ti4/contest/cron/CombatReplayCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayCron.java
@@ -22,6 +22,7 @@ public class CombatReplayCron {
 
     private static void runReplayTick() {
         if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        if (!CombatContestSettings.isEnabledStatic()) return;
         CombatContestSettings settings = SpringContext.getBean(CombatContestSettings.class);
         if (!shouldRun(settings.getReplayExecution().getReplayIntervalSeconds())) return;
         try {

--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionCron.java
@@ -25,6 +25,7 @@ public class CombatReplayPromotionCron {
 
     private static void promoteBestCandidate() {
         if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        if (!CombatContestSettings.isEnabledStatic()) return;
         CombatContestSettings settings = SpringContext.getBean(CombatContestSettings.class);
         if (!settings.getRuntime().isImmediatePromotionOnResolve()
                 && !shouldRun(settings.getPromotion().getIntervalSeconds())) return;

--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.experimental.UtilityClass;
 import ti4.contest.replay.core.CombatCandidateEventType;
 import ti4.contest.replay.core.CombatCandidateStatus;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.LazaxCombatSupport;
 import ti4.contest.replay.core.renderers.CombatReplayTileRenderer;
 import ti4.contest.replay.dispatch.ReplayDispatchPayload;
@@ -42,6 +43,7 @@ public class CombatReplayPromotionScoreBackfillCron {
 
     private static void runBackfill() {
         if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        if (!CombatContestSettings.isEnabledStatic()) return;
         BotLogger.logCron("Running CombatReplayPromotionScoreBackfillCron.");
         try {
             runBackfillInternal();

--- a/src/main/java/ti4/contest/cron/CombatReplaySelectionCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplaySelectionCron.java
@@ -25,6 +25,7 @@ public class CombatReplaySelectionCron {
 
     private static void refreshSelectionSettings() {
         if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        if (!CombatContestSettings.isEnabledStatic()) return;
         CombatContestSettings settings = SpringContext.getBean(CombatContestSettings.class);
         if (!shouldRun(settings.getCandidateSelection().getWindow().getRefreshCronIntervalSeconds())) return;
         BotLogger.logCron("Running CombatReplaySelectionCron.");

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+import ti4.spring.context.SpringContext;
 
 /**
  * Mutable in-memory settings for the replay contest system.
@@ -26,6 +27,7 @@ public class CombatContestSettings {
     @Setter(AccessLevel.NONE)
     private boolean isProd;
 
+    private boolean enabled;
     private CandidateSelection candidateSelection = new CandidateSelection();
     private Promotion promotion = new Promotion();
     private ReplayExecution replayExecution = new ReplayExecution();
@@ -176,6 +178,10 @@ public class CombatContestSettings {
     @JsonProperty("isProd")
     public boolean isProd() {
         return isProd;
+    }
+
+    public static boolean isEnabledStatic() {
+        return SpringContext.getBean(CombatContestSettings.class).isEnabled();
     }
 
     private void loadEnvironmentDefaults(boolean isProd) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -69,6 +69,7 @@ public class CombatReplayService {
     }
 
     public PreInteractionSnapshot capturePreInteractionSnapshot(Game game) {
+        if (!settings.isEnabled()) return PreInteractionSnapshot.empty();
         if (game == null) return PreInteractionSnapshot.empty();
 
         Map<Long, CandidateInitialSnapshot> snapshots = new HashMap<>();
@@ -91,6 +92,7 @@ public class CombatReplayService {
     }
 
     public void onSpaceCombatStarted(Game game, Player attacker, Player defender, Tile tile) {
+        if (!settings.isEnabled()) return;
         if (isDiscordantStarsGame(game)) return;
 
         boolean trackAllCombatsAsCandidates = settings.getRuntime().isTrackAllCombatsAsCandidates();
@@ -116,6 +118,7 @@ public class CombatReplayService {
     }
 
     public void onButtonInteractionSettled(Game game, Player player, ButtonInteractionEvent event) {
+        if (!settings.isEnabled()) return;
         for (CombatCandidateEntity candidate : getOpenCandidates(game)) {
             if (candidate.getStatus() == CombatCandidateStatus.PENDING_RESOLUTION
                     && !candidate
@@ -136,6 +139,7 @@ public class CombatReplayService {
     }
 
     public void finalizeExpiredPendingResolutionCandidates() {
+        if (!settings.isEnabled()) return;
         LocalDateTime cutoff =
                 LocalDateTime.now().minusSeconds(settings.getReplayExecution().getPendingResolutionWindowSeconds());
         for (CombatCandidateEntity candidate : candidateRepository.findByStatusAndPendingResolutionStartedAtBefore(
@@ -155,6 +159,7 @@ public class CombatReplayService {
             boolean whiff,
             boolean slam,
             CombatRollPayload payload) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = getTrackingCandidate(game, tile.getPosition());
         if (candidate == null || !isReplayRoll(rollType)) return;
         if (rollType != CombatRollType.SpaceCannonOffence && !matchesParticipants(candidate, player, opponent)) return;
@@ -175,6 +180,7 @@ public class CombatReplayService {
 
     public boolean isTrackedCandidateRoll(
             Game game, Player player, Player opponent, Tile tile, CombatRollType rollType) {
+        if (!settings.isEnabled()) return false;
         if (game == null || player == null || opponent == null || tile == null || !isReplayRoll(rollType)) {
             return false;
         }
@@ -202,6 +208,7 @@ public class CombatReplayService {
             MessageEmbed embed,
             String sourceChannelName,
             CombatReplayTrackedEvent trackedEvent) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
         ensureInitialSnapshot(candidate, game);
@@ -213,6 +220,7 @@ public class CombatReplayService {
     }
 
     public void mirrorLeaderPlayed(Game game, Player player, String leaderId, String sourceChannelName) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
         ensureInitialSnapshot(candidate, game);
@@ -232,6 +240,7 @@ public class CombatReplayService {
             String actionCardId,
             String sourceChannelName,
             CombatReplayTrackedEvent trackedEvent) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
         ensureInitialSnapshot(candidate, game);
@@ -248,6 +257,7 @@ public class CombatReplayService {
     }
 
     public void mirrorRetreatDeclared(Game game, Player player, String sourceChannelName) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
         ensureInitialSnapshot(candidate, game);
@@ -262,6 +272,7 @@ public class CombatReplayService {
     }
 
     public void mirrorRetreatResolved(Game game, Player player, String destination, String sourceChannelName) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
         ensureInitialSnapshot(candidate, game);
@@ -276,6 +287,7 @@ public class CombatReplayService {
     }
 
     public void mirrorAssaultCannonAssigned(Game game, Player player, String sourceChannelName) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
         ensureInitialSnapshot(candidate, game);
@@ -290,6 +302,7 @@ public class CombatReplayService {
     }
 
     public void mirrorGravitonExhausted(Game game, Player player, String sourceChannelName) {
+        if (!settings.isEnabled()) return;
         CombatCandidateEntity candidate = resolveCandidateForMirrorEvent(game, player, sourceChannelName);
         if (candidate == null) return;
         ensureInitialSnapshot(candidate, game);
@@ -611,6 +624,7 @@ public class CombatReplayService {
     }
 
     public void refreshSelectionSnapshot() {
+        if (!settings.isEnabled()) return;
         LocalDateTime now = LocalDateTime.now();
         List<CombatObservationEntity> window = observationRepository.findByStartedAtGreaterThanEqualOrderByStartedAtAsc(
                 now.minusMinutes(settings.getCandidateSelection().getWindow().getLookbackMinutes()));

--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -30,6 +30,7 @@ import ti4.contest.cron.CombatReplayCron;
 import ti4.contest.cron.CombatReplayPromotionCron;
 import ti4.contest.cron.CombatReplayPromotionScoreBackfillCron;
 import ti4.contest.cron.CombatReplaySelectionCron;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.cron.AutoPingCron;
 import ti4.cron.BothelperDashboardCron;
 import ti4.cron.CategoryCleanupCron;
@@ -308,11 +309,13 @@ public class JdaService {
         SabotageAutoReactCron.register();
         FastScFollowCron.register();
         CloseLaunchThreadsCron.register();
-        CombatReplaySelectionCron.register();
-        CombatReplayPromotionCron.register();
-        CombatReplayPromotionScoreBackfillCron.register();
-        CombatReplayCron.register();
-        CombatContestJanitorCron.register();
+        if (CombatContestSettings.isEnabledStatic()) {
+            CombatReplaySelectionCron.register();
+            CombatReplayPromotionCron.register();
+            CombatReplayPromotionScoreBackfillCron.register();
+            CombatReplayCron.register();
+            CombatContestJanitorCron.register();
+        }
         InteractionLogCron.register();
         LongExecutionHistoryCron.register();
         CategoryCleanupCron.register();

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -97,10 +97,11 @@ public class ButtonProcessor {
 
                 beforeTime = System.currentTimeMillis();
                 context.save();
+                saveRuntime = System.currentTimeMillis() - beforeTime;
+                
                 if (combatReplayService != null && context.getGame() != null) {
                     combatReplayService.onButtonInteractionSettled(context.getGame(), context.getPlayer(), event);
                 }
-                saveRuntime = System.currentTimeMillis() - beforeTime;
             } finally {
                 if (combatReplayService != null) {
                     combatReplayService.clearPreInteractionSnapshot();

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -11,6 +11,8 @@ import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.contest.replay.buttons.CombatSideBetButtonIds;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.interactions.listeners.context.ButtonContext;
 import ti4.discord.interactions.routing.AnnotationHandler;
@@ -81,10 +83,13 @@ public class ButtonProcessor {
 
         log(event);
         try {
-            CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
-            CombatReplayService.PreInteractionSnapshot preInteractionSnapshot =
-                    combatReplayService.capturePreInteractionSnapshot(context.getGame());
-            combatReplayService.setPreInteractionSnapshot(preInteractionSnapshot);
+            CombatReplayService combatReplayService =
+                    CombatContestSettings.isEnabledStatic() ? SpringContext.getBean(CombatReplayService.class) : null;
+            if (combatReplayService != null) {
+                CombatReplayService.PreInteractionSnapshot preInteractionSnapshot =
+                        combatReplayService.capturePreInteractionSnapshot(context.getGame());
+                combatReplayService.setPreInteractionSnapshot(preInteractionSnapshot);
+            }
             try {
                 long beforeTime = System.currentTimeMillis();
                 resolveButtonInteractionEvent(context);
@@ -92,12 +97,14 @@ public class ButtonProcessor {
 
                 beforeTime = System.currentTimeMillis();
                 context.save();
-                if (context.getGame() != null) {
+                if (combatReplayService != null && context.getGame() != null) {
                     combatReplayService.onButtonInteractionSettled(context.getGame(), context.getPlayer(), event);
                 }
                 saveRuntime = System.currentTimeMillis() - beforeTime;
             } finally {
-                combatReplayService.clearPreInteractionSnapshot();
+                if (combatReplayService != null) {
+                    combatReplayService.clearPreInteractionSnapshot();
+                }
             }
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(event, context), "Something went wrong with button interaction", e);
@@ -131,6 +138,7 @@ public class ButtonProcessor {
 
     private static boolean handleKnownButtons(ButtonContext context) {
         String buttonID = context.getButtonID();
+        if (!CombatContestSettings.isEnabledStatic() && isCombatReplayButton(buttonID)) return true;
         // Check for exact match first
         if (knownButtons.containsKey(buttonID)) {
             RollbarManager.put("button_handler_id", buttonID);
@@ -154,6 +162,11 @@ public class ButtonProcessor {
             return true;
         }
         return false;
+    }
+
+    private static boolean isCombatReplayButton(String buttonID) {
+        return buttonID != null
+                && (buttonID.startsWith(CombatSideBetButtonIds.PREFIX) || buttonID.startsWith("combatReplayDebug_"));
     }
 
     private static void resolveButtonInteractionEvent(ButtonContext context) {

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -98,7 +98,7 @@ public class ButtonProcessor {
                 beforeTime = System.currentTimeMillis();
                 context.save();
                 saveRuntime = System.currentTimeMillis() - beforeTime;
-                
+
                 if (combatReplayService != null && context.getGame() != null) {
                     combatReplayService.onButtonInteractionSettled(context.getGame(), context.getPlayer(), event);
                 }

--- a/src/main/java/ti4/discord/interactions/listeners/LazaxMinigameReactionListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/LazaxMinigameReactionListener.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayHouseService;
 import ti4.contest.replay.service.CombatReplayLeaderboardService;
 import ti4.discord.JdaService;
@@ -45,6 +46,7 @@ class LazaxMinigameReactionListener extends ListenerAdapter {
     }
 
     private void handleLazaxMinigameReaction(MessageReactionAddEvent event, Message message) {
+        if (!CombatContestSettings.isEnabledStatic()) return;
         if (!message.getAuthor().isBot()) return;
         applyHouseAssignmentIfPredictionReaction(event, message);
         applyRoleUpdateIfSubscriptionPrompt(event, message);

--- a/src/main/java/ti4/discord/interactions/listeners/MessageListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/MessageListener.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayHouseService;
 import ti4.discord.JdaService;
 import ti4.executors.ExecutorServiceManager;
@@ -115,6 +116,7 @@ class MessageListener extends ListenerAdapter {
     }
 
     private static void addHouseEmojiReactionToLazaxMessages(MessageReceivedEvent event) {
+        if (!CombatContestSettings.isEnabledStatic()) return;
         SpringContext.getBean(CombatReplayHouseService.class).addHouseEmojiReactionIfNeeded(event);
     }
 

--- a/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.listeners.context.ModalContext;
@@ -77,14 +78,19 @@ public final class ModalListener extends ListenerAdapter {
             RollbarManager.put("modal_id", event.getModalId());
             RollbarManager.put("game_name", GameNameService.getGameNameFromChannel(event));
 
-            CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
-            combatReplayService.setPreInteractionSnapshot(
-                    combatReplayService.capturePreInteractionSnapshot(context.getGame()));
+            CombatReplayService combatReplayService =
+                    CombatContestSettings.isEnabledStatic() ? SpringContext.getBean(CombatReplayService.class) : null;
+            if (combatReplayService != null) {
+                combatReplayService.setPreInteractionSnapshot(
+                        combatReplayService.capturePreInteractionSnapshot(context.getGame()));
+            }
             try {
                 resolveModalInteractionEvent(context);
                 context.save();
             } finally {
-                combatReplayService.clearPreInteractionSnapshot();
+                if (combatReplayService != null) {
+                    combatReplayService.clearPreInteractionSnapshot();
+                }
             }
         } catch (Exception e) {
             String message = "Modal issue in event: " + event.getModalId() + "\n> Channel: "

--- a/src/main/java/ti4/discord/interactions/listeners/SlashCommandListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/SlashCommandListener.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionE
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.interactions.commands.Command;
 import ti4.discord.interactions.commands.GameStateContainer;
@@ -73,11 +74,12 @@ class SlashCommandListener extends ListenerAdapter implements CommandListener {
 
         ParentCommand command = SlashCommandManager.getCommand(event.getName());
         Command<SlashCommandInteractionEvent> resolvedCommand = getCommand(event);
-        CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
+        CombatReplayService combatReplayService =
+                CombatContestSettings.isEnabledStatic() ? SpringContext.getBean(CombatReplayService.class) : null;
         try {
             if (command.accept(event)) {
                 command.preExecute(event);
-                if (resolvedCommand instanceof GameStateContainer gameStateContainer) {
+                if (combatReplayService != null && resolvedCommand instanceof GameStateContainer gameStateContainer) {
                     combatReplayService.setPreInteractionSnapshot(
                             combatReplayService.capturePreInteractionSnapshot(gameStateContainer.getGame()));
                 }
@@ -91,7 +93,9 @@ class SlashCommandListener extends ListenerAdapter implements CommandListener {
         } catch (Exception e) {
             command.onException(event, e);
         } finally {
-            combatReplayService.clearPreInteractionSnapshot();
+            if (combatReplayService != null) {
+                combatReplayService.clearPreInteractionSnapshot();
+            }
             RollbarManager.clear();
         }
 

--- a/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
+++ b/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.interactions.listeners.context.SelectionMenuContext;
 import ti4.discord.interactions.routing.AnnotationHandler;
@@ -52,14 +53,20 @@ public final class SelectionMenuProcessor {
             RollbarManager.put("game_name", GameNameService.getGameNameFromChannel(event));
 
             if (context.isValid()) {
-                CombatReplayService combatReplayService = SpringContext.getBean(CombatReplayService.class);
-                combatReplayService.setPreInteractionSnapshot(
-                        combatReplayService.capturePreInteractionSnapshot(context.getGame()));
+                CombatReplayService combatReplayService = CombatContestSettings.isEnabledStatic()
+                        ? SpringContext.getBean(CombatReplayService.class)
+                        : null;
+                if (combatReplayService != null) {
+                    combatReplayService.setPreInteractionSnapshot(
+                            combatReplayService.capturePreInteractionSnapshot(context.getGame()));
+                }
                 try {
                     resolveSelectionMenu(context);
                     context.save();
                 } finally {
-                    combatReplayService.clearPreInteractionSnapshot();
+                    if (combatReplayService != null) {
+                        combatReplayService.clearPreInteractionSnapshot();
+                    }
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.requests.restaction.ThreadChannelAction;
 import net.dv8tion.jda.api.utils.FileUpload;
 import org.apache.commons.lang3.StringUtils;
 import ti4.ResourceHelper;
+import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatReplayDecoys;
 import ti4.contest.replay.service.CombatReplayService;
 import ti4.discord.interactions.buttons.Buttons;
@@ -125,7 +126,9 @@ public class StartCombatService {
             GenericInteractionCreateEvent event,
             String specialCombatTitle) {
         RoundStatsTracker.incrementCombatsInitiated(game, player);
-        SpringContext.getBean(CombatReplayService.class).onSpaceCombatStarted(game, player, player2, tile);
+        if (CombatContestSettings.isEnabledStatic()) {
+            SpringContext.getBean(CombatReplayService.class).onSpaceCombatStarted(game, player, player2, tile);
+        }
         String threadName = combatThreadName(game, player, player2, tile, specialCombatTitle);
         if (!game.isFowMode()) {
             findOrCreateCombatThread(
@@ -359,7 +362,7 @@ public class StartCombatService {
                 amount++;
             }
         }
-        if (amount > 2 || tile.getNumberOfUnitsInSystem() > 2) {
+        if (CombatContestSettings.isEnabledStatic() && (amount > 2 || tile.getNumberOfUnitsInSystem() > 2)) {
             MessageHelper.sendMessageToChannel(
                     threadChannel,
                     CombatReplayDecoys.appendDebugDecoySummary(

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -1,3 +1,5 @@
+enabled: true
+
 candidateSelection:
   window:
     lookbackMinutes: 480

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -1,3 +1,5 @@
+enabled: false
+
 candidateSelection:
   window:
     lookbackMinutes: 480

--- a/src/test/java/ti4/contest/replay/core/CombatContestSettingsTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatContestSettingsTest.java
@@ -13,6 +13,7 @@ class CombatContestSettingsTest {
         CombatContestSettings settings = new CombatContestSettings();
 
         assertFalse(settings.isProd());
+        assertTrue(settings.isEnabled());
         assertTrue(settings.getRuntime().isDevMode());
         assertEquals(60, settings.getReplayExecution().getDiscussionWindowSeconds());
         assertEquals(60, settings.getReplayExecution().getSideBetWindowSeconds());
@@ -26,6 +27,7 @@ class CombatContestSettingsTest {
         CombatContestSettings settings = new CombatContestSettings(false);
 
         assertTrue(settings.isProd());
+        assertFalse(settings.isEnabled());
         assertFalse(settings.getRuntime().isDevMode());
         assertEquals(900, settings.getReplayExecution().getDiscussionWindowSeconds());
         assertEquals(600, settings.getReplayExecution().getSideBetWindowSeconds());
@@ -39,6 +41,7 @@ class CombatContestSettingsTest {
         CombatContestSettings settings = new CombatContestSettings(true);
 
         assertFalse(settings.isProd());
+        assertTrue(settings.isEnabled());
         assertTrue(settings.getRuntime().isDevMode());
         assertEquals(60, settings.getReplayExecution().getDiscussionWindowSeconds());
         assertEquals(60, settings.getReplayExecution().getSideBetWindowSeconds());


### PR DESCRIPTION
## Summary
- Add a top-level combat contest `enabled` setting that is on in dev and off in prod.
- No-op replay observation, candidate/event tracking, snapshot hooks, and replay cron work when disabled.
- Keep Lazax commands available while only swallowing replay-specific side bet/debug buttons when disabled.

## Test Plan
- `mvn -q spotless:check`
- `mvn -q -Dtest=CombatContestSettingsTest test` cannot run locally with Java 21 because the project requires Java release 26.