### PR TITLE
Add combat double or bust support classes

### DIFF
--- a/src/main/java/ti4/contest/replay/buttons/CombatDoubleOrBustButtonHandler.java
+++ b/src/main/java/ti4/contest/replay/buttons/CombatDoubleOrBustButtonHandler.java
@@ -1,0 +1,32 @@
+package ti4.contest.replay.buttons;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.service.CombatDoubleOrBustService;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.logging.BotLogger;
+import ti4.spring.context.SpringContext;
+
+@UtilityClass
+class CombatDoubleOrBustButtonHandler {
+
+    @ButtonHandler(value = CombatDoubleOrBustButtonIds.PREFIX, save = false)
+    public static void toggleDoubleOrBust(ButtonInteractionEvent event, String buttonId) {
+        try {
+            Long contestId = CombatDoubleOrBustButtonIds.parse(buttonId);
+            CombatDoubleOrBustService.ToggleResult result =
+                    SpringContext.getBean(CombatDoubleOrBustService.class).toggle(event, contestId);
+            event.getHook().editOriginal(result.message()).queue(Consumers.nop(), BotLogger::catchRestError);
+        } catch (IllegalArgumentException e) {
+            event.getHook()
+                    .editOriginal("This Double or Bust button is malformed.")
+                    .queue(Consumers.nop(), BotLogger::catchRestError);
+        } catch (Exception e) {
+            BotLogger.error(event, "Unexpected Double or Bust button failure", e);
+            event.getHook()
+                    .editOriginal("Double or Bust failed. Please try again or report this if it keeps happening.")
+                    .queue(Consumers.nop(), BotLogger::catchRestError);
+        }
+    }
+}

--- a/src/main/java/ti4/contest/replay/buttons/CombatDoubleOrBustButtonIds.java
+++ b/src/main/java/ti4/contest/replay/buttons/CombatDoubleOrBustButtonIds.java
@@ -1,0 +1,19 @@
+package ti4.contest.replay.buttons;
+
+public final class CombatDoubleOrBustButtonIds {
+
+    public static final String PREFIX = "combatDoubleOrBust_";
+
+    private CombatDoubleOrBustButtonIds() {}
+
+    public static String format(Long contestId) {
+        return PREFIX + contestId;
+    }
+
+    public static Long parse(String buttonId) {
+        if (buttonId == null || !buttonId.startsWith(PREFIX)) {
+            throw new IllegalArgumentException("Unknown Double or Bust button id: " + buttonId);
+        }
+        return Long.parseLong(buttonId.substring(PREFIX.length()));
+    }
+}

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -183,7 +183,7 @@ public class CombatContestSettings {
         private int dynamicPayoutCap = 50;
         private double afbWhiffSelectionBias = 2.0;
         private double roundOneWhiffSelectionBias = 3.0;
-        private double roundOneSlamSelectionBias = 3.0;
+        private double roundOneSlamSelectionBias = 1.5;
         private double winnerOneHpPayoutMultiplier = 0.75;
         private String dynamicPayoutTiers = "0.20:4,0.10:5,0.05:8,0.025:12,0.01:20,0.005:30";
     }

--- a/src/main/java/ti4/contest/replay/entities/CombatDoubleOrBustEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatDoubleOrBustEntity.java
@@ -1,0 +1,45 @@
+package ti4.contest.replay.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "combat_double_or_bust",
+        indexes = @Index(name = "idx_double_or_bust_contest_user", columnList = "contest_id, discord_user_id"),
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uk_double_or_bust_contest_user",
+                        columnNames = {"contest_id", "discord_user_id"}))
+public class CombatDoubleOrBustEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "contest_id", nullable = false)
+    private Long contestId;
+
+    @Column(name = "discord_user_id", nullable = false)
+    private String discordUserId;
+
+    @Column(name = "discord_user_name", nullable = false)
+    private String discordUserName;
+
+    @Column(name = "enabled", nullable = false)
+    private Boolean enabled;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/ti4/contest/replay/entities/CombatReplayPredictionEntity.java
+++ b/src/main/java/ti4/contest/replay/entities/CombatReplayPredictionEntity.java
@@ -51,4 +51,10 @@ public class CombatReplayPredictionEntity {
 
     @Column(name = "defender_predictions_json", nullable = false, columnDefinition = "TEXT")
     private String defenderPredictionsJson;
+
+    @Column(name = "attacker_double_or_bust_json", columnDefinition = "TEXT")
+    private String attackerDoubleOrBustJson;
+
+    @Column(name = "defender_double_or_bust_json", columnDefinition = "TEXT")
+    private String defenderDoubleOrBustJson;
 }

--- a/src/main/java/ti4/contest/replay/repository/CombatDoubleOrBustRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatDoubleOrBustRepository.java
@@ -1,0 +1,16 @@
+package ti4.contest.replay.repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import ti4.contest.replay.entities.CombatDoubleOrBustEntity;
+
+public interface CombatDoubleOrBustRepository extends JpaRepository<CombatDoubleOrBustEntity, Long> {
+
+    Optional<CombatDoubleOrBustEntity> findByContestIdAndDiscordUserId(Long contestId, String discordUserId);
+
+    List<CombatDoubleOrBustEntity> findByContestIdAndEnabledTrue(Long contestId);
+
+    List<CombatDoubleOrBustEntity> findByContestIdAndDiscordUserIdIn(Long contestId, Collection<String> discordUserIds);
+}

--- a/src/main/java/ti4/contest/replay/service/CombatDoubleOrBustService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatDoubleOrBustService.java
@@ -1,0 +1,86 @@
+package ti4.contest.replay.service;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import org.springframework.stereotype.Service;
+import ti4.contest.replay.entities.CombatCandidateEntity;
+import ti4.contest.replay.entities.CombatDoubleOrBustEntity;
+import ti4.contest.replay.entities.CombatReplayContestEntity;
+import ti4.contest.replay.repository.CombatCandidateRepository;
+import ti4.contest.replay.repository.CombatDoubleOrBustRepository;
+import ti4.contest.replay.repository.CombatReplayContestRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CombatDoubleOrBustService {
+
+    private final CombatReplayContestRepository replayContestRepository;
+    private final CombatCandidateRepository candidateRepository;
+    private final CombatDoubleOrBustRepository doubleOrBustRepository;
+    private final CombatReplaySideBetUiService sideBetUiService;
+
+    public synchronized ToggleResult toggle(ButtonInteractionEvent event, Long contestId) {
+        if (event == null || contestId == null) return ToggleResult.rejected("Double or Bust context is incomplete.");
+
+        CombatReplayContestEntity contest =
+                replayContestRepository.findById(contestId).orElse(null);
+        if (contest == null) return ToggleResult.rejected("This combat contest is no longer available.");
+        if (contest.getReplayStartAt() == null || !LocalDateTime.now().isBefore(contest.getReplayStartAt())) {
+            return ToggleResult.rejected("The Double or Bust window is closed.");
+        }
+
+        String userId = event.getUser().getId();
+        String userName = event.getUser().getEffectiveName();
+        CombatDoubleOrBustEntity doubleOrBust = doubleOrBustRepository
+                .findByContestIdAndDiscordUserId(contestId, userId)
+                .orElseGet(CombatDoubleOrBustEntity::new);
+        doubleOrBust.setContestId(contestId);
+        doubleOrBust.setDiscordUserId(userId);
+        doubleOrBust.setDiscordUserName(userName);
+        doubleOrBust.setEnabled(!Boolean.TRUE.equals(doubleOrBust.getEnabled()));
+        doubleOrBust.setUpdatedAt(LocalDateTime.now());
+        doubleOrBustRepository.save(doubleOrBust);
+        refreshSummary(event, contest);
+
+        if (Boolean.TRUE.equals(doubleOrBust.getEnabled())) {
+            return ToggleResult.accepted("You are doubling for this combat. Correct prediction: double payout. "
+                    + "Incorrect prediction: regular loss plus your predicted side's would-have-won payout.");
+        }
+        return ToggleResult.accepted("You are no longer doubling for this combat.");
+    }
+
+    private void refreshSummary(ButtonInteractionEvent event, CombatReplayContestEntity contest) {
+        if (event == null || contest == null || contest.getCandidateId() == null) return;
+        CombatCandidateEntity candidate =
+                candidateRepository.findById(contest.getCandidateId()).orElse(null);
+        sideBetUiService.refreshSummaryMessage(event.getMessageChannel(), contest, candidate);
+    }
+
+    public Set<String> lockedDoubleOrBustUserIds(Long contestId) {
+        if (contestId == null) return Set.of();
+        Set<String> userIds = new HashSet<>();
+        for (CombatDoubleOrBustEntity doubleOrBust : doubleOrBustRepository.findByContestIdAndEnabledTrue(contestId)) {
+            userIds.add(doubleOrBust.getDiscordUserId());
+        }
+        return userIds;
+    }
+
+    public List<CombatDoubleOrBustEntity> findForUsers(Long contestId, Set<String> userIds) {
+        if (contestId == null || userIds == null || userIds.isEmpty()) return List.of();
+        return doubleOrBustRepository.findByContestIdAndDiscordUserIdIn(contestId, userIds);
+    }
+
+    public record ToggleResult(boolean accepted, String message) {
+        public static ToggleResult accepted(String message) {
+            return new ToggleResult(true, message);
+        }
+
+        public static ToggleResult rejected(String message) {
+            return new ToggleResult(false, message);
+        }
+    }
+}

--- a/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayLeaderboardService.java
@@ -27,6 +27,7 @@ import ti4.contest.replay.entities.CombatReplayPredictionEntity;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
 import ti4.contest.replay.repository.CombatReplayLeaderboardEntryRepository;
 import ti4.contest.replay.repository.CombatReplayPredictionRepository;
+import ti4.contest.replay.service.CombatReplayPredictionScorer.BustedPredictionSummary;
 import ti4.contest.replay.service.CombatReplayPredictionScorer.LockedPrediction;
 import ti4.contest.replay.service.CombatReplayPredictionScorer.ScoredPredictions;
 import ti4.contest.replay.service.CombatReplayPredictionScorer.WinningPredictionSummary;
@@ -62,6 +63,7 @@ public class CombatReplayLeaderboardService {
     private final CombatReplayPredictionRepository replayPredictionRepository;
     private final CombatReplayLeaderboardEntryRepository leaderboardEntryRepository;
     private final CombatReplaySideBetService sideBetService;
+    private final CombatDoubleOrBustService doubleOrBustService;
 
     public void lockPredictionsAtReplayStart(
             Game game, CombatReplayContestEntity replayContest, CombatCandidateEntity candidate) {
@@ -259,13 +261,18 @@ public class CombatReplayLeaderboardService {
         lockedPrediction.setDefenderPredictionCount(defenderPredictions.size());
         lockedPrediction.setAttackerPredictionsJson(writeLockedPredictions(attackerPredictions));
         lockedPrediction.setDefenderPredictionsJson(writeLockedPredictions(defenderPredictions));
+        Set<String> doubleOrBustUserIds = doubleOrBustService.lockedDoubleOrBustUserIds(replayContest.getId());
+        lockedPrediction.setAttackerDoubleOrBustJson(
+                writeStringSet(retainPredictedUserIds(attackerPredictions, doubleOrBustUserIds)));
+        lockedPrediction.setDefenderDoubleOrBustJson(
+                writeStringSet(retainPredictedUserIds(defenderPredictions, doubleOrBustUserIds)));
         return lockedPrediction;
     }
 
     private ScoredContestResult scoreSideBetOnlyContest(
             CombatCandidateEntity candidate, CombatReplayContestEntity replayContest) {
         SideBetResolution sideBetResolution = sideBetService.resolveSideBets(candidate, replayContest);
-        return new ScoredContestResult(0, List.of(), sideBetResolution.resolvedSideBets());
+        return new ScoredContestResult(0, List.of(), List.of(), sideBetResolution.resolvedSideBets());
     }
 
     private synchronized ScoredContestResult scoreReplayContest(
@@ -287,7 +294,12 @@ public class CombatReplayLeaderboardService {
         List<LockedPrediction> defenderPredictions =
                 readLockedPredictions(lockedPrediction.getDefenderPredictionsJson());
         ScoredPredictions scoredPredictions = CombatReplayPredictionScorer.score(
-                attackerPredictions, defenderPredictions, candidate.getWinnerFaction(), candidate.getAttackerFaction());
+                attackerPredictions,
+                defenderPredictions,
+                readStringSet(lockedPrediction.getAttackerDoubleOrBustJson()),
+                readStringSet(lockedPrediction.getDefenderDoubleOrBustJson()),
+                candidate.getWinnerFaction(),
+                candidate.getAttackerFaction());
 
         List<String> userIds = new ArrayList<>();
         for (LockedPrediction prediction : scoredPredictions.allPredictions()) {
@@ -304,7 +316,11 @@ public class CombatReplayLeaderboardService {
             applyContestResult(
                     scoredPredictions.allPredictions(),
                     scoredPredictions.winningPredictions(),
+                    scoredPredictions.losingPredictions(),
                     scoredPredictions.pointsAwarded(),
+                    scoredPredictions.winningDoubleOrBustUserIds(),
+                    scoredPredictions.losingDoubleOrBustUserIds(),
+                    scoredPredictions.bustPenalty(),
                     entriesByUser);
             leaderboardEntryRepository.saveAll(entriesByUser.values());
             SideBetResolution sideBetResolution = sideBetService.resolveSideBets(candidate, replayContest);
@@ -319,18 +335,34 @@ public class CombatReplayLeaderboardService {
         return new ScoredContestResult(
                 scoredPredictions.totalPredictions(),
                 CombatReplayPredictionScorer.resultSummaries(
-                        scoredPredictions.winningPredictions(), scoredPredictions.pointsAwarded(), entriesByUser),
+                        scoredPredictions.winningPredictions(),
+                        scoredPredictions.pointsAwarded(),
+                        scoredPredictions.winningDoubleOrBustUserIds(),
+                        entriesByUser),
+                CombatReplayPredictionScorer.bustedSummaries(
+                        scoredPredictions.losingPredictions(),
+                        scoredPredictions.losingDoubleOrBustUserIds(),
+                        scoredPredictions.bustPenalty(),
+                        entriesByUser),
                 resolvedSideBets);
     }
 
     private void applyContestResult(
             List<LockedPrediction> allPredictions,
             List<LockedPrediction> winningPredictions,
+            List<LockedPrediction> losingPredictions,
             int pointsAwarded,
+            Set<String> winningDoubleOrBustUserIds,
+            Set<String> losingDoubleOrBustUserIds,
+            int bustPenalty,
             Map<String, CombatReplayLeaderboardEntryEntity> entriesByUser) {
         Set<String> winningUserIds = new HashSet<>();
         for (LockedPrediction prediction : winningPredictions) {
             winningUserIds.add(prediction.discordUserId());
+        }
+        Set<String> losingUserIds = new HashSet<>();
+        for (LockedPrediction prediction : losingPredictions) {
+            losingUserIds.add(prediction.discordUserId());
         }
         LocalDateTime now = LocalDateTime.now();
 
@@ -342,9 +374,17 @@ public class CombatReplayLeaderboardService {
             entry.setPredictionCount(safeInt(entry.getPredictionCount()) + 1);
             if (winningUserIds.contains(prediction.discordUserId())) {
                 entry.setCorrectPredictions(safeInt(entry.getCorrectPredictions()) + 1);
-                entry.setTotalPoints(safeInt(entry.getTotalPoints()) + pointsAwarded);
+                int bonus = winningDoubleOrBustUserIds.contains(prediction.discordUserId())
+                        ? pointsAwarded * 2
+                        : pointsAwarded;
+                entry.setTotalPoints(safeInt(entry.getTotalPoints()) + bonus);
             } else {
-                entry.setTotalPoints(Math.max(0, safeInt(entry.getTotalPoints()) + WRONG_PREDICTION_PENALTY));
+                int penalty = WRONG_PREDICTION_PENALTY;
+                if (losingUserIds.contains(prediction.discordUserId())
+                        && losingDoubleOrBustUserIds.contains(prediction.discordUserId())) {
+                    penalty -= bustPenalty;
+                }
+                entry.setTotalPoints(Math.max(0, safeInt(entry.getTotalPoints()) + penalty));
             }
             entry.setUpdatedAt(now);
         }
@@ -386,9 +426,21 @@ public class CombatReplayLeaderboardService {
                         .append(prediction.totalPoints())
                         .append(" points (pred +")
                         .append(prediction.pointsAwarded())
+                        .append(prediction.doubled() ? ", doubled!" : "")
                         .append(")\n");
             }
             message = winners.toString().trim();
+        }
+        if (!result.bustedPredictions().isEmpty()) {
+            StringBuilder withBusted = new StringBuilder(message).append("\n\n");
+            for (BustedPredictionSummary prediction : result.bustedPredictions()) {
+                withBusted
+                        .append(getSafeLeaderboardName(prediction.discordUserName()))
+                        .append(" - -")
+                        .append(prediction.pointsLost())
+                        .append(" points (busted!)\n");
+            }
+            message = withBusted.toString().trim();
         }
         MessageHelper.splitAndSentWithAction(message, threadOrChannel, _ -> {
             if (afterPost != null) {
@@ -506,6 +558,25 @@ public class CombatReplayLeaderboardService {
         }
     }
 
+    private Set<String> retainPredictedUserIds(List<LockedPrediction> predictions, Set<String> userIds) {
+        if (predictions == null || predictions.isEmpty() || userIds == null || userIds.isEmpty()) return Set.of();
+        Set<String> retained = new HashSet<>();
+        for (LockedPrediction prediction : predictions) {
+            if (userIds.contains(prediction.discordUserId())) {
+                retained.add(prediction.discordUserId());
+            }
+        }
+        return retained;
+    }
+
+    private String writeStringSet(Set<String> values) {
+        try {
+            return JsonMapperManager.basic().writeValueAsString(values == null ? Set.of() : values);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to write Double or Bust snapshot.", e);
+        }
+    }
+
     private List<LockedPrediction> readLockedPredictions(String predictionsJson) {
         if (predictionsJson == null || predictionsJson.isBlank()) return List.of();
         try {
@@ -514,6 +585,16 @@ public class CombatReplayLeaderboardService {
                     .readValue(predictionsJson);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to read replay prediction snapshot.", e);
+        }
+    }
+
+    private Set<String> readStringSet(String valuesJson) {
+        if (valuesJson == null || valuesJson.isBlank()) return Set.of();
+        try {
+            return new HashSet<>(
+                    JsonMapperManager.basic().readerForListOf(String.class).readValue(valuesJson));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to read Double or Bust snapshot.", e);
         }
     }
 
@@ -553,5 +634,6 @@ public class CombatReplayLeaderboardService {
     record ScoredContestResult(
             int totalPredictions,
             List<WinningPredictionSummary> winningPredictions,
+            List<BustedPredictionSummary> bustedPredictions,
             List<ResolvedSideBet> winningSideBets) {}
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplayPredictionScorer.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayPredictionScorer.java
@@ -1,8 +1,10 @@
 package ti4.contest.replay.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import ti4.contest.replay.core.CombatPredictionPayout;
 import ti4.contest.replay.entities.CombatReplayLeaderboardEntryEntity;
 
@@ -14,12 +16,20 @@ final class CombatReplayPredictionScorer {
     static ScoredPredictions score(
             List<LockedPrediction> attackerPredictions,
             List<LockedPrediction> defenderPredictions,
+            Set<String> attackerDoubleOrBustUserIds,
+            Set<String> defenderDoubleOrBustUserIds,
             String winnerFaction,
             String attackerFaction) {
         List<LockedPrediction> winningPredictions = List.of();
+        List<LockedPrediction> losingPredictions = List.of();
+        Set<String> winningDoubleOrBustUserIds = Set.of();
+        Set<String> losingDoubleOrBustUserIds = Set.of();
         if (winnerFaction != null) {
-            winningPredictions =
-                    winnerFaction.equalsIgnoreCase(attackerFaction) ? attackerPredictions : defenderPredictions;
+            boolean attackerWon = winnerFaction.equalsIgnoreCase(attackerFaction);
+            winningPredictions = attackerWon ? attackerPredictions : defenderPredictions;
+            losingPredictions = attackerWon ? defenderPredictions : attackerPredictions;
+            winningDoubleOrBustUserIds = attackerWon ? attackerDoubleOrBustUserIds : defenderDoubleOrBustUserIds;
+            losingDoubleOrBustUserIds = attackerWon ? defenderDoubleOrBustUserIds : attackerDoubleOrBustUserIds;
         }
         List<LockedPrediction> allPredictions =
                 new ArrayList<>(attackerPredictions.size() + defenderPredictions.size());
@@ -30,25 +40,71 @@ final class CombatReplayPredictionScorer {
         int totalPredictions = allPredictions.size();
         int pointsAwarded =
                 winnerPredictions == 0 ? 0 : CombatPredictionPayout.points(winnerPredictions, totalPredictions);
-        return new ScoredPredictions(totalPredictions, pointsAwarded, allPredictions, winningPredictions);
+        int attackerWouldHaveWonPoints = attackerPredictions.isEmpty()
+                ? 0
+                : CombatPredictionPayout.points(attackerPredictions.size(), totalPredictions);
+        int defenderWouldHaveWonPoints = defenderPredictions.isEmpty()
+                ? 0
+                : CombatPredictionPayout.points(defenderPredictions.size(), totalPredictions);
+        int bustPenalty = winnerFaction != null && winnerFaction.equalsIgnoreCase(attackerFaction)
+                ? defenderWouldHaveWonPoints
+                : attackerWouldHaveWonPoints;
+        return new ScoredPredictions(
+                totalPredictions,
+                pointsAwarded,
+                allPredictions,
+                winningPredictions,
+                losingPredictions,
+                safeSet(winningDoubleOrBustUserIds),
+                safeSet(losingDoubleOrBustUserIds),
+                bustPenalty);
     }
 
     static List<WinningPredictionSummary> resultSummaries(
             List<LockedPrediction> winningPredictions,
             int predictionPointsAwarded,
+            Set<String> winningDoubleOrBustUserIds,
             Map<String, CombatReplayLeaderboardEntryEntity> entriesByUser) {
         List<WinningPredictionSummary> summaries = new ArrayList<>(winningPredictions.size());
         for (LockedPrediction prediction : winningPredictions) {
             CombatReplayLeaderboardEntryEntity entry = entriesByUser.get(prediction.discordUserId());
+            boolean doubled = winningDoubleOrBustUserIds != null
+                    && winningDoubleOrBustUserIds.contains(prediction.discordUserId());
             summaries.add(new WinningPredictionSummary(
                     prediction.discordUserId(),
                     prediction.discordUserName(),
-                    predictionPointsAwarded,
+                    doubled ? predictionPointsAwarded * 2 : predictionPointsAwarded,
+                    doubled,
                     entry == null ? 0 : safeInt(entry.getTotalPoints())));
         }
         summaries.sort((left, right) -> {
             int totalPointsComparison = Integer.compare(right.totalPoints(), left.totalPoints());
             if (totalPointsComparison != 0) return totalPointsComparison;
+            return left.discordUserName().compareToIgnoreCase(right.discordUserName());
+        });
+        return summaries;
+    }
+
+    static List<BustedPredictionSummary> bustedSummaries(
+            List<LockedPrediction> losingPredictions,
+            Set<String> losingDoubleOrBustUserIds,
+            int bustPenalty,
+            Map<String, CombatReplayLeaderboardEntryEntity> entriesByUser) {
+        if (losingDoubleOrBustUserIds == null || losingDoubleOrBustUserIds.isEmpty()) return List.of();
+        List<BustedPredictionSummary> summaries = new ArrayList<>();
+        int pointsLost = 4 + bustPenalty;
+        for (LockedPrediction prediction : losingPredictions) {
+            if (!losingDoubleOrBustUserIds.contains(prediction.discordUserId())) continue;
+            CombatReplayLeaderboardEntryEntity entry = entriesByUser.get(prediction.discordUserId());
+            summaries.add(new BustedPredictionSummary(
+                    prediction.discordUserId(),
+                    prediction.discordUserName(),
+                    pointsLost,
+                    entry == null ? 0 : safeInt(entry.getTotalPoints())));
+        }
+        summaries.sort((left, right) -> {
+            int pointsLostComparison = Integer.compare(right.pointsLost(), left.pointsLost());
+            if (pointsLostComparison != 0) return pointsLostComparison;
             return left.discordUserName().compareToIgnoreCase(right.discordUserName());
         });
         return summaries;
@@ -64,7 +120,18 @@ final class CombatReplayPredictionScorer {
             int totalPredictions,
             int pointsAwarded,
             List<LockedPrediction> allPredictions,
-            List<LockedPrediction> winningPredictions) {}
+            List<LockedPrediction> winningPredictions,
+            List<LockedPrediction> losingPredictions,
+            Set<String> winningDoubleOrBustUserIds,
+            Set<String> losingDoubleOrBustUserIds,
+            int bustPenalty) {}
 
-    record WinningPredictionSummary(String discordUserId, String discordUserName, int pointsAwarded, int totalPoints) {}
+    record WinningPredictionSummary(
+            String discordUserId, String discordUserName, int pointsAwarded, boolean doubled, int totalPoints) {}
+
+    record BustedPredictionSummary(String discordUserId, String discordUserName, int pointsLost, int totalPoints) {}
+
+    private static Set<String> safeSet(Set<String> value) {
+        return value == null ? Set.of() : new HashSet<>(value);
+    }
 }

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetUiService.java
@@ -13,13 +13,16 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import org.apache.commons.lang3.function.Consumers;
 import org.springframework.stereotype.Service;
+import ti4.contest.replay.buttons.CombatDoubleOrBustButtonIds;
 import ti4.contest.replay.buttons.CombatSideBetButtonIds;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.core.CombatSideBetType;
 import ti4.contest.replay.entities.CombatCandidateEntity;
 import ti4.contest.replay.entities.CombatContestSideBetEntity;
+import ti4.contest.replay.entities.CombatDoubleOrBustEntity;
 import ti4.contest.replay.entities.CombatReplayContestEntity;
 import ti4.contest.replay.repository.CombatContestSideBetRepository;
+import ti4.contest.replay.repository.CombatDoubleOrBustRepository;
 import ti4.contest.replay.repository.CombatReplayContestRepository;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.game.Game;
@@ -38,6 +41,7 @@ class CombatReplaySideBetUiService {
     private final CombatContestSettings settings;
     private final CombatReplayContestRepository replayContestRepository;
     private final CombatContestSideBetRepository sideBetRepository;
+    private final CombatDoubleOrBustRepository doubleOrBustRepository;
     private final CombatReplaySideBetPayoutService payoutService;
     private final CombatSideBetAvailabilityService availabilityService;
 
@@ -54,6 +58,7 @@ class CombatReplaySideBetUiService {
         ensureSummaryMessage(channel, game, contest);
         postFactionButtons(channel, game, contest, candidate, candidate.getAttackerFaction());
         postFactionButtons(channel, game, contest, candidate, candidate.getDefenderFaction());
+        postDoubleOrBustButton(channel, contest);
     }
 
     private String sideBetPrompt() {
@@ -127,6 +132,14 @@ class CombatReplaySideBetUiService {
         replayContestRepository.save(contest);
     }
 
+    private void postDoubleOrBustButton(MessageChannel channel, CombatReplayContestEntity contest) {
+        if (channel == null || contest == null || contest.getId() == null) return;
+        Button button = Buttons.green(CombatDoubleOrBustButtonIds.format(contest.getId()), "Double or Bust");
+        if (sideBetWindowClosed(contest)) button = button.asDisabled();
+        MessageHelper.sendMessageToChannelWithButton(
+                channel, "## Double or Bust\nSet your Double or Bust before the replay begins.", button);
+    }
+
     private void ensureSummaryMessage(MessageChannel channel, Game game, CombatReplayContestEntity contest) {
         Long summaryMessageId = contest.getSideBetSummaryMessageId();
         if (summaryMessageId != null && summaryMessageId > 0) {
@@ -165,6 +178,8 @@ class CombatReplaySideBetUiService {
 
     private String renderSummaryMessage(Game game, CombatReplayContestEntity contest) {
         List<CombatContestSideBetEntity> sideBets = sideBetRepository.findByContestId(contest.getId());
+        List<CombatDoubleOrBustEntity> doubleOrBusts =
+                doubleOrBustRepository.findByContestIdAndEnabledTrue(contest.getId());
         sideBets.sort(sideBetOrder());
         StringBuilder message = new StringBuilder();
         message.append("```text\n");
@@ -172,14 +187,21 @@ class CombatReplaySideBetUiService {
         message.append("----+------------------------------\n");
         if (sideBets.isEmpty()) {
             message.append(" -  | No side bets placed\n");
-            message.append("```");
-            return message.toString();
+        } else {
+            Map<String, Long> countsByBet = summarizeBetCounts(sideBets, game);
+            for (Map.Entry<String, Long> entry :
+                    sortBetCountsByQuantityDesc(countsByBet).entrySet()) {
+                message.append(String.format("%-3s | %s%n", entry.getValue() + "x", entry.getKey()));
+            }
         }
 
-        Map<String, Long> countsByBet = summarizeBetCounts(sideBets, game);
-        for (Map.Entry<String, Long> entry :
-                sortBetCountsByQuantityDesc(countsByBet).entrySet()) {
-            message.append(String.format("%-3s | %s%n", entry.getValue() + "x", entry.getKey()));
+        message.append("\n");
+        message.append(String.format("%-3s | %s%n", "Qty", "Double or Bust"));
+        message.append("----+------------------------------\n");
+        if (doubleOrBusts.isEmpty()) {
+            message.append(" -  | No Double or Bust entries\n");
+        } else {
+            message.append(String.format("%-3s | People enabled%n", doubleOrBusts.size() + "x"));
         }
         message.append("```");
         return message.toString();

--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.contest.replay.buttons.CombatDoubleOrBustButtonIds;
 import ti4.contest.replay.buttons.CombatSideBetButtonIds;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.contest.replay.service.CombatReplayService;
@@ -150,7 +151,9 @@ public class ButtonProcessor {
 
     private static boolean isCombatReplayButton(String buttonID) {
         return buttonID != null
-                && (buttonID.startsWith(CombatSideBetButtonIds.PREFIX) || buttonID.startsWith("combatReplayDebug_"));
+                && (buttonID.startsWith(CombatSideBetButtonIds.PREFIX)
+                        || buttonID.startsWith(CombatDoubleOrBustButtonIds.PREFIX)
+                        || buttonID.startsWith("combatReplayDebug_"));
     }
 
     private static void resolveButtonInteractionEvent(ButtonContext context) {

--- a/src/main/java/ti4/discord/interactions/listeners/ButtonListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ButtonListener.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.AsyncTI4DiscordBot;
+import ti4.contest.replay.buttons.CombatDoubleOrBustButtonIds;
 import ti4.contest.replay.buttons.CombatSideBetButtonIds;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.buttons.ButtonProcessor;
@@ -63,7 +64,9 @@ class ButtonListener extends ListenerAdapter {
     private static boolean shouldShowBotIsThinking(ButtonInteractionEvent event) {
         String buttonId = event.getButton().getCustomId();
         return BUTTONS_TO_THINK_ABOUT.contains(buttonId)
-                || (buttonId != null && buttonId.startsWith(CombatSideBetButtonIds.PREFIX));
+                || (buttonId != null
+                        && (buttonId.startsWith(CombatSideBetButtonIds.PREFIX)
+                                || buttonId.startsWith(CombatDoubleOrBustButtonIds.PREFIX)));
     }
 
     /**

--- a/src/main/java/ti4/discord/interactions/listeners/context/ListenerContext.java
+++ b/src/main/java/ti4/discord/interactions/listeners/context/ListenerContext.java
@@ -12,6 +12,7 @@ import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.contest.replay.buttons.CombatDoubleOrBustButtonIds;
 import ti4.contest.replay.buttons.CombatSideBetButtonIds;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.buttons.Buttons;
@@ -54,7 +55,9 @@ public abstract class ListenerContext {
     }
 
     private boolean allowsNonPlayerInteraction() {
-        return "showGameAgain".equalsIgnoreCase(componentID) || componentID.startsWith(CombatSideBetButtonIds.PREFIX);
+        return "showGameAgain".equalsIgnoreCase(componentID)
+                || componentID.startsWith(CombatSideBetButtonIds.PREFIX)
+                || componentID.startsWith(CombatDoubleOrBustButtonIds.PREFIX);
     }
 
     ListenerContext(GenericInteractionCreateEvent event, String compID) {


### PR DESCRIPTION
## Summary
- Add Double or Bust button id parsing and button handler.
- Add persistence entity, repository, and service for contest/user Double or Bust toggles.

## Test Plan
- Not run; committed only the previously untracked support classes as requested.