### PR TITLE
Re-enable production combat replay window

### DIFF
--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -22,8 +22,6 @@ import ti4.spring.context.SpringContext;
 @Setter
 public class CombatContestSettings {
 
-    public static final int PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS = 8;
-
     @Setter(AccessLevel.NONE)
     private boolean isProd;
 
@@ -67,9 +65,13 @@ public class CombatContestSettings {
                 candidateSelection.targetCandidatesPerHour >= 0,
                 "candidateSelection.targetCandidatesPerHour must be >= 0.");
         require(promotion.intervalSeconds > 0, "promotion.intervalSeconds must be > 0.");
-        require(promotion.candidateLookbackHours > 0, "promotion.candidateLookbackHours must be > 0.");
-        require(promotion.maxPromotionsPerHour >= 0, "promotion.maxPromotionsPerHour must be >= 0.");
         require(replayExecution.startDelaySeconds >= 0, "replayExecution.startDelaySeconds must be >= 0.");
+        require(
+                replayExecution.dailyLockHourCentral >= -1 && replayExecution.dailyLockHourCentral <= 23,
+                "replayExecution.dailyLockHourCentral must be between -1 and 23.");
+        require(
+                replayExecution.dailyLockMinuteCentral >= 0 && replayExecution.dailyLockMinuteCentral <= 59,
+                "replayExecution.dailyLockMinuteCentral must be between 0 and 59.");
         require(replayExecution.replayIntervalSeconds > 0, "replayExecution.replayIntervalSeconds must be > 0.");
         require(replayExecution.maxEventGapSeconds >= 0, "replayExecution.maxEventGapSeconds must be >= 0.");
         require(
@@ -144,14 +146,14 @@ public class CombatContestSettings {
     public static class Promotion {
         private boolean enabled;
         private int intervalSeconds = 60;
-        private int candidateLookbackHours = 12;
-        private int maxPromotionsPerHour = 1;
     }
 
     @Getter
     @Setter
     public static class ReplayExecution {
         private int startDelaySeconds = 15 * 60;
+        private int dailyLockHourCentral = -1;
+        private int dailyLockMinuteCentral;
         private int replayIntervalSeconds = 15;
         private int maxEventGapSeconds = 30;
         private int pendingResolutionWindowSeconds = 900;

--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -184,7 +184,7 @@ public class LazaxCombatSupport {
                 + "\n"
                 + "**System:** " + tileRepresentation + "\n"
                 + "**Combat:** Space Combat\n"
-                + "**Predict the winner by reacting below.**\n"
+                + "**React below to predict the winner. Side betting is open in the replay thread.**\n"
                 + "_Losers get -4 points._\n"
                 + attackerLine + "\n"
                 + defenderLine;

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
@@ -43,12 +43,10 @@ public interface CombatCandidateRepository extends JpaRepository<CombatCandidate
             where c.status = :status
               and c.promotionStatus = :promotionStatus
               and c.resolvedAt is not null
-              and c.resolvedAt >= :resolvedAfter
             """)
     List<CombatCandidateEntity> findResolvedPromotionCandidates(
             @Param("status") CombatCandidateStatus status,
-            @Param("promotionStatus") CombatCandidatePromotionStatus promotionStatus,
-            @Param("resolvedAfter") LocalDateTime resolvedAfter);
+            @Param("promotionStatus") CombatCandidatePromotionStatus promotionStatus);
 
     List<CombatCandidateEntity> findByPromotionStatusAndResolvedAtBefore(
             CombatCandidatePromotionStatus promotionStatus, LocalDateTime resolvedAt);

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
@@ -29,6 +29,8 @@ public interface CombatReplayContestRepository extends JpaRepository<CombatRepla
     List<CombatReplayContestEntity> findByReplayStatusInAndNextReplayAtLessThanEqualOrderByNextReplayAtAsc(
             Collection<CombatContestReplayStatus> replayStatuses, LocalDateTime nextReplayAt);
 
+    boolean existsByReplayStatusIn(Collection<CombatContestReplayStatus> replayStatuses);
+
     boolean existsByPostedAtGreaterThanEqual(LocalDateTime postedAt);
 
     long countByPostedAtGreaterThanEqual(LocalDateTime postedAt);

--- a/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
@@ -27,25 +27,18 @@ import ti4.message.MessageHelper;
 public class CombatReplayExecutionService {
 
     private static final List<String> PREDICTION_LOCK_TITLES = List.of(
+            "Predictions and Side Bets Open",
             "The Wagers Open",
-            "The Archives Open",
-            "Predictions Are Open",
-            "The War Ledger Opens",
             "The Betting Hall Opens",
-            "Call for Predictions",
-            "The Scribes Await",
+            "The War Ledger Opens",
+            "The Archives Open",
             "Cast Your Wager");
     private static final List<String> PREDICTION_LOCK_SUBTITLES = List.of(
-            "_The Lazax recorders now accept predictions for the coming clash._",
-            "_The archives invite your judgment before the battle unfolds._",
-            "_The war ledger opens to all who would call the victor._",
+            "_The Lazax ledgers now accept predictions and side bets for the coming clash._",
             "_The betting hall stirs as a new contest enters the record._",
-            "_The scribes stand ready to record your chosen champion._",
-            "_A new combat has been entered into the annals; predictions are welcome._",
-            "_The archives seek your verdict before the first volleys are fired._",
-            "_The next battle stands before the record; declare your pick._",
-            "_The Lazax ledgers are open to those bold enough to choose a side._",
-            "_Another clash enters the chronicles; place your wager in the record._");
+            "_The war ledger opens before the battle unfolds._",
+            "_The next battle stands before the record; place your wager._",
+            "_Another clash enters the chronicles; place your calls and side bets in the record._");
 
     private final CombatContestSettings settings;
     private final CombatCandidateRepository candidateRepository;
@@ -72,7 +65,7 @@ public class CombatReplayExecutionService {
             Game game = loadGame(winner.getGameName());
             replaySideBetService.postSideBetButtonsIfNeeded(replayChannel, game, contest, winner);
             markSideBetButtonsPosted(contest, LocalDateTime.now());
-            announcePredictionLockCountdown(replayChannel);
+            announcePredictionLockCountdown(replayChannel, contest);
         } catch (Exception e) {
             BotLogger.error("Failed to post replay context at promotion.", e);
         }
@@ -140,29 +133,56 @@ public class CombatReplayExecutionService {
         replayContestRepository.save(contest);
     }
 
-    private void announcePredictionLockCountdown(MessageChannel channel) {
-        int startDelaySeconds = replayStartDelaySeconds();
+    private void announcePredictionLockCountdown(MessageChannel channel, CombatReplayContestEntity contest) {
+        Duration votingWindow = votingWindowRemaining(contest);
         String title = RandomHelper.pickRandomFromList(PREDICTION_LOCK_TITLES);
         String subtitle = RandomHelper.pickRandomFromList(PREDICTION_LOCK_SUBTITLES);
-        String message = startDelaySeconds <= 0
-                ? "## " + title + "\n" + subtitle + "\nVoting is now open. The combat begins immediately."
-                : "## " + title + "\n" + subtitle + "\nVoting is now open for **"
-                        + formatVotingWindow(startDelaySeconds) + "**.";
+        String message = votingWindow.isZero() || votingWindow.isNegative()
+                ? "## " + title + "\n" + subtitle
+                        + "\nPredictions and side bets are open. The combat begins immediately."
+                : "## " + title + "\n" + subtitle + "\nPredictions and side bets are open for **"
+                        + formatVotingWindow(votingWindow) + "**." + predictionLockTimeText();
         MessageHelper.sendMessageToChannel(channel, message);
     }
 
-    private String formatVotingWindow(int startDelaySeconds) {
-        if (startDelaySeconds < 60) {
-            return startDelaySeconds + " " + (startDelaySeconds == 1 ? "second" : "seconds");
+    private String predictionLockTimeText() {
+        int dailyLockHourCentral = settings.getReplayExecution().getDailyLockHourCentral();
+        if (dailyLockHourCentral < 0) return "";
+        return "\nPredictions and side bets lock at **"
+                + formatCentralLockTime(
+                        dailyLockHourCentral, settings.getReplayExecution().getDailyLockMinuteCentral())
+                + " Central**.";
+    }
+
+    private String formatCentralLockTime(int hour, int minute) {
+        int displayHour = hour % 12;
+        if (displayHour == 0) displayHour = 12;
+        return String.format("%d:%02d %s", displayHour, minute, hour < 12 ? "AM" : "PM");
+    }
+
+    private Duration votingWindowRemaining(CombatReplayContestEntity contest) {
+        if (contest == null || contest.getReplayStartAt() == null) {
+            return Duration.ofSeconds(settings.getReplayExecution().getStartDelaySeconds());
         }
-        if (startDelaySeconds % 60 == 0) {
-            int minutes = startDelaySeconds / 60;
+        return Duration.between(LocalDateTime.now(), contest.getReplayStartAt());
+    }
+
+    private String formatVotingWindow(Duration votingWindow) {
+        long totalSeconds = Math.max(0, votingWindow.toSeconds());
+        if (totalSeconds < 60) {
+            return totalSeconds + " " + (totalSeconds == 1 ? "second" : "seconds");
+        }
+        if (totalSeconds < 3600) {
+            long minutes = (totalSeconds + 59) / 60;
             return minutes + " " + (minutes == 1 ? "minute" : "minutes");
         }
-        int minutes = startDelaySeconds / 60;
-        int seconds = startDelaySeconds % 60;
-        return minutes + " " + (minutes == 1 ? "minute" : "minutes") + " " + seconds + " "
-                + (seconds == 1 ? "second" : "seconds");
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        if (minutes == 0) {
+            return hours + " " + (hours == 1 ? "hour" : "hours");
+        }
+        return hours + " " + (hours == 1 ? "hour" : "hours") + " " + minutes + " "
+                + (minutes == 1 ? "minute" : "minutes");
     }
 
     private void completeReplayContest(CombatReplayContestEntity contest) {
@@ -220,10 +240,6 @@ public class CombatReplayExecutionService {
                 currentEvent,
                 nextEvent,
                 Duration.ofSeconds(settings.getReplayExecution().getMaxEventGapSeconds()));
-    }
-
-    private int replayStartDelaySeconds() {
-        return settings.getReplayExecution().getStartDelaySeconds();
     }
 
     private CombatCandidateEntity loadCandidate(Long candidateId) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
@@ -30,23 +30,9 @@ public class CombatReplayJanitorService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime observationCutoff = now.minusDays(settings.getRetention().getObservationRetentionDays());
 
-        expireStaleResolvedCandidates(now);
         observationRepository.deleteAll(observationRepository.findByStartedAtBefore(observationCutoff));
         deleteExpiredCandidateEvents(now);
         clearCompletedReplayErrors();
-    }
-
-    private void expireStaleResolvedCandidates(LocalDateTime now) {
-        int expirationLookbackHours = Math.max(
-                settings.getPromotion().getCandidateLookbackHours(),
-                CombatContestSettings.PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS);
-        List<CombatCandidateEntity> staleCandidates = candidateRepository.findByPromotionStatusAndResolvedAtBefore(
-                CombatCandidatePromotionStatus.PENDING, now.minusHours(expirationLookbackHours));
-        for (CombatCandidateEntity candidate : staleCandidates) {
-            if (candidate.getStatus() != CombatCandidateStatus.RESOLVED) continue;
-            candidate.setPromotionStatus(CombatCandidatePromotionStatus.EXPIRED);
-            candidateRepository.save(candidate);
-        }
     }
 
     private void deleteExpiredCandidateEvents(LocalDateTime now) {
@@ -75,6 +61,7 @@ public class CombatReplayJanitorService {
         for (CombatCandidateEventEntity event : oldEvents) {
             CombatCandidateEntity candidate = candidatesById.get(event.getCandidateId());
             if (candidate == null || candidate.getStatus() == CombatCandidateStatus.TRACKING) continue;
+            if (candidate.getPromotionStatus() == CombatCandidatePromotionStatus.PENDING) continue;
 
             if (!isPastRetentionCutoff(candidate, retentionCutoff)) {
                 continue;

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -1,14 +1,15 @@
 package ti4.contest.replay.service;
 
 import java.time.Clock;
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
@@ -39,8 +40,9 @@ import ti4.logging.BotLogger;
 public class CombatReplayPromotionService {
 
     private static final String PROMOTION_DISABLED_REASON = "Candidate-to-contest promotion is disabled.";
-    private static final Duration PUBLIC_PROMOTION_COOLDOWN = Duration.ofHours(2);
-    private static final Duration PUBLIC_PROMOTION_COOLDOWN_GRACE = Duration.ofMinutes(5);
+    private static final ZoneId CENTRAL_TIME = ZoneId.of("America/Chicago");
+    private static final Set<CombatContestReplayStatus> ACTIVE_REPLAY_STATUSES =
+            Set.of(CombatContestReplayStatus.PENDING, CombatContestReplayStatus.REPLAYING);
 
     private final CombatContestSettings settings;
     private final CombatCandidateRepository candidateRepository;
@@ -54,22 +56,16 @@ public class CombatReplayPromotionService {
     public void promoteBestCandidateIfDue() {
         if (!settings.getPromotion().isEnabled()) return;
 
-        LocalDateTime now = LocalDateTime.now(clock);
         if (settings.getRuntime().isImmediatePromotionOnResolve()) {
-            CombatCandidateEntity winner = selectPromotionWinner(findPromotionCandidates(now));
+            CombatCandidateEntity winner = selectPromotionWinner(findPromotionCandidates());
             if (winner == null) return;
             promoteCandidate(winner);
             return;
         }
 
-        int maxPromotionsPerHour = settings.getPromotion().getMaxPromotionsPerHour();
-        if (maxPromotionsPerHour <= 0) return;
+        if (replayContestRepository.existsByReplayStatusIn(ACTIVE_REPLAY_STATUSES)) return;
 
-        LocalDateTime publicPromotionWindow = now.truncatedTo(ChronoUnit.MINUTES);
-        if (publicPromotionWindow.getMinute() != 0) return;
-        if (!canPublicPromoteAt(publicPromotionWindow)) return;
-
-        CombatCandidateEntity winner = selectPromotionWinner(findPromotionCandidates(publicPromotionWindow));
+        CombatCandidateEntity winner = selectPromotionWinner(findPromotionCandidates());
         if (winner == null) return;
         promoteCandidate(winner);
     }
@@ -116,22 +112,13 @@ public class CombatReplayPromotionService {
         return CombatReplayContestLifecycleService.ForcePromoteResult.promoted(contest);
     }
 
-    private List<CombatCandidateEntity> findPromotionCandidates(LocalDateTime now) {
-        int configuredLookbackHours = settings.getPromotion().getCandidateLookbackHours();
-        int maxLookbackHours =
-                Math.max(configuredLookbackHours, CombatContestSettings.PROMOTION_LOOKBACK_FALLBACK_MAX_HOURS);
-        for (int lookbackHours = configuredLookbackHours; lookbackHours <= maxLookbackHours; lookbackHours++) {
-            List<CombatCandidateEntity> candidates = candidateRepository.findResolvedPromotionCandidates(
-                    CombatCandidateStatus.RESOLVED,
-                    CombatCandidatePromotionStatus.PENDING,
-                    now.minusHours(lookbackHours));
-            candidates = candidates.stream()
-                    .filter(candidate -> !expireIfDiscordantStars(candidate))
-                    .filter(this::usesCurrentReplaySnapshotFormat)
-                    .toList();
-            if (!candidates.isEmpty()) return candidates;
-        }
-        return List.of();
+    private List<CombatCandidateEntity> findPromotionCandidates() {
+        List<CombatCandidateEntity> candidates = candidateRepository.findResolvedPromotionCandidates(
+                CombatCandidateStatus.RESOLVED, CombatCandidatePromotionStatus.PENDING);
+        return candidates.stream()
+                .filter(candidate -> !expireIfDiscordantStars(candidate))
+                .filter(this::usesCurrentReplaySnapshotFormat)
+                .toList();
     }
 
     private CombatReplayContestEntity promoteCandidate(CombatCandidateEntity winner) {
@@ -143,10 +130,6 @@ public class CombatReplayPromotionService {
     private CombatReplayContestEntity promoteCandidate(
             CombatCandidateEntity winner, CombatReplayContestEntity existingContest) {
         if (expireIfDiscordantStars(winner)) return null;
-
-        CombatObservationEntity observation =
-                observationRepository.findById(winner.getObservationId()).orElse(null);
-        if (observation == null) return null;
 
         Game game = loadGame(winner.getGameName());
         if (game == null) return null;
@@ -172,25 +155,8 @@ public class CombatReplayPromotionService {
         }
     }
 
-    private boolean canPublicPromoteAt(LocalDateTime publicPromotionWindow) {
-        if (publicPromotionWindow == null) return false;
-        if (!settings.getRuntime().isDevMode()
-                && replayContestRepository.countByPostedAtGreaterThanEqual(
-                                publicPromotionCooldownCutoff(publicPromotionWindow))
-                        > 0) {
-            return false;
-        }
-        return replayContestRepository.countByPostedAtGreaterThanEqual(
-                        publicPromotionWindow.truncatedTo(ChronoUnit.HOURS))
-                < settings.getPromotion().getMaxPromotionsPerHour();
-    }
-
     void setClock(Clock clock) {
         this.clock = clock == null ? Clock.systemDefaultZone() : clock;
-    }
-
-    static LocalDateTime publicPromotionCooldownCutoff(LocalDateTime now) {
-        return now.minus(PUBLIC_PROMOTION_COOLDOWN).plus(PUBLIC_PROMOTION_COOLDOWN_GRACE);
     }
 
     String snapshotStartSummaryText(CombatCandidateEntity candidate) {
@@ -332,7 +298,7 @@ public class CombatReplayPromotionService {
             long publicMessageId,
             Long publicThreadId,
             LocalDateTime promotedAt) {
-        LocalDateTime replayStartAt = promotedAt.plusSeconds(replayStartDelaySeconds());
+        LocalDateTime replayStartAt = computeReplayStartAt(promotedAt);
         contest.setCandidateId(winner.getId());
         contest.setPostedAt(promotedAt);
         contest.setPublicChannelId(publicChannelId);
@@ -344,8 +310,22 @@ public class CombatReplayPromotionService {
         contest.setNextEventSequence(1);
     }
 
-    private int replayStartDelaySeconds() {
-        return settings.getReplayExecution().getStartDelaySeconds();
+    private LocalDateTime computeReplayStartAt(LocalDateTime promotedAt) {
+        int dailyLockHourCentral = settings.getReplayExecution().getDailyLockHourCentral();
+        if (dailyLockHourCentral < 0) {
+            return promotedAt.plusSeconds(settings.getReplayExecution().getStartDelaySeconds());
+        }
+
+        ZonedDateTime promotedCentral = promotedAt.atZone(clock.getZone()).withZoneSameInstant(CENTRAL_TIME);
+        ZonedDateTime replayStartCentral = promotedCentral
+                .withHour(dailyLockHourCentral)
+                .withMinute(settings.getReplayExecution().getDailyLockMinuteCentral())
+                .withSecond(0)
+                .withNano(0);
+        if (!replayStartCentral.isAfter(promotedCentral)) {
+            replayStartCentral = replayStartCentral.plusDays(1);
+        }
+        return replayStartCentral.withZoneSameInstant(clock.getZone()).toLocalDateTime();
     }
 
     private Game loadGame(String gameName) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
@@ -25,7 +25,6 @@ import ti4.discord.interactions.buttons.Buttons;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.persistence.GameManager;
-import ti4.helpers.ButtonHelper;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 
@@ -66,7 +65,6 @@ class CombatReplaySideBetUiService {
             MessageChannel channel, CombatReplayContestEntity contest, CombatCandidateEntity candidate) {
         Game game = loadReplayGame(candidate);
         refreshSummaryMessage(channel, contest, game);
-        revealPublicSideBetButtonsIfClosed(channel, game, contest, candidate);
     }
 
     public String renderUserSummary(
@@ -91,7 +89,7 @@ class CombatReplaySideBetUiService {
 
     private List<Button> buttonsForFaction(
             Game game, CombatReplayContestEntity contest, CombatCandidateEntity candidate, String faction) {
-        return buttonsForFaction(game, contest, candidate, faction, false, false);
+        return buttonsForFaction(game, contest, candidate, faction, sideBetWindowClosed(contest));
     }
 
     private List<Button> buttonsForFaction(
@@ -99,22 +97,21 @@ class CombatReplaySideBetUiService {
             CombatReplayContestEntity contest,
             CombatCandidateEntity candidate,
             String faction,
-            boolean revealPayouts,
             boolean disabled) {
         List<Button> buttons = new ArrayList<>();
         for (CombatSideBetType type : availabilityService.availableTypes(candidate, faction)) {
             int profitPoints = payoutService.offeredPayout(contest, candidate, type, faction);
             Button button = Buttons.gray(
                     CombatSideBetButtonIds.format(contest.getId(), type, faction),
-                    buttonLabel(type, profitPoints, revealPayouts),
+                    buttonLabel(type, profitPoints),
                     type.emoji());
             buttons.add(disabled ? button.asDisabled() : button);
         }
         return buttons;
     }
 
-    private String buttonLabel(CombatSideBetType type, int profitPoints, boolean revealPayout) {
-        return revealPayout ? type.label() + " +" + profitPoints + " pts" : type.label();
+    private String buttonLabel(CombatSideBetType type, int profitPoints) {
+        return type.label() + " +" + profitPoints + " pts";
     }
 
     private void saveSideBetButtonMessageId(
@@ -128,43 +125,6 @@ class CombatReplaySideBetUiService {
             return;
         }
         replayContestRepository.save(contest);
-    }
-
-    private void revealPublicSideBetButtonsIfClosed(
-            MessageChannel channel, Game game, CombatReplayContestEntity contest, CombatCandidateEntity candidate) {
-        if (channel == null || contest == null || candidate == null || !sideBetWindowClosed(contest)) return;
-        revealPublicSideBetButtons(
-                channel,
-                game,
-                contest,
-                candidate,
-                candidate.getAttackerFaction(),
-                contest.getSideBetAttackerButtonMessageId());
-        revealPublicSideBetButtons(
-                channel,
-                game,
-                contest,
-                candidate,
-                candidate.getDefenderFaction(),
-                contest.getSideBetDefenderButtonMessageId());
-    }
-
-    private void revealPublicSideBetButtons(
-            MessageChannel channel,
-            Game game,
-            CombatReplayContestEntity contest,
-            CombatCandidateEntity candidate,
-            String faction,
-            Long messageId) {
-        if (messageId == null || messageId <= 0) return;
-        List<Button> buttons = buttonsForFaction(game, contest, candidate, faction, true, true);
-        if (buttons.isEmpty()) return;
-        channel.retrieveMessageById(messageId)
-                .queue(
-                        message -> message.editMessage(factionSectionTitle(game, faction))
-                                .setComponents(ButtonHelper.turnButtonListIntoActionRowList(buttons))
-                                .queue(Consumers.nop(), BotLogger::catchRestError),
-                        BotLogger::catchRestError);
     }
 
     private void ensureSummaryMessage(MessageChannel channel, Game game, CombatReplayContestEntity contest) {
@@ -206,38 +166,20 @@ class CombatReplaySideBetUiService {
     private String renderSummaryMessage(Game game, CombatReplayContestEntity contest) {
         List<CombatContestSideBetEntity> sideBets = sideBetRepository.findByContestId(contest.getId());
         sideBets.sort(sideBetOrder());
-        boolean sideBetWindowClosed = sideBetWindowClosed(contest);
         StringBuilder message = new StringBuilder();
+        message.append("```text\n");
+        message.append(String.format("%-3s | %s%n", "Qty", "Bet"));
+        message.append("----+------------------------------\n");
         if (sideBets.isEmpty()) {
-            message.append("```text\n");
-            if (sideBetWindowClosed) {
-                message.append(String.format("%-3s | %s%n", "Qty", "Bet"));
-                message.append("----+------------------------------\n");
-                message.append(" -  | No side bets placed\n");
-            } else {
-                message.append("Bet\n");
-                message.append("------------------------------\n");
-                message.append("Waiting for the first bet\n");
-            }
+            message.append(" -  | No side bets placed\n");
             message.append("```");
             return message.toString();
         }
 
-        Map<String, Long> countsByBet = summarizeBetCounts(sideBets, game, sideBetWindowClosed);
-        message.append("```text\n");
-        if (sideBetWindowClosed) {
-            message.append(String.format("%-3s | %s%n", "Qty", "Bet"));
-            message.append("----+------------------------------\n");
-            for (Map.Entry<String, Long> entry :
-                    sortBetCountsByQuantityDesc(countsByBet).entrySet()) {
-                message.append(String.format("%-3s | %s%n", entry.getValue() + "x", entry.getKey()));
-            }
-        } else {
-            message.append("Bet\n");
-            message.append("------------------------------\n");
-            for (String label : sortBetLabelsAlphabetically(countsByBet.keySet())) {
-                message.append(label).append("\n");
-            }
+        Map<String, Long> countsByBet = summarizeBetCounts(sideBets, game);
+        for (Map.Entry<String, Long> entry :
+                sortBetCountsByQuantityDesc(countsByBet).entrySet()) {
+            message.append(String.format("%-3s | %s%n", entry.getValue() + "x", entry.getKey()));
         }
         message.append("```");
         return message.toString();
@@ -259,8 +201,7 @@ class CombatReplaySideBetUiService {
             return message.toString();
         }
 
-        for (Map.Entry<String, Long> entry :
-                summarizeUserBetCounts(bets, game, sideBetWindowClosed(contest)).entrySet()) {
+        for (Map.Entry<String, Long> entry : summarizeUserBetCounts(bets, game).entrySet()) {
             message.append("- ")
                     .append(entry.getValue())
                     .append("x ")
@@ -276,21 +217,19 @@ class CombatReplaySideBetUiService {
                 .thenComparing(CombatContestSideBetEntity::getId, Comparator.nullsLast(Comparator.naturalOrder()));
     }
 
-    private Map<String, Long> summarizeBetCounts(
-            List<CombatContestSideBetEntity> sideBets, Game game, boolean revealPayouts) {
+    private Map<String, Long> summarizeBetCounts(List<CombatContestSideBetEntity> sideBets, Game game) {
         Map<String, Long> countsByBet = new LinkedHashMap<>();
         for (CombatContestSideBetEntity sideBet : sideBets) {
-            String label = formatFriendlyBetLabel(game, sideBet, true, revealPayouts);
+            String label = formatFriendlyBetLabel(game, sideBet, true);
             countsByBet.merge(label, 1L, Long::sum);
         }
         return countsByBet;
     }
 
-    private Map<String, Long> summarizeUserBetCounts(
-            List<CombatContestSideBetEntity> sideBets, Game game, boolean revealPayouts) {
+    private Map<String, Long> summarizeUserBetCounts(List<CombatContestSideBetEntity> sideBets, Game game) {
         Map<String, Long> countsByBet = new LinkedHashMap<>();
         for (CombatContestSideBetEntity sideBet : sideBets) {
-            String label = formatFriendlyBetLabel(game, sideBet, false, revealPayouts);
+            String label = formatFriendlyBetLabel(game, sideBet, false);
             countsByBet.merge(label, 1L, Long::sum);
         }
         return countsByBet;
@@ -308,26 +247,16 @@ class CombatReplaySideBetUiService {
         return sorted;
     }
 
-    private List<String> sortBetLabelsAlphabetically(Iterable<String> labels) {
-        List<String> sorted = new ArrayList<>();
-        for (String label : labels) {
-            sorted.add(label);
-        }
-        sorted.sort(String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder()));
-        return sorted;
-    }
-
     private boolean sideBetWindowClosed(CombatReplayContestEntity contest) {
         return contest.getReplayStartAt() != null && !LocalDateTime.now().isBefore(contest.getReplayStartAt());
     }
 
-    private String formatFriendlyBetLabel(
-            Game game, CombatContestSideBetEntity sideBet, boolean useShortFactionId, boolean revealPayout) {
+    private String formatFriendlyBetLabel(Game game, CombatContestSideBetEntity sideBet, boolean useShortFactionId) {
         String faction = useShortFactionId
                 ? buttonFactionIdLabel(game, sideBet.getTargetFaction())
                 : buttonFactionDisplayName(game, sideBet.getTargetFaction());
         String label = faction + " " + sideBet.getBetType().label();
-        return revealPayout ? label + " +" + payoutService.resolvedProfitPoints(sideBet) : label;
+        return label + " +" + payoutService.resolvedProfitPoints(sideBet) + " pts";
     }
 
     private String factionSectionTitle(Game game, String faction) {

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -9,11 +9,11 @@ candidateSelection:
 promotion:
   enabled: true
   intervalSeconds: 5
-  candidateLookbackHours: 12
-  maxPromotionsPerHour: 100
 
 replayExecution:
   startDelaySeconds: 15
+  dailyLockHourCentral: -1
+  dailyLockMinuteCentral: 0
   replayIntervalSeconds: 1
   maxEventGapSeconds: 1
   pendingResolutionWindowSeconds: 30

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -1,19 +1,19 @@
-enabled: false
+enabled: true
 
 candidateSelection:
   window:
     lookbackMinutes: 480
     refreshCronIntervalSeconds: 300
-  targetCandidatesPerHour: 4
+  targetCandidatesPerHour: 8
 
 promotion:
   enabled: true
-  intervalSeconds: 60
-  candidateLookbackHours: 12
-  maxPromotionsPerHour: 1
+  intervalSeconds: 5
 
 replayExecution:
-  startDelaySeconds: 900
+  startDelaySeconds: 86400
+  dailyLockHourCentral: 10
+  dailyLockMinuteCentral: 0
   replayIntervalSeconds: 15
   maxEventGapSeconds: 30
   pendingResolutionWindowSeconds: 900

--- a/src/test/java/ti4/contest/replay/core/CombatContestSettingsTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatContestSettingsTest.java
@@ -23,8 +23,12 @@ class CombatContestSettingsTest {
         CombatContestSettings settings = new CombatContestSettings(false);
 
         assertTrue(settings.isProd());
-        assertFalse(settings.isEnabled());
+        assertTrue(settings.isEnabled());
         assertFalse(settings.getRuntime().isDevMode());
+        assertEquals(8, settings.getCandidateSelection().getTargetCandidatesPerHour());
+        assertEquals(86_400, settings.getReplayExecution().getStartDelaySeconds());
+        assertEquals(10, settings.getReplayExecution().getDailyLockHourCentral());
+        assertEquals(0, settings.getReplayExecution().getDailyLockMinuteCentral());
         assertEquals(100, settings.getInitialIndividualPoints());
     }
 


### PR DESCRIPTION
## Summary
- Re-enable combat replay in production with a single shared prediction and side-betting window that locks at 10:00 AM Central.
- Promote the best pending resolved candidate only when no replay contest is active, and remove the resolved-candidate promotion lookback/expiry path.
- Make side-bet counts and payouts public for the full contest while preserving backend rejection after replay start.

## Test Plan
- Not run per request.
- Ran `git diff --check`.