### PR TITLE
Fix TIGL mode recursion

### DIFF
--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -838,7 +838,7 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
     @Override
     public void setCompetitiveTIGLGame(boolean competitiveTIGLGame) {
         boolean isFracturedTIGL = TIGLHelper.isFracturedTIGLGame(this);
-        boolean hasAlwaysIncompatibleMode = isAllianceMode() || isCommunityMode();
+        boolean hasAlwaysIncompatibleMode = super.isAllianceMode() || super.isCommunityMode();
         boolean hasStandardOnlyIncompatibleMode =
                 isAbsolMode() || isMiltyModMode() || isDiscordantStarsMode() || isHomebrewSCMode() || isFowMode();
         if (hasAlwaysIncompatibleMode || (!isFracturedTIGL && hasStandardOnlyIncompatibleMode)) {


### PR DESCRIPTION
## Summary
- Read raw Alliance/Community mode flags while enforcing TIGL incompatibility to avoid recursive mode setter dispatch.
- Prevents StackOverflowError when Alliance or Community mode disables TIGL setup state.

## Test Plan
- Not run locally: Maven compilation requires Java 26, but this machine has Java 21.