### PR TITLE
Disable round stats tracking via kill switch

### DIFF
--- a/src/main/java/ti4/service/statistics/round/RoundStatsTracker.java
+++ b/src/main/java/ti4/service/statistics/round/RoundStatsTracker.java
@@ -6,6 +6,7 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.logging.BotLogger;
 import ti4.service.persistence.SqlitePersistenceGate;
+import ti4.settings.GlobalSettings;
 import ti4.spring.context.SpringContext;
 import ti4.spring.service.roundstats.GameRoundStatsService;
 
@@ -53,7 +54,7 @@ public class RoundStatsTracker {
     }
 
     private static void withService(Consumer<GameRoundStatsService> operation) {
-        if (SqlitePersistenceGate.isDisabled()) {
+        if (isDisabled()) {
             return;
         }
         try {
@@ -63,5 +64,10 @@ public class RoundStatsTracker {
         } catch (Exception e) {
             BotLogger.error("Round stats tracking failed.", e);
         }
+    }
+
+    private static boolean isDisabled() {
+        return SqlitePersistenceGate.isDisabled()
+                || GlobalSettings.ImplementedSettings.ROUND_STATS_TRACKING_DISABLED.getAsBoolean(false);
     }
 }

--- a/src/main/java/ti4/settings/GlobalSettings.java
+++ b/src/main/java/ti4/settings/GlobalSettings.java
@@ -29,6 +29,7 @@ public final class GlobalSettings {
         MAX_GAMES_PER_CATEGORY, // Max # of games when creating a category
         ALLOW_GAME_CREATION,
         SQLITE_PERSISTENCE_DISABLED, // Temporarily no-op auxiliary SQLite/JDBC reads and writes during migration
+        ROUND_STATS_TRACKING_DISABLED, // Temporarily no-op round stats tracking reads and writes
         READY_TO_RECEIVE_COMMANDS, // Whether the bot is ready to receive commands
         BOT_LOG_WEBHOOK_URL; // Webhook URL to send rogue bot log messages to
 


### PR DESCRIPTION
## Summary
- add a `round_stats_tracking_disabled` global setting to no-op round stats tracking
- keep existing round stats code in place while preventing tracker calls from touching Spring/JDBC when disabled

## Test Plan
- `git diff --check`
- `mvn -q -DskipTests compile` *(fails locally: current Java is 21, project requires release 26)*