### PR TITLE
Fix retreat options for missing adjacent tiles

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -1129,6 +1129,9 @@ public final class ButtonHelperModifyUnits {
         }
         for (String pos2 : positions) {
             Tile tile = game.getTileByPosition(pos2);
+            if (tile == null) {
+                continue;
+            }
             boolean skipNonFrontierEmptySystem = !Mapper.getFrontierTileIds().contains(tile.getTileID())
                     && tile.getPlanetUnitHolders().isEmpty()
                     && tile.getUnitHolders().size() != 2;


### PR DESCRIPTION
## Summary
- Skip unresolved adjacent tile positions when building retreat destination buttons
- Prevent retreat button handling from dereferencing a null tile

## Verification
- Not run, per request; CI will compile.