### PR TITLE
Avoid logging message JSON for Discord server errors

### DIFF
--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -727,7 +727,7 @@ public class MessageHelper {
         sb.append(channel.getAsMention()).append("\nRestAction Failure within MessageHelper.splitAndSentWithAction: ");
         sb.append(errorHeader);
         sb.append("\n```").append(error.getMessage()).append("```");
-        if (messageCreateData != null) {
+        if (messageCreateData != null && !isDiscordServerError(error)) {
             String messageJSON = messageCreateData.toData().toPrettyString();
             sb.append("\nMessageContent: ").append(messageCreateData.getContent());
             int maxJSONLength = 1500;


### PR DESCRIPTION
### Motivation
- Prevent dumping `messageCreateData` JSON into logs when the failure is a Discord-side/server error to reduce noise and avoid revealing large payloads for errors outside our control.

### Description
- Add a guard to only append the `messageCreateData` JSON in `getRestActionFailureMessage` when `!isDiscordServerError(error)` so server-side errors skip logging the message payload while preserving truncation behavior for long JSON.

### Testing
- Ran the project's automated unit test suite (`mvn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee2e4ffcc832d8173a283e69e25f1)