### PR TITLE
Add missing trove4j runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <java.version>26</java.version>
     <lombok.version>1.18.46</lombok.version>
     <jda.version>6.4.1</jda.version>
+    <trove4j.version>3.0.3</trove4j.version>
     <aws.sdk.version>2.44.0</aws.sdk.version>
     <hibernate-dialects.version>7.3.2.Final</hibernate-dialects.version>
     <reflections.version>0.10.2</reflections.version>
@@ -95,6 +96,11 @@
           <artifactId>opus-java</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.trove4j</groupId>
+      <artifactId>trove4j</artifactId>
+      <version>${trove4j.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary
- Add an explicit `net.sf.trove4j:trove4j` dependency for JDA startup
- Pin the version in Maven properties so the Spring Boot package includes the legacy `gnu.trove.map.*` classes

## Verification
- `mvn -B -ntp -DskipTests dependency:tree -Dincludes=net.dv8tion:JDA,net.sf.trove4j:trove4j`
- `mvn -B -ntp dependency:get -Dartifact=net.sf.trove4j:trove4j:3.0.3` and verified `gnu/trove/map/TLongObjectMap.class` exists in the jar
- `mvn -B -ntp -DskipTests dependency:build-classpath -Dmdep.outputFile=target/classpath.txt` and verified `trove4j-3.0.3.jar` is present

Full package build was not run to completion locally because this machine has Java 21 and the project is configured for Java 26 (`release version 26 not supported`).

Tests intentionally not run per request.