### PR TITLE
Fix queued Milty pick with no active drafter

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/milty/MiltyDraftButtonHandlers.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/milty/MiltyDraftButtonHandlers.java
@@ -97,8 +97,13 @@ class MiltyDraftButtonHandlers {
     private void queueMiltyDraftPick(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
         MiltyDraftManager manager = game.getMiltyDraftManager();
         ButtonHelper.deleteMessage(event);
-        if (manager.getCurrentDraftPlayer(game) == null
-                && manager.getCurrentDraftPlayer(game).equals(player)) {
+        Player currentDraftPlayer = manager.getCurrentDraftPlayer(game);
+        if (currentDraftPlayer == null) {
+            MessageHelper.sendMessageToChannel(
+                    event.getMessageChannel(), "No one is currently up to draft, so queueing a pick is not available.");
+            return;
+        }
+        if (currentDraftPlayer.equals(player)) {
             MessageHelper.sendMessageToChannel(
                     event.getMessageChannel(), "You are up to draft and you should just do that instead of queueing.");
             return;


### PR DESCRIPTION
## Summary
- Avoid dereferencing a null current Milty draft player when a queued-pick button is pressed.
- Treat queued-pick presses with no active drafter as unavailable instead of appending another queued pick.
- Preserve the existing guard that tells the active drafter to draft directly rather than queue.

## Test Plan
- Not run per request; CI will compile and test.