### PR TITLE
Clean up refreshed cards info pins

### DIFF
--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -876,6 +876,38 @@ public class MessageHelper {
                 msg -> rotatePinnedCardsInfoMessage(game, threadChannel, storedValueKeyPrefix, msg));
     }
 
+    public static void clearPinnedCardsInfoMessages(
+            @NotNull Game game,
+            @NotNull Player player,
+            @NotNull List<String> storedValueKeyPrefixes,
+            @NotNull Runnable afterCleared) {
+        ThreadChannel threadChannel = player.getCardsInfoThread();
+        if (threadChannel == null) {
+            afterCleared.run();
+            return;
+        }
+
+        threadChannel
+                .retrievePinnedMessages()
+                .queue(
+                        messages -> {
+                            for (var pinnedMessage : messages) {
+                                Message message = pinnedMessage.getMessage();
+                                if (isBotCardsInfoPin(message)) {
+                                    message.unpin().queue(Consumers.nop(), BotLogger::catchRestError);
+                                }
+                            }
+                            clearStoredCardsInfoPinIds(game, threadChannel, storedValueKeyPrefixes);
+                            afterCleared.run();
+                        },
+                        error -> {
+                            BotLogger.warning(
+                                    "Failed to retrieve pinned cards info messages for " + player.getUserName(), error);
+                            clearStoredCardsInfoPinIds(game, threadChannel, storedValueKeyPrefixes);
+                            afterCleared.run();
+                        });
+    }
+
     public static void sendMessageToPlayerCardsInfoThreadWithButtonsAndPin(
             @NotNull Game game,
             @NotNull Player player,
@@ -897,6 +929,23 @@ public class MessageHelper {
                 msg -> rotatePinnedCardsInfoMessage(game, threadChannel, storedValueKeyPrefix, msg),
                 null,
                 buttons);
+    }
+
+    private static void clearStoredCardsInfoPinIds(
+            @NotNull Game game, @NotNull ThreadChannel threadChannel, @NotNull List<String> storedValueKeyPrefixes) {
+        for (String storedValueKeyPrefix : storedValueKeyPrefixes) {
+            game.removeStoredValue(storedValueKeyPrefix + "_" + threadChannel.getId());
+        }
+    }
+
+    private static boolean isBotCardsInfoPin(@NotNull Message message) {
+        if (!message.getAuthor().isBot()) return false;
+        String content = message.getContentRaw();
+        return content.startsWith("__Scored Secret Objectives__")
+                || content.startsWith("__Unscored Secret Objectives:")
+                || content.startsWith("__Action Cards__")
+                || content.startsWith("### __Promissory notes")
+                || content.startsWith("## __Promissory notes__");
     }
 
     private static void rotatePinnedCardsInfoMessage(

--- a/src/main/java/ti4/service/info/CardsInfoService.java
+++ b/src/main/java/ti4/service/info/CardsInfoService.java
@@ -28,14 +28,25 @@ import ti4.service.fow.RiftSetModeService;
 @UtilityClass
 public class CardsInfoService {
 
+    private static final List<String> PINNED_CARDS_INFO_MESSAGE_KEYS =
+            List.of("pinned_so_info_message_id", "pinned_ac_info_message_id", "pinned_pn_info_message_id");
+
     public static void sendCardsInfo(Game game, Player player, GenericInteractionCreateEvent event) {
         if (player == null) return;
-        String headerText = player.getRepresentation() + " Somebody" + CommandHelper.getHeaderText(event);
-        MessageHelper.sendMessageToPlayerCardsInfoThread(player, headerText);
-        sendCardsInfo(game, player);
+        MessageHelper.clearPinnedCardsInfoMessages(game, player, PINNED_CARDS_INFO_MESSAGE_KEYS, () -> {
+            String headerText = player.getRepresentation() + " Somebody" + CommandHelper.getHeaderText(event);
+            MessageHelper.sendMessageToPlayerCardsInfoThread(player, headerText);
+            sendCardsInfoWithoutPinCleanup(game, player);
+        });
     }
 
     public static void sendCardsInfo(Game game, Player player) {
+        if (player == null) return;
+        MessageHelper.clearPinnedCardsInfoMessages(
+                game, player, PINNED_CARDS_INFO_MESSAGE_KEYS, () -> sendCardsInfoWithoutPinCleanup(game, player));
+    }
+
+    private static void sendCardsInfoWithoutPinCleanup(Game game, Player player) {
         SecretObjectiveInfoService.sendSecretObjectiveInfo(game, player);
         ActionCardHelper.sendActionCardInfo(game, player);
         PromissoryNoteHelper.sendPromissoryNoteInfo(game, player, false);


### PR DESCRIPTION
## Summary
- unpin stale bot-created cards-info AC/SO/PN messages before reposting refreshed cards info
- clear stored cards-info pin ids so the refreshed messages become the active pinned sections

## Test Plan
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -q spotless:apply
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -q -DskipTests compile
- JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home mvn -q test