### PR TITLE
Fix Twilight's Fall map build for non-player entries

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -259,8 +259,10 @@ public final class ButtonHelperTwilightsFall {
         }
         manager.setPlayers(playerIDs);
 
-        for (Player p : game.getPlayers().values()) {
-            setPositionAndSendHomeFleetButtons(game, p);
+        for (Player p : game.getRealPlayers()) {
+            if (!setPositionAndSendHomeFleetButtons(game, p)) {
+                return;
+            }
 
             DraftBag bag = p.getDraftHand();
             PlayerDraft draft = manager.getPlayerDraft(p);
@@ -311,8 +313,10 @@ public final class ButtonHelperTwilightsFall {
             playerIDs.add(p.getUserID());
         }
         manager.setPlayers(playerIDs);
-        for (Player p : game.getPlayers().values()) {
-            setPositionAndSendHomeFleetButtons(game, p);
+        for (Player p : game.getRealPlayers()) {
+            if (!setPositionAndSendHomeFleetButtons(game, p)) {
+                return;
+            }
         }
 
         try {
@@ -340,15 +344,32 @@ public final class ButtonHelperTwilightsFall {
         MantisMapBuildService.initializeMapBuilding(mapBuildContext);
     }
 
-    private static void setPositionAndSendHomeFleetButtons(Game game, Player player) {
+    private static boolean setPositionAndSendHomeFleetButtons(Game game, Player player) {
         DraftBag bag = player.getDraftHand();
         PlayerDraft draft = game.getMiltyDraftManager().getPlayerDraft(player);
+        if (bag == null) {
+            MessageHelper.sendMessageToChannel(
+                    game.getActionsChannel(),
+                    player.getRepresentationUnfogged()
+                            + " does not have a drafted hand, so the Twilight's Fall map build could not start.");
+            return false;
+        }
 
         // Set draft position
-        DraftItem draftPos = bag.getCategory(DraftCategory.DRAFTORDER).getFirst();
+        List<DraftItem> draftPositions = bag.getCategory(DraftCategory.DRAFTORDER);
+        List<DraftItem> homeSystems = bag.getCategory(DraftCategory.HOMESYSTEM);
+        List<DraftItem> startingFleets = bag.getCategory(DraftCategory.STARTINGFLEET);
+        if (draftPositions.isEmpty() || homeSystems.isEmpty() || startingFleets.isEmpty()) {
+            MessageHelper.sendMessageToChannel(
+                    game.getActionsChannel(),
+                    player.getRepresentationUnfogged()
+                            + " is missing a drafted position, home system, or starting fleet, so the Twilight's Fall map build could not start.");
+            return false;
+        }
+        DraftItem draftPos = draftPositions.getFirst();
         int draftNum = Integer.parseInt(draftPos.getItemId());
         draft.setPosition(draftNum);
-        draft.setFaction(bag.getCategory(DraftCategory.HOMESYSTEM).getFirst().getItemId());
+        draft.setFaction(homeSystems.getFirst().getItemId());
         if (draftNum == 1) game.setSpeaker(player);
 
         // Send home system picker
@@ -356,7 +377,7 @@ public final class ButtonHelperTwilightsFall {
         List<ContainerChildComponent> hsComps = new ArrayList<>();
         hsComps.add(TextDisplay.of(DraftCategory.HOMESYSTEM.title(game)));
         player.removeStoredValue("draftedHS");
-        for (DraftItem item : bag.getCategory(DraftCategory.HOMESYSTEM)) {
+        for (DraftItem item : homeSystems) {
             if (hsComps.size() > 1) hsComps.add(Separator.createDivider(Spacing.LARGE));
             hsComps.addAll(item.getTextDisplays(game, player, false));
             String buttonID = "chooseHomeSystem_" + item.getItemId();
@@ -373,7 +394,7 @@ public final class ButtonHelperTwilightsFall {
         List<Button> fleetButtons = new ArrayList<>();
         List<ContainerChildComponent> fleetComps = new ArrayList<>();
         fleetComps.add(TextDisplay.of(DraftCategory.STARTINGFLEET.title(game)));
-        for (DraftItem item : bag.getCategory(DraftCategory.STARTINGFLEET)) {
+        for (DraftItem item : startingFleets) {
             if (fleetComps.size() > 1) fleetComps.add(Separator.createDivider(Spacing.LARGE));
             fleetComps.addAll(item.getTextDisplays(game, player, false));
             String buttonID = "chooseStartingFleet_" + item.getItemId();
@@ -385,6 +406,7 @@ public final class ButtonHelperTwilightsFall {
                 player.getRepresentation() + " after choosing your home system, choose a starting fleet");
         fleetMessageBuilder.append(Container.of(fleetComps));
         fleetMessageBuilder.send();
+        return true;
     }
 
     @ButtonHandler("chooseHomeSystem_")


### PR DESCRIPTION
## Summary
- only initialize Twilight's Fall map setup for real players
- guard missing draft hands/setup categories before reading first draft items
- report a clear actions-channel message instead of throwing out of the button handler

## Tests
- Not run per request.