### PR TITLE
Fix Proxima targeting with no defender

### DIFF
--- a/src/main/java/ti4/service/tech/BastionTechService.java
+++ b/src/main/java/ti4/service/tech/BastionTechService.java
@@ -115,6 +115,13 @@ public class BastionTechService {
                     break;
                 }
             }
+            if (p2 == null) {
+                MessageHelper.sendMessageToEventChannel(
+                        event,
+                        "Cannot use " + proxima() + " on " + planet.getRepresentation(game)
+                                + " because there are no opposing units there.");
+                return;
+            }
 
             var units = CombatRollService.getProximaBombardUnit(p1);
             String planetN = planet.getName();


### PR DESCRIPTION
## Summary
- Stop Proxima Targeting VI resolution when the selected planet has no opposing units.
- Return a user-facing message instead of rolling against a null defender.

## Test Plan
- Not run; requested to create the PR without compiling.