### PR TITLE
Fix Leader type fallback when missing in JSON

### DIFF
--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -1024,7 +1024,7 @@ public class CombatReplayService {
 
     private static double safeRatio(double weaker, double stronger) {
         if (stronger <= 0) return 0.0;
-        return Math.max(0.0, Math.min(1.0, weaker / stronger));
+        return Math.clamp(weaker / stronger, 0.0, 1.0);
     }
 
     private String firstNonBlank(String first, String fallback) {
@@ -1051,7 +1051,7 @@ public class CombatReplayService {
         }
     }
 
-    public record CandidateInitialSnapshot(
+    private record CandidateInitialSnapshot(
             String preReplayContextText,
             String initialRenderSnapshotJson,
             int attackerDestroyerCount,

--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -1,7 +1,7 @@
 package ti4.game;
 
-import static java.util.function.Predicate.*;
-import static org.apache.commons.collections4.CollectionUtils.*;
+import static java.util.function.Predicate.not;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import java.awt.Point;
 import java.lang.reflect.Field;
@@ -1061,7 +1061,6 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
                 setMainChannelID(mainGameChannel.getId());
                 return mainGameChannel;
             }
-            // BotLogger.log("Could not retrieve MainGameChannel for " + getName(), e);
         }
         return null;
     }

--- a/src/main/java/ti4/game/Leader.java
+++ b/src/main/java/ti4/game/Leader.java
@@ -41,7 +41,7 @@ public class Leader {
             @JsonProperty("locked") boolean locked,
             @JsonProperty("active") boolean active) {
         this.id = id;
-        this.type = type;
+        this.type = type == null ? getTypeFromLeaderId(id) : type;
         this.tgCount = tgCount;
         this.exhausted = exhausted;
         this.locked = locked;
@@ -50,16 +50,27 @@ public class Leader {
 
     public Leader(String id) {
         this.id = id;
-        if (id.contains(Constants.AGENT)) {
+        type = getTypeFromLeaderId(id);
+        if (Constants.AGENT.equals(type)) {
             locked = false;
-            type = Constants.AGENT;
-        } else if (id.contains(Constants.COMMANDER)) {
-            type = Constants.COMMANDER;
-        } else if (id.contains(Constants.HERO)) {
-            type = Constants.HERO;
-        } else if (id.contains(Constants.ENVOY)) {
-            type = Constants.ENVOY;
         }
+    }
+
+
+    private static String getTypeFromLeaderId(String id) {
+        if (id.contains(Constants.AGENT)) {
+            return Constants.AGENT;
+        }
+        if (id.contains(Constants.COMMANDER)) {
+            return Constants.COMMANDER;
+        }
+        if (id.contains(Constants.HERO)) {
+            return Constants.HERO;
+        }
+        if (id.contains(Constants.ENVOY)) {
+            return Constants.ENVOY;
+        }
+        return null;
     }
 
     @JsonIgnore

--- a/src/main/java/ti4/game/Leader.java
+++ b/src/main/java/ti4/game/Leader.java
@@ -10,15 +10,17 @@ import lombok.Getter;
 import lombok.Setter;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.apache.commons.lang3.StringUtils;
 import ti4.helpers.Constants;
 import ti4.image.Mapper;
+import ti4.logging.BotLogger;
 import ti4.model.LeaderModel;
 import ti4.service.emoji.MiscEmojis;
 
 @Getter
 public class Leader {
     private final String id;
-    private String type;
+    private final String type;
 
     @Setter
     private int tgCount;
@@ -41,7 +43,7 @@ public class Leader {
             @JsonProperty("locked") boolean locked,
             @JsonProperty("active") boolean active) {
         this.id = id;
-        this.type = type == null ? getTypeFromLeaderId(id) : type;
+        this.type = type;
         this.tgCount = tgCount;
         this.exhausted = exhausted;
         this.locked = locked;
@@ -49,13 +51,16 @@ public class Leader {
     }
 
     public Leader(String id) {
+        this(id, null);
+    }
+
+    public Leader(String id, String type) {
         this.id = id;
-        type = getTypeFromLeaderId(id);
+        this.type = StringUtils.isBlank(type) ? getTypeFromLeaderId(id) : type;
         if (Constants.AGENT.equals(type)) {
             locked = false;
         }
     }
-
 
     private static String getTypeFromLeaderId(String id) {
         if (id.contains(Constants.AGENT)) {
@@ -70,6 +75,7 @@ public class Leader {
         if (id.contains(Constants.ENVOY)) {
             return Constants.ENVOY;
         }
+        BotLogger.error("Could not infer Leader type from id: " + id);
         return null;
     }
 

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -1067,7 +1067,7 @@ class GameLoadService {
                     List<Leader> leaderList = new ArrayList<>();
                     while (leaderInfos.hasMoreTokens()) {
                         String[] split = leaderInfos.nextToken().split(",");
-                        Leader leader = new Leader(split[0]);
+                        Leader leader = new Leader(split[0], split[1]);
                         leader.setTgCount(Integer.parseInt(split[2]));
                         leader.setExhausted(Boolean.parseBoolean(split[3]));
                         leader.setLocked(Boolean.parseBoolean(split[4]));

--- a/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
+++ b/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
@@ -583,9 +583,9 @@ public class PlayStrategyCardService {
             StrategyCardModel scModel,
             List<Button> scButtons,
             List<Player> playersToReact) {
-        long playGameSaveTime = message.getTimeCreated().toInstant().toEpochMilli();
+        long messageCreationTime = message.getTimeCreated().toInstant().toEpochMilli();
         StrategyCardMessageService.replaceStrategyCardMessage(
-                game.getName(), message.getId(), playRound, scToPlay, playGameSaveTime);
+                game.getName(), message.getId(), playRound, scToPlay, messageCreationTime);
         for (Player reactingPlayer : playersToReact) {
             Emoji reactionEmoji = Helper.getPlayerReactionEmoji(game, reactingPlayer, message);
             message.addReaction(reactionEmoji).queue(Consumers.nop(), BotLogger::catchRestError);


### PR DESCRIPTION
### Motivation
- Some `Leader` JSON payloads have `"type": null`, which resulted in `Leader` instances with a null `type` field and inconsistent behavior elsewhere.

### Description
- When deserializing in the `Leader` constructor, set `type` to `getTypeFromLeaderId(id)` if the incoming `type` is `null` by using `this.type = type == null ? getTypeFromLeaderId(id) : type;`.
- Added a private helper `getTypeFromLeaderId(String id)` that returns one of the constants `Constants.AGENT`, `Constants.COMMANDER`, `Constants.HERO`, `Constants.ENVOY`, or `null` based on the `id`.
- Reused the helper in the ID-only constructor and preserved the prior behavior that agents (`Constants.AGENT`) start unlocked.

### Testing
- Ran `mvn -q -DskipITs test`, which could not complete in this environment due to a Maven parent POM resolution error (`org.springframework.boot:spring-boot-starter-parent:4.1.0-RC1` returned HTTP 403), so automated tests did not run to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f9aad194832d9a3c7b0f0489e976)