### PR TITLE
Handle unknown emoji reaction failures

### DIFF
--- a/src/main/java/ti4/helpers/discord/DiscordHelper.java
+++ b/src/main/java/ti4/helpers/discord/DiscordHelper.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.requests.Response;
 public class DiscordHelper {
 
     private static final int DISCORD_UNKNOWN_MESSAGE_ERROR_CODE = 10_008;
+    private static final int DISCORD_UNKNOWN_EMOJI_ERROR_CODE = 10_014;
     private static final int DISCORD_UNKNOWN_WEBHOOK_ERROR_CODE = 10_015;
 
     public static boolean isDiscordServerError(Throwable error) {
@@ -26,6 +27,11 @@ public class DiscordHelper {
     public static boolean isUnknownWebhookError(Throwable error) {
         return error instanceof ErrorResponseException restError
                 && restError.getErrorCode() == DISCORD_UNKNOWN_WEBHOOK_ERROR_CODE;
+    }
+
+    public static boolean isUnknownEmojiError(Throwable error) {
+        return error instanceof ErrorResponseException restError
+                && restError.getErrorCode() == DISCORD_UNKNOWN_EMOJI_ERROR_CODE;
     }
 
     public static boolean isIgnorableError(Throwable error) {

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -2,6 +2,7 @@ package ti4.message;
 
 import static ti4.helpers.discord.DiscordHelper.isDiscordServerError;
 import static ti4.helpers.discord.DiscordHelper.isIgnorableError;
+import static ti4.helpers.discord.DiscordHelper.isUnknownEmojiError;
 import static ti4.helpers.discord.DiscordHelper.isUnknownMessageError;
 
 import java.io.File;
@@ -205,13 +206,14 @@ public class MessageHelper {
 
     private static void addFactionReactToMessage(Game game, Player player, Message message) {
         Emoji reactionEmoji = Helper.getPlayerReactionEmoji(game, player, message);
-        message.addReaction(reactionEmoji).queue(null, error -> handleFailedReaction(game, player, message, error));
-        String messageId = message.getId();
-        GameMessageManager.addReaction(game.getName(), player.getFaction(), messageId);
+        message.addReaction(reactionEmoji)
+                .queue(
+                        _ -> GameMessageManager.addReaction(game.getName(), player.getFaction(), message.getId()),
+                        error -> handleFailedReaction(game, player, message, error));
     }
 
     private static void handleFailedReaction(Game game, Player player, Message message, Throwable error) {
-        if (isUnknownMessageError(error)) {
+        if (isUnknownMessageError(error) || isUnknownEmojiError(error)) {
             return;
         }
         if (isDiscordServerError(error)) {


### PR DESCRIPTION
## Summary
- add a Discord helper for 10014 Unknown Emoji responses
- ignore unknown emoji failures when adding faction reactions
- only mark persistent faction reactions after Discord confirms the reaction was added

## Verification
- not run per request