### PR TITLE
Disable combat replay janitor

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayJanitorService.java
@@ -1,92 +1,12 @@
 package ti4.contest.replay.service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import ti4.contest.replay.core.*;
-import ti4.contest.replay.entities.*;
-import ti4.contest.replay.repository.*;
 
 /**
- * Cleans up stale replay data and expires candidates that were never promoted in time.
+ * Intentionally disabled: combat replay candidates and events are retained indefinitely.
  */
 @Service
-@RequiredArgsConstructor
 public class CombatReplayJanitorService {
 
-    private final CombatContestSettings settings;
-    private final CombatCandidateRepository candidateRepository;
-    private final CombatObservationRepository observationRepository;
-    private final CombatCandidateEventRepository candidateEventRepository;
-    private final CombatReplayContestRepository replayContestRepository;
-
-    public void runJanitor() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime observationCutoff = now.minusDays(settings.getRetention().getObservationRetentionDays());
-
-        observationRepository.deleteAll(observationRepository.findByStartedAtBefore(observationCutoff));
-        deleteExpiredCandidateEvents(now);
-        clearCompletedReplayErrors();
-    }
-
-    private void deleteExpiredCandidateEvents(LocalDateTime now) {
-        LocalDateTime retentionCutoff = now.minusDays(settings.getRetention().getEventRetentionDays());
-        List<CombatCandidateEventEntity> oldEvents = candidateEventRepository.findByOccurredAtBefore(retentionCutoff);
-        if (oldEvents.isEmpty()) return;
-
-        Set<Long> candidateIds = new HashSet<>();
-        for (CombatCandidateEventEntity event : oldEvents) {
-            candidateIds.add(event.getCandidateId());
-        }
-
-        Map<Long, CombatCandidateEntity> candidatesById = new HashMap<>();
-        for (CombatCandidateEntity candidate : candidateRepository.findAllById(candidateIds)) {
-            candidatesById.put(candidate.getId(), candidate);
-        }
-
-        Map<Long, CombatReplayContestEntity> contestsByCandidateId = new HashMap<>();
-        for (Long candidateId : candidateIds) {
-            replayContestRepository
-                    .findByCandidateId(candidateId)
-                    .ifPresent(contest -> contestsByCandidateId.put(contest.getCandidateId(), contest));
-        }
-
-        List<CombatCandidateEventEntity> toDelete = new ArrayList<>();
-        for (CombatCandidateEventEntity event : oldEvents) {
-            CombatCandidateEntity candidate = candidatesById.get(event.getCandidateId());
-            if (candidate == null || candidate.getStatus() == CombatCandidateStatus.TRACKING) continue;
-            if (candidate.getPromotionStatus() == CombatCandidatePromotionStatus.PENDING) continue;
-
-            if (!isPastRetentionCutoff(candidate, retentionCutoff)) {
-                continue;
-            }
-
-            CombatReplayContestEntity contest = contestsByCandidateId.get(candidate.getId());
-            if (contest != null && contest.getReplayStatus() != CombatContestReplayStatus.COMPLETED) continue;
-            toDelete.add(event);
-        }
-
-        candidateEventRepository.deleteAll(toDelete);
-    }
-
-    private void clearCompletedReplayErrors() {
-        for (CombatReplayContestEntity contest : replayContestRepository.findAll()) {
-            if (contest.getReplayStatus() != CombatContestReplayStatus.COMPLETED) continue;
-            if (contest.getReplayError() == null) continue;
-            contest.setReplayError(null);
-            replayContestRepository.save(contest);
-        }
-    }
-
-    private boolean isPastRetentionCutoff(CombatCandidateEntity candidate, LocalDateTime retentionCutoff) {
-        LocalDateTime terminalAt =
-                candidate.getPromotedAt() != null ? candidate.getPromotedAt() : candidate.getResolvedAt();
-        return terminalAt != null && !terminalAt.isAfter(retentionCutoff);
-    }
+    public void runJanitor() {}
 }

--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -27,7 +27,6 @@ import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.AsyncTI4DiscordBot;
-import ti4.contest.cron.CombatContestJanitorCron;
 import ti4.contest.cron.CombatReplayCron;
 import ti4.contest.cron.CombatReplayPromotionCron;
 import ti4.contest.cron.CombatReplayPromotionScoreBackfillCron;
@@ -337,7 +336,6 @@ public class JdaService {
             CombatReplayPromotionCron.register();
             CombatReplayPromotionScoreBackfillCron.register();
             CombatReplayCron.register();
-            CombatContestJanitorCron.register();
         }
         InteractionLogCron.register();
         LongExecutionHistoryCron.register();


### PR DESCRIPTION
## Summary
- Stop registering the combat replay janitor cron.
- Make the combat replay janitor service a no-op so replay candidates, observations, and event streams are retained indefinitely.

## Test Plan
- Not run.
- Ran `git diff --check`.