### PR TITLE
Fix franken draft null cards info thread

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -3464,7 +3464,7 @@ public class ButtonHelper {
                         sb.append(unitModel.getUnitEmoji()).append(' ');
                         sb.append(privateGame ? unitModel.getBaseType() : unitModel.getName());
                         sb.append(getCombatProfileForTileSummary(
-                                        tile, unitHolder, unitModel, player, combatSummaryContext))
+                                        game, tile, unitHolder, unitModel, player, combatSummaryContext))
                                 .append('\n');
                     } else {
                         sb.append(unitKey).append('\n');
@@ -3478,12 +3478,14 @@ public class ButtonHelper {
     }
 
     private static String getCombatProfileForTileSummary(
+            Game game,
             Tile tile,
             UnitHolder unitHolder,
             UnitModel unitModel,
             Player player,
             @Nullable CombatSummaryContext combatSummaryContext) {
-        if (combatSummaryContext == null
+        if (game.isFowMode()
+                || combatSummaryContext == null
                 || !combatSummaryContext.combatPlayers().contains(player)) {
             return "";
         }

--- a/src/main/java/ti4/service/franken/FrankenDraftBagService.java
+++ b/src/main/java/ti4/service/franken/FrankenDraftBagService.java
@@ -108,12 +108,19 @@ public class FrankenDraftBagService {
         }
 
         List<Color> accents = getAccents();
-        for (Player player : game.getPlayers().values()) {
+        for (Player player : game.getRealPlayers()) {
+            ThreadChannel cardsInfoThread = player.getCardsInfoThread();
+            if (cardsInfoThread == null) {
+                BotLogger.warning("Cannot apply Franken draft bag for " + player.getUserName() + " in game "
+                        + game.getName() + " because their cards info thread is null.");
+                continue;
+            }
+
             player.setStoredValue("frankenBuilt", "n");
             for (DraftCategory category : componentCategories) {
-                MessageV2Builder builder = new MessageV2Builder(player.getCardsInfoThread());
                 Container c = postDraftCategoryContainer(player, category);
                 if (c == null) continue;
+                MessageV2Builder builder = new MessageV2Builder(cardsInfoThread);
                 builder.append(c.withAccentColor(accents.getFirst()));
                 Collections.rotate(accents, -1);
                 builder.send();
@@ -129,14 +136,14 @@ public class FrankenDraftBagService {
                 String msg = player.getRepresentation()
                         + ", you should only keep 2 abilities, 1 genome, and 1 unit out of those you drafted."
                         + " Instead of keeping one (or two) of those, you may use these buttons to take one (or two) of these generic technologies.";
-                MessageHelper.sendMessageToChannelWithEmbeds(player.getCardsInfoThread(), msg, embeds);
+                MessageHelper.sendMessageToChannelWithEmbeds(cardsInfoThread, msg, embeds);
                 buttons.add(Buttons.green("getTech_wavelength__noPay__comp", "Select Wavelength"));
                 buttons.add(Buttons.green("getTech_antimatter__noPay__comp", "Select Antimatter"));
-                MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), "Get Technology", buttons);
-                MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), "Get Technology", buttons);
+                MessageHelper.sendMessageToChannel(cardsInfoThread, "Get Technology", buttons);
+                MessageHelper.sendMessageToChannel(cardsInfoThread, "Get Technology", buttons);
             }
 
-            MessageV2Builder builder = new MessageV2Builder(player.getCardsInfoThread());
+            MessageV2Builder builder = new MessageV2Builder(cardsInfoThread);
             builder.append(getFrankenPlayerSummaryContainer(player));
             builder.send();
         }


### PR DESCRIPTION
## Summary
- apply completed Franken draft bags only to real players
- reuse a resolved cards info thread for each player before sending draft components
- skip and warn when a real player has no cards info thread instead of aborting the whole handler

## Verification
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn compile -DskipTests

Tests were not added per request.