### PR TITLE
FrankenDraz show components button UI updates

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/draft/FrankenButtonHandler.java
@@ -26,7 +26,6 @@ import ti4.draft.DraftItem;
 import ti4.draft.FrankenDrazDraft;
 import ti4.draft.InauguralSpliceFrankenDraft;
 import ti4.draft.TwilightsFallFrankenDraft;
-import ti4.draft.items.FactionDraftItem;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.ButtonHelper;
@@ -444,13 +443,10 @@ public class FrankenButtonHandler {
 
     @ButtonHandler(value = "frankenFactionComponents", save = false)
     private static void showFactionComponents(ButtonInteractionEvent event, Player player, String buttonID) {
-        String faction = buttonID.split(";")[1];
-        FactionDraftItem item = new FactionDraftItem(faction);
-        String msg =
-                "## " + item.getTitle(player.getGame()) + " Components\n" + item.getComponentList(player.getGame());
-        MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), msg);
-        MessageHelper.sendEphemeralMessageToEventChannel(
-                event, "Sent " + item.getShortDescription() + " components to your cards info thread.");
+        if (player.getGame().getActiveBagDraft() instanceof FrankenDrazDraft frankenDrazDraft) {
+            String faction = buttonID.split(";")[1];
+            frankenDrazDraft.sendFactionComponentCards(event, player, faction);
+        }
     }
 
     @ButtonHandler(value = "frankenDrazCategory", save = false)

--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -1,6 +1,8 @@
 package ti4.draft;
 
+import java.awt.Color;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -192,6 +194,31 @@ public class FrankenDrazDraft extends FrankenDraft {
                 player.getCardsInfoThread(),
                 "Choose a drafted component category to view. Additional components are added automatically. Optional Swaps will appear in their respective categories when expanded. Home systems and starting fleet must be added manually, as well as any additional or optional components added via these components. Category buttons are present for your convenience.",
                 getPostDraftCategoryButtons(player));
+    }
+
+    public void sendFactionComponentCards(ButtonInteractionEvent event, Player player, String faction) {
+        FactionDraftItem item = new FactionDraftItem(faction);
+        List<DraftItem> components = item.getComponents(player.getGame());
+        if (components.isEmpty()) {
+            MessageHelper.sendMessageToChannel(
+                    player.getCardsInfoThread(), "## " + item.getTitle(player.getGame()) + " Components\nNone.");
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "Sent " + item.getShortDescription() + " components to your cards info thread.");
+            return;
+        }
+
+        List<Color> accents = FrankenDraftBagService.getAccents();
+        MessageV2Builder builder = new MessageV2Builder(player.getCardsInfoThread());
+        builder.append("## " + item.getTitle(player.getGame()) + " Components");
+        for (DraftItem component : components) {
+            List<ContainerChildComponent> cardComponents = new ArrayList<>();
+            cardComponents.addAll(component.getTextDisplays(player.getGame(), player, true));
+            builder.append(Container.of(cardComponents).withAccentColor(accents.getFirst()));
+            Collections.rotate(accents, -1);
+        }
+        builder.send();
+        MessageHelper.sendEphemeralMessageToEventChannel(
+                event, "Sent " + item.getShortDescription() + " components to your cards info thread.");
     }
 
     public void sendPostDraftCategory(Player player, DraftCategory category) {


### PR DESCRIPTION
Updated FrankenDraz "Show Components" button during draft to show frankendraft-style component list in cards info thread instead of a basic list of draftable components.