### PR TITLE
Drain stale cards info pins

### DIFF
--- a/src/main/java/ti4/message/CardsInfoPinCleanupService.java
+++ b/src/main/java/ti4/message/CardsInfoPinCleanupService.java
@@ -1,0 +1,75 @@
+package ti4.message;
+
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import org.apache.commons.lang3.StringUtils;
+import ti4.logging.BotLogger;
+
+@UtilityClass
+class CardsInfoPinCleanupService {
+
+    private static final long DRAIN_INTERVAL_MILLIS = 500;
+    private static final Queue<Message> UNPIN_QUEUE = new ConcurrentLinkedQueue<>();
+    private static final Set<String> QUEUED_MESSAGE_IDS = ConcurrentHashMap.newKeySet();
+    private static final ScheduledExecutorService UNPIN_DRAIN = Executors.newSingleThreadScheduledExecutor(
+            Thread.ofPlatform().daemon().name("cards-info-pin-cleanup").factory());
+
+    static {
+        UNPIN_DRAIN.scheduleAtFixedRate(
+                CardsInfoPinCleanupService::drainOne,
+                DRAIN_INTERVAL_MILLIS,
+                DRAIN_INTERVAL_MILLIS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    public static void queueStalePinnedMessageCleanup(ThreadChannel threadChannel, Set<String> protectedMessageIds) {
+        if (threadChannel == null) {
+            return;
+        }
+
+        threadChannel
+                .retrievePinnedMessages()
+                .queue(
+                        pinnedMessages -> {
+                            for (var pinnedMessage : pinnedMessages) {
+                                Message message = pinnedMessage.getMessage();
+                                if (message == null || isProtected(message, protectedMessageIds)) continue;
+                                if (!message.getAuthor().isBot()) continue;
+                                queueUnpin(message);
+                            }
+                        },
+                        BotLogger::catchRestError);
+    }
+
+    private static boolean isProtected(Message message, Set<String> protectedMessageIds) {
+        return message != null
+                && protectedMessageIds != null
+                && StringUtils.isNotBlank(message.getId())
+                && protectedMessageIds.contains(message.getId());
+    }
+
+    private static void queueUnpin(Message message) {
+        if (message == null) return;
+        String messageId = message.getId();
+        if (!QUEUED_MESSAGE_IDS.add(messageId)) return;
+        UNPIN_QUEUE.add(message);
+    }
+
+    private static void drainOne() {
+        Message message = UNPIN_QUEUE.poll();
+        if (message == null) return;
+        String messageId = message.getId();
+        message.unpin().queue(ignored -> QUEUED_MESSAGE_IDS.remove(messageId), error -> {
+            QUEUED_MESSAGE_IDS.remove(messageId);
+            BotLogger.catchRestError(error);
+        });
+    }
+}

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -8,9 +8,11 @@ import java.io.File;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -904,23 +906,30 @@ public class MessageHelper {
             @NotNull String storedValueKeyPrefix,
             @NotNull Message msg) {
         String storedValueKey = storedValueKeyPrefix + "_" + threadChannel.getId();
-        String previousMessageId = game.getStoredValue(storedValueKey);
-
-        if (StringUtils.isNotBlank(previousMessageId) && !previousMessageId.equals(msg.getId())) {
-            threadChannel
-                    .retrieveMessageById(previousMessageId)
-                    .queue(
-                            previousMessage ->
-                                    previousMessage.unpin().queue(Consumers.nop(), BotLogger::catchRestError),
-                            BotLogger::catchRestError);
-        }
-
         pinCardsInfoMessage(game, storedValueKey, msg);
+        CardsInfoPinCleanupService.queueStalePinnedMessageCleanup(
+                threadChannel, cardsInfoPinnedMessageIds(game, threadChannel));
     }
 
     private static void pinCardsInfoMessage(@NotNull Game game, @NotNull String storedValueKey, @NotNull Message msg) {
         game.setStoredValue(storedValueKey, msg.getId());
         msg.pin().queue(Consumers.nop(), BotLogger::catchRestError);
+    }
+
+    private static Set<String> cardsInfoPinnedMessageIds(@NotNull Game game, @NotNull ThreadChannel threadChannel) {
+        String threadId = threadChannel.getId();
+        Set<String> messageIds = new HashSet<>();
+        addStoredMessageId(game, messageIds, "pinned_ac_info_message_id_" + threadId);
+        addStoredMessageId(game, messageIds, "pinned_so_info_message_id_" + threadId);
+        addStoredMessageId(game, messageIds, "pinned_pn_info_message_id_" + threadId);
+        return messageIds;
+    }
+
+    private static void addStoredMessageId(Game game, Set<String> messageIds, String storedValueKey) {
+        String messageId = game.getStoredValue(storedValueKey);
+        if (StringUtils.isNotBlank(messageId)) {
+            messageIds.add(messageId);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replace single previous-pin cleanup with a background queue for stale cards-info pins.
- Preserve current AC/SO/PN pins and unpin older bot-authored pins from the same cards-info thread at 2 per second globally.

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -DskipTests compile