### PR TITLE
FrankenDraz helper commands

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/SlashCommandManager.java
+++ b/src/main/java/ti4/discord/interactions/commands/SlashCommandManager.java
@@ -24,6 +24,7 @@ import ti4.discord.interactions.commands.event.EventCommand;
 import ti4.discord.interactions.commands.explore.ExploreCommand;
 import ti4.discord.interactions.commands.fow.FOWCommand;
 import ti4.discord.interactions.commands.franken.FrankenCommand;
+import ti4.discord.interactions.commands.frankendraz.FrankenDrazCommand;
 import ti4.discord.interactions.commands.game.GameCommand;
 import ti4.discord.interactions.commands.help.HelpCommand;
 import ti4.discord.interactions.commands.installation.InstallationCommand;
@@ -124,6 +125,7 @@ public class SlashCommandManager {
                     new InstallationCommand(),
                     new MiltyCommand(),
                     new FrankenCommand(),
+                    new FrankenDrazCommand(),
                     new CaptureCommand(),
                     new GenericButtonCommand(),
                     new DiscordantStarsCommand(),

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazAddFaction.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazAddFaction.java
@@ -1,0 +1,39 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.GameStateSubcommand;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+
+class FrankenDrazAddFaction extends GameStateSubcommand {
+
+    FrankenDrazAddFaction() {
+        super("add_faction", "Add a faction's components", true, true);
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION, "Faction to add")
+                .setRequired(true)
+                .setAutoComplete(true));
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Player faction or color")
+                .setAutoComplete(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getGame();
+        Player player = getPlayer();
+        String faction = FrankenDrazFactionHelper.resolveFaction(
+                event.getOption(Constants.FACTION, null, OptionMapping::getAsString), event);
+        if (faction == null || !FrankenDrazFactionHelper.canManagePostDraftComponents(game, player, event)) {
+            return;
+        }
+
+        FrankenDrazFactionHelper.ComponentChange change =
+                FrankenDrazFactionHelper.addFactionComponents(game, player, faction);
+        MessageHelper.sendMessageToEventChannel(
+                event, FrankenDrazFactionHelper.buildAddMessage(player, faction, change.added()));
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazCommand.java
@@ -1,0 +1,33 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import ti4.discord.interactions.commands.ParentCommand;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.helpers.Constants;
+
+public class FrankenDrazCommand implements ParentCommand {
+
+    private final Map<String, Subcommand> subcommands = Stream.of(
+                    new FrankenDrazAddFaction(),
+                    new FrankenDrazRemoveFaction(),
+                    new FrankenDrazSwapFaction(),
+                    new FrankenDrazHelp())
+            .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
+
+    @Override
+    public String getName() {
+        return Constants.FRANKENDRAZ;
+    }
+
+    @Override
+    public String getDescription() {
+        return "FrankenDraz";
+    }
+
+    @Override
+    public Map<String, Subcommand> getSubcommands() {
+        return subcommands;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazFactionHelper.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazFactionHelper.java
@@ -1,0 +1,140 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.apache.commons.lang3.StringUtils;
+import ti4.draft.DraftBag;
+import ti4.draft.DraftCategory;
+import ti4.draft.DraftItem;
+import ti4.draft.FrankenDrazDraft;
+import ti4.draft.items.FactionDraftItem;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.AliasHandler;
+import ti4.image.Mapper;
+import ti4.message.MessageHelper;
+import ti4.model.FactionModel;
+
+final class FrankenDrazFactionHelper {
+
+    private FrankenDrazFactionHelper() {}
+
+    static String resolveFaction(String rawFaction, SlashCommandInteractionEvent event) {
+        if (StringUtils.isBlank(rawFaction)) {
+            MessageHelper.sendMessageToEventChannel(event, "Please provide a faction.");
+            return null;
+        }
+
+        String faction = AliasHandler.resolveFaction(rawFaction.toLowerCase());
+        if (!Mapper.isValidFaction(faction)) {
+            MessageHelper.sendMessageToEventChannel(event, "Invalid faction: " + rawFaction);
+            return null;
+        }
+        return faction;
+    }
+
+    static boolean canManagePostDraftComponents(Game game, Player player, SlashCommandInteractionEvent event) {
+        if (!(game.getActiveBagDraft() instanceof FrankenDrazDraft)) {
+            MessageHelper.sendMessageToEventChannel(event, "This command can only be used in a FrankenDraz draft.");
+            return false;
+        }
+        if (player.getDraftHand() == null) {
+            MessageHelper.sendMessageToEventChannel(event, player.getRepresentation() + " does not have a draft hand.");
+            return false;
+        }
+        if (player.getDraftHand().getCategoryCount(DraftCategory.FACTION) > 0) {
+            MessageHelper.sendMessageToEventChannel(
+                    event, "This command can only be used after the FrankenDraz draft bags have been applied.");
+            return false;
+        }
+        return true;
+    }
+
+    static ComponentChange addFactionComponents(Game game, Player player, String faction) {
+        DraftBag hand = player.getDraftHand();
+        Set<String> existingAliases =
+                hand.Contents.stream().map(DraftItem::getAlias).collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<DraftItem> added = new ArrayList<>();
+        for (DraftItem component : getFactionComponents(game, faction)) {
+            if (existingAliases.add(component.getAlias())) {
+                hand.Contents.add(component);
+                added.add(component);
+            }
+        }
+        return new ComponentChange(added, List.of());
+    }
+
+    static ComponentChange removeFactionComponents(Game game, Player player, String faction) {
+        Set<String> componentAliases = getFactionComponents(game, faction).stream()
+                .map(DraftItem::getAlias)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<DraftItem> removed = new ArrayList<>();
+        player.getDraftHand().Contents.removeIf(item -> {
+            if (!componentAliases.contains(item.getAlias())) {
+                return false;
+            }
+            removed.add(item);
+            return true;
+        });
+        return new ComponentChange(List.of(), removed);
+    }
+
+    static String buildAddMessage(Player player, String faction, List<DraftItem> added) {
+        return player.getRepresentation() + " added " + added.size() + " post-draft components from "
+                + factionName(faction) + "." + summarizeItems(added, "Added");
+    }
+
+    static String buildRemoveMessage(Player player, String faction, List<DraftItem> removed) {
+        return player.getRepresentation() + " removed " + removed.size() + " post-draft components from "
+                + factionName(faction) + "." + summarizeItems(removed, "Removed");
+    }
+
+    static String buildSwapMessage(
+            Player player,
+            String removeFaction,
+            String addFaction,
+            ComponentChange removeChange,
+            ComponentChange addChange) {
+        return player.getRepresentation() + " swapped post-draft components from " + factionName(removeFaction)
+                + " to " + factionName(addFaction) + ".\n"
+                + "Removed " + removeChange.removed().size() + " components."
+                + summarizeItems(removeChange.removed(), "Removed")
+                + "\nAdded " + addChange.added().size() + " components."
+                + summarizeItems(addChange.added(), "Added");
+    }
+
+    private static List<DraftItem> getFactionComponents(Game game, String faction) {
+        return new FactionDraftItem(faction).getComponents(game);
+    }
+
+    private static String summarizeItems(List<DraftItem> items, String label) {
+        if (items.isEmpty()) {
+            return "\n> " + label + ": none";
+        }
+
+        Map<DraftCategory, List<DraftItem>> byCategory =
+                items.stream().collect(Collectors.groupingBy(DraftItem::getItemCategory));
+        StringBuilder summary = new StringBuilder();
+        byCategory.entrySet().stream().sorted(Map.Entry.comparingByKey()).forEach(entry -> summary.append("\n> ")
+                .append(entry.getKey())
+                .append(": ")
+                .append(entry.getValue().stream()
+                        .map(DraftItem::getShortDescription)
+                        .collect(Collectors.joining(", "))));
+        return summary.toString();
+    }
+
+    private static String factionName(String faction) {
+        FactionModel model = Mapper.getFaction(faction);
+        return model == null ? faction : model.getFactionName();
+    }
+
+    record ComponentChange(List<DraftItem> added, List<DraftItem> removed) {}
+}

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazHelp.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazHelp.java
@@ -1,0 +1,32 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.message.MessageHelper;
+
+class FrankenDrazHelp extends Subcommand {
+
+    FrankenDrazHelp() {
+        super("help", "Show FrankenDraz help");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        MessageHelper.sendMessageToEventChannel(event, """
+                ## FrankenDraz
+                Start FrankenDraz with `/franken start_franken_draft draft_mode: frankendraz`.
+
+                In FrankenDraz, players draft entire factions instead of individual faction components. Each player drafts 6 factions, 3 blue tiles, and 2 red tiles. Discordant Stars factions are included by default. The Obsidian and The Firmament are automatically banned.
+
+                After the draft is complete, each player gets category buttons in their cards info thread. Open a category to view the drafted components and choose which ones to add to the faction. Home systems and starting fleets are informational and must still be set up manually (for now).
+
+                The limits for components follow powered franken limits. (4 abilities, 3 faction techs, 1 of everything else)
+
+                Use the following post-draft commands in case of any issues:
+
+                `/frankendraz add_faction`
+                `/frankendraz remove_faction`
+                `/frankendraz swap_faction`
+                """);
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazRemoveFaction.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazRemoveFaction.java
@@ -1,0 +1,39 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.GameStateSubcommand;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+
+class FrankenDrazRemoveFaction extends GameStateSubcommand {
+
+    FrankenDrazRemoveFaction() {
+        super("remove_faction", "Remove a faction's components", true, true);
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION, "Faction to remove")
+                .setRequired(true)
+                .setAutoComplete(true));
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Player faction or color")
+                .setAutoComplete(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getGame();
+        Player player = getPlayer();
+        String faction = FrankenDrazFactionHelper.resolveFaction(
+                event.getOption(Constants.FACTION, null, OptionMapping::getAsString), event);
+        if (faction == null || !FrankenDrazFactionHelper.canManagePostDraftComponents(game, player, event)) {
+            return;
+        }
+
+        FrankenDrazFactionHelper.ComponentChange change =
+                FrankenDrazFactionHelper.removeFactionComponents(game, player, faction);
+        MessageHelper.sendMessageToEventChannel(
+                event, FrankenDrazFactionHelper.buildRemoveMessage(player, faction, change.removed()));
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazSwapFaction.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazSwapFaction.java
@@ -1,0 +1,49 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.GameStateSubcommand;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+
+class FrankenDrazSwapFaction extends GameStateSubcommand {
+
+    FrankenDrazSwapFaction() {
+        super("swap_faction", "Swap out a drafted faction", true, true);
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION, "Faction to remove")
+                .setRequired(true)
+                .setAutoComplete(true));
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION2, "Faction to add")
+                .setRequired(true)
+                .setAutoComplete(true));
+        addOptions(new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Player faction or color")
+                .setAutoComplete(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getGame();
+        Player player = getPlayer();
+        String removeFaction = FrankenDrazFactionHelper.resolveFaction(
+                event.getOption(Constants.FACTION, null, OptionMapping::getAsString), event);
+        String addFaction = FrankenDrazFactionHelper.resolveFaction(
+                event.getOption(Constants.FACTION2, null, OptionMapping::getAsString), event);
+        if (removeFaction == null
+                || addFaction == null
+                || !FrankenDrazFactionHelper.canManagePostDraftComponents(game, player, event)) {
+            return;
+        }
+
+        FrankenDrazFactionHelper.ComponentChange removeChange =
+                FrankenDrazFactionHelper.removeFactionComponents(game, player, removeFaction);
+        FrankenDrazFactionHelper.ComponentChange addChange =
+                FrankenDrazFactionHelper.addFactionComponents(game, player, addFaction);
+        MessageHelper.sendMessageToEventChannel(
+                event,
+                FrankenDrazFactionHelper.buildSwapMessage(player, removeFaction, addFaction, removeChange, addChange));
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1061,6 +1061,7 @@ public final class Constants {
     public static final String INCLUDE_OPTIONS = "include_options";
     public static final String CARDS_INFO = "cards_info";
     public static final String FRANKEN = "franken";
+    public static final String FRANKENDRAZ = "frankendraz";
     public static final String SHOW_GAME_AS_PLAYER = "show_game_as";
     public static final String CHECK_PRIVATE_COMMUNICATIONS = "check_private_communications";
 


### PR DESCRIPTION
Adds 1 command with 4 subcommands to help with issues and errors post-draft. They are only able to be run after a FrankenDraz draft has been completed.

`/frankendraz add_faction`
`/frankendraz remove_faction`
`/frankendraz swap_faction`

and one "help" command to explain the mode:

`/frankendraz help`

All command logic is isolated and does not interfere with any other franken commands.