### PR TITLE
Hide combat profiles in FoW tile summaries

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -3464,7 +3464,7 @@ public class ButtonHelper {
                         sb.append(unitModel.getUnitEmoji()).append(' ');
                         sb.append(privateGame ? unitModel.getBaseType() : unitModel.getName());
                         sb.append(getCombatProfileForTileSummary(
-                                        tile, unitHolder, unitModel, player, combatSummaryContext))
+                                        game, tile, unitHolder, unitModel, player, combatSummaryContext))
                                 .append('\n');
                     } else {
                         sb.append(unitKey).append('\n');
@@ -3478,12 +3478,14 @@ public class ButtonHelper {
     }
 
     private static String getCombatProfileForTileSummary(
+            Game game,
             Tile tile,
             UnitHolder unitHolder,
             UnitModel unitModel,
             Player player,
             @Nullable CombatSummaryContext combatSummaryContext) {
-        if (combatSummaryContext == null
+        if (game.isFowMode()
+                || combatSummaryContext == null
                 || !combatSummaryContext.combatPlayers().contains(player)) {
             return "";
         }


### PR DESCRIPTION
## Summary
- Skip combat profile details in combat tile summaries when FoW mode is enabled.
- Add coverage for public games showing combat profiles and FoW games hiding them.

## Test Plan
- Not run locally: Maven compilation requires Java 26, but this machine has Java 21.