### PR TITLE
Rebalance combat replay side bets

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayPromotionScoreBackfillCron.java
@@ -64,10 +64,16 @@ public class CombatReplayPromotionScoreBackfillCron {
         int updated = 0;
         int skipped = 0;
         for (CombatCandidateEntity candidate : candidateRepository.findByStatus(CombatCandidateStatus.RESOLVED)) {
-            if (recomputePromotionScore(candidate)) {
-                updated++;
-            } else {
+            try {
+                if (recomputePromotionScore(candidate)) {
+                    updated++;
+                } else {
+                    skipped++;
+                }
+            } catch (Exception e) {
                 skipped++;
+                BotLogger.warning(
+                        "Skipped combat replay promotion-score backfill for candidate " + candidate.getId() + ".", e);
             }
         }
 

--- a/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
+++ b/src/main/java/ti4/contest/replay/core/CombatContestSettings.java
@@ -184,7 +184,7 @@ public class CombatContestSettings {
         private double afbWhiffSelectionBias = 2.0;
         private double roundOneWhiffSelectionBias = 3.0;
         private double roundOneSlamSelectionBias = 1.5;
-        private double winnerOneHpPayoutMultiplier = 0.75;
+        private double winnerOneHpPayoutMultiplier = 0.5625;
         private String dynamicPayoutTiers = "0.20:4,0.10:5,0.05:8,0.025:12,0.01:20,0.005:30";
     }
 }

--- a/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
+++ b/src/main/java/ti4/contest/replay/core/CombatSideBetType.java
@@ -15,19 +15,19 @@ public enum CombatSideBetType {
     /** Current AFB side bet: player rolls AFB and scores zero hits. */
     AFB_WHIFF("AFB Whiff", UnitEmojis.destroyer, 0, 4),
     /** Current dynamic side bet: player scores zero hits in their first combat roll. */
-    ROUND_ONE_WHIFF("R1 Whiff", DiceEmojis.d10red_1, 0, 10),
+    ROUND_ONE_WHIFF("R1 Whiff", DiceEmojis.d10red_1, 0, 20),
     /** Current dynamic side bet: every die in player's first combat roll hits. */
     ROUND_ONE_SLAM("R1 Slam", DiceEmojis.d10green_0, 0, 30),
     /** Current tracked interaction side bet. */
-    MORALE_BOOST("Plays Morale Boost", CardEmojis.ActionCard, 0, 12),
+    MORALE_BOOST("Plays Morale Boost", CardEmojis.ActionCard, 0, 16),
     /** Current tracked interaction side bet. */
     SHIELDS_HOLDING("Plays Shields Holding", CardEmojis.ActionCard, 0, 8),
     /** Current tracked interaction side bet. */
     DIRECT_HIT("Plays Direct Hit", CardEmojis.ActionCard, 0, 8),
     /** Current tracked interaction side bet. */
-    FIGHTER_PROTOTYPE("Plays Fighter Prototype", CardEmojis.ActionCard, 0, 24),
+    FIGHTER_PROTOTYPE("Plays Fighter Prototype", CardEmojis.ActionCard, 0, 32),
     /** Current dynamic resolution side bet. */
-    WINNER_ONE_HP("Wins On 1️⃣ HP", "1️⃣", 0, 35);
+    WINNER_ONE_HP("Wins On 1️⃣ HP", "1️⃣", 0, 26);
 
     private final String label;
     private final TI4Emoji emoji;

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -48,6 +48,8 @@ import ti4.service.combat.CombatUnitSelectionHelper;
 public class CombatReplayService {
 
     private static final Pattern SYSTEM_TILE_PATTERN = Pattern.compile("-system-([^-]+)-");
+    private static final double ENDING_TENSION_SURVIVAL_THRESHOLD = 0.20;
+    private static final double ENDING_TENSION_CLOSE_FIGHT_SCORE = 0.2;
     private static final Set<CombatCandidateStatus> OPEN_CANDIDATE_STATUSES =
             EnumSet.of(CombatCandidateStatus.TRACKING, CombatCandidateStatus.PENDING_RESOLUTION);
     private static final ThreadLocal<PreInteractionSnapshot> preInteractionSnapshot = new ThreadLocal<>();
@@ -647,8 +649,13 @@ public class CombatReplayService {
         double winnerSurvivalRatio = safeRatio(winnerRemainingHp, winnerInitialHp);
         double roundScore = Math.sqrt(Math.max(0, roundsObserved)) * sizeFactor;
         double openingBalanceScore = 0.9 * Math.pow(strengthRatio, 3.0);
-        double endingTensionScore = winnerRemainingHp <= 0 ? 0.0 : 5.0 * Math.exp(-6.0 * winnerSurvivalRatio);
+        double endingTensionScore = endingTensionScore(winnerRemainingHp, winnerSurvivalRatio);
         return roundScore + openingBalanceScore + endingTensionScore;
+    }
+
+    private static double endingTensionScore(double winnerRemainingHp, double winnerSurvivalRatio) {
+        if (winnerRemainingHp <= 0 || winnerSurvivalRatio <= 0) return 0.0;
+        return winnerSurvivalRatio <= ENDING_TENSION_SURVIVAL_THRESHOLD ? ENDING_TENSION_CLOSE_FIGHT_SCORE : 0.0;
     }
 
     public static double computeDrawPromotionScore(InitialCombatStats initialStats, int roundsObserved) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplaySideBetPayoutService.java
@@ -90,9 +90,20 @@ public class CombatReplaySideBetPayoutService {
     private int dynamicPayout(CombatSideBetType betType, double probability) {
         double adjustedProbability = Math.min(1.0, probability * selectionBiasMultiplier(betType));
         for (PayoutTier tier : dynamicPayoutTiers()) {
-            if (adjustedProbability >= tier.minimumProbability()) return Math.min(tier.payout(), maxDynamicPayout());
+            if (adjustedProbability >= tier.minimumProbability()) {
+                return boundedDynamicPayout(betType, tier.payout());
+            }
         }
-        return maxDynamicPayout();
+        return boundedDynamicPayout(betType, maxDynamicPayout());
+    }
+
+    private int boundedDynamicPayout(CombatSideBetType betType, int payout) {
+        int minimumPayout =
+                switch (betType) {
+                    case ROUND_ONE_WHIFF -> 20;
+                    default -> 1;
+                };
+        return Math.min(maxDynamicPayout(), Math.max(minimumPayout, payout));
     }
 
     private double selectionBiasMultiplier(CombatSideBetType betType) {

--- a/src/main/resources/config/combat-contest-dev.yml
+++ b/src/main/resources/config/combat-contest-dev.yml
@@ -35,7 +35,7 @@ sideBets:
   afbWhiffSelectionBias: 2.0
   roundOneWhiffSelectionBias: 3.0
   roundOneSlamSelectionBias: 3.0
-  winnerOneHpPayoutMultiplier: 0.75
+  winnerOneHpPayoutMultiplier: 0.5625
   dynamicPayoutTiers: "0.20:4,0.10:5,0.05:8,0.025:12,0.01:20,0.005:30"
 
 initialIndividualPoints: 100

--- a/src/main/resources/config/combat-contest-prod.yml
+++ b/src/main/resources/config/combat-contest-prod.yml
@@ -35,7 +35,7 @@ sideBets:
   afbWhiffSelectionBias: 2.0
   roundOneWhiffSelectionBias: 3.0
   roundOneSlamSelectionBias: 3.0
-  winnerOneHpPayoutMultiplier: 0.75
+  winnerOneHpPayoutMultiplier: 0.5625
   dynamicPayoutTiers: "0.20:4,0.10:5,0.05:8,0.025:12,0.01:20,0.005:30"
 
 initialIndividualPoints: 100

--- a/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
+++ b/src/test/java/ti4/contest/replay/core/CombatSideBetTypeTest.java
@@ -20,13 +20,13 @@ class CombatSideBetTypeTest {
         Map<CombatSideBetType, Integer> expectedPayouts = Map.of(
                 CombatSideBetType.AFB_SKIPPED, 6,
                 CombatSideBetType.AFB_WHIFF, 4,
-                CombatSideBetType.ROUND_ONE_WHIFF, 10,
+                CombatSideBetType.ROUND_ONE_WHIFF, 20,
                 CombatSideBetType.ROUND_ONE_SLAM, 30,
-                CombatSideBetType.MORALE_BOOST, 12,
+                CombatSideBetType.MORALE_BOOST, 16,
                 CombatSideBetType.SHIELDS_HOLDING, 8,
                 CombatSideBetType.DIRECT_HIT, 8,
-                CombatSideBetType.FIGHTER_PROTOTYPE, 24,
-                CombatSideBetType.WINNER_ONE_HP, 35);
+                CombatSideBetType.FIGHTER_PROTOTYPE, 32,
+                CombatSideBetType.WINNER_ONE_HP, 26);
 
         expectedPayouts.forEach((type, expectedPayout) -> assertEquals(expectedPayout, type.profitPoints()));
     }

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -66,8 +66,8 @@ class CombatReplayServiceTest {
                 "muaat",
                 4);
 
-        assertEquals(2.2033, blowoutScore, 0.0001);
-        assertEquals(3.6705, squeakerScore, 0.0001);
+        assertEquals(2.1117, blowoutScore, 0.0001);
+        assertEquals(2.6971, squeakerScore, 0.0001);
         assertTrue(squeakerScore > blowoutScore);
     }
 
@@ -84,6 +84,37 @@ class CombatReplayServiceTest {
                 candidate, initialStats, attackerRemaining, defenderRemaining, "yin", 2);
 
         assertEquals(attackerWinScore, defenderWinScore, 0.0001);
+    }
+
+    @Test
+    void promotionScoreUsesFlatCloseSurvivalBonus() {
+        CombatCandidateEntity candidate = candidate("sol", "yin");
+        CombatReplayService.InitialCombatStats initialStats = initialStats(12, 12, 20, 20);
+
+        double oneHpScore = CombatReplayService.computePromotionScore(
+                candidate,
+                initialStats,
+                new LazaxCombatSupport.FleetStrength(4.0, 1.0, 0.0),
+                new LazaxCombatSupport.FleetStrength(0.0, 0.0, 0.0),
+                "sol",
+                3);
+        double fourHpScore = CombatReplayService.computePromotionScore(
+                candidate,
+                initialStats,
+                new LazaxCombatSupport.FleetStrength(4.0, 4.0, 0.0),
+                new LazaxCombatSupport.FleetStrength(0.0, 0.0, 0.0),
+                "sol",
+                3);
+        double fiveHpScore = CombatReplayService.computePromotionScore(
+                candidate,
+                initialStats,
+                new LazaxCombatSupport.FleetStrength(4.0, 5.0, 0.0),
+                new LazaxCombatSupport.FleetStrength(0.0, 0.0, 0.0),
+                "sol",
+                3);
+
+        assertEquals(oneHpScore, fourHpScore, 0.0001);
+        assertEquals(0.2, fourHpScore - fiveHpScore, 0.0001);
     }
 
     @Test
@@ -108,8 +139,8 @@ class CombatReplayServiceTest {
         double snapshotScore = CombatReplayService.computePromotionScore(
                 candidate, replaySnapshotStats, attackerRemaining, defenderRemaining, "hacan", 3);
 
-        assertEquals(2.2074, staleScore, 0.0001);
-        assertEquals(0.9888, snapshotScore, 0.0001);
+        assertEquals(2.1386, staleScore, 0.0001);
+        assertEquals(0.9199, snapshotScore, 0.0001);
         assertTrue(snapshotScore < staleScore);
     }
 

--- a/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplaySideBetPayoutServiceTest.java
@@ -39,7 +39,7 @@ class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
 
         int payout = service.offeredPayout(contest, candidate(30, 30), CombatSideBetType.WINNER_ONE_HP, "sol");
 
-        assertEquals(35, payout);
+        assertEquals(26, payout);
     }
 
     @Test
@@ -49,7 +49,7 @@ class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
 
         int payout = service.offeredPayout(contest, candidate, CombatSideBetType.ROUND_ONE_WHIFF, "sol");
 
-        assertEquals(4, payout);
+        assertEquals(20, payout);
         verifyNoInteractions(eventRepository);
     }
 
@@ -135,7 +135,7 @@ class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
 
         int payout = service.offeredPayout(contest, candidate, CombatSideBetType.ROUND_ONE_WHIFF, "sol");
 
-        assertEquals(10, payout);
+        assertEquals(20, payout);
         verifyNoInteractions(eventRepository);
     }
 
@@ -147,7 +147,7 @@ class CombatReplaySideBetPayoutServiceTest extends BaseTi4Test {
 
         int payout = service.offeredPayout(oddsContest(), candidate, CombatSideBetType.WINNER_ONE_HP, "sol");
 
-        assertEquals(5, payout);
+        assertEquals(3, payout);
         verifyNoInteractions(eventRepository);
     }
 


### PR DESCRIPTION
## Summary
- Replace the monotonic winner-survival promotion bonus with a flat +0.2 close-fight bonus when the winner survives at 20% HP or less, reducing exact-1HP selection bias without promoting 35% HP finishes specifically.
- Increase underperforming side-bet payouts for R1 Whiff, Morale Boost, and Fighter Prototype, and reduce WINNER_ONE_HP payouts by about 25%.
- Make the promotion-score backfill resilient per candidate so missing or bad replay snapshots are skipped without aborting the cron.

## Test Plan
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) PATH="$JAVA_HOME/bin:$PATH" mvn -q -Dtest=CombatReplayServiceTest,CombatSideBetTypeTest,CombatReplaySideBetPayoutServiceTest,CombatContestSettingsTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) PATH="$JAVA_HOME/bin:$PATH" mvn -q test`