### PR TITLE
Stop automatic cards info pinning

### DIFF
--- a/src/main/java/ti4/cron/CardsInfoPinCleanupCron.java
+++ b/src/main/java/ti4/cron/CardsInfoPinCleanupCron.java
@@ -1,0 +1,47 @@
+package ti4.cron;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.experimental.UtilityClass;
+import ti4.executors.ExecutionLockType;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.persistence.ConsumeGameUtility;
+import ti4.game.persistence.GameManager;
+import ti4.game.persistence.ManagedGame;
+import ti4.logging.BotLogger;
+import ti4.message.CardsInfoPinCleanupService;
+import ti4.spring.service.deploy.ActiveLeaseService;
+
+@UtilityClass
+public class CardsInfoPinCleanupCron {
+
+    private static final long MANUAL_ONLY_DELAY_DAYS = Long.MAX_VALUE;
+
+    public static void register() {
+        CronManager.scheduleOnce(
+                CardsInfoPinCleanupCron.class, CardsInfoPinCleanupCron::cleanup, MANUAL_ONLY_DELAY_DAYS, TimeUnit.DAYS);
+    }
+
+    private static void cleanup() {
+        if (!ActiveLeaseService.shouldCurrentProcessRunScheduledWork()) return;
+        BotLogger.logCron("Running CardsInfoPinCleanupCron.");
+        try {
+            List<String> gameNames = GameManager.getManagedGames().stream()
+                    .filter(ManagedGame::isActive)
+                    .map(ManagedGame::getName)
+                    .toList();
+
+            ConsumeGameUtility.consumeGames(gameNames, CardsInfoPinCleanupCron::cleanupGame, ExecutionLockType.READ);
+        } catch (Exception e) {
+            BotLogger.error("**CardsInfoPinCleanupCron failed.**", e);
+        }
+        BotLogger.logCron("Finished CardsInfoPinCleanupCron.");
+    }
+
+    private static void cleanupGame(Game game) {
+        for (Player player : game.getRealPlayers()) {
+            CardsInfoPinCleanupService.queuePinnedBotMessageCleanup(player.getCardsInfoThread());
+        }
+    }
+}

--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -34,6 +34,7 @@ import ti4.contest.cron.CombatReplaySelectionCron;
 import ti4.contest.replay.core.CombatContestSettings;
 import ti4.cron.AutoPingCron;
 import ti4.cron.BothelperDashboardCron;
+import ti4.cron.CardsInfoPinCleanupCron;
 import ti4.cron.CategoryCleanupCron;
 import ti4.cron.CloseLaunchThreadsCron;
 import ti4.cron.CronManager;
@@ -326,6 +327,7 @@ public class JdaService {
         OldUndoFileCleanupCron.register();
         EndOldGamesCron.register();
         GameMessageCleanupCron.register();
+        CardsInfoPinCleanupCron.register();
         LogButtonRuntimeStatisticsCron.register();
         TechSummaryCron.register();
         SabotageAutoReactCron.register();

--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -59,8 +59,6 @@ import ti4.spring.context.SpringContext;
 @UtilityClass
 public class ActionCardHelper {
 
-    private static final String PINNED_AC_INFO_MESSAGE_ID = "pinned_ac_info_message_id";
-
     private static final Set<String> WAR_MACHINE_IDS = Set.of(
             "war_machine1",
             "war_machine2",
@@ -82,8 +80,7 @@ public class ActionCardHelper {
 
     public static void sendActionCardInfo(Game game, Player player) {
         // AC INFO
-        MessageHelper.sendMessageToPlayerCardsInfoThreadAndPin(
-                game, player, PINNED_AC_INFO_MESSAGE_ID, getActionCardInfo(game, player));
+        MessageHelper.sendMessageToPlayerCardsInfoThread(player, getActionCardInfo(game, player));
         Map<String, Integer> actionCards = player.getActionCards();
         if (actionCards != null && !actionCards.isEmpty()) {
             MessageHelper.sendMessageToChannelWithButtons(

--- a/src/main/java/ti4/helpers/PromissoryNoteHelper.java
+++ b/src/main/java/ti4/helpers/PromissoryNoteHelper.java
@@ -33,13 +33,9 @@ import ti4.service.unit.AddUnitService;
 @UtilityClass
 public class PromissoryNoteHelper {
 
-    private static final String PINNED_PN_INFO_MESSAGE_ID = "pinned_pn_info_message_id";
-
     public static void sendPromissoryNoteInfo(Game game, Player player, boolean longFormat) {
-        MessageHelper.sendMessageToPlayerCardsInfoThreadWithButtonsAndPin(
-                game,
-                player,
-                PINNED_PN_INFO_MESSAGE_ID,
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCardsInfoThread(),
                 getPromissoryNoteCardInfo(game, player, longFormat, false),
                 getPNButtons(game, player));
     }

--- a/src/main/java/ti4/message/CardsInfoPinCleanupService.java
+++ b/src/main/java/ti4/message/CardsInfoPinCleanupService.java
@@ -14,19 +14,27 @@ import org.apache.commons.lang3.StringUtils;
 import ti4.logging.BotLogger;
 
 @UtilityClass
-class CardsInfoPinCleanupService {
+public class CardsInfoPinCleanupService {
 
-    private static final long DRAIN_INTERVAL_MILLIS = 500;
+    private static final long PIN_RETRIEVAL_DRAIN_INTERVAL_MILLIS = 1000;
+    private static final long UNPIN_DRAIN_INTERVAL_MILLIS = 250;
+    private static final Queue<PinnedMessageCleanupRequest> PIN_RETRIEVAL_QUEUE = new ConcurrentLinkedQueue<>();
     private static final Queue<Message> UNPIN_QUEUE = new ConcurrentLinkedQueue<>();
+    private static final Set<String> QUEUED_THREAD_IDS = ConcurrentHashMap.newKeySet();
     private static final Set<String> QUEUED_MESSAGE_IDS = ConcurrentHashMap.newKeySet();
-    private static final ScheduledExecutorService UNPIN_DRAIN = Executors.newSingleThreadScheduledExecutor(
+    private static final ScheduledExecutorService PIN_CLEANUP_DRAIN = Executors.newSingleThreadScheduledExecutor(
             Thread.ofPlatform().daemon().name("cards-info-pin-cleanup").factory());
 
     static {
-        UNPIN_DRAIN.scheduleAtFixedRate(
-                CardsInfoPinCleanupService::drainOne,
-                DRAIN_INTERVAL_MILLIS,
-                DRAIN_INTERVAL_MILLIS,
+        PIN_CLEANUP_DRAIN.scheduleAtFixedRate(
+                CardsInfoPinCleanupService::drainOnePinnedMessageRetrieval,
+                PIN_RETRIEVAL_DRAIN_INTERVAL_MILLIS,
+                PIN_RETRIEVAL_DRAIN_INTERVAL_MILLIS,
+                TimeUnit.MILLISECONDS);
+        PIN_CLEANUP_DRAIN.scheduleAtFixedRate(
+                CardsInfoPinCleanupService::drainOneUnpin,
+                UNPIN_DRAIN_INTERVAL_MILLIS,
+                UNPIN_DRAIN_INTERVAL_MILLIS,
                 TimeUnit.MILLISECONDS);
     }
 
@@ -35,18 +43,36 @@ class CardsInfoPinCleanupService {
             return;
         }
 
-        threadChannel
+        String threadId = threadChannel.getId();
+        if (!QUEUED_THREAD_IDS.add(threadId)) return;
+        PIN_RETRIEVAL_QUEUE.add(new PinnedMessageCleanupRequest(
+                threadChannel, protectedMessageIds == null ? Set.of() : Set.copyOf(protectedMessageIds)));
+    }
+
+    private static void drainOnePinnedMessageRetrieval() {
+        PinnedMessageCleanupRequest request = PIN_RETRIEVAL_QUEUE.poll();
+        if (request == null) return;
+
+        request.threadChannel()
                 .retrievePinnedMessages()
                 .queue(
                         pinnedMessages -> {
+                            QUEUED_THREAD_IDS.remove(request.threadChannel().getId());
                             for (var pinnedMessage : pinnedMessages) {
                                 Message message = pinnedMessage.getMessage();
-                                if (isProtected(message, protectedMessageIds)) continue;
+                                if (message == null || isProtected(message, request.protectedMessageIds())) continue;
                                 if (!message.getAuthor().isBot()) continue;
                                 queueUnpin(message);
                             }
                         },
-                        BotLogger::catchRestError);
+                        error -> {
+                            QUEUED_THREAD_IDS.remove(request.threadChannel().getId());
+                            BotLogger.catchRestError(error);
+                        });
+    }
+
+    public static void queuePinnedBotMessageCleanup(ThreadChannel threadChannel) {
+        queueStalePinnedMessageCleanup(threadChannel, Set.of());
     }
 
     private static boolean isProtected(Message message, Set<String> protectedMessageIds) {
@@ -63,7 +89,7 @@ class CardsInfoPinCleanupService {
         UNPIN_QUEUE.add(message);
     }
 
-    private static void drainOne() {
+    private static void drainOneUnpin() {
         Message message = UNPIN_QUEUE.poll();
         if (message == null) return;
         String messageId = message.getId();
@@ -72,4 +98,6 @@ class CardsInfoPinCleanupService {
             BotLogger.catchRestError(error);
         });
     }
+
+    private record PinnedMessageCleanupRequest(ThreadChannel threadChannel, Set<String> protectedMessageIds) {}
 }

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -9,11 +9,9 @@ import java.io.File;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -879,15 +877,7 @@ public class MessageHelper {
             return;
         }
 
-        ThreadChannel threadChannel = player.getCardsInfoThread();
-        if (threadChannel == null) {
-            return;
-        }
-
-        splitAndSentWithAction(
-                messageText,
-                threadChannel,
-                msg -> rotatePinnedCardsInfoMessage(game, threadChannel, storedValueKeyPrefix, msg));
+        sendMessageToPlayerCardsInfoThread(player, messageText);
     }
 
     public static void sendMessageToPlayerCardsInfoThreadWithButtonsAndPin(
@@ -905,44 +895,7 @@ public class MessageHelper {
             return;
         }
 
-        splitAndSentWithAction(
-                messageText,
-                threadChannel,
-                msg -> rotatePinnedCardsInfoMessage(game, threadChannel, storedValueKeyPrefix, msg),
-                null,
-                buttons);
-    }
-
-    private static void rotatePinnedCardsInfoMessage(
-            @NotNull Game game,
-            @NotNull ThreadChannel threadChannel,
-            @NotNull String storedValueKeyPrefix,
-            @NotNull Message msg) {
-        String storedValueKey = storedValueKeyPrefix + "_" + threadChannel.getId();
-        pinCardsInfoMessage(game, storedValueKey, msg);
-        CardsInfoPinCleanupService.queueStalePinnedMessageCleanup(
-                threadChannel, cardsInfoPinnedMessageIds(game, threadChannel));
-    }
-
-    private static void pinCardsInfoMessage(@NotNull Game game, @NotNull String storedValueKey, @NotNull Message msg) {
-        game.setStoredValue(storedValueKey, msg.getId());
-        msg.pin().queue(Consumers.nop(), BotLogger::catchRestError);
-    }
-
-    private static Set<String> cardsInfoPinnedMessageIds(@NotNull Game game, @NotNull ThreadChannel threadChannel) {
-        String threadId = threadChannel.getId();
-        Set<String> messageIds = new HashSet<>();
-        addStoredMessageId(game, messageIds, "pinned_ac_info_message_id_" + threadId);
-        addStoredMessageId(game, messageIds, "pinned_so_info_message_id_" + threadId);
-        addStoredMessageId(game, messageIds, "pinned_pn_info_message_id_" + threadId);
-        return messageIds;
-    }
-
-    private static void addStoredMessageId(Game game, Set<String> messageIds, String storedValueKey) {
-        String messageId = game.getStoredValue(storedValueKey);
-        if (StringUtils.isNotBlank(messageId)) {
-            messageIds.add(messageId);
-        }
+        sendMessageToChannelWithButtons(threadChannel, messageText, buttons);
     }
 
     /**

--- a/src/main/java/ti4/service/info/SecretObjectiveInfoService.java
+++ b/src/main/java/ti4/service/info/SecretObjectiveInfoService.java
@@ -22,8 +22,6 @@ import ti4.service.emoji.CardEmojis;
 @UtilityClass
 public class SecretObjectiveInfoService {
 
-    private static final String PINNED_SO_INFO_MESSAGE_ID = "pinned_so_info_message_id";
-
     public static void sendSecretObjectiveInfo(Game game, Player player, ButtonInteractionEvent event) {
         sendSecretObjectiveInfo(game, player, event, false, false);
     }
@@ -66,8 +64,7 @@ public class SecretObjectiveInfoService {
     public static void sendSecretObjectiveInfo(
             Game game, Player player, boolean autoDiscardButtons, boolean autoScoreButtons) {
         // SO INFO
-        MessageHelper.sendMessageToPlayerCardsInfoThreadAndPin(
-                game, player, PINNED_SO_INFO_MESSAGE_ID, getSecretObjectiveCardInfo(game, player));
+        MessageHelper.sendMessageToPlayerCardsInfoThread(player, getSecretObjectiveCardInfo(game, player));
 
         if (player.getSecretsUnscored().isEmpty()) return;
 


### PR DESCRIPTION
## Summary
- Stop automatically pinning refreshed action card, secret objective, and promissory note info messages in cards-info threads.
- Add a manual-only cards-info pin cleanup cron that scans active games and queues pinned bot-authored cards-info messages for cleanup.
- Throttle both pinned-message retrievals and unpins to reduce Discord rate-limit risk.

## Test Plan
- mvn -q spotless:apply
- JAVA_HOME=$(/usr/libexec/java_home -v 26) mvn -q -DskipTests compile
- git diff --check