### PR TITLE
Fix missing cards-info thread recovery

### DIFF
--- a/src/main/java/ti4/game/Player.java
+++ b/src/main/java/ti4/game/Player.java
@@ -68,6 +68,7 @@ import ti4.helpers.StringHelper;
 import ti4.helpers.TIGLHelper.TIGLRank;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
+import ti4.helpers.discord.DiscordHelper;
 import ti4.image.DrawingUtil;
 import ti4.image.Mapper;
 import ti4.image.PositionMapper;
@@ -695,12 +696,25 @@ public class Player extends PlayerProperties implements StoredValueHelper {
     private ThreadChannel findCardsInfoThreadByIdOrName(TextChannel actionsChannel, String name) {
         Long id = getCardsInfoThreadIdLong();
         if (id != null) {
-            ThreadChannel thread = DiscordChannelUtility.retrieveThreadChannelById(actionsChannel.getGuild(), id)
-                    .complete();
+            ThreadChannel thread = retrieveCardsInfoThreadById(actionsChannel, id);
             if (thread != null) return thread;
         }
         return DiscordChannelUtility.retrieveFirstThreadChannelByNameIgnoringCase(actionsChannel, name)
                 .complete();
+    }
+
+    @Nullable
+    private ThreadChannel retrieveCardsInfoThreadById(TextChannel actionsChannel, Long id) {
+        try {
+            return DiscordChannelUtility.retrieveThreadChannelById(actionsChannel.getGuild(), id)
+                    .complete();
+        } catch (RuntimeException e) {
+            if (DiscordHelper.isUnknownChannelError(e)) {
+                setCardsInfoThreadID(null);
+                return null;
+            }
+            throw e;
+        }
     }
 
     private Long getCardsInfoThreadIdLong() {

--- a/src/main/java/ti4/helpers/discord/DiscordHelper.java
+++ b/src/main/java/ti4/helpers/discord/DiscordHelper.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 public class DiscordHelper {
 
     private static final int DISCORD_UNKNOWN_MESSAGE_ERROR_CODE = 10_008;
+    private static final int DISCORD_UNKNOWN_CHANNEL_ERROR_CODE = 10_003;
     private static final int DISCORD_UNKNOWN_EMOJI_ERROR_CODE = 10_014;
     private static final int DISCORD_UNKNOWN_WEBHOOK_ERROR_CODE = 10_015;
 
@@ -22,6 +23,11 @@ public class DiscordHelper {
 
     public static boolean isUnknownMessageError(Throwable error) {
         return hasDiscordErrorCode(error, DISCORD_UNKNOWN_MESSAGE_ERROR_CODE);
+    }
+
+    public static boolean isUnknownChannelError(Throwable error) {
+        return error instanceof ErrorResponseException restError
+                && restError.getErrorCode() == DISCORD_UNKNOWN_CHANNEL_ERROR_CODE;
     }
 
     public static boolean isUnknownWebhookError(Throwable error) {


### PR DESCRIPTION
## Summary
- Fixes a Cards Info button failure when a player's saved cards-info thread ID points at a Discord channel that no longer exists.
- Discord returns `10003 Unknown Channel` for that stale ID; the old flow let that exception abort before trying the existing thread-name fallback.
- The fix treats that specific response as a stale stored pointer, clears the saved thread ID, and then continues through the normal thread-name lookup/new-thread creation path.

## Test Plan
- Not run, per request.