### PR TITLE
Frankendraz draft mode

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
@@ -464,6 +464,15 @@ public class FrankenButtonHandler {
         }
     }
 
+    @ButtonHandler(value = "frankenDrazCloseCategory", save = false)
+    private static void closeFrankenDrazCategory(ButtonInteractionEvent event, Player player, String buttonID) {
+        if (player.getGame().getActiveBagDraft() instanceof FrankenDrazDraft frankenDrazDraft) {
+            DraftCategory category = DraftCategory.valueOf(buttonID.split(";")[1]);
+            frankenDrazDraft.closePostDraftCategory(event, player, category);
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "Closed " + category.toString() + ".");
+        }
+    }
+
     private static void expandFrankenDrazDraft(Game game, BagDraft draft) {
         if (draft instanceof FrankenDrazDraft frankenDrazDraft) {
             frankenDrazDraft.expandFactionPackages(game);

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
@@ -284,10 +284,7 @@ public class FrankenButtonHandler {
     private static void refreshContainers(ButtonInteractionEvent event, Player player) {
         MessageV2Editor editor = new MessageV2Editor();
         List<Color> accents = FrankenDraftBagService.getAccents();
-        List<DraftCategory> postDraftCategories = player.getGame().getActiveBagDraft() instanceof FrankenDrazDraft
-                ? ((FrankenDrazDraft) player.getGame().getActiveBagDraft()).getPostDraftComponentCategories()
-                : FrankenDraftBagService.componentCategories;
-        for (DraftCategory cat : postDraftCategories) {
+        for (DraftCategory cat : FrankenDraftBagService.componentCategories) {
             Container c2 = FrankenDraftBagService.postDraftCategoryContainer(player, cat);
             if (c2 == null) continue;
             c2 = c2.withAccentColor(accents.getFirst());
@@ -297,7 +294,7 @@ public class FrankenButtonHandler {
         Container summary = FrankenDraftBagService.getFrankenPlayerSummaryContainer(player);
         editor.replace(replaceContainer(summary), summary);
 
-        int limit = postDraftCategories.size() * 2 + 4;
+        int limit = FrankenDraftBagService.componentCategories.size() * 2 + 4;
         editor.applyAroundMessage(event.getMessage(), limit, null);
     }
 

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
@@ -25,6 +25,7 @@ import ti4.draft.DraftCategory;
 import ti4.draft.DraftItem;
 import ti4.draft.InauguralSpliceFrankenDraft;
 import ti4.draft.TwilightsFallFrankenDraft;
+import ti4.draft.items.FactionDraftItem;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.ButtonHelper;
@@ -427,5 +428,16 @@ public class FrankenButtonHandler {
 
         FrankenDraftBagService.showPlayerBag(game, player);
         event.getMessage().delete().queue(Consumers.nop(), BotLogger::catchRestError);
+    }
+
+    @ButtonHandler(value = "frankenFactionComponents", save = false)
+    private static void showFactionComponents(ButtonInteractionEvent event, Player player, String buttonID) {
+        String faction = buttonID.split(";")[1];
+        FactionDraftItem item = new FactionDraftItem(faction);
+        String msg =
+                "## " + item.getTitle(player.getGame()) + " Components\n" + item.getComponentList(player.getGame());
+        MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), msg);
+        MessageHelper.sendEphemeralMessageToEventChannel(
+                event, "Sent " + item.getShortDescription() + " components to your cards info thread.");
     }
 }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
@@ -23,6 +23,7 @@ import ti4.draft.BagDraft;
 import ti4.draft.DraftBag;
 import ti4.draft.DraftCategory;
 import ti4.draft.DraftItem;
+import ti4.draft.FrankenDrazDraft;
 import ti4.draft.InauguralSpliceFrankenDraft;
 import ti4.draft.TwilightsFallFrankenDraft;
 import ti4.draft.items.FactionDraftItem;
@@ -338,9 +339,11 @@ public class FrankenButtonHandler {
                                     List.of(startStrategyPhaseButton));
                             FrankenDraftBagService.applyDraftBags(event, game, false);
                         } else {
-                            String draftType = (draft instanceof TwilightsFallFrankenDraft)
-                                    ? "Twilight's Fall Draft"
-                                    : "FrankenDraft";
+                            expandFrankenDrazDraft(game, draft);
+                            String draftType = "FrankenDraft";
+                            if (draft instanceof TwilightsFallFrankenDraft) {
+                                draftType = "Twilight's Fall Draft";
+                            }
                             String msg = game.getPing() + " the draft stage of the " + draftType + " is complete. ";
                             msg += "Use the buttons below to choose how to set up the map. ";
                             msg += "Once the map is finalized, select your components from your drafted hand.";
@@ -370,6 +373,7 @@ public class FrankenButtonHandler {
                                         List.of(startStrategyPhaseButton));
                                 FrankenDraftBagService.applyDraftBags(event, game, false);
                             } else {
+                                expandFrankenDrazDraft(game, draft);
                                 Button randomizeButton =
                                         Buttons.green("startFrankenSliceBuild", "Randomize Your Slices (Sorta)");
                                 Button mantisButton = Buttons.green("startFrankenMantisBuild", "Mantis Build Slices");
@@ -439,5 +443,19 @@ public class FrankenButtonHandler {
         MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), msg);
         MessageHelper.sendEphemeralMessageToEventChannel(
                 event, "Sent " + item.getShortDescription() + " components to your cards info thread.");
+    }
+
+    @ButtonHandler(value = "frankenDrazCategory", save = false)
+    private static void showFrankenDrazCategory(ButtonInteractionEvent event, Player player, String buttonID) {
+        if (player.getGame().getActiveBagDraft() instanceof FrankenDrazDraft frankenDrazDraft) {
+            DraftCategory category = DraftCategory.valueOf(buttonID.split(";")[1]);
+            frankenDrazDraft.sendPostDraftCategory(player, category);
+        }
+    }
+
+    private static void expandFrankenDrazDraft(Game game, BagDraft draft) {
+        if (draft instanceof FrankenDrazDraft frankenDrazDraft) {
+            frankenDrazDraft.expandFactionPackages(game);
+        }
     }
 }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
@@ -64,7 +64,11 @@ public class FrankenButtonHandler {
         String frankenItem = buttonID.replace("frankenItemAdd", "");
         DraftItem draftItem = DraftItem.generateFromAlias(frankenItem);
         resolveFrankenItemAdd(event, player, draftItem);
-        refreshContainers(event, player);
+        if (player.getGame().getActiveBagDraft() instanceof FrankenDrazDraft frankenDrazDraft) {
+            frankenDrazDraft.refreshPostDraftCategory(event, player, draftItem.getItemCategory());
+        } else {
+            refreshContainers(event, player);
+        }
     }
 
     public static void resolveFrankenItemAdd(ButtonInteractionEvent event, Player player, DraftItem item) {
@@ -96,7 +100,11 @@ public class FrankenButtonHandler {
         String frankenItem = buttonID.replace("frankenItemRemove", "");
         DraftItem draftItem = DraftItem.generateFromAlias(frankenItem);
         resolveFrankenItemRemove(event, player, draftItem);
-        refreshContainers(event, player);
+        if (player.getGame().getActiveBagDraft() instanceof FrankenDrazDraft frankenDrazDraft) {
+            frankenDrazDraft.refreshPostDraftCategory(event, player, draftItem.getItemCategory());
+        } else {
+            refreshContainers(event, player);
+        }
     }
 
     public static void resolveFrankenItemRemove(ButtonInteractionEvent event, Player player, DraftItem item) {
@@ -276,7 +284,10 @@ public class FrankenButtonHandler {
     private static void refreshContainers(ButtonInteractionEvent event, Player player) {
         MessageV2Editor editor = new MessageV2Editor();
         List<Color> accents = FrankenDraftBagService.getAccents();
-        for (DraftCategory cat : FrankenDraftBagService.componentCategories) {
+        List<DraftCategory> postDraftCategories = player.getGame().getActiveBagDraft() instanceof FrankenDrazDraft
+                ? ((FrankenDrazDraft) player.getGame().getActiveBagDraft()).getPostDraftComponentCategories()
+                : FrankenDraftBagService.componentCategories;
+        for (DraftCategory cat : postDraftCategories) {
             Container c2 = FrankenDraftBagService.postDraftCategoryContainer(player, cat);
             if (c2 == null) continue;
             c2 = c2.withAccentColor(accents.getFirst());
@@ -286,7 +297,7 @@ public class FrankenButtonHandler {
         Container summary = FrankenDraftBagService.getFrankenPlayerSummaryContainer(player);
         editor.replace(replaceContainer(summary), summary);
 
-        int limit = FrankenDraftBagService.componentCategories.size() * 2 + 4;
+        int limit = postDraftCategories.size() * 2 + 4;
         editor.applyAroundMessage(event.getMessage(), limit, null);
     }
 

--- a/src/main/java/ti4/discord/interactions/commands/franken/StartFrankenDraft.java
+++ b/src/main/java/ti4/discord/interactions/commands/franken/StartFrankenDraft.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.discord.interactions.commands.GameStateSubcommand;
 import ti4.draft.FrankenDraft;
+import ti4.draft.FrankenDrazDraft;
 import ti4.draft.InauguralSpliceFrankenDraft;
 import ti4.draft.OnePickFrankenDraft;
 import ti4.draft.OverdraftFrankenDraft;
@@ -64,6 +65,7 @@ class StartFrankenDraft extends GameStateSubcommand {
                 case OVERDRAFT -> game.setBagDraft(new OverdraftFrankenDraft(game));
                 case POWEREDONEPICK -> game.setBagDraft(new PoweredOnePickFrankenDraft(game));
                 case POWEREDOVERDRAFT -> game.setBagDraft(new PoweredOverdraftFrankenDraft(game));
+                case FRANKENDRAZ -> game.setBagDraft(new FrankenDrazDraft(game));
                 case TWILIGHTSFALL -> {
                     game.setupTwilightsFallMode(event);
                     game.setBagDraft(new TwilightsFallFrankenDraft(game));

--- a/src/main/java/ti4/draft/BagDraft.java
+++ b/src/main/java/ti4/draft/BagDraft.java
@@ -32,6 +32,7 @@ public abstract class BagDraft {
             case "overdraft_franken" -> new OverdraftFrankenDraft(game);
             case "poweredonepick_franken" -> new PoweredOnePickFrankenDraft(game);
             case "powered_overdraft_franken" -> new PoweredOverdraftFrankenDraft(game);
+            case "frankendraz" -> new FrankenDrazDraft(game);
             case "twilights_fall" -> new TwilightsFallFrankenDraft(game);
             case "inaugural_splice" -> new InauguralSpliceFrankenDraft(game);
             default -> null;
@@ -40,6 +41,10 @@ public abstract class BagDraft {
 
     BagDraft(Game owner) {
         this.owner = owner;
+    }
+
+    protected Game getOwner() {
+        return owner;
     }
 
     public abstract int getItemLimitForCategory(DraftCategory category);

--- a/src/main/java/ti4/draft/DraftCategory.java
+++ b/src/main/java/ti4/draft/DraftCategory.java
@@ -12,6 +12,7 @@ import ti4.service.emoji.TileEmojis;
 import ti4.service.emoji.UnitEmojis;
 
 public enum DraftCategory {
+    FACTION,
     ABILITY,
     TECH,
     BREAKTHROUGH,
@@ -36,6 +37,7 @@ public enum DraftCategory {
         TI4Emoji emoji = emoji(game);
         return "## "
                 + switch (this) {
+                    case FACTION -> "Factions";
                     case ABILITY -> "Abilities";
                     case TECH -> game.isTwilightsFallMode() ? "Abilities" : "Faction Techs";
                     case AGENT -> game.isTwilightsFallMode() ? "Genomes" : "Agents";
@@ -61,6 +63,7 @@ public enum DraftCategory {
 
     public TI4Emoji emoji(Game game) {
         return switch (this) {
+            case FACTION -> FactionEmojis.Muaat;
             case ABILITY -> MiscEmojis.tf_ability;
             case TECH -> game.isTwilightsFallMode() ? MiscEmojis.tf_ability : TechEmojis.CyberneticPropulsion;
             case AGENT -> game.isTwilightsFallMode() ? MiscEmojis.tf_genome : LeaderEmojis.Agent;

--- a/src/main/java/ti4/draft/DraftItem.java
+++ b/src/main/java/ti4/draft/DraftItem.java
@@ -14,6 +14,7 @@ import ti4.draft.items.BlueTileDraftItem;
 import ti4.draft.items.BreakthroughDraftItem;
 import ti4.draft.items.CommanderDraftItem;
 import ti4.draft.items.CommoditiesDraftItem;
+import ti4.draft.items.FactionDraftItem;
 import ti4.draft.items.FlagshipDraftItem;
 import ti4.draft.items.HeroDraftItem;
 import ti4.draft.items.HomeSystemDraftItem;
@@ -83,6 +84,7 @@ public abstract class DraftItem {
 
     public static DraftItem generate(DraftCategory category, String itemId) {
         return switch (category) {
+            case FACTION -> new FactionDraftItem(itemId);
             case ABILITY -> new AbilityDraftItem(itemId);
             case TECH -> new TechDraftItem(itemId);
             case AGENT -> new AgentDraftItem(itemId);

--- a/src/main/java/ti4/draft/FrankenDraft.java
+++ b/src/main/java/ti4/draft/FrankenDraft.java
@@ -47,7 +47,7 @@ public class FrankenDraft extends BagDraft {
             case COMMODITIES, FLAGSHIP, MECH -> 2;
             case HERO, COMMANDER, AGENT, BREAKTHROUGH -> 2;
             case DRAFTORDER -> 1;
-            case UNIT, PLOT, MAHACTKING -> 0;
+            case FACTION, UNIT, PLOT, MAHACTKING -> 0;
         };
     }
 
@@ -60,7 +60,7 @@ public class FrankenDraft extends BagDraft {
             case COMMODITIES, FLAGSHIP, MECH -> 1;
             case HERO, COMMANDER, AGENT, BREAKTHROUGH -> 1;
             case DRAFTORDER, STARTINGFLEET -> 1;
-            case UNIT, PLOT, MAHACTKING -> 0;
+            case FACTION, UNIT, PLOT, MAHACTKING -> 0;
         };
     }
 

--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.components.textdisplay.TextDisplay;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import org.apache.commons.lang3.function.Consumers;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.draft.items.BlueTileDraftItem;
 import ti4.draft.items.FactionDraftItem;
@@ -25,6 +26,7 @@ import ti4.draft.items.SpeakerOrderDraftItem;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.PatternHelper;
+import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.message.componentsV2.MessageV2Builder;
 import ti4.message.componentsV2.MessageV2Editor;
@@ -237,6 +239,33 @@ public class FrankenDrazDraft extends FrankenDraft {
         });
     }
 
+    public void closePostDraftCategory(ButtonInteractionEvent event, Player player, DraftCategory category) {
+        if (!POST_DRAFT_COMPONENT_CATEGORIES.contains(category)) {
+            return;
+        }
+
+        int lookback = buildPostDraftCategoryContainers(player, category).size() * 2 + 4;
+        event.getMessage()
+                .getChannel()
+                .getHistoryAround(event.getMessage().getIdLong(), lookback)
+                .queue(
+                        messageHistory -> {
+                            if (isPostDraftCategoryMessage(event.getMessage(), player.getGame(), category)) {
+                                event.getMessage().delete().queue(Consumers.nop(), BotLogger::catchRestError);
+                            }
+                            for (Message message : messageHistory.getRetrievedHistory()) {
+                                if (message.getIdLong() == event.getMessage().getIdLong()
+                                        || !message.getAuthor().isBot()) {
+                                    continue;
+                                }
+                                if (isPostDraftCategoryMessage(message, player.getGame(), category)) {
+                                    message.delete().queue(Consumers.nop(), BotLogger::catchRestError);
+                                }
+                            }
+                        },
+                        BotLogger::catchRestError);
+    }
+
     @Override
     public int getBagSize() {
         return 12;
@@ -298,7 +327,11 @@ public class FrankenDrazDraft extends FrankenDraft {
             components.addAll(item.getTextDisplays(player.getGame(), player, true));
         }
 
-        components.addAll(ActionRow.partitionOf(getApplyButtons(player, category, items)));
+        if (!isManualSetupCategory(category)) {
+            components.addAll(ActionRow.partitionOf(getApplyButtons(player, category, items)));
+        }
+        components.add(ActionRow.of(Buttons.red(
+                player.factionButtonChecker() + "frankenDrazCloseCategory;" + category.name(), "Close Category")));
         return Container.of(components);
     }
 
@@ -321,6 +354,20 @@ public class FrankenDrazDraft extends FrankenDraft {
     private static boolean isOversized(Container container) {
         return MessageV2Builder.CountComponents(container) > Message.MAX_COMPONENT_COUNT_IN_COMPONENT_TREE
                 || MessageV2Builder.CountCharacters(container) > Message.MAX_CONTENT_LENGTH_COMPONENT_V2;
+    }
+
+    private static boolean isManualSetupCategory(DraftCategory category) {
+        return category == DraftCategory.HOMESYSTEM || category == DraftCategory.STARTINGFLEET;
+    }
+
+    private static boolean isPostDraftCategoryMessage(Message message, Game game, DraftCategory category) {
+        String categoryTitle = category.title(game);
+        return message.getComponentTree().getComponents().stream()
+                .filter(Container.class::isInstance)
+                .map(Container.class::cast)
+                .map(FrankenDrazDraft::getContainerTitle)
+                .anyMatch(title ->
+                        categoryTitle.equals(title) || (title != null && title.startsWith(categoryTitle + " (")));
     }
 
     private static Predicate<Component> matchesContainerTitle(Container replacement) {

--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -187,10 +187,6 @@ public class FrankenDrazDraft extends FrankenDraft {
         }
     }
 
-    public List<DraftCategory> getPostDraftComponentCategories() {
-        return POST_DRAFT_COMPONENT_CATEGORIES;
-    }
-
     public void sendPostDraftComponentButtons(Player player) {
         MessageHelper.sendMessageToChannel(
                 player.getCardsInfoThread(),

--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -1,0 +1,201 @@
+package ti4.draft;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import ti4.draft.items.BlueTileDraftItem;
+import ti4.draft.items.FactionDraftItem;
+import ti4.draft.items.RedTileDraftItem;
+import ti4.draft.items.SpeakerOrderDraftItem;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.PatternHelper;
+import ti4.message.MessageHelper;
+import ti4.model.FactionModel;
+import ti4.service.milty.MiltyDraftHelper;
+import ti4.service.milty.MiltyDraftManager;
+
+public class FrankenDrazDraft extends FrankenDraft {
+    private static final List<String> AUTO_BANNED_FACTIONS = List.of("obsidian", "firmament");
+    public FrankenDrazDraft(Game owner) {
+        super(owner);
+    }
+
+    @Override
+    public int getItemLimitForCategory(DraftCategory category) {
+        return switch (category) {
+            case FACTION -> 6;
+            case BLUETILE -> 3;
+            case REDTILE -> 2;
+            case DRAFTORDER -> 1;
+            default -> 0;
+        };
+    }
+
+    @Override
+    public int getKeptItemLimitForCategory(DraftCategory category) {
+        return switch (category) {
+            case ABILITY -> 4;
+            case TECH, BLUETILE -> 3;
+            case REDTILE -> 2;
+            case COMMODITIES, FLAGSHIP, MECH, PN -> 1;
+            case HERO, COMMANDER, AGENT, BREAKTHROUGH -> 1;
+            case DRAFTORDER, STARTINGFLEET, STARTINGTECH, HOMESYSTEM -> 1;
+            case FACTION, UNIT, PLOT, MAHACTKING -> 0;
+        };
+    }
+
+    @Override
+    public int getPicksFromFirstBag() {
+        return 2;
+    }
+
+    @Override
+    public int getPicksFromNextBags() {
+        return 1;
+    }
+
+    @Override
+    public String getSaveString() {
+        return "frankendraz";
+    }
+
+    @Override
+    public List<DraftBag> generateBags(Game game) {
+        Map<DraftCategory, List<DraftItem>> allDraftableItems = new HashMap<>();
+        List<FactionModel> allDraftableFactions = getDraftableFactionsForGame(game);
+        allDraftableItems.put(DraftCategory.FACTION, FactionDraftItem.buildAllDraftableItems(allDraftableFactions));
+        allDraftableItems.put(DraftCategory.DRAFTORDER, SpeakerOrderDraftItem.buildAllDraftableItems(game));
+
+        MiltyDraftManager draftManager = game.getMiltyDraftManager();
+        draftManager.clear();
+        MiltyDraftHelper.initDraftTiles(draftManager, game);
+        allDraftableItems.put(DraftCategory.REDTILE, RedTileDraftItem.buildAllDraftableItems(draftManager, game));
+        allDraftableItems.put(DraftCategory.BLUETILE, BlueTileDraftItem.buildAllDraftableItems(draftManager, game));
+
+        List<DraftBag> bags = new ArrayList<>();
+        Map<DraftCategory, Integer> missingItems = new HashMap<>();
+        for (int i = 0; i < game.getRealPlayers().size(); i++) {
+            DraftBag bag = new DraftBag();
+
+            for (Map.Entry<DraftCategory, List<DraftItem>> draftableCollection : allDraftableItems.entrySet()) {
+                DraftCategory category = draftableCollection.getKey();
+                int categoryLimit = getItemLimitForCategory(category);
+                for (int j = 0; j < categoryLimit; j++) {
+                    if (!draftableCollection.getValue().isEmpty()) {
+                        bag.Contents.add(draftableCollection.getValue().removeFirst());
+                    } else {
+                        missingItems.compute(category, (c, x) -> x == null ? 1 : x + 1);
+                    }
+                }
+            }
+
+            if (!missingItems.isEmpty()) {
+                StringBuilder issue = new StringBuilder(
+                        game.getPing() + " an issue was encountered while building the FrankenDraz draft.");
+                issue.append("\nOne or more bags are missing components.");
+                for (var e : missingItems.entrySet()) {
+                    issue.append("\n> ")
+                            .append(e.getKey().toString())
+                            .append(" is missing ")
+                            .append(e.getValue())
+                            .append(" components.");
+                }
+                MessageHelper.sendMessageToChannel(game.getActionsChannel(), issue.toString());
+                return null;
+            }
+            bags.add(bag);
+        }
+
+        return bags;
+    }
+
+    @Override
+    public boolean isDraftStageComplete() {
+        for (Player player : getOwnerPlayers()) {
+            if (!hasExpandedFactionComponents(player.getDraftHand())) {
+                return super.isDraftStageComplete();
+            }
+        }
+
+        for (Player player : getOwnerPlayers()) {
+            DraftBag hand = player.getDraftHand();
+            if (hand.getCategoryCount(DraftCategory.FACTION) > 0
+                    || hand.getCategoryCount(DraftCategory.BLUETILE) != getItemLimitForCategory(DraftCategory.BLUETILE)
+                    || hand.getCategoryCount(DraftCategory.REDTILE) != getItemLimitForCategory(DraftCategory.REDTILE)
+                    || hand.getCategoryCount(DraftCategory.DRAFTORDER)
+                            != getItemLimitForCategory(DraftCategory.DRAFTORDER)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void expandFactionPackages(Game game) {
+        for (Player player : game.getRealPlayers()) {
+            DraftBag hand = player.getDraftHand();
+            Map<String, DraftItem> expanded = new LinkedHashMap<>();
+            for (DraftItem item : hand.Contents) {
+                if (item.getItemCategory() != DraftCategory.FACTION) {
+                    expanded.putIfAbsent(item.getAlias(), item);
+                }
+            }
+            for (DraftItem item : hand.Contents) {
+                if (item instanceof FactionDraftItem factionItem) {
+                    for (DraftItem component : factionItem.getComponents(game)) {
+                        expanded.putIfAbsent(component.getAlias(), component);
+                    }
+                }
+            }
+            hand.Contents.clear();
+            hand.Contents.addAll(expanded.values());
+        }
+    }
+
+    @Override
+    public int getBagSize() {
+        return 12;
+    }
+
+    private List<Player> getOwnerPlayers() {
+        return getOwner().getRealPlayers();
+    }
+
+    private static boolean hasExpandedFactionComponents(DraftBag hand) {
+        return hand.getCategoryCount(DraftCategory.HOMESYSTEM) > 0
+                || hand.getCategoryCount(DraftCategory.STARTINGFLEET) > 0
+                || hand.getCategoryCount(DraftCategory.ABILITY) > 0
+                || hand.getCategoryCount(DraftCategory.TECH) > 0
+                || hand.getCategoryCount(DraftCategory.AGENT) > 0
+                || hand.getCategoryCount(DraftCategory.COMMANDER) > 0
+                || hand.getCategoryCount(DraftCategory.HERO) > 0
+                || hand.getCategoryCount(DraftCategory.MECH) > 0
+                || hand.getCategoryCount(DraftCategory.FLAGSHIP) > 0
+                || hand.getCategoryCount(DraftCategory.PN) > 0
+                || hand.getCategoryCount(DraftCategory.STARTINGTECH) > 0
+                || hand.getCategoryCount(DraftCategory.BREAKTHROUGH) > 0;
+    }
+
+    private static List<FactionModel> getDraftableFactionsForGame(Game game) {
+        Map<String, FactionModel> factions = new LinkedHashMap<>();
+        for (FactionModel faction : FrankenDraft.getAllFrankenLegalFactions(game)) {
+            factions.put(faction.getAlias(), faction);
+        }
+        for (FactionModel faction : FrankenDraft.getAllFrankenLegalFactions(null)) {
+            if (faction.getSource().isDs()) {
+                factions.put(faction.getAlias(), faction);
+            }
+        }
+
+        String[] bannedFactions = PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue("bannedFactions"));
+        for (String bannedFaction : bannedFactions) {
+            factions.remove(bannedFaction);
+        }
+        for (String faction : AUTO_BANNED_FACTIONS) {
+            factions.remove(faction);
+        }
+        return new ArrayList<>(factions.values());
+    }
+}

--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import net.dv8tion.jda.api.components.Component;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.components.container.Container;
@@ -14,6 +16,7 @@ import net.dv8tion.jda.api.components.separator.Separator.Spacing;
 import net.dv8tion.jda.api.components.textdisplay.TextDisplay;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.draft.items.BlueTileDraftItem;
 import ti4.draft.items.FactionDraftItem;
@@ -24,6 +27,7 @@ import ti4.game.Player;
 import ti4.helpers.PatternHelper;
 import ti4.message.MessageHelper;
 import ti4.message.componentsV2.MessageV2Builder;
+import ti4.message.componentsV2.MessageV2Editor;
 import ti4.model.FactionModel;
 import ti4.service.franken.FrankenDraftBagService;
 import ti4.service.milty.MiltyDraftHelper;
@@ -212,6 +216,27 @@ public class FrankenDrazDraft extends FrankenDraft {
         }
     }
 
+    public void refreshPostDraftCategory(ButtonInteractionEvent event, Player player, DraftCategory category) {
+        if (!POST_DRAFT_COMPONENT_CATEGORIES.contains(category)) {
+            return;
+        }
+
+        List<Container> containers = buildPostDraftCategoryContainers(player, category);
+        if (containers.isEmpty()) {
+            return;
+        }
+
+        MessageV2Editor editor = new MessageV2Editor();
+        for (Container container : containers) {
+            Container replacement = container.withAccentColor(
+                    FrankenDraftBagService.getAccents().getFirst());
+            editor.replace(matchesContainerTitle(replacement), replacement);
+        }
+        editor.applyAroundMessage(event.getMessage(), containers.size() * 2 + 2, changed -> {
+            if (!changed) sendPostDraftCategory(player, category);
+        });
+    }
+
     @Override
     public int getBagSize() {
         return 12;
@@ -296,6 +321,24 @@ public class FrankenDrazDraft extends FrankenDraft {
     private static boolean isOversized(Container container) {
         return MessageV2Builder.CountComponents(container) > Message.MAX_COMPONENT_COUNT_IN_COMPONENT_TREE
                 || MessageV2Builder.CountCharacters(container) > Message.MAX_CONTENT_LENGTH_COMPONENT_V2;
+    }
+
+    private static Predicate<Component> matchesContainerTitle(Container replacement) {
+        String replacementTitle = getContainerTitle(replacement);
+        return component -> component instanceof Container container
+                && replacementTitle != null
+                && replacementTitle.equals(getContainerTitle(container));
+    }
+
+    private static String getContainerTitle(Container container) {
+        if (container.getComponents().isEmpty()) {
+            return null;
+        }
+        ContainerChildComponent child = container.getComponents().getFirst();
+        if (child instanceof TextDisplay textDisplay) {
+            return textDisplay.getContent();
+        }
+        return null;
     }
 
     private static String categoryLabel(DraftCategory category) {

--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -5,6 +5,16 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.container.Container;
+import net.dv8tion.jda.api.components.container.ContainerChildComponent;
+import net.dv8tion.jda.api.components.separator.Separator;
+import net.dv8tion.jda.api.components.separator.Separator.Spacing;
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import ti4.discord.interactions.buttons.Buttons;
 import ti4.draft.items.BlueTileDraftItem;
 import ti4.draft.items.FactionDraftItem;
 import ti4.draft.items.RedTileDraftItem;
@@ -13,12 +23,29 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.PatternHelper;
 import ti4.message.MessageHelper;
+import ti4.message.componentsV2.MessageV2Builder;
 import ti4.model.FactionModel;
+import ti4.service.franken.FrankenDraftBagService;
 import ti4.service.milty.MiltyDraftHelper;
 import ti4.service.milty.MiltyDraftManager;
 
 public class FrankenDrazDraft extends FrankenDraft {
     private static final List<String> AUTO_BANNED_FACTIONS = List.of("obsidian", "firmament");
+    private static final List<DraftCategory> POST_DRAFT_COMPONENT_CATEGORIES = List.of(
+            DraftCategory.ABILITY,
+            DraftCategory.TECH,
+            DraftCategory.BREAKTHROUGH,
+            DraftCategory.AGENT,
+            DraftCategory.COMMANDER,
+            DraftCategory.HERO,
+            DraftCategory.MECH,
+            DraftCategory.FLAGSHIP,
+            DraftCategory.COMMODITIES,
+            DraftCategory.PN,
+            DraftCategory.HOMESYSTEM,
+            DraftCategory.STARTINGTECH,
+            DraftCategory.STARTINGFLEET);
+
     public FrankenDrazDraft(Game owner) {
         super(owner);
     }
@@ -154,6 +181,37 @@ public class FrankenDrazDraft extends FrankenDraft {
         }
     }
 
+    public List<DraftCategory> getPostDraftComponentCategories() {
+        return POST_DRAFT_COMPONENT_CATEGORIES;
+    }
+
+    public void sendPostDraftComponentButtons(Player player) {
+        MessageHelper.sendMessageToChannel(
+                player.getCardsInfoThread(),
+                "Choose a drafted component category to view. Additional components are added automatically. Optional Swaps will appear in their respective categories when expanded. Home systems and starting fleet must be added manually, as well as any additional or optional components added via these components. Category buttons are present for your convenience.",
+                getPostDraftCategoryButtons(player));
+    }
+
+    public void sendPostDraftCategory(Player player, DraftCategory category) {
+        if (!POST_DRAFT_COMPONENT_CATEGORIES.contains(category)) {
+            return;
+        }
+
+        ThreadChannel cardsInfoThread = player.getCardsInfoThread();
+        List<Container> containers = buildPostDraftCategoryContainers(player, category);
+        if (containers.isEmpty()) {
+            MessageHelper.sendMessageToChannel(cardsInfoThread, "You have no drafted " + categoryLabel(category) + ".");
+            return;
+        }
+
+        for (Container container : containers) {
+            MessageV2Builder builder = new MessageV2Builder(cardsInfoThread);
+            builder.append(container.withAccentColor(
+                    FrankenDraftBagService.getAccents().getFirst()));
+            builder.send();
+        }
+    }
+
     @Override
     public int getBagSize() {
         return 12;
@@ -161,6 +219,102 @@ public class FrankenDrazDraft extends FrankenDraft {
 
     private List<Player> getOwnerPlayers() {
         return getOwner().getRealPlayers();
+    }
+
+    private List<Button> getPostDraftCategoryButtons(Player player) {
+        List<Button> buttons = new ArrayList<>();
+        for (DraftCategory category : POST_DRAFT_COMPONENT_CATEGORIES) {
+            String buttonID = player.factionButtonChecker() + "frankenDrazCategory;" + category.name();
+            buttons.add(Buttons.gray(buttonID, categoryLabel(category), category.emoji(player.getGame())));
+        }
+        return buttons;
+    }
+
+    private List<Container> buildPostDraftCategoryContainers(Player player, DraftCategory category) {
+        List<DraftItem> all = player.getDraftHand().getCategory(category);
+        if (all.isEmpty()) {
+            return List.of();
+        }
+
+        List<List<DraftItem>> groups = new ArrayList<>();
+        List<DraftItem> current = new ArrayList<>();
+        for (DraftItem item : all) {
+            current.add(item);
+            Container candidate =
+                    buildPostDraftCategoryContainer(player, category, current, category.title(player.getGame()));
+            if (isOversized(candidate) && current.size() > 1) {
+                current.removeLast();
+                groups.add(current);
+                current = new ArrayList<>(List.of(item));
+            }
+        }
+        if (!current.isEmpty()) {
+            groups.add(current);
+        }
+
+        List<Container> containers = new ArrayList<>();
+        for (int i = 0; i < groups.size(); i++) {
+            String title = category.title(player.getGame());
+            if (groups.size() > 1) {
+                title += " (" + (i + 1) + "/" + groups.size() + ")";
+            }
+            containers.add(buildPostDraftCategoryContainer(player, category, groups.get(i), title));
+        }
+        return containers;
+    }
+
+    private Container buildPostDraftCategoryContainer(
+            Player player, DraftCategory category, List<DraftItem> items, String title) {
+        List<ContainerChildComponent> components = new ArrayList<>();
+        components.add(TextDisplay.of(title));
+
+        for (DraftItem item : items) {
+            if (components.size() > 1) components.add(Separator.createDivider(Spacing.LARGE));
+            components.addAll(item.getTextDisplays(player.getGame(), player, true));
+        }
+
+        components.addAll(ActionRow.partitionOf(getApplyButtons(player, category, items)));
+        return Container.of(components);
+    }
+
+    private List<Button> getApplyButtons(Player player, DraftCategory category, List<DraftItem> items) {
+        List<Button> buttons = new ArrayList<>();
+        List<String> appliedItems = player.getStoredList("appliedFrankenItems");
+        int limit = getKeptItemLimitForCategory(category);
+        int taken = player.getDraftHand().getCategoryAppliedCount(appliedItems, category);
+        boolean atLimit = taken >= limit;
+
+        for (DraftItem item : items) {
+            boolean alreadyHas = appliedItems.contains(item.getAlias());
+            Button button = item.getAddButton().withDisabled(atLimit);
+            if (alreadyHas) button = item.getRemoveButton();
+            buttons.add(button);
+        }
+        return buttons;
+    }
+
+    private static boolean isOversized(Container container) {
+        return MessageV2Builder.CountComponents(container) > Message.MAX_COMPONENT_COUNT_IN_COMPONENT_TREE
+                || MessageV2Builder.CountCharacters(container) > Message.MAX_CONTENT_LENGTH_COMPONENT_V2;
+    }
+
+    private static String categoryLabel(DraftCategory category) {
+        return switch (category) {
+            case ABILITY -> "Abilities";
+            case TECH -> "Faction Techs";
+            case BREAKTHROUGH -> "Breakthroughs";
+            case AGENT -> "Agents";
+            case COMMANDER -> "Commanders";
+            case HERO -> "Heroes";
+            case MECH -> "Mechs";
+            case FLAGSHIP -> "Flagships";
+            case COMMODITIES -> "Commodities";
+            case PN -> "Promissory Notes";
+            case HOMESYSTEM -> "Home Systems";
+            case STARTINGTECH -> "Starting Techs";
+            case STARTINGFLEET -> "Starting Fleets";
+            default -> category.toString();
+        };
     }
 
     private static boolean hasExpandedFactionComponents(DraftBag hand) {

--- a/src/main/java/ti4/draft/PoweredFrankenDraft.java
+++ b/src/main/java/ti4/draft/PoweredFrankenDraft.java
@@ -18,7 +18,7 @@ public class PoweredFrankenDraft extends FrankenDraft {
             case FLAGSHIP, MECH, BREAKTHROUGH -> 2;
             case PN, COMMODITIES, REDTILE -> 2;
             case DRAFTORDER -> 1;
-            case UNIT, PLOT, MAHACTKING -> 0;
+            case FACTION, UNIT, PLOT, MAHACTKING -> 0;
         };
     }
 
@@ -32,7 +32,7 @@ public class PoweredFrankenDraft extends FrankenDraft {
             case COMMODITIES, FLAGSHIP, MECH, PN -> 1;
             case HERO, COMMANDER, AGENT, BREAKTHROUGH -> 1;
             case DRAFTORDER, STARTINGFLEET, STARTINGTECH, HOMESYSTEM -> 1;
-            case UNIT, PLOT, MAHACTKING -> 0;
+            case FACTION, UNIT, PLOT, MAHACTKING -> 0;
         };
     }
 

--- a/src/main/java/ti4/draft/PoweredOverdraftFrankenDraft.java
+++ b/src/main/java/ti4/draft/PoweredOverdraftFrankenDraft.java
@@ -18,7 +18,7 @@ public class PoweredOverdraftFrankenDraft extends FrankenDraft {
             case FLAGSHIP, MECH, BREAKTHROUGH -> 2;
             case PN, COMMODITIES, REDTILE -> 2;
             case DRAFTORDER -> 1;
-            case UNIT, PLOT, MAHACTKING -> 0;
+            case FACTION, UNIT, PLOT, MAHACTKING -> 0;
         };
     }
 

--- a/src/main/java/ti4/draft/items/FactionDraftItem.java
+++ b/src/main/java/ti4/draft/items/FactionDraftItem.java
@@ -1,0 +1,225 @@
+package ti4.draft.items;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay;
+import ti4.draft.BagDraft;
+import ti4.draft.DraftCategory;
+import ti4.draft.DraftItem;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.PatternHelper;
+import ti4.image.Mapper;
+import ti4.model.DraftErrataModel;
+import ti4.model.FactionModel;
+import ti4.model.LeaderModel;
+import ti4.model.UnitModel;
+import ti4.service.emoji.FactionEmojis;
+import ti4.service.emoji.TI4Emoji;
+
+public class FactionDraftItem extends DraftItem {
+
+    public FactionDraftItem(String itemId) {
+        super(DraftCategory.FACTION, itemId);
+    }
+
+    @JsonIgnore
+    @Override
+    public String getTitle(Game game) {
+        FactionModel faction = getFaction();
+        if (faction == null) {
+            return getAlias();
+        }
+        return faction.getNameRepresentation();
+    }
+
+    @JsonIgnore
+    @Override
+    public String getShortDescription() {
+        FactionModel faction = getFaction();
+        if (faction == null) {
+            return getAlias();
+        }
+        return faction.getShortName();
+    }
+
+    @JsonIgnore
+    @Override
+    protected String getLongDescriptionImpl() {
+        return getLongDescriptionImpl(null);
+    }
+
+    @JsonIgnore
+    @Override
+    protected String getLongDescriptionImpl(Game game) {
+        FactionModel faction = getFaction();
+        if (faction == null) {
+            return "";
+        }
+        if (game == null) {
+            return faction.getFactionName();
+        }
+
+        return getComponentList(game);
+    }
+
+    @JsonIgnore
+    @Override
+    public List<TextDisplay> getTextDisplays(Game game, Player player, boolean showDescr) {
+        return List.of(TextDisplay.of(getTitle(game)));
+    }
+
+    @JsonIgnore
+    public String getComponentList(Game game) {
+        FactionModel faction = getFaction();
+        if (faction == null) {
+            return "";
+        }
+
+        Map<DraftCategory, List<DraftItem>> components =
+                getComponents(game).stream().collect(Collectors.groupingBy(DraftItem::getItemCategory));
+        StringBuilder sb = new StringBuilder();
+        sb.append("Commodities: ").append(faction.getCommodities());
+        for (DraftCategory category : DraftCategory.values()) {
+            if (category == DraftCategory.FACTION) {
+                continue;
+            }
+            List<DraftItem> items = components.get(category);
+            if (items == null || items.isEmpty()) {
+                continue;
+            }
+            sb.append('\n').append(category.title(game).replace("## ", "")).append(": ");
+            sb.append(items.stream().map(DraftItem::getShortDescription).collect(Collectors.joining(", ")));
+        }
+        return sb.toString();
+    }
+
+    @JsonIgnore
+    @Override
+    public TI4Emoji getItemEmoji() {
+        return FactionEmojis.getFactionIcon(getItemId());
+    }
+
+    @Override
+    public boolean isDraftable(Player player) {
+        if (player.getDraftHand().Contents.contains(this)) {
+            return false;
+        }
+        BagDraft draft = player.getGame().getActiveBagDraft();
+        if (draft.playerQueueIsFull(player)) {
+            return false;
+        }
+        int taken = player.getDraftHand().getCategoryCount(DraftCategory.FACTION)
+                + player.getDraftQueue().getCategoryCount(DraftCategory.FACTION);
+        return taken < draft.getItemLimitForCategory(DraftCategory.FACTION);
+    }
+
+    @JsonIgnore
+    public List<DraftItem> getComponents(Game game) {
+        FactionModel faction = getFaction();
+        if (faction == null) {
+            return List.of();
+        }
+
+        List<DraftItem> components = new ArrayList<>();
+        for (String ability : faction.getAbilities()) {
+            addIfAllowed(game, components, DraftCategory.ABILITY, ability, ability);
+        }
+        for (String tech : faction.getFactionTech()) {
+            addIfAllowed(game, components, DraftCategory.TECH, tech, tech);
+        }
+        for (String leader : faction.getLeaders()) {
+            LeaderModel model = Mapper.getLeader(leader);
+            if (model == null) {
+                continue;
+            }
+            switch (model.getType()) {
+                case "agent" -> addIfAllowed(game, components, DraftCategory.AGENT, leader, leader);
+                case "commander" -> addIfAllowed(game, components, DraftCategory.COMMANDER, leader, leader);
+                case "hero" -> addIfAllowed(game, components, DraftCategory.HERO, leader, leader);
+                default -> {}
+            }
+        }
+        for (String unit : faction.getUnits()) {
+            UnitModel model = Mapper.getUnit(unit);
+            if (model == null) {
+                continue;
+            }
+            switch (model.getBaseType()) {
+                case "mech" -> addIfAllowed(game, components, DraftCategory.MECH, unit, faction.getAlias());
+                case "flagship" -> addIfAllowed(game, components, DraftCategory.FLAGSHIP, unit, faction.getAlias());
+                default -> {}
+            }
+        }
+        addIfAllowed(game, components, DraftCategory.COMMODITIES, faction.getAlias(), faction.getAlias());
+        for (String pn : faction.getPromissoryNotes()) {
+            addIfAllowed(game, components, DraftCategory.PN, pn, pn);
+        }
+        addIfAllowed(game, components, DraftCategory.HOMESYSTEM, faction.getAlias(), faction.getAlias());
+        addIfAllowed(game, components, DraftCategory.STARTINGTECH, faction.getAlias(), faction.getAlias());
+        addIfAllowed(game, components, DraftCategory.STARTINGFLEET, faction.getAlias(), faction.getAlias());
+
+        String breakthrough = faction.getBreakthrough();
+        if (Mapper.isValidBreakthrough(breakthrough)) {
+            addIfAllowed(game, components, DraftCategory.BREAKTHROUGH, breakthrough, breakthrough);
+        }
+        return components;
+    }
+
+    private static void addIfAllowed(
+            Game game, List<DraftItem> components, DraftCategory category, String itemId, String banValue) {
+        if (isBanned(game, category, banValue)) {
+            return;
+        }
+        DraftItem item = DraftItem.generate(category, itemId);
+        if (Boolean.TRUE.equals(item.getErrata().getUndraftable())) {
+            return;
+        }
+        components.add(item);
+    }
+
+    private static boolean isBanned(Game game, DraftCategory category, String value) {
+        return switch (category) {
+            case ABILITY -> storedListContains(game, "bannedAbilities", value);
+            case TECH -> storedListContains(game, "bannedTechs", value);
+            case BREAKTHROUGH -> storedListContains(game, "bannedBreakthroughs", value);
+            case AGENT, COMMANDER, HERO -> storedListContains(game, "bannedLeaders", value);
+            case MECH -> storedListContains(game, "bannedMechs", value);
+            case FLAGSHIP -> storedListContains(game, "bannedFSs", value);
+            case COMMODITIES -> storedListContains(game, "bannedComms", value);
+            case PN -> storedListContains(game, "bannedPNs", value);
+            case HOMESYSTEM -> storedListContains(game, "bannedHSs", value);
+            case STARTINGTECH -> storedListContains(game, "bannedStartingTechs", value);
+            case STARTINGFLEET -> storedListContains(game, "bannedFleets", value);
+            default -> false;
+        };
+    }
+
+    private static boolean storedListContains(Game game, String key, String value) {
+        return Arrays.asList(PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue(key)))
+                .contains(value);
+    }
+
+    @JsonIgnore
+    private FactionModel getFaction() {
+        return Mapper.getFaction(getItemId());
+    }
+
+    public static List<DraftItem> buildAllDraftableItems(List<FactionModel> factions) {
+        List<DraftItem> allItems = buildAllItems(factions);
+        DraftErrataModel.filterUndraftablesAndShuffle(allItems, DraftCategory.FACTION);
+        return allItems;
+    }
+
+    public static List<DraftItem> buildAllItems(List<FactionModel> factions) {
+        List<DraftItem> allItems = new ArrayList<>();
+        for (FactionModel faction : factions) {
+            allItems.add(DraftItem.generate(DraftCategory.FACTION, faction.getAlias()));
+        }
+        return allItems;
+    }
+}

--- a/src/main/java/ti4/service/franken/FrankenDraftBagService.java
+++ b/src/main/java/ti4/service/franken/FrankenDraftBagService.java
@@ -32,6 +32,7 @@ import ti4.draft.DraftItem;
 import ti4.draft.FrankenDraft;
 import ti4.draft.InauguralSpliceFrankenDraft;
 import ti4.draft.items.AgentDraftItem;
+import ti4.draft.items.FactionDraftItem;
 import ti4.draft.items.HeroDraftItem;
 import ti4.game.Game;
 import ti4.game.Player;
@@ -290,7 +291,11 @@ public class FrankenDraftBagService {
             // Add each item to the container
             for (DraftItem item : all) {
                 if (components.size() > 1) components.add(Separator.createDivider(Spacing.LARGE));
-                components.addAll(item.getTextDisplays(game, player, true));
+                components.addAll(item.getTextDisplays(game, player, cat != DraftCategory.FACTION));
+                if (item instanceof FactionDraftItem) {
+                    String buttonID = player.factionButtonChecker() + "frankenFactionComponents;" + item.getItemId();
+                    components.add(ActionRow.of(Buttons.gray(buttonID, "Show Components", item.getItemEmoji())));
+                }
             }
             // Then either...
             if (!DraftItem.isDraftable(player, cat)) {

--- a/src/main/java/ti4/service/franken/FrankenDraftBagService.java
+++ b/src/main/java/ti4/service/franken/FrankenDraftBagService.java
@@ -30,6 +30,7 @@ import ti4.draft.DraftBag;
 import ti4.draft.DraftCategory;
 import ti4.draft.DraftItem;
 import ti4.draft.FrankenDraft;
+import ti4.draft.FrankenDrazDraft;
 import ti4.draft.InauguralSpliceFrankenDraft;
 import ti4.draft.items.AgentDraftItem;
 import ti4.draft.items.FactionDraftItem;
@@ -118,13 +119,17 @@ public class FrankenDraftBagService {
             }
 
             player.setStoredValue("frankenBuilt", "n");
-            for (DraftCategory category : componentCategories) {
-                Container c = postDraftCategoryContainer(player, category);
-                if (c == null) continue;
-                MessageV2Builder builder = new MessageV2Builder(cardsInfoThread);
-                builder.append(c.withAccentColor(accents.getFirst()));
-                Collections.rotate(accents, -1);
-                builder.send();
+            if (game.getActiveBagDraft() instanceof FrankenDrazDraft frankenDrazDraft) {
+                frankenDrazDraft.sendPostDraftComponentButtons(player);
+            } else {
+                for (DraftCategory category : componentCategories) {
+                    Container c = postDraftCategoryContainer(player, category);
+                    if (c == null) continue;
+                    MessageV2Builder builder = new MessageV2Builder(cardsInfoThread);
+                    builder.append(c.withAccentColor(accents.getFirst()));
+                    Collections.rotate(accents, -1);
+                    builder.send();
+                }
             }
 
             if (game.isTwilightsFallMode()) {
@@ -455,6 +460,8 @@ public class FrankenDraftBagService {
         String draftName = "Franken Draft";
         if (draft instanceof InauguralSpliceFrankenDraft) {
             draftName = "Inaugural Splice";
+        } else if (draft instanceof FrankenDrazDraft) {
+            draftName = "FrankenDraz";
         }
 
         String message;

--- a/src/main/java/ti4/service/franken/FrankenDraftMode.java
+++ b/src/main/java/ti4/service/franken/FrankenDraftMode.java
@@ -6,6 +6,8 @@ public enum FrankenDraftMode {
     OVERDRAFT("overdraft", "Keep everything you draft except for mechs and flagships"),
     POWEREDONEPICK("poweredonepick", "Combines powered and onepick modes."),
     POWEREDOVERDRAFT("powered_overdraft", "Combines powered and overdraft modes."),
+    FRANKENDRAZ(
+            "frankendraz", "Draft faction packages, then build from their components using powered franken limits."),
     TWILIGHTSFALL("twilights_fall", "Used for Thunder's Edge Twilights Fall Franken Draft"),
     INAUGURALSPLICE("inaugural_splice", "Used for Thunder's Edge Twilights Fall RAW Draft");
 

--- a/src/test/java/ti4/draft/FrankenDrazDraftTest.java
+++ b/src/test/java/ti4/draft/FrankenDrazDraftTest.java
@@ -1,0 +1,159 @@
+package ti4.draft;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import ti4.draft.items.FactionDraftItem;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.image.Mapper;
+import ti4.model.FactionModel;
+import ti4.testUtils.BaseTi4Test;
+
+class FrankenDrazDraftTest extends BaseTi4Test {
+
+    @Test
+    void generateDraftLoadsFrankenDraz() {
+        Game game = new Game();
+
+        assertInstanceOf(FrankenDrazDraft.class, BagDraft.generateDraft("frankendraz", game));
+    }
+
+    @Test
+    void defaultFrankenDraftDoesNotUseFactionPackages() {
+        Game game = new Game();
+        FrankenDraft draft = new FrankenDraft(game);
+
+        assertEquals(0, draft.getItemLimitForCategory(DraftCategory.FACTION));
+        assertEquals(33, draft.getBagSize());
+    }
+
+    @Test
+    void factionPackageMetadataAndAliasRoundTripWork() {
+        Game game = new Game();
+        DraftItem item = DraftItem.generate(DraftCategory.FACTION, "arborec");
+
+        assertInstanceOf(FactionDraftItem.class, item);
+        assertEquals(item, DraftItem.generateFromAlias(item.getAlias()));
+        assertFalse(item.getTitle(game).isEmpty());
+        assertFalse(item.getShortDescription().isEmpty());
+        assertNotNull(item.getItemEmoji());
+        assertFalse(((FactionDraftItem) item).getComponentList(game).isEmpty());
+    }
+
+    @Test
+    void generateBagsUsesSixFactionPackagesAndMapSetupItems() {
+        Game game = setupGame(6);
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+        game.setBagDraft(draft);
+
+        List<DraftBag> bags = assertDoesNotThrow(() -> draft.generateBags(game));
+
+        assertNotNull(bags);
+        assertEquals(6, bags.size());
+        for (DraftBag bag : bags) {
+            assertEquals(6, bag.getCategoryCount(DraftCategory.FACTION));
+            assertEquals(3, bag.getCategoryCount(DraftCategory.BLUETILE));
+            assertEquals(2, bag.getCategoryCount(DraftCategory.REDTILE));
+            assertEquals(1, bag.getCategoryCount(DraftCategory.DRAFTORDER));
+            assertEquals(12, bag.Contents.size());
+        }
+    }
+
+    @Test
+    void generateBagsAutoBansObsidianAndFirmament() {
+        Game game = setupGame(6);
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+        game.setBagDraft(draft);
+
+        List<DraftBag> bags = assertDoesNotThrow(() -> draft.generateBags(game));
+
+        assertNotNull(bags);
+        assertFalse(bags.stream()
+                .flatMap(bag -> bag.Contents.stream())
+                .anyMatch(item -> item.getItemCategory() == DraftCategory.FACTION
+                        && List.of("obsidian", "firmament").contains(item.getItemId())));
+    }
+
+    @Test
+    void expansionRemovesPackagesAndAddsFactionComponents() {
+        Game game = setupGame(1);
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+        game.setBagDraft(draft);
+        Player player = game.getRealPlayers().getFirst();
+
+        player.getDraftHand().Contents.add(DraftItem.generate(DraftCategory.FACTION, "sol"));
+        addMapSetupItems(player.getDraftHand());
+
+        draft.expandFactionPackages(game);
+
+        DraftBag hand = player.getDraftHand();
+        assertEquals(0, hand.getCategoryCount(DraftCategory.FACTION));
+        assertTrue(hand.getCategoryCount(DraftCategory.ABILITY) > 0);
+        assertTrue(hand.getCategoryCount(DraftCategory.HOMESYSTEM) > 0);
+        assertTrue(hand.getCategoryCount(DraftCategory.STARTINGFLEET) > 0);
+        assertEquals(3, hand.getCategoryCount(DraftCategory.BLUETILE));
+        assertEquals(2, hand.getCategoryCount(DraftCategory.REDTILE));
+        assertEquals(1, hand.getCategoryCount(DraftCategory.DRAFTORDER));
+        assertTrue(draft.isDraftStageComplete());
+    }
+
+    @Test
+    void expansionRespectsExistingComponentBans() {
+        Game game = setupGame(1);
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+        game.setBagDraft(draft);
+        Player player = game.getRealPlayers().getFirst();
+        FactionModel sol = Mapper.getFaction("sol");
+        String bannedAbility = sol.getAbilities().getFirst();
+        game.setStoredValue("bannedAbilities", bannedAbility);
+
+        player.getDraftHand().Contents.add(DraftItem.generate(DraftCategory.FACTION, "sol"));
+        addMapSetupItems(player.getDraftHand());
+
+        draft.expandFactionPackages(game);
+
+        assertFalse(player.getDraftHand().Contents.stream()
+                .anyMatch(item -> item.getItemCategory() == DraftCategory.ABILITY
+                        && item.getItemId().equals(bannedAbility)));
+    }
+
+    @Test
+    void mapSetupItemsAloneDoNotCompleteDraft() {
+        Game game = setupGame(1);
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+        game.setBagDraft(draft);
+        Player player = game.getRealPlayers().getFirst();
+        addMapSetupItems(player.getDraftHand());
+
+        assertFalse(draft.isDraftStageComplete());
+    }
+
+    private static Game setupGame(int players) {
+        Game game = new Game();
+        game.newGameSetup();
+        game.setName("frankendraz-test");
+        String[] colors = {"red", "blue", "green", "yellow", "purple", "orange"};
+        for (int i = 1; i <= players; i++) {
+            Player player = game.addPlayer("player" + i, "Player " + i);
+            player.setFaction(game, "franken" + (i + 2));
+            player.setColor(colors[i - 1]);
+        }
+        return game;
+    }
+
+    private static void addMapSetupItems(DraftBag hand) {
+        hand.Contents.add(DraftItem.generate(DraftCategory.BLUETILE, "19"));
+        hand.Contents.add(DraftItem.generate(DraftCategory.BLUETILE, "20"));
+        hand.Contents.add(DraftItem.generate(DraftCategory.BLUETILE, "21"));
+        hand.Contents.add(DraftItem.generate(DraftCategory.REDTILE, "39"));
+        hand.Contents.add(DraftItem.generate(DraftCategory.REDTILE, "40"));
+        hand.Contents.add(DraftItem.generate(DraftCategory.DRAFTORDER, "1"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new FrankenDraft variant, **FrankenDraz**, available through the existing `/franken start_franken_draft draft_mode` option.

## What Changed

- Added `frankendraz` as a new Franken draft mode.
- Added faction-package draft items and a new `FACTION` draft category.

## Safety / Scope

All FrankenDraz-specific behavior is gated behind `FrankenDrazDraft`.

Existing FrankenDraft modes should retain their current bag generation, draft limits, post-draft display, and component selection behavior.

I tried to keep most of the modes logic self-contained.