### PR TITLE
Ignore wrapped unknown emoji REST errors

### DIFF
--- a/src/main/java/ti4/helpers/discord/DiscordHelper.java
+++ b/src/main/java/ti4/helpers/discord/DiscordHelper.java
@@ -29,8 +29,7 @@ public class DiscordHelper {
     }
 
     public static boolean isUnknownEmojiError(Throwable error) {
-        return error instanceof ErrorResponseException restError
-                && restError.getErrorCode() == DISCORD_UNKNOWN_EMOJI_ERROR_CODE;
+        return hasDiscordErrorCode(error, DISCORD_UNKNOWN_EMOJI_ERROR_CODE);
     }
 
     public static boolean isIgnorableError(Throwable error) {


### PR DESCRIPTION
## Summary
- Treat Discord unknown emoji errors like other Discord REST code checks, even when wrapped.
- Allows existing persistent faction reaction handling to skip stale/missing emoji reactions instead of logging noisy failures.

## Verification
- Not run per request; CI will compile.