### PR TITLE
Fix stop bot lease rollout behavior

### DIFF
--- a/.github/workflows/stop-bot.yml
+++ b/.github/workflows/stop-bot.yml
@@ -18,12 +18,30 @@ jobs:
           set -eu
           
           cd ${{ vars.HOST_TI4_REPO_DIR }}
-          
-          echo "Building docker image..."
+
+          echo "Pulling deployment config from GitHub..."
+          git pull --ff-only
+
+          export COMPOSE_PROJECT_NAME="ti4-bot"
           docker version
-          docker build -t tibot .
-          
-          echo "Shutting Down TIBot... giving 600 seconds to shutdown"
-          docker stop $(docker ps -q) --time 600
+
+          running_tibot_containers="$(docker ps -q --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --filter "label=com.docker.compose.service=tibot" || true)"
+          if [ -z "$running_tibot_containers" ]; then
+            echo "No running TIBot containers found."
+          fi
+
+          for container in $running_tibot_containers; do
+            echo "Draining TIBot container $container"
+            docker exec "$container" sh -c 'wget -qO- --post-data="" http://127.0.0.1:8081/api/public/deploy/drain || true; for i in $(seq 1 15); do wget -q -O - http://127.0.0.1:8081/api/public/ready >/dev/null 2>&1 || break; sleep 1; done' || true
+
+            echo "Stopping TIBot container $container... giving 600 seconds to shutdown"
+            docker stop --time 600 "$container"
+          done
+
+          stopped_tibot_containers="$(docker ps -a -q --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --filter "label=com.docker.compose.service=tibot" || true)"
+          for container in $stopped_tibot_containers; do
+            echo "Removing stopped TIBot container $container"
+            docker rm "$container" || true
+          done
 
           echo "DONE!"

--- a/scripts/deploy_tibot_single_instance.sh
+++ b/scripts/deploy_tibot_single_instance.sh
@@ -9,11 +9,12 @@ stop_timeout_seconds="${STOP_TIMEOUT_SECONDS:-600}"
 log_tail_lines="${ROLLBACK_LOG_TAIL_LINES:-200}"
 
 old_ids_file="$(mktemp)"
+existing_ids_file="$(mktemp)"
 new_ids_file="$(mktemp)"
 new_container_id=""
 
 cleanup_tmp_files() {
-  rm -f "$old_ids_file" "$new_ids_file"
+  rm -f "$old_ids_file" "$existing_ids_file" "$new_ids_file"
 }
 
 cleanup_new_container() {
@@ -51,12 +52,23 @@ health_status() {
 
 trap 'cleanup_tmp_files' EXIT
 
+existing_container_ids="$(compose ps --all -q "$service" || true)"
+printf '%s\n' "$existing_container_ids" | sed '/^$/d' > "$existing_ids_file"
+
 old_container_ids="$(compose ps -q "$service" || true)"
 printf '%s\n' "$old_container_ids" | sed '/^$/d' > "$old_ids_file"
 old_container_count="$(count_lines < "$old_ids_file")"
 target_container_count=$((old_container_count + 1))
 
-echo "Found $old_container_count existing $service container(s)."
+echo "Found $old_container_count running $service container(s)."
+while IFS= read -r existing_container_id; do
+  [ -z "$existing_container_id" ] && continue
+  if ! grep -qxF "$existing_container_id" "$old_ids_file"; then
+    echo "Removing stopped $service container before rollout: $existing_container_id"
+    docker rm "$existing_container_id" || true
+  fi
+done < "$existing_ids_file"
+
 echo "Scaling '$service' to $target_container_count total container(s) to create exactly one rollout candidate."
 compose up --detach --scale "$service=$target_container_count" --no-recreate "$service"
 


### PR DESCRIPTION
## Summary
- Drain and remove only Compose-managed tibot containers in the StopBot workflow.
- Remove stopped tibot service containers before rollout so deploys after StopBot create a fresh container from the requested image.
- Keep rolling deploy behavior intact when an active bot is already running.

## Test Plan
- bash -n scripts/deploy_tibot_single_instance.sh
- git diff --check -- .github/workflows/stop-bot.yml scripts/deploy_tibot_single_instance.sh