### PR TITLE
Fix agents starting locked

### DIFF
--- a/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
@@ -23,6 +23,7 @@ import ti4.logging.BotLogger;
 public class DataMigrationManager {
 
     private static final DateTimeFormatter MIGRATION_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyy");
+    private static final long LOCKED_AGENT_BUG_INTRODUCED_AT = 1778513644000L;
 
     ///
     /// To add a new migration,
@@ -54,6 +55,7 @@ public class DataMigrationManager {
         //         DataMigrationManager::renameGarboziaToBozgarbia_201025_withEnded);
         // migrations.put("fixMisspelledAgendaIds_200226", DataMigrationManager::fixMisspelledAgendaIds_200226);
         // migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
+        migrations.put("unlockLockedAgents_120526", DataMigrationManager::unlockLockedAgents_120526);
     }
 
     public static void runMigrations() {
@@ -184,5 +186,22 @@ public class DataMigrationManager {
                 "senate_sancuary", "senate_sanctuary");
 
         return MigrationHelper.replaceAgendaCards(game, List.of(game.getAgendaDeckID()), replacements);
+    }
+
+    public static Boolean unlockLockedAgents_120526(Game game) {
+        if (game.getCreationDateTime() < LOCKED_AGENT_BUG_INTRODUCED_AT) {
+            return false;
+        }
+
+        boolean changed = false;
+        for (Player player : game.getPlayers().values()) {
+            for (var leader : player.getLeaders()) {
+                if (leader.isLocked() && "agent".equals(leader.getType())) {
+                    leader.setLocked(false);
+                    changed = true;
+                }
+            }
+        }
+        return changed;
     }
 }


### PR DESCRIPTION
## Summary
- Use the inferred leader type when deciding whether a new leader should start unlocked
- Add a migration to unlock existing saved leaders whose type is agent

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:check
- git diff --check