### PR TITLE
Add Lazax combat replay reminders

### DIFF
--- a/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
+++ b/src/main/java/ti4/contest/replay/core/LazaxCombatSupport.java
@@ -179,9 +179,8 @@ public class LazaxCombatSupport {
         String attackerLine = formatReplayLegendLine(attacker, candidate.getAttackerFaction(), false);
         String defenderLine = formatReplayLegendLine(defender, candidate.getDefenderFaction(), false);
 
-        String openerText = "## A New Combat Contest Has Emerged!\n"
-                + roleMention
-                + "\n"
+        String openerText = (roleMention == null || roleMention.isBlank() ? "" : roleMention + "\n")
+                + "## A New Combat Contest Has Emerged!\n"
                 + "**System:** " + tileRepresentation + "\n"
                 + "**Combat:** Space Combat\n"
                 + "**React below to predict the winner. Side betting is open in the replay thread.**\n"

--- a/src/main/java/ti4/contest/replay/entities/CombatReplayContestEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatReplayContestEntity.java
@@ -75,6 +75,9 @@ public class CombatReplayContestEntity {
     @Column(name = "pre_replay_context_posted_at")
     private LocalDateTime preReplayContextPostedAt;
 
+    @Column(name = "replay_start_warning_posted_at")
+    private LocalDateTime replayStartWarningPostedAt;
+
     @Column(name = "leaderboard_posted_at")
     private LocalDateTime leaderboardPostedAt;
 

--- a/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatReplayContestRepository.java
@@ -5,6 +5,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import ti4.contest.replay.core.CombatContestReplayStatus;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 
@@ -28,6 +31,20 @@ public interface CombatReplayContestRepository extends JpaRepository<CombatRepla
 
     List<CombatReplayContestEntity> findByReplayStatusInAndNextReplayAtLessThanEqualOrderByNextReplayAtAsc(
             Collection<CombatContestReplayStatus> replayStatuses, LocalDateTime nextReplayAt);
+
+    List<CombatReplayContestEntity>
+            findByReplayStatusAndReplayStartWarningPostedAtIsNullAndReplayStartAtBetweenOrderByReplayStartAtAsc(
+                    CombatContestReplayStatus replayStatus, LocalDateTime startInclusive, LocalDateTime endInclusive);
+
+    @Transactional
+    @Modifying
+    @Query("""
+            update CombatReplayContestEntity contest
+            set contest.replayStartWarningPostedAt = ?2
+            where contest.id = ?1
+                and contest.replayStartWarningPostedAt is null
+            """)
+    int markReplayStartWarningPostedIfUnset(Long contestId, LocalDateTime postedAt);
 
     boolean existsByReplayStatusIn(Collection<CombatContestReplayStatus> replayStatuses);
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayExecutionService.java
@@ -39,6 +39,13 @@ public class CombatReplayExecutionService {
             "_The war ledger opens before the battle unfolds._",
             "_The next battle stands before the record; place your wager._",
             "_Another clash enters the chronicles; place your calls and side bets in the record._");
+    private static final Duration REPLAY_START_WARNING_LEAD_TIME = Duration.ofMinutes(5);
+    private static final List<String> REPLAY_START_WARNING_LORE = List.of(
+            "_The arbiters have sealed the last wagers, and the archive-drones are turning their lenses toward the field._",
+            "_Across the old imperial datavaults, quills of light scratch the names of fleets about to become precedent._",
+            "_The Hall of Cartographers grows silent as the final tactical overlays settle into place._",
+            "_A Lazax clerk strikes the bronze bell of remembrance; the combat record is nearly ready to unfold._",
+            "_Witness-scribes gather at the edge of the war table while the last echoes of prophecy fade._");
 
     private final CombatContestSettings settings;
     private final CombatCandidateRepository candidateRepository;
@@ -49,6 +56,7 @@ public class CombatReplayExecutionService {
     private final CombatReplayDiscordPostService discordPostService;
 
     public void runReplayTick() {
+        postReplayStartWarnings();
         List<CombatReplayContestEntity> dueContests =
                 replayContestRepository.findByReplayStatusInAndNextReplayAtLessThanEqualOrderByNextReplayAtAsc(
                         Set.of(CombatContestReplayStatus.PENDING, CombatContestReplayStatus.REPLAYING),
@@ -56,6 +64,36 @@ public class CombatReplayExecutionService {
         for (CombatReplayContestEntity contest : dueContests) {
             replaySingleContest(contest);
         }
+    }
+
+    private void postReplayStartWarnings() {
+        LocalDateTime now = LocalDateTime.now();
+        List<CombatReplayContestEntity> contests =
+                replayContestRepository
+                        .findByReplayStatusAndReplayStartWarningPostedAtIsNullAndReplayStartAtBetweenOrderByReplayStartAtAsc(
+                                CombatContestReplayStatus.PENDING, now, now.plus(REPLAY_START_WARNING_LEAD_TIME));
+        for (CombatReplayContestEntity contest : contests) {
+            postReplayStartWarning(contest);
+        }
+    }
+
+    private void postReplayStartWarning(CombatReplayContestEntity contest) {
+        try {
+            int claimed =
+                    replayContestRepository.markReplayStartWarningPostedIfUnset(contest.getId(), LocalDateTime.now());
+            if (claimed == 0) return;
+
+            MessageChannel channel = discordPostService.getContestThreadOrChannel(contest);
+            if (channel == null) return;
+            MessageHelper.sendMessageToChannel(channel, buildReplayStartWarningMessage(channel));
+        } catch (Exception e) {
+            BotLogger.error("Failed to post combat replay start warning.", e);
+        }
+    }
+
+    private String buildReplayStartWarningMessage(MessageChannel channel) {
+        return LazaxMinigameRoleHelper.mention(channel) + " replay starts in 5 minutes!\n"
+                + RandomHelper.pickRandomFromList(REPLAY_START_WARNING_LORE);
     }
 
     public void postPromotionContext(

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -48,7 +48,7 @@ import ti4.message.MessageHelper;
 public class CombatReplayLeaderboardService {
 
     public static final String LAZAX_MINIGAME_SUBSCRIPTION_MARKER = "-# Lazax Minigame Subscription";
-    public static final String LAZAX_MINIGAME_ROLE_NAME = "Lazax Minigame";
+    public static final String LAZAX_MINIGAME_ROLE_NAME = LazaxMinigameRoleHelper.ROLE_NAME;
 
     private static final int WRONG_PREDICTION_PENALTY = -4;
     private static final String SUBSCRIBE_EMOJI = "\uD83D\uDFE2";
@@ -381,9 +381,8 @@ public class CombatReplayLeaderboardService {
         } else {
             StringBuilder winners = new StringBuilder(message).append("\n\n");
             for (WinningPredictionSummary prediction : winningPredictions) {
-                winners.append("<@")
-                        .append(prediction.discordUserId())
-                        .append("> - ")
+                winners.append(getSafeLeaderboardName(prediction.discordUserName()))
+                        .append(" - ")
                         .append(prediction.totalPoints())
                         .append(" points (pred +")
                         .append(prediction.pointsAwarded())
@@ -405,9 +404,8 @@ public class CombatReplayLeaderboardService {
         StringBuilder message = new StringBuilder("## Side Bets\n");
         for (AggregatedSideBetSummary sideBet : aggregatedSideBets) {
             String repeats = sideBet.hitCount() > 1 ? " x" + sideBet.hitCount() : "";
-            message.append("<@")
-                    .append(sideBet.discordUserId())
-                    .append("> - *")
+            message.append(getSafeLeaderboardName(sideBet.discordUserName()))
+                    .append(" - *")
                     .append(sideBet.label())
                     .append("*")
                     .append(repeats)

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPromotionService.java
@@ -134,11 +134,12 @@ public class CombatReplayPromotionService {
         Game game = loadGame(winner.getGameName());
         if (game == null) return null;
 
-        String startSummaryText = snapshotStartSummaryText(winner);
-        String message = LazaxCombatSupport.formatReplayAnnouncement(game, winner, "", startSummaryText);
-
         TextChannel contestChannel = discordPostService.getContestChannel();
         if (contestChannel == null) return null;
+
+        String startSummaryText = snapshotStartSummaryText(winner);
+        String message = LazaxCombatSupport.formatReplayAnnouncement(
+                game, winner, LazaxMinigameRoleHelper.mention(contestChannel), startSummaryText);
 
         try {
             LocalDateTime promotedAt = LocalDateTime.now(clock);
@@ -272,6 +273,7 @@ public class CombatReplayPromotionService {
         configureReplayContest(existingContest, winner, publicChannelId, publicMessageId, publicThreadId, promotedAt);
         existingContest.setReplayCompletedAt(null);
         existingContest.setPreReplayContextPostedAt(null);
+        existingContest.setReplayStartWarningPostedAt(null);
         existingContest.setLeaderboardPostedAt(null);
         existingContest.setSideBetSummaryMessageId(null);
         existingContest.setSideBetButtonsPostedAt(null);

--- a/src/main/java/ti4/contest/replay/service/LazaxMinigameRoleHelper.java
+++ b/src/main/java/ti4/contest/replay/service/LazaxMinigameRoleHelper.java
@@ -1,0 +1,31 @@
+package ti4.contest.replay.service;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import ti4.discord.JdaService;
+
+@UtilityClass
+public class LazaxMinigameRoleHelper {
+
+    public static final String ROLE_NAME = "Lazax Minigame";
+
+    public String mention(MessageChannel channel) {
+        Role role = findRole(channel);
+        return role == null ? "@" + ROLE_NAME : role.getAsMention();
+    }
+
+    public Role findRole(MessageChannel channel) {
+        if (channel instanceof GuildMessageChannel guildChannel) {
+            return findRole(guildChannel.getGuild());
+        }
+        return JdaService.guildPrimary == null ? null : findRole(JdaService.guildPrimary);
+    }
+
+    public Role findRole(Guild guild) {
+        if (guild == null) return null;
+        return guild.getRolesByName(ROLE_NAME, true).stream().findFirst().orElse(null);
+    }
+}

--- a/src/main/java/ti4/discord/interactions/listeners/LazaxMinigameReactionListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/LazaxMinigameReactionListener.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayLeaderboardService;
+import ti4.contest.replay.service.LazaxMinigameRoleHelper;
 import ti4.discord.JdaService;
 import ti4.executors.ExecutorServiceManager;
 import ti4.logging.BotLogger;
@@ -56,10 +57,7 @@ class LazaxMinigameReactionListener extends ListenerAdapter {
         String emoji = event.getEmoji().getName();
         if (!SUBSCRIBE_EMOJI.equals(emoji) && !UNSUBSCRIBE_EMOJI.equals(emoji)) return;
 
-        Role role =
-                event.getGuild().getRolesByName(CombatReplayLeaderboardService.LAZAX_MINIGAME_ROLE_NAME, true).stream()
-                        .findFirst()
-                        .orElse(null);
+        Role role = LazaxMinigameRoleHelper.findRole(event.getGuild());
         if (role == null) {
             BotLogger.warning("Lazax Minigame role not found in guild: "
                     + event.getGuild().getId());


### PR DESCRIPTION
## Summary
- tag Lazax Minigame at the top of combat contest announcements and before replay start
- add an idempotent five-minute replay warning so concurrent cron runs do not double-post
- show prediction and side-bet result names without pinging users

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests compile
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -Dtest='ti4.contest.replay.service.*Test,ti4.contest.replay.core.renderers.*Test' test
- git diff --check