### PR TITLE
Comment out locked agent migration

### DIFF
--- a/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
+++ b/src/main/java/ti4/game/persistence/migration/DataMigrationManager.java
@@ -54,8 +54,9 @@ public class DataMigrationManager {
         //         DataMigrationManager::renameGarboziaToBozgarbia_201025_withEnded);
         // migrations.put("fixMisspelledAgendaIds_200226", DataMigrationManager::fixMisspelledAgendaIds_200226);
         // migrations.put("exampleMigration_061023", DataMigrationManager::exampleMigration_061023);
-        migrations.put(
-                "unlockLockedAgentsBySetupState_120526", DataMigrationManager::unlockLockedAgentsBySetupState_120526);
+        // migrations.put(
+        //         "unlockLockedAgentsBySetupState_120526",
+        //         DataMigrationManager::unlockLockedAgentsBySetupState_120526);
     }
 
     public static void runMigrations() {


### PR DESCRIPTION
## Summary
- Comment out the locked-agent migration registration so it no longer runs automatically
- Leave the migration method in place for reference/manual use

## Test Plan
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q spotless:check
- git diff --check