### PR TITLE
Rerun locked agent migration by saved state

### DIFF
--- a/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
@@ -23,7 +23,6 @@ import ti4.logging.BotLogger;
 public class DataMigrationManager {
 
     private static final DateTimeFormatter MIGRATION_DATE_FORMATTER = DateTimeFormatter.ofPattern("ddMMyy");
-    private static final long LOCKED_AGENT_BUG_INTRODUCED_AT = 1778513644000L;
 
     ///
     /// To add a new migration,
@@ -55,7 +54,8 @@ public class DataMigrationManager {
         //         DataMigrationManager::renameGarboziaToBozgarbia_201025_withEnded);
         // migrations.put("fixMisspelledAgendaIds_200226", DataMigrationManager::fixMisspelledAgendaIds_200226);
         // migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
-        migrations.put("unlockLockedAgents_120526", DataMigrationManager::unlockLockedAgents_120526);
+        migrations.put(
+                "unlockLockedAgentsBySetupState_120526", DataMigrationManager::unlockLockedAgentsBySetupState_120526);
     }
 
     public static void runMigrations() {
@@ -188,11 +188,7 @@ public class DataMigrationManager {
         return MigrationHelper.replaceAgendaCards(game, List.of(game.getAgendaDeckID()), replacements);
     }
 
-    public static Boolean unlockLockedAgents_120526(Game game) {
-        if (game.getCreationDateTime() < LOCKED_AGENT_BUG_INTRODUCED_AT) {
-            return false;
-        }
-
+    public static Boolean unlockLockedAgentsBySetupState_120526(Game game) {
         boolean changed = false;
         for (Player player : game.getPlayers().values()) {
             for (var leader : player.getLeaders()) {


### PR DESCRIPTION
## Summary
- Replace the time-gated locked-agent migration with a new migration name so it can run again
- Detect impacted games by saved state: locked leaders whose type is agent
- Preserve the existing changed-games reporting, which lists only games where locked agents were actually updated

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:check
- git diff --check