### PR TITLE
Add Firmament and Obsidian to franken draft excluded factions list

### DIFF
--- a/src/main/java/ti4/draft/FrankenDraft.java
+++ b/src/main/java/ti4/draft/FrankenDraft.java
@@ -88,7 +88,9 @@ public class FrankenDraft extends BagDraft {
         "neutral",
         "kaltrim",
         "xin",
-        "sarcosa"
+        "sarcosa",
+        "firmament",
+        "obsidian"
     };
 
     private static List<FactionModel> getDraftableFactionsForGame(Game game) {


### PR DESCRIPTION
Auto-banned until they're working as intended. Franken only.