### PR TITLE
Handle missing guild in observer command

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/game/Observer.java
+++ b/src/main/java/ti4/discord/interactions/commands/game/Observer.java
@@ -52,6 +52,14 @@ class Observer extends Subcommand {
 
         ManagedGame game = GameManager.getManagedGame(gameName);
         Guild guild = game.getGuild();
+        if (guild == null) {
+            MessageHelper.sendMessageToChannel(
+                    event.getChannel(),
+                    "Could not determine the server for game: " + gameName
+                            + ". Please make sure the game channels still exist.");
+            return;
+        }
+
         Member member = guild.getMemberById(user.getId());
 
         if (member == null && event.getGuild() != null) {

--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -1128,11 +1128,25 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
     }
 
     /**
-     * @return Guild that the ActionsChannel or MainGameChannel resides
+     * @return Guild associated with this game's channels or stored guild id
      */
     @Nullable
     public Guild getGuild() {
-        return getActionsChannel() == null ? null : getActionsChannel().getGuild();
+        TextChannel actionsChannel = getActionsChannel();
+        if (actionsChannel != null) {
+            return actionsChannel.getGuild();
+        }
+
+        TextChannel tableTalkChannel = getTableTalkChannel();
+        if (tableTalkChannel != null) {
+            return tableTalkChannel.getGuild();
+        }
+
+        if (JdaService.jda != null && StringUtils.isNumeric(getGuildID())) {
+            return JdaService.jda.getGuildById(getGuildID());
+        }
+
+        return null;
     }
 
     public void setCurrentReacts(String messageID, String factionsWhoReacted) {


### PR DESCRIPTION
## Summary
- Resolve game guild lookup from actions channel, table talk channel, or stored guild id
- Guard `/game observer` when no guild can be determined so it sends a user-facing message instead of throwing an NPE

## Verification
- `mvn spotless:apply -DspotlessFiles=src/main/java/ti4/game/Game.java,src/main/java/ti4/discord/interactions/commands/game/Observer.java`
- Compile not run per follow-up request