### PR TITLE
Add SQLite persistence migration toggle

### DIFF
--- a/src/main/java/ti4/cron/PersistToSqlCron.java
+++ b/src/main/java/ti4/cron/PersistToSqlCron.java
@@ -3,6 +3,7 @@ package ti4.cron;
 import java.time.ZoneId;
 import lombok.experimental.UtilityClass;
 import ti4.logging.BotLogger;
+import ti4.service.persistence.SqlitePersistenceGate;
 import ti4.spring.context.SpringContext;
 import ti4.spring.service.deploy.ActiveLeaseService;
 import ti4.spring.service.persistence.PersistAllEntitiesService;
@@ -17,6 +18,10 @@ public class PersistToSqlCron {
 
     private static void persist() {
         if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        if (SqlitePersistenceGate.isDisabled()) {
+            BotLogger.logCron("Skipping PersistToSqlCron because SQLite-backed auxiliary persistence is disabled.");
+            return;
+        }
         BotLogger.logCron("Running PersistToSqlCron.");
         try {
             SpringContext.getBean(PersistAllEntitiesService.class).persistAll();

--- a/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
@@ -25,6 +25,7 @@ public class DeveloperCommand implements ParentCommand {
                     new CustomCommand(),
                     new RunAgainstSpecificGame(),
                     new ProduceNucleusGenStats(),
+                    new SqlitePersistence(),
                     new RunSql())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 

--- a/src/main/java/ti4/discord/interactions/commands/developer/RunSql.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunSql.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.message.MessageHelper;
+import ti4.service.persistence.SqlitePersistenceGate;
 import ti4.spring.context.SpringContext;
 import ti4.spring.service.developer.RunSqlService;
 
@@ -20,6 +21,11 @@ class RunSql extends Subcommand {
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
+        if (SqlitePersistenceGate.isDisabled()) {
+            MessageHelper.sendMessageToEventChannel(
+                    event, "SQL execution is disabled while SQLite-backed auxiliary persistence is off.");
+            return;
+        }
         String sql = event.getOption("sql").getAsString();
         RunSqlService runSqlService = SpringContext.getBean(RunSqlService.class);
         String result = runSqlService.executeSql(sql);

--- a/src/main/java/ti4/discord/interactions/commands/developer/SqlitePersistence.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/SqlitePersistence.java
@@ -1,0 +1,35 @@
+package ti4.discord.interactions.commands.developer;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.message.MessageHelper;
+import ti4.service.persistence.SqlitePersistenceGate;
+
+class SqlitePersistence extends Subcommand {
+
+    private static final String OPTION_MODE = "mode";
+
+    SqlitePersistence() {
+        super("sqlite_persistence", "Temporarily no-op auxiliary SQLite persistence during PostgreSQL migration.");
+        addOptions(new OptionData(OptionType.STRING, OPTION_MODE, "Whether SQLite-backed auxiliary persistence is on.")
+                .setRequired(true)
+                .addChoice("on", "on")
+                .addChoice("off", "off")
+                .addChoice("status", "status"));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        String mode = event.getOption(OPTION_MODE).getAsString();
+        switch (mode) {
+            case "on" -> SqlitePersistenceGate.setDisabled(false);
+            case "off" -> SqlitePersistenceGate.setDisabled(true);
+            case "status" -> {}
+            default -> MessageHelper.sendMessageToEventChannel(event, "Unknown mode: `" + mode + "`");
+        }
+
+        MessageHelper.sendMessageToEventChannel(event, SqlitePersistenceGate.statusMessage());
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand.java
@@ -3,9 +3,12 @@ package ti4.discord.interactions.commands.statistics;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.discord.interactions.commands.ParentCommand;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+import ti4.service.persistence.SqlitePersistenceGate;
 
 public class StatisticsCommand implements ParentCommand {
 
@@ -41,5 +44,15 @@ public class StatisticsCommand implements ParentCommand {
     @Override
     public Map<String, Subcommand> getSubcommands() {
         return subcommands;
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        if (SqlitePersistenceGate.isDisabled()) {
+            MessageHelper.sendMessageToEventChannel(
+                    event, "Statistics are unavailable while SQLite-backed auxiliary persistence is off.");
+            return;
+        }
+        ParentCommand.super.execute(event);
     }
 }

--- a/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand2.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand2.java
@@ -3,9 +3,12 @@ package ti4.discord.interactions.commands.statistics;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.discord.interactions.commands.ParentCommand;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+import ti4.service.persistence.SqlitePersistenceGate;
 
 public class StatisticsCommand2 implements ParentCommand {
 
@@ -31,5 +34,15 @@ public class StatisticsCommand2 implements ParentCommand {
     @Override
     public Map<String, Subcommand> getSubcommands() {
         return subcommands;
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        if (SqlitePersistenceGate.isDisabled()) {
+            MessageHelper.sendMessageToEventChannel(
+                    event, "Statistics are unavailable while SQLite-backed auxiliary persistence is off.");
+            return;
+        }
+        ParentCommand.super.execute(event);
     }
 }

--- a/src/main/java/ti4/service/persistence/SqlitePersistenceGate.java
+++ b/src/main/java/ti4/service/persistence/SqlitePersistenceGate.java
@@ -1,0 +1,25 @@
+package ti4.service.persistence;
+
+import lombok.experimental.UtilityClass;
+import ti4.settings.GlobalSettings;
+
+@UtilityClass
+public class SqlitePersistenceGate {
+
+    public static boolean isDisabled() {
+        return GlobalSettings.ImplementedSettings.SQLITE_PERSISTENCE_DISABLED.getAsBoolean(false);
+    }
+
+    public static void setDisabled(boolean disabled) {
+        GlobalSettings.setSetting(GlobalSettings.ImplementedSettings.SQLITE_PERSISTENCE_DISABLED, disabled);
+    }
+
+    public static String statusMessage() {
+        if (!isDisabled()) {
+            return "SQLite-backed auxiliary persistence is **ON**.";
+        }
+        return "SQLite-backed auxiliary persistence is **OFF**. Game commands and file saves still run, but"
+                + " SQLite/JDBC-backed statistics, dashboard caches, map image metadata, message cache, and SQL"
+                + " developer commands are no-op.";
+    }
+}

--- a/src/main/java/ti4/service/statistics/round/RoundStatsTracker.java
+++ b/src/main/java/ti4/service/statistics/round/RoundStatsTracker.java
@@ -5,6 +5,7 @@ import lombok.experimental.UtilityClass;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.logging.BotLogger;
+import ti4.service.persistence.SqlitePersistenceGate;
 import ti4.spring.context.SpringContext;
 import ti4.spring.service.roundstats.GameRoundStatsService;
 
@@ -52,6 +53,9 @@ public class RoundStatsTracker {
     }
 
     private static void withService(Consumer<GameRoundStatsService> operation) {
+        if (SqlitePersistenceGate.isDisabled()) {
+            return;
+        }
         try {
             operation.accept(SpringContext.getBean(GameRoundStatsService.class));
         } catch (IllegalStateException ignored) {

--- a/src/main/java/ti4/settings/GlobalSettings.java
+++ b/src/main/java/ti4/settings/GlobalSettings.java
@@ -28,6 +28,7 @@ public final class GlobalSettings {
         GUILD_ID_FOR_NEW_GAME_CATEGORIES, // Which guild to create new game categories in (DEPRECATED)
         MAX_GAMES_PER_CATEGORY, // Max # of games when creating a category
         ALLOW_GAME_CREATION,
+        SQLITE_PERSISTENCE_DISABLED, // Temporarily no-op auxiliary SQLite/JDBC reads and writes during migration
         READY_TO_RECEIVE_COMMANDS, // Whether the bot is ready to receive commands
         BOT_LOG_WEBHOOK_URL; // Webhook URL to send rogue bot log messages to
 

--- a/src/main/java/ti4/spring/api/dashboard/PlayerAggregatesService.java
+++ b/src/main/java/ti4/spring/api/dashboard/PlayerAggregatesService.java
@@ -25,6 +25,7 @@ import ti4.game.persistence.ManagedGame;
 import ti4.image.Mapper;
 import ti4.logging.BotLogger;
 import ti4.model.TechnologyModel;
+import ti4.service.persistence.SqlitePersistenceGate;
 import ti4.spring.service.roundstats.GameRoundPlayerStats;
 import ti4.spring.service.roundstats.GameRoundPlayerStatsRepository;
 import tools.jackson.databind.json.JsonMapper;
@@ -66,6 +67,10 @@ class PlayerAggregatesService {
      * 4) Return fresh cached payload if present, otherwise an empty aggregate shell.
      */
     PlayerDashboardResponse.PlayerAggregates getOrQueueRefresh(String userId, List<ManagedGame> playerGames) {
+        if (SqlitePersistenceGate.isDisabled()) {
+            List<String> completedGameIds = getTrackedCompletedGameIds(playerGames);
+            return emptyAggregates(false, "", completedGameIds.size(), 0, null, completedGameIds);
+        }
         CacheContext context = buildCacheContext(userId, playerGames);
         if (needsRefresh(context)) {
             queueRecompute(context.userId(), context.completedGameIds(), context.completedGamesHash());

--- a/src/main/java/ti4/spring/api/image/GameImageService.java
+++ b/src/main/java/ti4/spring/api/image/GameImageService.java
@@ -12,6 +12,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import ti4.game.persistence.GameManager;
+import ti4.service.persistence.SqlitePersistenceGate;
 
 @Service
 @RequiredArgsConstructor
@@ -22,12 +23,14 @@ public class GameImageService {
 
     @NotNull
     Optional<MapImageData> getLatestMapImageData(String gameName) {
+        if (SqlitePersistenceGate.isDisabled()) return Optional.empty();
         if (!GameManager.isValid(gameName)) return Optional.empty();
         return mapImageDataRepository.findById(gameName);
     }
 
     @Nullable
     public String getLatestMapImageName(String gameName) {
+        if (SqlitePersistenceGate.isDisabled()) return null;
         if (!GameManager.isValid(gameName)) return null;
         return mapImageDataRepository
                 .findById(gameName)
@@ -36,6 +39,7 @@ public class GameImageService {
     }
 
     public void saveDiscordMessageId(String gameName, long discordMessageId, long guildId, long channelId) {
+        if (SqlitePersistenceGate.isDisabled()) return;
         if (isBlank(gameName) || !GameManager.isValid(gameName)) return;
         MapImageData mapImageData = loadOrCreate(gameName);
         mapImageData.setLatestDiscordMessageId(discordMessageId);
@@ -62,6 +66,7 @@ public class GameImageService {
      * This allows the web frontend to retrieve the player's personalized map.
      */
     public void savePlayerDiscordMessageId(String gameName, String playerId, long messageId, long channelId) {
+        if (SqlitePersistenceGate.isDisabled()) return;
         if (isBlank(gameName) || isBlank(playerId)) return;
 
         PlayerMapImageData data = playerMapImageDataRepository
@@ -79,6 +84,7 @@ public class GameImageService {
      */
     @NotNull
     Optional<PlayerMapImageData> getPlayerMapImageData(String gameName, String playerId) {
+        if (SqlitePersistenceGate.isDisabled()) return Optional.empty();
         if (isBlank(gameName) || isBlank(playerId)) return Optional.empty();
         return playerMapImageDataRepository.findByGameNameAndPlayerId(gameName, playerId);
     }

--- a/src/main/java/ti4/spring/service/messagecache/SavedBotMessagesService.java
+++ b/src/main/java/ti4/spring/service/messagecache/SavedBotMessagesService.java
@@ -8,6 +8,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ti4.logging.BotLogger;
+import ti4.service.persistence.SqlitePersistenceGate;
 import ti4.spring.context.SpringContext;
 
 @AllArgsConstructor
@@ -19,6 +20,7 @@ public class SavedBotMessagesService {
     private final BotDiscordMessageEntityRepository botDiscordMessageEntityRepository;
 
     public void cache(Message message) {
+        if (SqlitePersistenceGate.isDisabled()) return;
         if (!isImportantMessage(message)) return;
 
         long createdAtEpochMillis = message.getTimeCreated().toInstant().toEpochMilli();
@@ -40,6 +42,7 @@ public class SavedBotMessagesService {
 
     @Nullable
     public String getContent(long messageId) {
+        if (SqlitePersistenceGate.isDisabled()) return null;
         return botDiscordMessageEntityRepository
                 .findById(messageId)
                 .map(BotDiscordMessageEntity::getContent)
@@ -49,12 +52,18 @@ public class SavedBotMessagesService {
     @Scheduled(cron = "0 */30 * * * *")
     @Transactional
     public void removeExpiredMessages() {
+        if (SqlitePersistenceGate.isDisabled()) {
+            BotLogger.info(
+                    "Skipping bot message cache cleanup because SQLite-backed auxiliary persistence is disabled.");
+            return;
+        }
         long cutoff = System.currentTimeMillis() - RETENTION_MILLIS;
         long deletedRowCount = botDiscordMessageEntityRepository.deleteByCreatedAtEpochMillisLessThan(cutoff);
         BotLogger.info("Deleted " + deletedRowCount + " rows from the `bot_discord_message` table.");
     }
 
     public void remove(long messageId) {
+        if (SqlitePersistenceGate.isDisabled()) return;
         botDiscordMessageEntityRepository.deleteById(messageId);
     }
 

--- a/src/main/java/ti4/spring/service/tournamentwinner/TourneyWinnerService.java
+++ b/src/main/java/ti4/spring/service/tournamentwinner/TourneyWinnerService.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import net.dv8tion.jda.api.entities.User;
 import org.springframework.stereotype.Service;
 import ti4.discord.JdaService;
+import ti4.service.persistence.SqlitePersistenceGate;
 
 @AllArgsConstructor
 @Service
@@ -13,18 +14,23 @@ public class TourneyWinnerService {
     private TournamentWinnerRepository tournamentWinnerRepository;
 
     public boolean exists(String userId) {
+        if (SqlitePersistenceGate.isDisabled()) return false;
         return tournamentWinnerRepository.existsByUserId(userId);
     }
 
     public void add(String userId, String userName, String tourneyName) {
+        if (SqlitePersistenceGate.isDisabled()) return;
         tournamentWinnerRepository.save(new TournamentWinner(userId, userName, tourneyName));
     }
 
     public void remove(String userId, String tourneyName) {
+        if (SqlitePersistenceGate.isDisabled()) return;
         tournamentWinnerRepository.deleteByUserIdAndTourneyName(userId, tourneyName);
     }
 
     public String allWinnersToString() {
+        if (SqlitePersistenceGate.isDisabled())
+            return "Tournament winner data is unavailable while SQLite persistence is disabled.";
         StringBuilder sb = new StringBuilder("__**All Async TI4 Tournament Winners:**__");
         List<TournamentWinner> winners = tournamentWinnerRepository.findAll();
         for (TournamentWinner winner : winners) {


### PR DESCRIPTION
## Summary
- Add `/developer sqlite_persistence` with `on`, `off`, and `status` modes for migration windows.
- No-op SQLite/JDBC-backed auxiliary persistence while disabled: SQL-backed stats commands, persist-to-SQL cron, round stats tracking, dashboard aggregate cache, map image metadata, bot message cache, tournament winner repository access, and `/developer run_sql`.
- Keep the main bot running: no interaction drain, no active lease changes, and no changes to file-backed game saves.

## Test Plan
- `git diff --check`
- `docker build -t ti4-sqlite-persistence-gate-check .`

Note: host `mvn -q -DskipTests compile` is blocked locally because this machine does not have a Java 26 compiler (`release version 26 not supported`).