### PR TITLE
Recover stale cards-info thread ids

### DIFF
--- a/src/main/java/ti4/game/Player.java
+++ b/src/main/java/ti4/game/Player.java
@@ -1,5 +1,7 @@
 package ti4.game;
 
+import static ti4.helpers.discord.DiscordHelper.isUnknownChannelError;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.awt.Color;
 import java.util.ArrayList;
@@ -664,7 +666,7 @@ public class Player extends PlayerProperties implements StoredValueHelper {
                 ? String.format("%s-cards-info-%s-private", game.getName(), userName)
                 : String.format("%s%s-%s", Constants.CARDS_INFO_THREAD_PREFIX, game.getName(), userName);
 
-        ThreadChannel foundThread = findCardsInfoThreadByIdOrName(actionsChannel, threadName);
+        ThreadChannel foundThread = findCardsInfoThreadByIdOrName(actionsChannel, threadName, createIfMissing);
 
         if (foundThread != null) {
             setCardsInfoThreadID(foundThread.getId());
@@ -692,15 +694,43 @@ public class Player extends PlayerProperties implements StoredValueHelper {
     }
 
     @Nullable
-    private ThreadChannel findCardsInfoThreadByIdOrName(TextChannel actionsChannel, String name) {
+    private ThreadChannel findCardsInfoThreadByIdOrName(
+            TextChannel actionsChannel, String name, boolean createIfMissing) {
         Long id = getCardsInfoThreadIdLong();
         if (id != null) {
-            ThreadChannel thread = DiscordChannelUtility.retrieveThreadChannelById(actionsChannel.getGuild(), id)
-                    .complete();
-            if (thread != null) return thread;
+            try {
+                ThreadChannel thread = DiscordChannelUtility.retrieveThreadChannelById(actionsChannel.getGuild(), id)
+                        .complete();
+                if (thread != null) return thread;
+            } catch (RuntimeException e) {
+                if (isUnknownChannelError(e)) {
+                    if (createIfMissing || !game.isHasEnded()) {
+                        BotLogger.warning(
+                                new LogOrigin(this),
+                                "`Player.getCardsInfoThread`: Stored #cards-info thread ID no longer exists: "
+                                        + getCardsInfoThreadID() + " for potential thread name: " + name,
+                                e);
+                    }
+                    setCardsInfoThreadID(null);
+                } else {
+                    logCardsInfoThreadLookupFailure(
+                            "`Player.getCardsInfoThread`: Could not find existing #cards-info thread using ID: "
+                                    + getCardsInfoThreadID() + " for potential thread name: " + name,
+                            e,
+                            createIfMissing);
+                }
+            }
         }
-        return DiscordChannelUtility.retrieveFirstThreadChannelByNameIgnoringCase(actionsChannel, name)
-                .complete();
+        try {
+            return DiscordChannelUtility.retrieveFirstThreadChannelByNameIgnoringCase(actionsChannel, name)
+                    .complete();
+        } catch (RuntimeException e) {
+            logCardsInfoThreadLookupFailure(
+                    "`Player.getCardsInfoThread`: Could not find existing #cards-info thread using name: " + name,
+                    e,
+                    createIfMissing);
+            return null;
+        }
     }
 
     private Long getCardsInfoThreadIdLong() {

--- a/src/main/java/ti4/helpers/discord/DiscordHelper.java
+++ b/src/main/java/ti4/helpers/discord/DiscordHelper.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 public class DiscordHelper {
 
     private static final int DISCORD_UNKNOWN_MESSAGE_ERROR_CODE = 10_008;
+    private static final int DISCORD_UNKNOWN_CHANNEL_ERROR_CODE = 10_003;
     private static final int DISCORD_UNKNOWN_EMOJI_ERROR_CODE = 10_014;
     private static final int DISCORD_UNKNOWN_WEBHOOK_ERROR_CODE = 10_015;
 
@@ -22,6 +23,10 @@ public class DiscordHelper {
 
     public static boolean isUnknownMessageError(Throwable error) {
         return hasDiscordErrorCode(error, DISCORD_UNKNOWN_MESSAGE_ERROR_CODE);
+    }
+
+    public static boolean isUnknownChannelError(Throwable error) {
+        return hasDiscordErrorCode(error, DISCORD_UNKNOWN_CHANNEL_ERROR_CODE);
     }
 
     public static boolean isUnknownWebhookError(Throwable error) {


### PR DESCRIPTION
## Summary
- Recover when a saved cards-info thread id returns Discord 10003 Unknown Channel.
- Clear the stale id and continue through the existing name lookup/new-thread creation path.
- Add a reusable Discord unknown-channel helper alongside the existing unknown-message/webhook helpers.

## Test Plan
- mvn spotless:check
- git diff --check
- Not run per request: tests
- Attempted compile-only verification with `mvn -DskipTests compile`; blocked by local JDK 21 because the project requires release 26.