### PR TITLE
Fix autocomplete crash for models missing sources

### DIFF
--- a/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
+++ b/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
@@ -1729,6 +1729,7 @@ class AutoCompleteProvider {
             CommandAutoCompleteInteractionEvent event, Collection<T> models, ComponentSource source) {
         String enteredValue = event.getFocusedOption().getValue().toLowerCase();
         return models.stream()
+                .filter(model -> model.getSource() != null)
                 .filter(model -> model.search(enteredValue, source))
                 .filter(model -> !model.getSource().isHiddenFromSearch())
                 .filter(model -> !(model instanceof ColorableModelInterface cm) || !cm.isDupe())
@@ -1744,6 +1745,7 @@ class AutoCompleteProvider {
             boolean limithomebrew) {
         String enteredValue = event.getFocusedOption().getValue().toLowerCase();
         return models.stream()
+                .filter(model -> model.getSource() != null)
                 .filter(model -> model.search(enteredValue, source))
                 .filter(model -> !model.getSource().isHiddenFromSearch(source))
                 .filter(model -> !(model instanceof ColorableModelInterface cm) || !cm.isDupe())

--- a/src/main/java/ti4/model/AbilityModel.java
+++ b/src/main/java/ti4/model/AbilityModel.java
@@ -137,7 +137,7 @@ public class AbilityModel implements ModelInterface, EmbeddableModel {
         return id.contains(searchString)
                 || name.toLowerCase().contains(searchString)
                 || faction.toLowerCase().contains(searchString)
-                || source.toString().toLowerCase().contains(searchString)
+                || (source != null && source.toString().toLowerCase().contains(searchString))
                 || searchTags.contains(searchString);
     }
 


### PR DESCRIPTION
## Summary
- Skip source-less models in shared autocomplete search before source visibility checks.
- Make ability search source matching null-safe to avoid crashing on malformed ability data.

## Test Plan
- Not run locally: Maven compile requires Java release 26, but this machine has Java 21 (`release version 26 not supported`).