### PR TITLE
Fix agenda autoresolve context recovery

### DIFF
--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -3702,6 +3702,14 @@ public final class AgendaHelper {
     private static void autoResolve(@Nullable ButtonInteractionEvent event, Player player, String buttonID, Game game) {
         String result = buttonID.substring(buttonID.indexOf('_') + 1);
         if (result.contains("manual")) {
+            if (game.getCurrentAgendaInfo().split("_").length < 2) {
+                event.reply(
+                                "This agenda resolution window has closed. If you still need to resolve this effect, please do so manually.")
+                        .setEphemeral(true)
+                        .queue(Consumers.nop(), BotLogger::catchRestError);
+                return;
+            }
+
             if (result.contains("committee")) {
                 if (game.isACInDiscard("Confounding") && game.isACInDiscard("Confusing")) {
                     MessageHelper.sendMessageToChannel(


### PR DESCRIPTION
## Summary
- detect plain manual autoresolve presses when there is no active agenda resolution context
- reply ephemerally that the agenda resolution window has closed and manual handling is needed if players still want the effect
- prevent stale agenda resolution buttons from reaching agenda button generation with incomplete currentAgendaInfo

## Verification
- mvn spotless:apply
- git diff --check
- mvn -DskipTests compile (blocked locally: project requires release 26, local JDK is 21.0.4)