### PR TITLE
Milty draft source settings

### DIFF
--- a/src/main/java/ti4/helpers/settingsFramework/menus/AndcatReferenceCardsDraftableSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/AndcatReferenceCardsDraftableSettings.java
@@ -73,7 +73,7 @@ public class AndcatReferenceCardsDraftableSettings extends SettingsMenu {
         // Load JSON if applicable
         if (!(json == null
                 || !json.has("menuId")
-                || !MENU_ID.equals(json.get("menuId").asText("")))) {
+                || !MENU_ID.equals(json.get("menuId").asString("")))) {
             numPackages.initialize(json.get("numPackages"));
             banFactions.initialize(json.get("banFactions"));
 

--- a/src/main/java/ti4/helpers/settingsFramework/menus/DeckSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/DeckSettings.java
@@ -89,7 +89,7 @@ public class DeckSettings extends SettingsMenu {
         List<String> historicIDs = new ArrayList<>(List.of("decks"));
         if (json != null
                 && json.has("menuId")
-                && historicIDs.contains(json.get("menuId").asText(""))) {
+                && historicIDs.contains(json.get("menuId").asString(""))) {
             stage1.initialize(json.get("stage1"));
             stage2.initialize(json.get("stage2"));
             secrets.initialize(json.get("secrets"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/DraftSystemSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/DraftSystemSettings.java
@@ -91,7 +91,7 @@ public class DraftSystemSettings extends SettingsMenu {
         // Load JSON if applicable
         if (json != null
                 && json.has("menuId")
-                && MENU_ID.equals(json.get("menuId").asText(""))) {
+                && MENU_ID.equals(json.get("menuId").asString(""))) {
             draftOrchestrator.initialize(json.get("draftOrchestrator"));
             draftablesList.initialize(json.get("draftablesList"));
             preset = json.get("preset") != null ? json.get("preset").asText(null) : null;

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FactionDraftableSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FactionDraftableSettings.java
@@ -67,7 +67,7 @@ public class FactionDraftableSettings extends SettingsMenu {
         // Load JSON if applicable
         if (!(json == null
                 || !json.has("menuId")
-                || !MENU_ID.equals(json.get("menuId").asText("")))) {
+                || !MENU_ID.equals(json.get("menuId").asString("")))) {
             numFactions.initialize(json.get("numFactions"));
             banFactions.initialize(json.get("banFactions"));
             priFactions.initialize(json.get("priFactions"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FactionSourceSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FactionSourceSettings.java
@@ -1,0 +1,158 @@
+package ti4.helpers.settingsFramework.menus;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import ti4.helpers.settingsFramework.settings.IntegerRangeSetting;
+import ti4.helpers.settingsFramework.settings.SettingInterface;
+import ti4.image.Mapper;
+import ti4.model.Source.ComponentSource;
+import tools.jackson.databind.JsonNode;
+
+@Getter
+@JsonIgnoreProperties("messageId")
+public class FactionSourceSettings extends SettingsMenu {
+
+    private static final List<ComponentSource> LOGICAL_SOURCES = List.of(
+            ComponentSource.base,
+            ComponentSource.pok,
+            ComponentSource.ds,
+            ComponentSource.thunders_edge,
+            ComponentSource.eronous,
+            ComponentSource.ignis_aurora,
+            ComponentSource.balacasi);
+
+    private final IntegerRangeSetting base;
+    private final IntegerRangeSetting pok;
+    private final IntegerRangeSetting ds;
+    private final IntegerRangeSetting thundersEdge;
+    private final IntegerRangeSetting eronous;
+    private final IntegerRangeSetting ignisAurora;
+    private final IntegerRangeSetting whispers;
+
+    FactionSourceSettings(JsonNode json, SettingsMenu parent) {
+        super(
+                "factionSources",
+                "Faction Expansion Limits",
+                "Set min/max factions from each expansion in the draft pool",
+                parent);
+
+        int baseCount = countFactions(ComponentSource.base);
+        int pokCount = countFactions(
+                ComponentSource.pok,
+                ComponentSource.codex1,
+                ComponentSource.codex2,
+                ComponentSource.codex3,
+                ComponentSource.codex4);
+        int dsCount = countFactions(ComponentSource.ds);
+        int teCount = countFactions(ComponentSource.thunders_edge);
+        int eronousCount = countFactions(ComponentSource.eronous);
+        int ignisCount = countFactions(ComponentSource.ignis_aurora);
+        int balacasiCount = countFactions(ComponentSource.balacasi);
+
+        base = new IntegerRangeSetting(
+                "FactionBase", "Base Game factions", 0, 0, baseCount, baseCount, 0, baseCount, 1);
+        pok = new IntegerRangeSetting("FactionPoK", "PoK factions", 0, 0, pokCount, pokCount, 0, pokCount, 1);
+        ds = new IntegerRangeSetting("FactionDS", "Discordant Stars factions", 0, 0, dsCount, dsCount, 0, dsCount, 1);
+        thundersEdge =
+                new IntegerRangeSetting("FactionTE", "Thunder's Edge factions", 0, 0, teCount, teCount, 0, teCount, 1);
+        eronous = new IntegerRangeSetting(
+                "FactionEronous", "Eronous factions", 0, 0, eronousCount, eronousCount, 0, eronousCount, 1);
+        ignisAurora = new IntegerRangeSetting(
+                "FactionIgnis", "Ignis Aurora factions", 0, 0, ignisCount, ignisCount, 0, ignisCount, 1);
+        whispers = new IntegerRangeSetting(
+                "FactionWhispers",
+                "Whispers from the Void factions",
+                0,
+                0,
+                balacasiCount,
+                balacasiCount,
+                0,
+                balacasiCount,
+                1);
+
+        if (json != null && json.has("factionSourceSettings")) json = json.get("factionSourceSettings");
+        if (json != null
+                && json.has("menuId")
+                && "factionSources".equals(json.get("menuId").asString(""))) {
+            base.initialize(json.get("base"));
+            pok.initialize(json.get("pok"));
+            ds.initialize(json.get("ds"));
+            thundersEdge.initialize(json.get("thundersEdge"));
+            eronous.initialize(json.get("eronous"));
+            ignisAurora.initialize(json.get("ignisAurora"));
+            whispers.initialize(json.get("whispers"));
+        }
+    }
+
+    @Override
+    boolean showInParentSummary() {
+        return false;
+    }
+
+    @Override
+    public List<SettingInterface> settings() {
+        MiltySettings ms = getMiltySettings();
+        if (ms == null) return List.of();
+        List<ComponentSource> enabled = ms.getSourceSettings().getFactionSources();
+        return LOGICAL_SOURCES.stream()
+                .filter(s -> isEnabled(enabled, s))
+                .map(this::settingFor)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    public Map<ComponentSource, int[]> getConstraintMap() {
+        MiltySettings ms = getMiltySettings();
+        if (ms == null) return Map.of();
+        List<ComponentSource> enabled = ms.getSourceSettings().getFactionSources();
+        Map<ComponentSource, int[]> map = new EnumMap<>(ComponentSource.class);
+        for (ComponentSource src : LOGICAL_SOURCES) {
+            if (!isEnabled(enabled, src)) continue;
+            IntegerRangeSetting s = settingFor(src);
+            if (s != null) map.put(src, new int[] {s.getValLow(), s.getValHigh()});
+        }
+        return map;
+    }
+
+    private boolean isEnabled(List<ComponentSource> enabled, ComponentSource logical) {
+        if (logical == ComponentSource.pok)
+            return enabled.contains(ComponentSource.pok)
+                    || enabled.stream().anyMatch(s -> s.name().startsWith("codex"));
+        return enabled.contains(logical);
+    }
+
+    private IntegerRangeSetting settingFor(ComponentSource logical) {
+        return switch (logical) {
+            case base -> base;
+            case pok -> pok;
+            case ds -> ds;
+            case thunders_edge -> thundersEdge;
+            case eronous -> eronous;
+            case ignis_aurora -> ignisAurora;
+            case balacasi -> whispers;
+            default -> null;
+        };
+    }
+
+    private MiltySettings getMiltySettings() {
+        if (parent instanceof PlayerFactionSettings pfs && pfs.parent instanceof MiltySettings ms) {
+            return ms;
+        }
+        return null;
+    }
+
+    private static int countFactions(ComponentSource... sources) {
+        List<ComponentSource> sourceList = List.of(sources);
+        return (int) Mapper.getFactionsValues().stream()
+                .filter(f -> sourceList.contains(f.getSource()))
+                .filter(f -> !f.getAlias().contains("obsidian"))
+                .filter(f -> !f.getAlias().contains("neutral"))
+                .filter(f -> !f.getAlias().contains("keleres") || "keleresm".equals(f.getAlias()))
+                .count();
+    }
+}

--- a/src/main/java/ti4/helpers/settingsFramework/menus/GameSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/GameSettings.java
@@ -108,7 +108,7 @@ public class GameSettings extends SettingsMenu {
         List<String> historicIDs = new ArrayList<>(List.of("game"));
         if (json != null
                 && json.has("menuId")
-                && historicIDs.contains(json.get("menuId").asText(""))) {
+                && historicIDs.contains(json.get("menuId").asString(""))) {
             pointTotal.initialize(json.get("pointTotal"));
             stage1s.initialize(json.get("stage1s"));
             stage2s.initialize(json.get("stage2s"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/GameSetupSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/GameSetupSettings.java
@@ -96,7 +96,7 @@ public class GameSetupSettings extends SettingsMenu {
         // Load JSON if applicable
         if (json != null
                 && json.has("menuId")
-                && MENU_ID.equals(json.get("menuId").asText(""))) {
+                && MENU_ID.equals(json.get("menuId").asString(""))) {
             pointTotal.initialize(json.get("pointTotal"));
             stage1s.initialize(json.get("stage1s"));
             stage2s.initialize(json.get("stage2s"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/MahactKingDraftableSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/MahactKingDraftableSettings.java
@@ -57,7 +57,7 @@ public class MahactKingDraftableSettings extends SettingsMenu {
         // Load JSON if applicable
         if (!(json == null
                 || !json.has("menuId")
-                || !MENU_ID.equals(json.get("menuId").asText("")))) {
+                || !MENU_ID.equals(json.get("menuId").asString("")))) {
             numFactions.initialize(json.get("numFactions"));
             banFactions.initialize(json.get("banFactions"));
             priFactions.initialize(json.get("priFactions"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/MantisTileDraftableSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/MantisTileDraftableSettings.java
@@ -62,7 +62,7 @@ public class MantisTileDraftableSettings extends SettingsMenu {
         // Load JSON if applicable
         if (json == null
                 || !json.has("menuId")
-                || !MENU_ID.equals(json.get("menuId").asText(""))) {
+                || !MENU_ID.equals(json.get("menuId").asString(""))) {
             return;
         }
 

--- a/src/main/java/ti4/helpers/settingsFramework/menus/MiltySettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/MiltySettings.java
@@ -68,7 +68,7 @@ public class MiltySettings extends SettingsMenu {
         List<String> historicIDs = List.of("milty", "main");
         if (json != null
                 && json.has("menuId")
-                && historicIDs.contains(json.get("menuId").asText(""))) {
+                && historicIDs.contains(json.get("menuId").asString(""))) {
             draftMode.initialize(json.get("draftMode"));
         }
 

--- a/src/main/java/ti4/helpers/settingsFramework/menus/MiltySliceDraftableSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/MiltySliceDraftableSettings.java
@@ -63,7 +63,7 @@ public class MiltySliceDraftableSettings extends SettingsMenu {
         // Verify this is the correct JSON node and continue initialization
         if (json != null
                 && json.has("menuId")
-                && MENU_ID.equals(json.get("menuId").asText(""))) {
+                && MENU_ID.equals(json.get("menuId").asString(""))) {
             minimumRes.initialize(json.get("minimumRes"));
             minimumInf.initialize(json.get("minimumInf"));
             totalValue.initialize(json.get("totalValue"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/NucleusSliceDraftableSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/NucleusSliceDraftableSettings.java
@@ -110,7 +110,7 @@ public class NucleusSliceDraftableSettings extends SettingsMenu {
         // Load JSON if applicable
         if (json == null
                 || !json.has("menuId")
-                || !MENU_ID.equals(json.get("menuId").asText(""))) {
+                || !MENU_ID.equals(json.get("menuId").asString(""))) {
             return;
         }
 

--- a/src/main/java/ti4/helpers/settingsFramework/menus/PlayerFactionSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/PlayerFactionSettings.java
@@ -35,6 +35,7 @@ public class PlayerFactionSettings extends SettingsMenu {
     private ListSetting<Player> gamePlayers;
     private final ListSetting<FactionModel> banFactions;
     private final ListSetting<FactionModel> priFactions;
+    private final FactionSourceSettings factionSourceSettings;
 
     // ---------------------------------------------------------------------------------------------------------------------------------
     // Constructor & Initialization
@@ -94,17 +95,24 @@ public class PlayerFactionSettings extends SettingsMenu {
         List<String> historicIDs = new ArrayList<>(List.of("players"));
         if (json != null
                 && json.has("menuId")
-                && historicIDs.contains(json.get("menuId").asText(""))) {
+                && historicIDs.contains(json.get("menuId").asString(""))) {
             presetDraftOrder.initialize(json.get("presetDraftOrder"));
             gamePlayers.initialize(json.get("gamePlayers"));
             banFactions.initialize(json.get("banFactions"));
             priFactions.initialize(json.get("priFactions"));
         }
+
+        factionSourceSettings = new FactionSourceSettings(json, this);
     }
 
     // ---------------------------------------------------------------------------------------------------------------------------------
     // Overridden Implementation
     // ---------------------------------------------------------------------------------------------------------------------------------
+    @Override
+    protected List<SettingsMenu> categories() {
+        return List.of(factionSourceSettings);
+    }
+
     @Override
     public List<SettingInterface> settings() {
         List<SettingInterface> ls = new ArrayList<>();

--- a/src/main/java/ti4/helpers/settingsFramework/menus/PublicSnakeDraftSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/PublicSnakeDraftSettings.java
@@ -50,7 +50,7 @@ public class PublicSnakeDraftSettings extends SettingsMenu {
         // Load JSON if applicable
         if (!(json == null
                 || !json.has("menuId")
-                || !MENU_ID.equals(json.get("menuId").asText("")))) {
+                || !MENU_ID.equals(json.get("menuId").asString("")))) {
             presetDraftOrder.initialize(json.get("presetDraftOrder"));
 
             if (json.has("orderedPlayerIds")) {

--- a/src/main/java/ti4/helpers/settingsFramework/menus/SettingsMenu.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/SettingsMenu.java
@@ -72,6 +72,10 @@ public abstract class SettingsMenu {
         return Collections.emptyList();
     }
 
+    boolean showInParentSummary() {
+        return true;
+    }
+
     List<Button> specialButtons() {
         return Collections.emptyList();
     }
@@ -118,15 +122,17 @@ public abstract class SettingsMenu {
         }
         if (!enabledSettings().isEmpty()) sb.append('\n'); // extra line for formatting
 
-        if (!categories().isEmpty()) {
+        List<SettingsMenu> summarized =
+                categories().stream().filter(SettingsMenu::showInParentSummary).toList();
+        if (!summarized.isEmpty()) {
             List<String> catStrings = new ArrayList<>();
-            for (SettingsMenu cat : categories()) {
+            for (SettingsMenu cat : summarized) {
                 catStrings.add(cat.shortSummaryString(false));
             }
             String catStr = String.join("\n\n", catStrings);
             if (sb.length() + catStr.length() > 1999) {
                 List<String> shorterCatStrings = new ArrayList<>();
-                for (SettingsMenu cat : categories()) {
+                for (SettingsMenu cat : summarized) {
                     shorterCatStrings.add(cat.shortSummaryString(true));
                 }
                 catStr = String.join("\n\n", shorterCatStrings);

--- a/src/main/java/ti4/helpers/settingsFramework/menus/SliceDraftableSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/SliceDraftableSettings.java
@@ -98,7 +98,7 @@ public class SliceDraftableSettings extends SettingsMenu {
         // Load JSON if applicable
         if (!(json == null
                 || !json.has("menuId")
-                || !MENU_ID.equals(json.get("menuId").asText("")))) {
+                || !MENU_ID.equals(json.get("menuId").asString("")))) {
             numSlices.initialize(json.get("numSlices"));
             mapTemplate.initialize(json.get("mapTemplate"));
             mapGenerationMode.initialize(json.get("mapGenerationMode"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/SliceGenerationSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/SliceGenerationSettings.java
@@ -89,7 +89,7 @@ public class SliceGenerationSettings extends SettingsMenu {
         List<String> historicIDs = new ArrayList<>(List.of("slice"));
         if (json != null
                 && json.has("menuId")
-                && historicIDs.contains(json.get("menuId").asText(""))) {
+                && historicIDs.contains(json.get("menuId").asString(""))) {
             numSlices.initialize(json.get("numSlices"));
             numFactions.initialize(json.get("numFactions"));
             minimumRes.initialize(json.get("minimumRes"));

--- a/src/main/java/ti4/helpers/settingsFramework/menus/SourceSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/SourceSettings.java
@@ -38,6 +38,7 @@ public class SourceSettings extends SettingsMenu {
     private final BooleanSetting eronous;
     private final BooleanSetting actionCardDeck2;
     private final BooleanSetting teDemo;
+    private final BooleanSetting whispers;
 
     // ---------------------------------------------------------------------------------------------------------------------------------
     // Constructor & Initialization
@@ -63,6 +64,7 @@ public class SourceSettings extends SettingsMenu {
                 "Ignis Aurora Mod",
                 game.getTechnologyDeckID().toLowerCase().contains("baldrick"));
         eronous = new BooleanSetting("Eronous", "Eronous Tiles", false);
+        whispers = new BooleanSetting("WhispersVoid", "Whispers from the Void", false);
         actionCardDeck2 = new BooleanSetting("ActionCardDeck2", "Action Card Deck 2", game.isAcd2());
         // Emojis
         base.setEmoji(SourceEmojis.TI4BaseGame);
@@ -96,6 +98,7 @@ public class SourceSettings extends SettingsMenu {
             absol.initialize(json.get("absol"));
             ignis.initialize(json.get("ignis"));
             eronous.initialize(json.get("eronous"));
+            whispers.initialize(json.get("whispers"));
             actionCardDeck2.initialize(json.get("actionCardDeck2"));
         }
         base.setEditable(false);
@@ -117,6 +120,7 @@ public class SourceSettings extends SettingsMenu {
         ls.add(absol);
         ls.add(ignis);
         ls.add(eronous);
+        ls.add(whispers);
         ls.add(actionCardDeck2);
         return ls;
     }
@@ -161,6 +165,7 @@ public class SourceSettings extends SettingsMenu {
         if (teDemo.isVal()) sources.add(ComponentSource.thunders_edge);
         if (eronous.isVal()) sources.add(ComponentSource.eronous);
         if (ignis.isVal()) sources.add(ComponentSource.ignis_aurora);
+        if (whispers.isVal()) sources.add(ComponentSource.balacasi);
         return sources;
     }
 

--- a/src/main/java/ti4/helpers/settingsFramework/menus/SourceSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/SourceSettings.java
@@ -88,7 +88,7 @@ public class SourceSettings extends SettingsMenu {
         List<String> historicIDs = new ArrayList<>(List.of("source"));
         if (json != null
                 && json.has("menuId")
-                && historicIDs.contains(json.get("menuId").asText(""))) {
+                && historicIDs.contains(json.get("menuId").asString(""))) {
             base.initialize(json.get("base"));
             pok.initialize(json.get("pok"));
             codexes.initialize(json.get("codexes"));

--- a/src/main/java/ti4/service/milty/MiltyDraftSpec.java
+++ b/src/main/java/ti4/service/milty/MiltyDraftSpec.java
@@ -2,6 +2,7 @@ package ti4.service.milty;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import ti4.game.Game;
 import ti4.helpers.settingsFramework.menus.GameSettings;
@@ -18,6 +19,7 @@ public class MiltyDraftSpec {
     public List<String> playerIDs, bannedFactions, priorityFactions, playerDraftOrder;
     public MapTemplateModel template;
     public List<Source.ComponentSource> tileSources, factionSources;
+    public Map<Source.ComponentSource, int[]> sourceConstraints;
     public Integer numSlices, numFactions;
 
     // slice generation settings
@@ -85,6 +87,7 @@ public class MiltyDraftSpec {
         SourceSettings sources = settings.getSourceSettings();
         specs.tileSources = sources.getTileSources();
         specs.factionSources = sources.getFactionSources();
+        specs.sourceConstraints = pfSettings.getFactionSourceSettings().getConstraintMap();
 
         if (sliceSettings.getParsedSlices() != null) {
             specs.presetSlices = sliceSettings.getParsedSlices();

--- a/src/main/java/ti4/service/milty/MiltyService.java
+++ b/src/main/java/ti4/service/milty/MiltyService.java
@@ -3,7 +3,9 @@ package ti4.service.milty;
 import java.awt.Point;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -114,7 +116,41 @@ public class MiltyService {
                         || "keleresm".equals(f.getAlias())) // Limit the pool to only 1 keleres flavor
                 .map(FactionModel::getAlias)
                 .toList());
-        List<String> factionDraft = createFactionDraft(specs.numFactions, unbannedFactions, specs.priorityFactions);
+        if (specs.sourceConstraints != null && !specs.sourceConstraints.isEmpty()) {
+            Map<ComponentSource, Long> actualBySource = unbannedFactions.stream()
+                    .filter(f -> Mapper.getFaction(f) != null)
+                    .collect(Collectors.groupingBy(
+                            f -> logicalFactionSource(Mapper.getFaction(f).getSource()), Collectors.counting()));
+            long unconstrained = unbannedFactions.stream()
+                    .filter(f -> Mapper.getFaction(f) != null)
+                    .filter(f -> !specs.sourceConstraints.containsKey(
+                            logicalFactionSource(Mapper.getFaction(f).getSource())))
+                    .count();
+            int sumMins = 0, sumMaxes = (int) unconstrained;
+            for (Map.Entry<ComponentSource, int[]> e : specs.sourceConstraints.entrySet()) {
+                int actual = actualBySource.getOrDefault(e.getKey(), 0L).intValue();
+                sumMins += Math.min(e.getValue()[0], actual);
+                sumMaxes += Math.min(e.getValue()[1], actual);
+            }
+            if (sumMins > specs.numFactions) {
+                MessageHelper.sendMessageToChannel(
+                        event.getMessageChannel(),
+                        "Faction source minimums sum to **" + sumMins + "**, which exceeds the draft pool size of **"
+                                + specs.numFactions + "**. Reduce the minimums before starting.");
+                return "Could not start milty draft, fix the error and try again";
+            }
+            if (sumMaxes < specs.numFactions) {
+                MessageHelper.sendMessageToChannel(
+                        event.getMessageChannel(),
+                        "Faction source maximums sum to **" + sumMaxes
+                                + "**, which is less than the draft pool size of **" + specs.numFactions
+                                + "**. Increase the maximums before starting.");
+                return "Could not start milty draft, fix the error and try again";
+            }
+        }
+
+        List<String> factionDraft = createFactionDraft(
+                specs.numFactions, unbannedFactions, specs.priorityFactions, specs.sourceConstraints);
         draftManager.setFactionDraft(factionDraft);
 
         // validate slice count + sources
@@ -203,24 +239,99 @@ public class MiltyService {
         draftManager.setPlayers(players);
     }
 
+    /**
+     * Builds the faction draft pool.
+     * - Banned factions are excluded before this is called (not in {@code factions}).
+     * - Priority factions ({@code firstFactions}) bypass source constraints and are added first.
+     * - Per-source constraints cap/guarantee the remaining slots per expansion.
+     * - If constraints is null/empty, falls back to the original unconstrained shuffle.
+     */
     private static List<String> createFactionDraft(
-            int factionCount, List<String> factions, List<String> firstFactions) {
-        List<String> randomOrder = new ArrayList<>(firstFactions);
-        Collections.shuffle(randomOrder);
-        Collections.shuffle(factions);
-        randomOrder.addAll(factions);
-
-        int i = 0;
-        List<String> output = new ArrayList<>();
-        while (output.size() < factionCount) {
-            if (i >= randomOrder.size()) return output;
-            String f = randomOrder.get(i);
-            i++;
-            if (output.contains(f)) continue;
-            if (!factions.contains(f)) continue;
-            output.add(f);
+            int factionCount,
+            List<String> factions,
+            List<String> firstFactions,
+            Map<ComponentSource, int[]> constraints) {
+        if (constraints == null || constraints.isEmpty()) {
+            List<String> randomOrder = new ArrayList<>(firstFactions);
+            Collections.shuffle(randomOrder);
+            Collections.shuffle(factions);
+            randomOrder.addAll(factions);
+            List<String> output = new ArrayList<>();
+            int i = 0;
+            while (output.size() < factionCount) {
+                if (i >= randomOrder.size()) return output;
+                String f = randomOrder.get(i++);
+                if (!output.contains(f) && factions.contains(f)) output.add(f);
+            }
+            return output;
         }
-        return output;
+
+        // Priority factions bypass source constraints; add all eligible ones first
+        List<String> output = new ArrayList<>();
+        for (String pf : firstFactions) {
+            if (factions.contains(pf) && !output.contains(pf)) output.add(pf);
+        }
+
+        // Count priority factions per logical source so effective min/max accounts for them
+        Map<ComponentSource, Integer> priorityCountBySource = new HashMap<>();
+        for (String pf : output) {
+            FactionModel m = Mapper.getFaction(pf);
+            if (m == null) continue;
+            priorityCountBySource.merge(logicalFactionSource(m.getSource()), 1, Integer::sum);
+        }
+
+        // Group remaining factions by logical source
+        Map<ComponentSource, List<String>> bySource = new HashMap<>();
+        List<String> unconstrained = new ArrayList<>();
+        for (String f : factions) {
+            if (output.contains(f)) continue;
+            FactionModel m = Mapper.getFaction(f);
+            if (m == null) continue;
+            ComponentSource logical = logicalFactionSource(m.getSource());
+            if (constraints.containsKey(logical)) {
+                bySource.computeIfAbsent(logical, _ -> new ArrayList<>()).add(f);
+            } else {
+                unconstrained.add(f);
+            }
+        }
+        for (List<String> pool : bySource.values()) Collections.shuffle(pool);
+
+        // Apply effective min/max per source
+        List<String> guaranteed = new ArrayList<>();
+        List<String> available = new ArrayList<>();
+        for (Map.Entry<ComponentSource, List<String>> e : bySource.entrySet()) {
+            int[] range = constraints.get(e.getKey());
+            int priorityCount = priorityCountBySource.getOrDefault(e.getKey(), 0);
+            int effectiveMin = Math.max(0, range[0] - priorityCount);
+            int effectiveMax = Math.max(0, range[1] - priorityCount);
+            List<String> pool = e.getValue();
+            for (int i = 0; i < pool.size(); i++) {
+                if (i < effectiveMin) guaranteed.add(pool.get(i));
+                else if (i < effectiveMax) available.add(pool.get(i));
+                // beyond effectiveMax: excluded from pool
+            }
+        }
+        Collections.shuffle(unconstrained);
+        available.addAll(unconstrained);
+        Collections.shuffle(available);
+
+        // Fill: priority already in output, then guaranteed, then available up to factionCount
+        for (String g : guaranteed) {
+            if (!output.contains(g)) output.add(g);
+        }
+        for (String a : available) {
+            if (output.size() >= factionCount) break;
+            if (!output.contains(a)) output.add(a);
+        }
+
+        return output.subList(0, Math.min(factionCount, output.size()));
+    }
+
+    private static ComponentSource logicalFactionSource(ComponentSource source) {
+        return switch (source) {
+            case codex1, codex2, codex3, codex4 -> ComponentSource.pok;
+            default -> source;
+        };
     }
 
     public static void miltySetup(GenericInteractionCreateEvent event, Game game) {


### PR DESCRIPTION
Whispers from the Void faction toggle
Adds a toggle in the Milty draft source settings to include Balacasi (Whispers from the Void) factions in the draft pool.

Per-source faction expansion limits submenu
Adds a "Faction Expansion Limits" submenu under Players & Factions that lets you set min/max faction counts per expansion. The draft algorithm enforces these constraints, with pre-validation that catches impossible configurations before starting. Priority factions are excluded from constraint accounting. Limits are only visible inside the submenu, not the parent menu.

asText deprecation fix
Replaced all asText("") calls with asString("") across the settings framework menus.