### PR TITLE
Fix Franken draft apply with missing cards-info thread

### DIFF
--- a/src/main/java/ti4/service/franken/FrankenDraftBagService.java
+++ b/src/main/java/ti4/service/franken/FrankenDraftBagService.java
@@ -39,6 +39,7 @@ import ti4.helpers.discord.ContainerHelper;
 import ti4.image.Mapper;
 import ti4.image.PositionMapper;
 import ti4.logging.BotLogger;
+import ti4.logging.LogOrigin;
 import ti4.message.GameMessage;
 import ti4.message.GameMessageManager;
 import ti4.message.GameMessageType;
@@ -108,10 +109,18 @@ public class FrankenDraftBagService {
         }
 
         List<Color> accents = getAccents();
-        for (Player player : game.getPlayers().values()) {
+        for (Player player : game.getRealPlayers()) {
+            ThreadChannel cardsInfoThread = player.getCardsInfoThread();
+            if (cardsInfoThread == null) {
+                BotLogger.warning(
+                        new LogOrigin(player),
+                        "Could not apply Franken draft bag for player because their cards-info thread is missing.");
+                continue;
+            }
+
             player.setStoredValue("frankenBuilt", "n");
             for (DraftCategory category : componentCategories) {
-                MessageV2Builder builder = new MessageV2Builder(player.getCardsInfoThread());
+                MessageV2Builder builder = new MessageV2Builder(cardsInfoThread);
                 Container c = postDraftCategoryContainer(player, category);
                 if (c == null) continue;
                 builder.append(c.withAccentColor(accents.getFirst()));
@@ -129,14 +138,14 @@ public class FrankenDraftBagService {
                 String msg = player.getRepresentation()
                         + ", you should only keep 2 abilities, 1 genome, and 1 unit out of those you drafted."
                         + " Instead of keeping one (or two) of those, you may use these buttons to take one (or two) of these generic technologies.";
-                MessageHelper.sendMessageToChannelWithEmbeds(player.getCardsInfoThread(), msg, embeds);
+                MessageHelper.sendMessageToChannelWithEmbeds(cardsInfoThread, msg, embeds);
                 buttons.add(Buttons.green("getTech_wavelength__noPay__comp", "Select Wavelength"));
                 buttons.add(Buttons.green("getTech_antimatter__noPay__comp", "Select Antimatter"));
-                MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), "Get Technology", buttons);
-                MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), "Get Technology", buttons);
+                MessageHelper.sendMessageToChannel(cardsInfoThread, "Get Technology", buttons);
+                MessageHelper.sendMessageToChannel(cardsInfoThread, "Get Technology", buttons);
             }
 
-            MessageV2Builder builder = new MessageV2Builder(player.getCardsInfoThread());
+            MessageV2Builder builder = new MessageV2Builder(cardsInfoThread);
             builder.append(getFrankenPlayerSummaryContainer(player));
             builder.send();
         }


### PR DESCRIPTION
## Summary
- Apply Franken draft bags only to real players, matching the rest of the bag draft flow.
- Resolve each player cards-info thread once and skip/log that player if the thread is unavailable instead of throwing in `MessageV2Builder`.

## Test Plan
- Not run, per request.