### PR TITLE
Fix button locking outside game channels

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
+++ b/src/main/java/ti4/discord/interactions/buttons/ButtonProcessor.java
@@ -60,9 +60,10 @@ public class ButtonProcessor {
     public static void queue(ButtonInteractionEvent event) {
         String gameName = GameNameService.getGameNameFromChannel(event);
         String rawComponentID = event.getButton().getCustomId();
+        String lockName = gameName == null ? "button-message-" + event.getMessageId() : gameName;
         ExecutionLockType lockType = registry.isSave(rawComponentID) ? ExecutionLockType.WRITE : ExecutionLockType.READ;
         ExecutorServiceManager.runAsyncWithLock(
-                eventToString(event, gameName), gameName, event.getMessageChannel(), () -> process(event), lockType);
+                eventToString(event, gameName), lockName, event.getMessageChannel(), () -> process(event), lockType);
     }
 
     private static String eventToString(ButtonInteractionEvent event, String gameName) {


### PR DESCRIPTION
## Summary
- lock button interactions without a game name by source message id
- keep game-channel button interactions locked by game name
- prevents global buttons like joinGameList from reaching execution locking with a null game lock name

## Verification
- Not run: `mvn -q -DskipTests compile` fails locally because the active JDK is 21 and the project is configured for Java release 26.