### PR TITLE
Add Franken settings menu

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/milty/SettingMenuButtonHandlers.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/milty/SettingMenuButtonHandlers.java
@@ -17,6 +17,11 @@ class SettingMenuButtonHandlers {
             game.initializeDraftSystemSettings().parseButtonInput(event);
             return;
         }
+        String frankenNavPart = ".*_franken[._].*";
+        if (event.getCustomId().matches(frankenNavPart)) {
+            game.initializeFrankenSettings().parseButtonInput(event);
+            return;
+        }
 
         game.initializeMiltySettings().parseButtonInput(event);
     }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/milty/SettingMenuButtonHandlers.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/milty/SettingMenuButtonHandlers.java
@@ -4,6 +4,7 @@ import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
+import ti4.helpers.settingsFramework.menus.FrankenSettings;
 
 @UtilityClass
 class SettingMenuButtonHandlers {
@@ -17,8 +18,7 @@ class SettingMenuButtonHandlers {
             game.initializeDraftSystemSettings().parseButtonInput(event);
             return;
         }
-        String frankenNavPart = ".*_franken[._].*";
-        if (event.getCustomId().matches(frankenNavPart)) {
+        if (FrankenSettings.isFrankenMenuComponent(event.getCustomId())) {
             game.initializeFrankenSettings().parseButtonInput(event);
             return;
         }

--- a/src/main/java/ti4/discord/interactions/commands/franken/StartFrankenDraft.java
+++ b/src/main/java/ti4/discord/interactions/commands/franken/StartFrankenDraft.java
@@ -5,21 +5,11 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.discord.interactions.commands.GameStateSubcommand;
-import ti4.draft.FrankenDraft;
-import ti4.draft.FrankenDrazDraft;
-import ti4.draft.InauguralSpliceFrankenDraft;
-import ti4.draft.OnePickFrankenDraft;
-import ti4.draft.OverdraftFrankenDraft;
-import ti4.draft.PoweredFrankenDraft;
-import ti4.draft.PoweredOnePickFrankenDraft;
-import ti4.draft.PoweredOverdraftFrankenDraft;
-import ti4.draft.TwilightsFallFrankenDraft;
 import ti4.game.Game;
-import ti4.game.Player;
 import ti4.helpers.Constants;
 import ti4.message.MessageHelper;
-import ti4.service.franken.FrankenDraftBagService;
 import ti4.service.franken.FrankenDraftMode;
+import ti4.service.franken.FrankenDraftStartService;
 
 class StartFrankenDraft extends GameStateSubcommand {
 
@@ -37,15 +27,6 @@ class StartFrankenDraft extends GameStateSubcommand {
         Game game = getGame();
 
         boolean force = event.getOption(Constants.FORCE, Boolean.FALSE, OptionMapping::getAsBoolean);
-        if (!force
-                && game.getPlayers().values().stream().anyMatch(Player::isRealPlayer)
-                && !game.isTwilightsFallMode()) {
-            String message =
-                    "There are players that are currently set up already. Please rerun the command with the force option set to True to overwrite them.";
-            MessageHelper.sendMessageToChannel(event.getMessageChannel(), message);
-            return;
-        }
-
         String draftOption = event.getOption(Constants.DRAFT_MODE, "", OptionMapping::getAsString);
         FrankenDraftMode draftMode = FrankenDraftMode.fromString(draftOption);
         if (!"".equals(draftOption) && draftMode == null) {
@@ -53,30 +34,9 @@ class StartFrankenDraft extends GameStateSubcommand {
             return;
         }
 
-        FrankenDraftBagService.setUpFrankenFactions(game, event, force);
-        FrankenDraftBagService.clearPlayerHands(game);
-
-        if (draftMode == null) {
-            game.setBagDraft(new FrankenDraft(game));
-        } else {
-            switch (draftMode) {
-                case POWERED -> game.setBagDraft(new PoweredFrankenDraft(game));
-                case ONEPICK -> game.setBagDraft(new OnePickFrankenDraft(game));
-                case OVERDRAFT -> game.setBagDraft(new OverdraftFrankenDraft(game));
-                case POWEREDONEPICK -> game.setBagDraft(new PoweredOnePickFrankenDraft(game));
-                case POWEREDOVERDRAFT -> game.setBagDraft(new PoweredOverdraftFrankenDraft(game));
-                case FRANKENDRAZ -> game.setBagDraft(new FrankenDrazDraft(game));
-                case TWILIGHTSFALL -> {
-                    game.setupTwilightsFallMode(event);
-                    game.setBagDraft(new TwilightsFallFrankenDraft(game));
-                }
-                case INAUGURALSPLICE -> {
-                    game.setupTwilightsFallMode(event);
-                    game.setBagDraft(new InauguralSpliceFrankenDraft(game));
-                }
-            }
+        String error = FrankenDraftStartService.startFrankenDraft(event, game, force, draftMode);
+        if (error != null) {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), error);
         }
-
-        FrankenDraftBagService.startDraft(game);
     }
 }

--- a/src/main/java/ti4/discord/interactions/commands/franken/ban/BanService.java
+++ b/src/main/java/ti4/discord/interactions/commands/franken/ban/BanService.java
@@ -21,6 +21,12 @@ public class BanService implements IBanService {
             return "Successfully banned ability: " + Mapper.getAbility(id).getName() + ".\n";
         });
 
+        BAN_APPLIERS.put(Constants.BAN_FACTION, (game, id) -> {
+            if (isBlank(id) || !Mapper.getFactionIDs().contains(id)) return "";
+            appendStoredValue(game, "bannedFactions", id);
+            return "Successfully banned " + Mapper.getFaction(id).getFactionName() + ".\n";
+        });
+
         BAN_APPLIERS.put(Constants.BREAKTHROUGH, (game, id) -> {
             if (isBlank(id) || Mapper.getBreakthrough(id) == null) return "";
             appendStoredValue(game, "bannedBreakthroughs", id);
@@ -130,6 +136,7 @@ public class BanService implements IBanService {
 
     private static void appendStoredValue(Game game, String key, String value) {
         String prev = game.getStoredValue(key);
+        if (List.of(prev.split(Constants.FIN_SEPARATOR)).contains(value)) return;
         game.setStoredValue(key, prev.isEmpty() ? value : prev + Constants.FIN_SEPARATOR + value);
     }
 }

--- a/src/main/java/ti4/discord/interactions/commands/franken/ban/BanService.java
+++ b/src/main/java/ti4/discord/interactions/commands/franken/ban/BanService.java
@@ -1,8 +1,10 @@
 package ti4.discord.interactions.commands.franken.ban;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import ti4.game.Game;
 import ti4.game.Tile;
@@ -136,7 +138,9 @@ public class BanService implements IBanService {
 
     private static void appendStoredValue(Game game, String key, String value) {
         String prev = game.getStoredValue(key);
-        if (List.of(prev.split(Constants.FIN_SEPARATOR)).contains(value)) return;
-        game.setStoredValue(key, prev.isEmpty() ? value : prev + Constants.FIN_SEPARATOR + value);
+        Set<String> values = new LinkedHashSet<>();
+        if (!prev.isEmpty()) values.addAll(List.of(prev.split(Constants.FIN_SEPARATOR)));
+        if (!values.add(value)) return;
+        game.setStoredValue(key, String.join(Constants.FIN_SEPARATOR, values));
     }
 }

--- a/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
@@ -14,6 +14,7 @@ import ti4.discord.interactions.routing.ModalHandler;
 import ti4.executors.ExecutionLockType;
 import ti4.executors.ExecutorServiceManager;
 import ti4.game.Game;
+import ti4.helpers.settingsFramework.menus.FrankenSettings;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.logging.RollbarManager;
@@ -114,8 +115,7 @@ public final class ModalListener extends ListenerAdapter {
                 game.initializeDraftSystemSettings().parseInput(context);
                 return;
             }
-            String frankenNavPart = ".*_franken[._].*";
-            if (modalID.matches(frankenNavPart)) {
+            if (FrankenSettings.isFrankenMenuComponent(modalID)) {
                 game.initializeFrankenSettings().parseInput(context);
                 return;
             }

--- a/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
@@ -114,6 +114,11 @@ public final class ModalListener extends ListenerAdapter {
                 game.initializeDraftSystemSettings().parseInput(context);
                 return;
             }
+            String frankenNavPart = ".*_franken[._].*";
+            if (modalID.matches(frankenNavPart)) {
+                game.initializeFrankenSettings().parseInput(context);
+                return;
+            }
             game.initializeMiltySettings().parseInput(context);
         }
     }

--- a/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
+++ b/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
@@ -12,6 +12,7 @@ import ti4.discord.interactions.routing.SelectionHandler;
 import ti4.executors.ExecutionLockType;
 import ti4.executors.ExecutorServiceManager;
 import ti4.game.Game;
+import ti4.helpers.settingsFramework.menus.FrankenSettings;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.logging.RollbarManager;
@@ -106,8 +107,7 @@ public final class SelectionMenuProcessor {
             deleteMsg(event);
             return;
         }
-        String frankenNavPart = ".*_franken[._].*";
-        if (event.getCustomId().matches(frankenNavPart)) {
+        if (FrankenSettings.isFrankenMenuComponent(event.getCustomId())) {
             game.initializeFrankenSettings().parseSelectionInput(event);
             deleteMsg(event);
             return;

--- a/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
+++ b/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
@@ -106,6 +106,12 @@ public final class SelectionMenuProcessor {
             deleteMsg(event);
             return;
         }
+        String frankenNavPart = ".*_franken[._].*";
+        if (event.getCustomId().matches(frankenNavPart)) {
+            game.initializeFrankenSettings().parseSelectionInput(event);
+            deleteMsg(event);
+            return;
+        }
 
         game.initializeMiltySettings().parseSelectionInput(event);
         deleteMsg(event);

--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -69,6 +69,7 @@ import ti4.helpers.Units.UnitKey;
 import ti4.helpers.omega_phase.VoiceOfTheCouncilHelper;
 import ti4.helpers.settingsFramework.menus.DeckSettings;
 import ti4.helpers.settingsFramework.menus.DraftSystemSettings;
+import ti4.helpers.settingsFramework.menus.FrankenSettings;
 import ti4.helpers.settingsFramework.menus.GameSettings;
 import ti4.helpers.settingsFramework.menus.GameSetupSettings;
 import ti4.helpers.settingsFramework.menus.MiltySettings;
@@ -260,6 +261,10 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
 
     @Setter
     @Getter
+    private String frankenSettingsJson;
+
+    @Setter
+    @Getter
     private String draftString;
 
     @Setter
@@ -267,6 +272,9 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
 
     @Setter
     private DraftSystemSettings draftSystemSettings;
+
+    @Setter
+    private FrankenSettings frankenSettings;
 
     @Getter
     @Setter
@@ -493,6 +501,8 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
         draftString = null;
         draftSystemSettings = null;
         draftSystemSettingsJson = null;
+        frankenSettings = null;
+        frankenSettingsJson = null;
     }
 
     @NotNull
@@ -583,6 +593,33 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
             }
         }
         return draftSystemSettings;
+    }
+
+    public FrankenSettings getFrankenSettingsUnsafe() {
+        return frankenSettings;
+    }
+
+    public FrankenSettings initializeFrankenSettings() {
+        if (frankenSettings == null) {
+            if (frankenSettingsJson != null) {
+                try {
+                    JsonNode json = mapper.readTree(frankenSettingsJson);
+                    frankenSettings = new FrankenSettings(this, json);
+                } catch (Exception e) {
+                    BotLogger.error(
+                            new LogOrigin(this),
+                            "Failed loading franken draft settings for `" + getName() + "` "
+                                    + Constants.jabberwockyPing(),
+                            e);
+                    MessageHelper.sendMessageToChannel(
+                            getActionsChannel(), "Franken draft settings failed to load. Resetting to default.");
+                    frankenSettings = new FrankenSettings(this, null);
+                }
+            } else {
+                frankenSettings = new FrankenSettings(this, null);
+            }
+        }
+        return frankenSettings;
     }
 
     public void setPurgedPN(String purgedPN) {

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -716,6 +716,7 @@ class GameLoadService {
                 case Constants.DRAFT_MANAGER -> game.setDraftString(info); // We will parse this later
                 case Constants.DRAFT_SYSTEM_SETTINGS ->
                     game.setDraftSystemSettingsJson(info); // We will parse this later
+                case Constants.FRANKEN_DRAFT_SETTINGS -> game.setFrankenSettingsJson(info); // We will parse this later
                 case Constants.GAME_TAGS -> game.setTags(getCardList(info));
                 case Constants.TIGL_RANK -> {
                     TIGLHelper.TIGLRank rank = TIGLHelper.TIGLRank.fromString(info);

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -52,6 +52,7 @@ import ti4.helpers.StringHelper;
 import ti4.helpers.Units;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.settingsFramework.menus.DraftSystemSettings;
+import ti4.helpers.settingsFramework.menus.FrankenSettings;
 import ti4.helpers.settingsFramework.menus.MiltySettings;
 import ti4.image.Mapper;
 import ti4.json.JsonMapperManager;
@@ -683,6 +684,15 @@ class GameSaveService {
         } else if (game.getDraftSystemSettingsJson() != null) {
             // default to the already stored value, if we failed to read it previously
             writer.write(Constants.DRAFT_SYSTEM_SETTINGS + " " + game.getDraftSystemSettingsJson());
+            writer.write(System.lineSeparator());
+        }
+
+        FrankenSettings frankenSettings = game.getFrankenSettingsUnsafe();
+        if (frankenSettings != null) {
+            writer.write(Constants.FRANKEN_DRAFT_SETTINGS + " " + frankenSettings.json());
+            writer.write(System.lineSeparator());
+        } else if (game.getFrankenSettingsJson() != null) {
+            writer.write(Constants.FRANKEN_DRAFT_SETTINGS + " " + game.getFrankenSettingsJson());
             writer.write(System.lineSeparator());
         }
 

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1071,6 +1071,7 @@ public final class Constants {
     public static final String MILTY_DRAFT_SETTINGS = "milty_draft_settings";
     public static final String DRAFT_MANAGER = "draft_manager";
     public static final String DRAFT_SYSTEM_SETTINGS = "draft_system_settings";
+    public static final String FRANKEN_DRAFT_SETTINGS = "franken_draft_settings";
     public static final String DRAFT = "draft";
 
     // groups

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
@@ -1,0 +1,805 @@
+package ti4.helpers.settingsFramework.menus;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.selections.SelectOption;
+import net.dv8tion.jda.api.components.selections.StringSelectMenu;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.function.Consumers;
+import org.jetbrains.annotations.NotNull;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.commands.franken.ban.BanService;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.draft.FrankenDraft;
+import ti4.game.Game;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.Constants;
+import ti4.helpers.settingsFramework.settings.BooleanSetting;
+import ti4.helpers.settingsFramework.settings.ChoiceSetting;
+import ti4.helpers.settingsFramework.settings.ListSetting;
+import ti4.helpers.settingsFramework.settings.SettingInterface;
+import ti4.image.Mapper;
+import ti4.logging.BotLogger;
+import ti4.model.FactionModel;
+import ti4.service.franken.FrankenBanList;
+import ti4.service.franken.FrankenDraftMode;
+import ti4.service.franken.FrankenDraftStartService;
+import tools.jackson.databind.JsonNode;
+
+@Getter
+public class FrankenSettings extends SettingsMenu {
+
+    private static final String MENU_ID = "franken";
+    private static final String STANDARD_DRAFT = "standard";
+
+    private final ChoiceSetting<String> draftMode;
+    private final BooleanSetting force;
+    private final ListSetting<FactionModel> bannedFactions;
+    private final ListSetting<FrankenBanList> banLists;
+    private final FrankenComponentBanSettings componentBanSettings;
+
+    @JsonIgnore
+    private final Game game;
+
+    public FrankenSettings(@NotNull Game game, JsonNode json) {
+        super(MENU_ID, "Franken Settings", "Edit franken draft settings, then start the draft!", null);
+        this.game = game;
+
+        draftMode = new ChoiceSetting<>("DraftMode", "Draft Mode", STANDARD_DRAFT);
+        draftMode.setAllValues(draftModeOptions());
+        draftMode.setShow(FrankenSettings::draftModeLabel);
+
+        force = new BooleanSetting("Force", "Force overwrite existing player setups", false);
+
+        Set<String> empty = new HashSet<>();
+        bannedFactions = new ListSetting<FactionModel>(
+                "BannedFactions",
+                "Banned Factions",
+                "Ban faction",
+                "Unban faction",
+                legalFactionOptions(game),
+                empty,
+                empty) {
+            @Override
+            protected String shortValue() {
+                return effectiveBannedFactionSummary();
+            }
+
+            @Override
+            protected String longValue() {
+                return effectiveBannedFactionSummary();
+            }
+        };
+        bannedFactions.setGetEmoji(FactionModel::getFactionEmoji);
+        bannedFactions.setShow(FactionModel::getFactionName);
+
+        banLists = new ListSetting<>(
+                "BanLists", "Ban Lists", "Use ban list", "Remove ban list", banListOptions(), empty, empty);
+        banLists.setShow(FrankenBanList::getAutoCompleteName);
+
+        if (isMenuJson(json, MENU_ID)) {
+            draftMode.initialize(json.get("draftMode"));
+            force.initialize(json.get("force"));
+            bannedFactions.initialize(json.get("bannedFactions"));
+            banLists.initialize(json.get("banLists"));
+        }
+
+        componentBanSettings =
+                new FrankenComponentBanSettings(game, json != null ? json.get("componentBanSettings") : null, this);
+
+        if (json != null && json.has("messageId")) {
+            setMessageId(json.get("messageId").asText(null));
+        }
+    }
+
+    @Override
+    protected List<SettingInterface> settings() {
+        return List.of(draftMode, force, bannedFactions, banLists);
+    }
+
+    @Override
+    protected List<SettingsMenu> categories() {
+        return List.of(componentBanSettings);
+    }
+
+    @Override
+    protected List<Button> specialButtons() {
+        String prefix = menuAction + "_" + navId() + "_";
+        return new ArrayList<>(List.of(Buttons.green(prefix + "startFranken", "Start Franken Draft!")));
+    }
+
+    @Override
+    protected String handleSpecialButtonAction(GenericInteractionCreateEvent event, String action) {
+        String error =
+                switch (action) {
+                    case "startFranken" -> startDraft(event);
+                    default -> null;
+                };
+        return error == null ? "success" : error;
+    }
+
+    private String startDraft(GenericInteractionCreateEvent event) {
+        String validationError = FrankenDraftStartService.validateStartFrankenDraft(game, force.isVal());
+        if (validationError != null) {
+            return validationError;
+        }
+        applyBanSettings();
+        return FrankenDraftStartService.startFrankenDraft(event, game, force.isVal(), selectedDraftMode());
+    }
+
+    private void applyBanSettings() {
+        BanService banService = new BanService();
+        for (String faction : bannedFactions.getKeys()) {
+            banService.applyOption(game, Constants.BAN_FACTION, faction);
+        }
+        for (String banList : banLists.getKeys()) {
+            banService.applyBanList(game, FrankenBanList.fromString(banList));
+        }
+        componentBanSettings.applyBanSettings(banService);
+    }
+
+    private FrankenDraftMode selectedDraftMode() {
+        String selected = draftMode.getValue();
+        if (STANDARD_DRAFT.equals(selected)) {
+            return null;
+        }
+        return FrankenDraftMode.fromString(selected);
+    }
+
+    private String effectiveBannedFactionSummary() {
+        Map<String, Set<String>> banListSources = selectedBanListSources(Constants.BAN_FACTION);
+        Set<String> effectiveBans = new HashSet<>(bannedFactions.getKeys());
+        effectiveBans.addAll(banListSources.keySet());
+        List<String> values = effectiveBans.stream()
+                .map(key -> factionBanLabel(key, banListSources.getOrDefault(key, Set.of())))
+                .sorted()
+                .toList();
+        return "[" + String.join(",", values) + "]";
+    }
+
+    Map<String, Set<String>> selectedBanListSources(String banType) {
+        Map<String, Set<String>> sources = new LinkedHashMap<>();
+        for (FrankenBanList banList : selectedBanLists()) {
+            for (String id : banList.getBansForType(banType)) {
+                sources.computeIfAbsent(id, key -> new LinkedHashSet<>()).add(banList.getName());
+            }
+        }
+        return sources;
+    }
+
+    List<FrankenBanList> selectedBanLists() {
+        return banLists.getKeys().stream()
+                .map(FrankenBanList::fromString)
+                .filter(banList -> banList != null)
+                .toList();
+    }
+
+    private static String factionBanLabel(String id, Set<String> sources) {
+        return withSourceLabel(factionName(id), sources);
+    }
+
+    static String factionName(String id) {
+        FactionModel faction = Mapper.getFaction(id);
+        return faction == null ? id : faction.getFactionName();
+    }
+
+    static String withSourceLabel(String label, Set<String> sources) {
+        if (sources == null || sources.isEmpty()) {
+            return label;
+        }
+        return label + " _(from " + String.join(", ", sources.stream().sorted().toList()) + ")_";
+    }
+
+    static boolean isMenuJson(JsonNode json, String menuId) {
+        return json != null && json.has("menuId") && menuId.equals(json.get("menuId").asString(""));
+    }
+
+    private static Map<String, String> draftModeOptions() {
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put(STANDARD_DRAFT, STANDARD_DRAFT);
+        for (FrankenDraftMode mode : FrankenDraftMode.values()) {
+            options.put(mode.toString(), mode.toString());
+        }
+        return options;
+    }
+
+    private static String draftModeLabel(String key) {
+        if (STANDARD_DRAFT.equals(key)) {
+            return "Standard Franken Draft";
+        }
+        FrankenDraftMode mode = FrankenDraftMode.fromString(key);
+        return mode == null ? key : mode.getAutoCompleteName();
+    }
+
+    private static Set<Entry<String, FactionModel>> legalFactionOptions(Game game) {
+        return FrankenDraft.getAllFrankenLegalFactions(game).stream()
+                .collect(Collectors.toMap(FactionModel::getAlias, faction -> faction))
+                .entrySet();
+    }
+
+    private static Set<Entry<String, FrankenBanList>> banListOptions() {
+        return FrankenBanList.getAllBanLists().stream()
+                .collect(Collectors.toMap(FrankenBanList::toString, banList -> banList))
+                .entrySet();
+    }
+
+    @ButtonHandler("frankenSetup")
+    public static void setup(ButtonInteractionEvent event, Game game) {
+        FrankenSettings menu = game.initializeFrankenSettings();
+        menu.postMessageAndButtons(event);
+        ButtonHelper.deleteMessage(event);
+    }
+}
+
+@Getter
+class FrankenComponentBanSettings extends SettingsMenu {
+
+    private static final String MENU_ID = "frankenComponents";
+    private static final String KEY_SEPARATOR = "|";
+    private static final int PAGE_SIZE = 25;
+    private static final int MAX_SELECT_MENUS_PER_MESSAGE = 5;
+    private static final int SUMMARY_LIMIT = 20;
+    private static final Map<String, String> COMPONENT_TYPES = componentTypes();
+
+    private Set<String> bannedComponents = new HashSet<>();
+
+    @JsonIgnore
+    private final Game game;
+
+    FrankenComponentBanSettings(@NotNull Game game, JsonNode json, SettingsMenu parent) {
+        super(MENU_ID, "Component Ban Settings", "Ban individual Franken draft components.", parent);
+        this.game = game;
+
+        if (FrankenSettings.isMenuJson(json, MENU_ID)) {
+            initializeBannedComponents(json.get("bannedComponents"));
+        }
+    }
+
+    @Override
+    protected List<SettingInterface> settings() {
+        return List.of();
+    }
+
+    @Override
+    protected List<Button> specialButtons() {
+        String prefix = menuAction + "_" + navId() + "_";
+        List<Button> buttons = new ArrayList<>();
+        for (Map.Entry<String, String> componentType : COMPONENT_TYPES.entrySet()) {
+            buttons.add(Buttons.green(
+                    prefix + "componentBanPick~add~" + componentType.getKey() + "~0",
+                    "Ban " + componentType.getValue()));
+        }
+        if (!bannedComponents.isEmpty()) {
+            for (Map.Entry<String, String> componentType : COMPONENT_TYPES.entrySet()) {
+                if (hasBannedComponentOfType(componentType.getKey())) {
+                    buttons.add(Buttons.red(
+                            prefix + "componentBanPick~remove~" + componentType.getKey() + "~0",
+                            "Unban " + componentType.getValue()));
+                }
+            }
+            buttons.add(Buttons.red(prefix + "clearComponentBans", "Clear Component Bans"));
+        }
+        return buttons;
+    }
+
+    @Override
+    protected String handleSpecialButtonAction(GenericInteractionCreateEvent event, String action) {
+        if (action.startsWith("componentBanPick~")) {
+            String error = showComponentBanPicker(event, action);
+            return error == null ? "success" : error;
+        }
+        if (action.startsWith("componentBanSelect~")) {
+            String error = updateComponentBansFromSelection(event, action);
+            return error == null ? "success" : error;
+        }
+        if ("clearComponentBans".equals(action)) {
+            String error = clearComponentBans();
+            return error == null ? "success" : error;
+        }
+        return null;
+    }
+
+    @Override
+    public String menuSummaryString(String lastSettingTouched) {
+        StringBuilder sb = new StringBuilder("# **__").append(menuName).append(":__**");
+        for (String line : description) sb.append("\n- *").append(line).append("*");
+        sb.append("\n");
+        appendComponentSummary(sb);
+        return sb.toString();
+    }
+
+    @Override
+    public String shortSummaryString(boolean shortDescrOnly) {
+        StringBuilder sb = new StringBuilder("**__" + menuName + ":__**");
+        if (shortDescrOnly) {
+            for (String line : description) {
+                sb.append("\n- *").append(line).append("*");
+                break;
+            }
+            return sb.toString();
+        }
+        appendComponentSummary(sb);
+        return sb.toString();
+    }
+
+    void applyBanSettings(BanService banService) {
+        for (String componentKey : bannedComponents) {
+            String[] parts = splitComponentKey(componentKey);
+            if (parts.length != 2) {
+                continue;
+            }
+            banService.applyOption(game, parts[0], parts[1]);
+        }
+    }
+
+    private String showComponentBanPicker(GenericInteractionCreateEvent event, String action) {
+        if (!(event instanceof ButtonInteractionEvent buttonEvent)) {
+            return "Unknown Event";
+        }
+
+        ComponentAction componentAction = parseComponentAction(action);
+        if (componentAction == null) {
+            return "Invalid component ban action.";
+        }
+
+        List<Map.Entry<String, String>> entries = componentOptions(game, componentAction.componentType()).stream()
+                .filter(entry -> componentAction.add() != bannedComponents.contains(entry.getKey()))
+                .sorted(Map.Entry.comparingByValue())
+                .toList();
+        if (entries.isEmpty()) {
+            return "No " + COMPONENT_TYPES.get(componentAction.componentType()) + " components available to "
+                    + (componentAction.add() ? "ban." : "unban.");
+        }
+
+        List<List<Map.Entry<String, String>>> optionGroups = ListUtils.partition(entries, PAGE_SIZE);
+        int messageCount = Math.ceilDiv(optionGroups.size(), MAX_SELECT_MENUS_PER_MESSAGE);
+        String prefix = menuAction + "_" + navId() + "_componentBan";
+
+        buttonEvent
+                .getHook()
+                .sendMessage(componentPickerMessage(componentAction, optionGroups, 0, messageCount))
+                .addComponents(componentPickerRows(componentAction, prefix, optionGroups, 0))
+                .setEphemeral(true)
+                .queue(Consumers.nop(), BotLogger::catchRestError);
+
+        for (int messageIndex = 1; messageIndex < messageCount; messageIndex++) {
+            int firstGroup = messageIndex * MAX_SELECT_MENUS_PER_MESSAGE;
+            buttonEvent
+                    .getHook()
+                    .sendMessage(componentPickerMessage(componentAction, optionGroups, messageIndex, messageCount))
+                    .addComponents(componentPickerRows(componentAction, prefix, optionGroups, firstGroup))
+                    .setEphemeral(true)
+                    .queue(Consumers.nop(), BotLogger::catchRestError);
+        }
+        return null;
+    }
+
+    private static String componentPickerMessage(
+            ComponentAction componentAction,
+            List<List<Map.Entry<String, String>>> optionGroups,
+            int messageIndex,
+            int messageCount) {
+        int firstGroup = messageIndex * MAX_SELECT_MENUS_PER_MESSAGE;
+        int lastGroup = Math.min(firstGroup + MAX_SELECT_MENUS_PER_MESSAGE, optionGroups.size());
+        StringBuilder message = new StringBuilder(
+                componentAction.add() ? "Choose components to ban: " : "Choose components to unban: ");
+        message.append(COMPONENT_TYPES.get(componentAction.componentType()));
+        if (messageCount > 1) {
+            message.append(" (").append(messageIndex + 1).append("/").append(messageCount).append(")");
+        }
+        for (int groupIndex = firstGroup; groupIndex < lastGroup; groupIndex++) {
+            message.append("\n- List ")
+                    .append(groupIndex + 1)
+                    .append(": ")
+                    .append(alphabetRange(optionGroups.get(groupIndex)));
+        }
+        return message.toString();
+    }
+
+    private static List<ActionRow> componentPickerRows(
+            ComponentAction componentAction,
+            String prefix,
+            List<List<Map.Entry<String, String>>> optionGroups,
+            int firstGroup) {
+        String mode = componentAction.add() ? "add" : "remove";
+        int lastGroup = Math.min(firstGroup + MAX_SELECT_MENUS_PER_MESSAGE, optionGroups.size());
+        List<ActionRow> rows = new ArrayList<>();
+        for (int groupIndex = firstGroup; groupIndex < lastGroup; groupIndex++) {
+            List<Map.Entry<String, String>> group = optionGroups.get(groupIndex);
+            List<SelectOption> options = group.stream()
+                    .map(entry -> SelectOption.of(entry.getValue(), entry.getKey()))
+                    .toList();
+            String selectId = prefix + "Select~" + mode + "~" + componentAction.componentType() + "~" + groupIndex;
+            StringSelectMenu selectMenu = StringSelectMenu.create(selectId)
+                    .addOptions(options)
+                    .setPlaceholder((componentAction.add() ? "Ban " : "Unban ")
+                            + COMPONENT_TYPES.get(componentAction.componentType()) + " "
+                            + alphabetRange(group))
+                    .setRequiredRange(0, options.size())
+                    .build();
+            rows.add(ActionRow.of(selectMenu));
+        }
+        return rows;
+    }
+
+    private String updateComponentBansFromSelection(GenericInteractionCreateEvent event, String action) {
+        if (!(event instanceof StringSelectInteractionEvent selectEvent)) {
+            return "Unknown Event";
+        }
+
+        ComponentAction componentAction = parseComponentAction(action);
+        if (componentAction == null) {
+            return "Invalid component ban action.";
+        }
+        for (String key : selectEvent.getValues()) {
+            String[] parts = splitComponentKey(key);
+            if (parts.length != 2 || !parts[0].equals(componentAction.componentType())) {
+                continue;
+            }
+            if (componentAction.add()) {
+                bannedComponents.add(key);
+            } else {
+                bannedComponents.remove(key);
+            }
+        }
+        return null;
+    }
+
+    private String clearComponentBans() {
+        bannedComponents.clear();
+        return null;
+    }
+
+    private void appendComponentSummary(StringBuilder sb) {
+        Map<String, Set<String>> banListSources = selectedBanListComponentSources();
+        Set<String> effectiveBans = new HashSet<>(bannedComponents);
+        effectiveBans.addAll(banListSources.keySet());
+        if (effectiveBans.isEmpty()) {
+            sb.append("> No component bans selected.\n");
+            return;
+        }
+
+        List<String> labels = effectiveBans.stream()
+                .map(key -> componentLabel(key, banListSources.getOrDefault(key, Set.of())))
+                .sorted()
+                .toList();
+        List<String> shown = labels.subList(0, Math.min(labels.size(), SUMMARY_LIMIT));
+        for (String label : shown) {
+            sb.append("> ").append(label).append("\n");
+        }
+        if (labels.size() > SUMMARY_LIMIT) {
+            sb.append("> +").append(labels.size() - SUMMARY_LIMIT).append(" more\n");
+        }
+    }
+
+    private Map<String, Set<String>> selectedBanListComponentSources() {
+        Map<String, Set<String>> sources = new LinkedHashMap<>();
+        if (!(parent instanceof FrankenSettings frankenSettings)) {
+            return sources;
+        }
+        for (String type : COMPONENT_TYPES.keySet()) {
+            for (Map.Entry<String, Set<String>> entry : frankenSettings.selectedBanListSources(type).entrySet()) {
+                sources.put(componentKey(type, entry.getKey()), entry.getValue());
+            }
+        }
+        return sources;
+    }
+
+    private void initializeBannedComponents(JsonNode json) {
+        if (json == null || !json.isArray()) {
+            return;
+        }
+        bannedComponents.clear();
+        json.forEach(node -> {
+            if (!node.isTextual()) {
+                return;
+            }
+            String key = node.asText();
+            String[] parts = splitComponentKey(key);
+            if (parts.length == 2 && isValidComponent(game, parts[0], parts[1])) {
+                bannedComponents.add(key);
+            }
+        });
+    }
+
+    private static boolean isValidComponent(Game game, String type, String id) {
+        return switch (type) {
+            case Constants.ABILITY ->
+                Mapper.getAbility(id) != null && playableFactionHasComponent(game, id, FactionModel::getAbilities);
+            case Constants.BREAKTHROUGH ->
+                Mapper.getBreakthrough(id) != null
+                        && playableFactions(game).stream().anyMatch(faction -> id.equals(faction.getBreakthrough()));
+            case Constants.LEADER ->
+                Mapper.getLeader(id) != null && playableFactionHasComponent(game, id, FactionModel::getLeaders);
+            case Constants.PROMISSORY_NOTE_ID ->
+                Mapper.getPromissoryNote(id) != null
+                        && playableFactionHasComponent(game, id, FactionModel::getPromissoryNotes);
+            case Constants.TECH ->
+                Mapper.getTech(id) != null && playableFactionHasComponent(game, id, FactionModel::getFactionTech);
+            case Constants.TILE_NAME -> Mapper.getTileRepresentations().containsKey(id);
+            case Constants.UNIT_ID ->
+                isMechOrFlagship(id) && playableFactionHasComponent(game, id, FactionModel::getUnits);
+            case Constants.BAN_COMMODITIES, Constants.BAN_FLEET, Constants.BAN_HS, Constants.BAN_STARTING_TECH ->
+                playableFactionAliases(game).contains(id);
+            default -> false;
+        };
+    }
+
+    private static Set<Entry<String, String>> componentOptions(Game game, String type) {
+        Map<String, String> options = new LinkedHashMap<>();
+        List<FactionModel> factions = playableFactions(game);
+        switch (type) {
+            case Constants.ABILITY ->
+                addFactionComponents(
+                        options,
+                        type,
+                        factions,
+                        FactionModel::getAbilities,
+                        FrankenComponentBanSettings::abilityName);
+            case Constants.BREAKTHROUGH ->
+                addFactionComponents(
+                        options,
+                        type,
+                        factions,
+                        FrankenComponentBanSettings::breakthroughIds,
+                        FrankenComponentBanSettings::breakthroughName);
+            case Constants.LEADER ->
+                addFactionComponents(
+                        options,
+                        type,
+                        factions,
+                        FactionModel::getLeaders,
+                        FrankenComponentBanSettings::leaderName);
+            case Constants.PROMISSORY_NOTE_ID ->
+                addFactionComponents(
+                        options,
+                        type,
+                        factions,
+                        FactionModel::getPromissoryNotes,
+                        FrankenComponentBanSettings::promissoryName);
+            case Constants.TECH ->
+                addFactionComponents(
+                        options,
+                        type,
+                        factions,
+                        FactionModel::getFactionTech,
+                        FrankenComponentBanSettings::techName);
+            case Constants.TILE_NAME ->
+                Mapper.getTileRepresentations().forEach((id, name) -> addOption(options, type, id, name, id));
+            case Constants.UNIT_ID ->
+                addFactionComponents(
+                        options,
+                        type,
+                        factions,
+                        FrankenComponentBanSettings::unitIds,
+                        FrankenComponentBanSettings::unitName);
+            case Constants.BAN_COMMODITIES, Constants.BAN_FLEET, Constants.BAN_HS, Constants.BAN_STARTING_TECH ->
+                addFactionOptions(options, type, factions);
+            default -> {}
+        }
+        return options.entrySet();
+    }
+
+    private static void addFactionComponents(
+            Map<String, String> options,
+            String type,
+            List<FactionModel> factions,
+            Function<FactionModel, List<String>> componentIds,
+            Function<String, String> componentName) {
+        for (FactionModel faction : factions) {
+            List<String> ids = componentIds.apply(faction);
+            if (ids == null) {
+                continue;
+            }
+            for (String id : ids) {
+                addOption(options, type, id, componentName.apply(id), id);
+            }
+        }
+    }
+
+    private static void addFactionOptions(Map<String, String> options, String type, List<FactionModel> factions) {
+        for (FactionModel faction : factions) {
+            addOption(options, type, faction.getAlias(), faction.getFactionName(), faction.getAlias());
+        }
+    }
+
+    private static void addOption(Map<String, String> options, String type, String id, String name, String labelSuffix) {
+        if (id == null || id.isBlank() || name == null || name.isBlank()) {
+            return;
+        }
+        options.put(componentKey(type, id), abbreviate(name + " [" + labelSuffix + "]"));
+    }
+
+    private static List<String> breakthroughIds(FactionModel faction) {
+        String id = faction.getBreakthrough();
+        return id == null || id.isBlank() ? List.of() : List.of(id);
+    }
+
+    private static List<String> unitIds(FactionModel faction) {
+        return faction.getUnits().stream().filter(FrankenComponentBanSettings::isMechOrFlagship).toList();
+    }
+
+    private static boolean isMechOrFlagship(String id) {
+        var unit = Mapper.getUnit(id);
+        if (unit == null) {
+            return false;
+        }
+        String baseType = unit.getBaseType();
+        return Constants.MECH_ID.equalsIgnoreCase(baseType) || Constants.FLAGSHIP_ID.equalsIgnoreCase(baseType);
+    }
+
+    private static String abilityName(String id) {
+        var model = Mapper.getAbility(id);
+        return model == null ? null : model.getName();
+    }
+
+    private static String breakthroughName(String id) {
+        var model = Mapper.getBreakthrough(id);
+        return model == null ? null : model.getName();
+    }
+
+    private static String leaderName(String id) {
+        var model = Mapper.getLeader(id);
+        return model == null ? null : model.getName();
+    }
+
+    private static String promissoryName(String id) {
+        var model = Mapper.getPromissoryNote(id);
+        return model == null ? null : model.getName();
+    }
+
+    private static String techName(String id) {
+        var model = Mapper.getTech(id);
+        return model == null ? null : model.getName();
+    }
+
+    private static String unitName(String id) {
+        var model = Mapper.getUnit(id);
+        return model == null ? null : model.getName();
+    }
+
+    private static List<FactionModel> playableFactions(Game game) {
+        return FrankenDraft.getAllFrankenLegalFactions(game);
+    }
+
+    private static Set<String> playableFactionAliases(Game game) {
+        return playableFactions(game).stream().map(FactionModel::getAlias).collect(Collectors.toSet());
+    }
+
+    private static boolean playableFactionHasComponent(
+            Game game, String id, Function<FactionModel, List<String>> componentIds) {
+        return playableFactions(game).stream()
+                .map(componentIds)
+                .anyMatch(ids -> ids != null && ids.contains(id));
+    }
+
+    private static String componentKey(String type, String id) {
+        return type + KEY_SEPARATOR + id;
+    }
+
+    private static String[] splitComponentKey(String key) {
+        return key.split("\\" + KEY_SEPARATOR, 2);
+    }
+
+    private boolean hasBannedComponentOfType(String type) {
+        return bannedComponents.stream().anyMatch(key -> key.startsWith(type + KEY_SEPARATOR));
+    }
+
+    private static String componentLabel(String key, Set<String> sources) {
+        return FrankenSettings.withSourceLabel(componentLabel(key), sources);
+    }
+
+    private static String componentLabel(String key) {
+        String[] parts = splitComponentKey(key);
+        if (parts.length != 2) {
+            return key;
+        }
+
+        String type = parts[0];
+        String id = parts[1];
+        String name =
+                switch (type) {
+                    case Constants.ABILITY -> labelOrId(abilityName(id), id);
+                    case Constants.BREAKTHROUGH -> labelOrId(breakthroughName(id), id);
+                    case Constants.LEADER -> labelOrId(leaderName(id), id);
+                    case Constants.PROMISSORY_NOTE_ID -> labelOrId(promissoryName(id), id);
+                    case Constants.TECH -> labelOrId(techName(id), id);
+                    case Constants.TILE_NAME -> Mapper.getTileRepresentations().getOrDefault(id, id);
+                    case Constants.UNIT_ID -> labelOrId(unitName(id), id);
+                    case Constants.BAN_COMMODITIES -> FrankenSettings.factionName(id) + " commodities";
+                    case Constants.BAN_FLEET -> FrankenSettings.factionName(id) + " starting fleet";
+                    case Constants.BAN_HS -> FrankenSettings.factionName(id) + " home system";
+                    case Constants.BAN_STARTING_TECH -> FrankenSettings.factionName(id) + " starting tech";
+                    default -> id;
+                };
+
+        return "`" + type + "`: " + name + " [" + id + "]";
+    }
+
+    private static String labelOrId(String label, String id) {
+        return label == null ? id : label;
+    }
+
+    private static ComponentAction parseComponentAction(String action) {
+        String[] parts = action.split("~");
+        if (parts.length < 4) {
+            return null;
+        }
+        boolean add;
+        if ("add".equals(parts[1])) {
+            add = true;
+        } else if ("remove".equals(parts[1])) {
+            add = false;
+        } else {
+            return null;
+        }
+        String componentType = parts[2];
+        if (!COMPONENT_TYPES.containsKey(componentType)) {
+            return null;
+        }
+        int page;
+        try {
+            page = Integer.parseInt(parts[3]);
+        } catch (NumberFormatException e) {
+            page = 0;
+        }
+        return new ComponentAction(add, componentType, page);
+    }
+
+    private static Map<String, String> componentTypes() {
+        Map<String, String> componentTypes = new LinkedHashMap<>();
+        componentTypes.put(Constants.ABILITY, "Ability");
+        componentTypes.put(Constants.BREAKTHROUGH, "Breakthrough");
+        componentTypes.put(Constants.LEADER, "Leader");
+        componentTypes.put(Constants.PROMISSORY_NOTE_ID, "Promissory");
+        componentTypes.put(Constants.TECH, "Tech");
+        componentTypes.put(Constants.TILE_NAME, "Tile");
+        componentTypes.put(Constants.UNIT_ID, "Unit");
+        componentTypes.put(Constants.BAN_COMMODITIES, "Commodities");
+        componentTypes.put(Constants.BAN_FLEET, "Starting Fleet");
+        componentTypes.put(Constants.BAN_HS, "Home System");
+        componentTypes.put(Constants.BAN_STARTING_TECH, "Starting Tech");
+        return componentTypes;
+    }
+
+    private static String abbreviate(String label) {
+        if (label.length() <= 90) {
+            return label;
+        }
+        return label.substring(0, 87) + "...";
+    }
+
+    private static String alphabetRange(List<Map.Entry<String, String>> entries) {
+        if (entries.isEmpty()) {
+            return "";
+        }
+        String first = alphabetStart(entries.getFirst().getValue());
+        String last = alphabetStart(entries.getLast().getValue());
+        return first.equals(last) ? first : first + "-" + last;
+    }
+
+    private static String alphabetStart(String label) {
+        if (label == null || label.isBlank()) {
+            return "#";
+        }
+        char first = Character.toUpperCase(label.trim().charAt(0));
+        return Character.isLetterOrDigit(first) ? String.valueOf(first) : "#";
+    }
+
+    private record ComponentAction(boolean add, String componentType, int page) {}
+}

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
@@ -67,24 +67,25 @@ public class FrankenSettings extends SettingsMenu {
         force = new BooleanSetting("Force", "Force overwrite existing player setups", false);
 
         Set<String> empty = new HashSet<>();
-        bannedFactions = new ListSetting<FactionModel>(
-                "BannedFactions",
-                "Banned Factions",
-                "Ban faction",
-                "Unban faction",
-                legalFactionOptions(game),
-                empty,
-                empty) {
-            @Override
-            protected String shortValue() {
-                return effectiveBannedFactionSummary();
-            }
+        bannedFactions =
+                new ListSetting<FactionModel>(
+                        "BannedFactions",
+                        "Banned Factions",
+                        "Ban faction",
+                        "Unban faction",
+                        legalFactionOptions(game),
+                        empty,
+                        empty) {
+                    @Override
+                    protected String shortValue() {
+                        return effectiveBannedFactionSummary();
+                    }
 
-            @Override
-            protected String longValue() {
-                return effectiveBannedFactionSummary();
-            }
-        };
+                    @Override
+                    protected String longValue() {
+                        return effectiveBannedFactionSummary();
+                    }
+                };
         bannedFactions.setGetEmoji(FactionModel::getFactionEmoji);
         bannedFactions.setShow(FactionModel::getFactionName);
 
@@ -206,7 +207,9 @@ public class FrankenSettings extends SettingsMenu {
     }
 
     static boolean isMenuJson(JsonNode json, String menuId) {
-        return json != null && json.has("menuId") && menuId.equals(json.get("menuId").asString(""));
+        return json != null
+                && json.has("menuId")
+                && menuId.equals(json.get("menuId").asString(""));
     }
 
     private static Map<String, String> draftModeOptions() {
@@ -400,7 +403,11 @@ class FrankenComponentBanSettings extends SettingsMenu {
                 componentAction.add() ? "Choose components to ban: " : "Choose components to unban: ");
         message.append(COMPONENT_TYPES.get(componentAction.componentType()));
         if (messageCount > 1) {
-            message.append(" (").append(messageIndex + 1).append("/").append(messageCount).append(")");
+            message.append(" (")
+                    .append(messageIndex + 1)
+                    .append("/")
+                    .append(messageCount)
+                    .append(")");
         }
         for (int groupIndex = firstGroup; groupIndex < lastGroup; groupIndex++) {
             message.append("\n- List ")
@@ -493,7 +500,8 @@ class FrankenComponentBanSettings extends SettingsMenu {
             return sources;
         }
         for (String type : COMPONENT_TYPES.keySet()) {
-            for (Map.Entry<String, Set<String>> entry : frankenSettings.selectedBanListSources(type).entrySet()) {
+            for (Map.Entry<String, Set<String>> entry :
+                    frankenSettings.selectedBanListSources(type).entrySet()) {
                 sources.put(componentKey(type, entry.getKey()), entry.getValue());
             }
         }
@@ -546,11 +554,7 @@ class FrankenComponentBanSettings extends SettingsMenu {
         switch (type) {
             case Constants.ABILITY ->
                 addFactionComponents(
-                        options,
-                        type,
-                        factions,
-                        FactionModel::getAbilities,
-                        FrankenComponentBanSettings::abilityName);
+                        options, type, factions, FactionModel::getAbilities, FrankenComponentBanSettings::abilityName);
             case Constants.BREAKTHROUGH ->
                 addFactionComponents(
                         options,
@@ -560,11 +564,7 @@ class FrankenComponentBanSettings extends SettingsMenu {
                         FrankenComponentBanSettings::breakthroughName);
             case Constants.LEADER ->
                 addFactionComponents(
-                        options,
-                        type,
-                        factions,
-                        FactionModel::getLeaders,
-                        FrankenComponentBanSettings::leaderName);
+                        options, type, factions, FactionModel::getLeaders, FrankenComponentBanSettings::leaderName);
             case Constants.PROMISSORY_NOTE_ID ->
                 addFactionComponents(
                         options,
@@ -574,11 +574,7 @@ class FrankenComponentBanSettings extends SettingsMenu {
                         FrankenComponentBanSettings::promissoryName);
             case Constants.TECH ->
                 addFactionComponents(
-                        options,
-                        type,
-                        factions,
-                        FactionModel::getFactionTech,
-                        FrankenComponentBanSettings::techName);
+                        options, type, factions, FactionModel::getFactionTech, FrankenComponentBanSettings::techName);
             case Constants.TILE_NAME ->
                 Mapper.getTileRepresentations().forEach((id, name) -> addOption(options, type, id, name, id));
             case Constants.UNIT_ID ->
@@ -618,7 +614,8 @@ class FrankenComponentBanSettings extends SettingsMenu {
         }
     }
 
-    private static void addOption(Map<String, String> options, String type, String id, String name, String labelSuffix) {
+    private static void addOption(
+            Map<String, String> options, String type, String id, String name, String labelSuffix) {
         if (id == null || id.isBlank() || name == null || name.isBlank()) {
             return;
         }
@@ -631,7 +628,9 @@ class FrankenComponentBanSettings extends SettingsMenu {
     }
 
     private static List<String> unitIds(FactionModel faction) {
-        return faction.getUnits().stream().filter(FrankenComponentBanSettings::isMechOrFlagship).toList();
+        return faction.getUnits().stream()
+                .filter(FrankenComponentBanSettings::isMechOrFlagship)
+                .toList();
     }
 
     private static boolean isMechOrFlagship(String id) {
@@ -683,9 +682,7 @@ class FrankenComponentBanSettings extends SettingsMenu {
 
     private static boolean playableFactionHasComponent(
             Game game, String id, Function<FactionModel, List<String>> componentIds) {
-        return playableFactions(game).stream()
-                .map(componentIds)
-                .anyMatch(ids -> ids != null && ids.contains(id));
+        return playableFactions(game).stream().map(componentIds).anyMatch(ids -> ids != null && ids.contains(id));
     }
 
     private static String componentKey(String type, String id) {

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
@@ -212,6 +212,18 @@ public class FrankenSettings extends SettingsMenu {
                 && menuId.equals(json.get("menuId").asString(""));
     }
 
+    public static boolean isFrankenMenuComponent(String componentId) {
+        return isFrankenMenuComponent(componentId, "jmfA_franken")
+                || isFrankenMenuComponent(componentId, "jmfN_franken");
+    }
+
+    private static boolean isFrankenMenuComponent(String componentId, String prefix) {
+        return componentId != null
+                && (componentId.equals(prefix)
+                        || componentId.startsWith(prefix + "_")
+                        || componentId.startsWith(prefix + "."));
+    }
+
     private static Map<String, String> draftModeOptions() {
         Map<String, String> options = new LinkedHashMap<>();
         options.put(STANDARD_DRAFT, STANDARD_DRAFT);
@@ -525,7 +537,7 @@ class FrankenComponentBanSettings extends SettingsMenu {
         });
     }
 
-    private static boolean isValidComponent(Game game, String type, String id) {
+    static boolean isValidComponent(Game game, String type, String id) {
         return switch (type) {
             case Constants.ABILITY ->
                 Mapper.getAbility(id) != null && playableFactionHasComponent(game, id, FactionModel::getAbilities);
@@ -548,7 +560,7 @@ class FrankenComponentBanSettings extends SettingsMenu {
         };
     }
 
-    private static Set<Entry<String, String>> componentOptions(Game game, String type) {
+    static Set<Entry<String, String>> componentOptions(Game game, String type) {
         Map<String, String> options = new LinkedHashMap<>();
         List<FactionModel> factions = playableFactions(game);
         switch (type) {

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
@@ -9,18 +9,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
-import net.dv8tion.jda.api.components.selections.SelectOption;
-import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
-import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.function.Consumers;
 import org.jetbrains.annotations.NotNull;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.commands.franken.ban.BanService;
@@ -34,7 +27,6 @@ import ti4.helpers.settingsFramework.settings.ChoiceSetting;
 import ti4.helpers.settingsFramework.settings.ListSetting;
 import ti4.helpers.settingsFramework.settings.SettingInterface;
 import ti4.image.Mapper;
-import ti4.logging.BotLogger;
 import ti4.model.FactionModel;
 import ti4.service.franken.FrankenBanList;
 import ti4.service.franken.FrankenDraftMode;
@@ -51,7 +43,6 @@ public class FrankenSettings extends SettingsMenu {
     private final BooleanSetting force;
     private final ListSetting<FactionModel> bannedFactions;
     private final ListSetting<FrankenBanList> banLists;
-    private final FrankenComponentBanSettings componentBanSettings;
 
     @JsonIgnore
     private final Game game;
@@ -100,9 +91,6 @@ public class FrankenSettings extends SettingsMenu {
             banLists.initialize(json.get("banLists"));
         }
 
-        componentBanSettings =
-                new FrankenComponentBanSettings(game, json != null ? json.get("componentBanSettings") : null, this);
-
         if (json != null && json.has("messageId")) {
             setMessageId(json.get("messageId").asText(null));
         }
@@ -115,7 +103,7 @@ public class FrankenSettings extends SettingsMenu {
 
     @Override
     protected List<SettingsMenu> categories() {
-        return List.of(componentBanSettings);
+        return List.of();
     }
 
     @Override
@@ -132,6 +120,11 @@ public class FrankenSettings extends SettingsMenu {
                     default -> null;
                 };
         return error == null ? "success" : error;
+    }
+
+    @Override
+    public String menuSummaryString(String lastSettingTouched) {
+        return super.menuSummaryString(lastSettingTouched) + frankenNotes();
     }
 
     private String startDraft(GenericInteractionCreateEvent event) {
@@ -151,7 +144,6 @@ public class FrankenSettings extends SettingsMenu {
         for (String banList : banLists.getKeys()) {
             banService.applyBanList(game, FrankenBanList.fromString(banList));
         }
-        componentBanSettings.applyBanSettings(banService);
     }
 
     private FrankenDraftMode selectedDraftMode() {
@@ -171,6 +163,13 @@ public class FrankenSettings extends SettingsMenu {
                 .sorted()
                 .toList();
         return "[" + String.join(",", values) + "]";
+    }
+
+    private static String frankenNotes() {
+        return "\n\n"
+                + "**Notes:**\n"
+                + "> Use the game options and homebrew settings above to enable homebrew. DS auto includes BR, if you want to play without them, add the BR ban list.\n"
+                + "> Due to discord message limits, component bans must be handled manually via slash command. The ban list options have popular component bans.";
     }
 
     Map<String, Set<String>> selectedBanListSources(String banType) {
@@ -259,556 +258,4 @@ public class FrankenSettings extends SettingsMenu {
         menu.postMessageAndButtons(event);
         ButtonHelper.deleteMessage(event);
     }
-}
-
-@Getter
-class FrankenComponentBanSettings extends SettingsMenu {
-
-    private static final String MENU_ID = "frankenComponents";
-    private static final String KEY_SEPARATOR = "|";
-    private static final int PAGE_SIZE = 25;
-    private static final int MAX_SELECT_MENUS_PER_MESSAGE = 5;
-    private static final int SUMMARY_LIMIT = 20;
-    private static final Map<String, String> COMPONENT_TYPES = componentTypes();
-
-    private Set<String> bannedComponents = new HashSet<>();
-
-    @JsonIgnore
-    private final Game game;
-
-    FrankenComponentBanSettings(@NotNull Game game, JsonNode json, SettingsMenu parent) {
-        super(MENU_ID, "Component Ban Settings", "Ban individual Franken draft components.", parent);
-        this.game = game;
-
-        if (FrankenSettings.isMenuJson(json, MENU_ID)) {
-            initializeBannedComponents(json.get("bannedComponents"));
-        }
-    }
-
-    @Override
-    protected List<SettingInterface> settings() {
-        return List.of();
-    }
-
-    @Override
-    protected List<Button> specialButtons() {
-        String prefix = menuAction + "_" + navId() + "_";
-        List<Button> buttons = new ArrayList<>();
-        for (Map.Entry<String, String> componentType : COMPONENT_TYPES.entrySet()) {
-            buttons.add(Buttons.green(
-                    prefix + "componentBanPick~add~" + componentType.getKey() + "~0",
-                    "Ban " + componentType.getValue()));
-        }
-        if (!bannedComponents.isEmpty()) {
-            for (Map.Entry<String, String> componentType : COMPONENT_TYPES.entrySet()) {
-                if (hasBannedComponentOfType(componentType.getKey())) {
-                    buttons.add(Buttons.red(
-                            prefix + "componentBanPick~remove~" + componentType.getKey() + "~0",
-                            "Unban " + componentType.getValue()));
-                }
-            }
-            buttons.add(Buttons.red(prefix + "clearComponentBans", "Clear Component Bans"));
-        }
-        return buttons;
-    }
-
-    @Override
-    protected String handleSpecialButtonAction(GenericInteractionCreateEvent event, String action) {
-        if (action.startsWith("componentBanPick~")) {
-            String error = showComponentBanPicker(event, action);
-            return error == null ? "success" : error;
-        }
-        if (action.startsWith("componentBanSelect~")) {
-            String error = updateComponentBansFromSelection(event, action);
-            return error == null ? "success" : error;
-        }
-        if ("clearComponentBans".equals(action)) {
-            String error = clearComponentBans();
-            return error == null ? "success" : error;
-        }
-        return null;
-    }
-
-    @Override
-    public String menuSummaryString(String lastSettingTouched) {
-        StringBuilder sb = new StringBuilder("# **__").append(menuName).append(":__**");
-        for (String line : description) sb.append("\n- *").append(line).append("*");
-        sb.append("\n");
-        appendComponentSummary(sb);
-        return sb.toString();
-    }
-
-    @Override
-    public String shortSummaryString(boolean shortDescrOnly) {
-        StringBuilder sb = new StringBuilder("**__" + menuName + ":__**");
-        if (shortDescrOnly) {
-            for (String line : description) {
-                sb.append("\n- *").append(line).append("*");
-                break;
-            }
-            return sb.toString();
-        }
-        appendComponentSummary(sb);
-        return sb.toString();
-    }
-
-    void applyBanSettings(BanService banService) {
-        for (String componentKey : bannedComponents) {
-            String[] parts = splitComponentKey(componentKey);
-            if (parts.length != 2) {
-                continue;
-            }
-            banService.applyOption(game, parts[0], parts[1]);
-        }
-    }
-
-    private String showComponentBanPicker(GenericInteractionCreateEvent event, String action) {
-        if (!(event instanceof ButtonInteractionEvent buttonEvent)) {
-            return "Unknown Event";
-        }
-
-        ComponentAction componentAction = parseComponentAction(action);
-        if (componentAction == null) {
-            return "Invalid component ban action.";
-        }
-
-        List<Map.Entry<String, String>> entries = componentOptions(game, componentAction.componentType()).stream()
-                .filter(entry -> componentAction.add() != bannedComponents.contains(entry.getKey()))
-                .sorted(Map.Entry.comparingByValue())
-                .toList();
-        if (entries.isEmpty()) {
-            return "No " + COMPONENT_TYPES.get(componentAction.componentType()) + " components available to "
-                    + (componentAction.add() ? "ban." : "unban.");
-        }
-
-        List<List<Map.Entry<String, String>>> optionGroups = ListUtils.partition(entries, PAGE_SIZE);
-        int messageCount = Math.ceilDiv(optionGroups.size(), MAX_SELECT_MENUS_PER_MESSAGE);
-        String prefix = menuAction + "_" + navId() + "_componentBan";
-
-        buttonEvent
-                .getHook()
-                .sendMessage(componentPickerMessage(componentAction, optionGroups, 0, messageCount))
-                .addComponents(componentPickerRows(componentAction, prefix, optionGroups, 0))
-                .setEphemeral(true)
-                .queue(Consumers.nop(), BotLogger::catchRestError);
-
-        for (int messageIndex = 1; messageIndex < messageCount; messageIndex++) {
-            int firstGroup = messageIndex * MAX_SELECT_MENUS_PER_MESSAGE;
-            buttonEvent
-                    .getHook()
-                    .sendMessage(componentPickerMessage(componentAction, optionGroups, messageIndex, messageCount))
-                    .addComponents(componentPickerRows(componentAction, prefix, optionGroups, firstGroup))
-                    .setEphemeral(true)
-                    .queue(Consumers.nop(), BotLogger::catchRestError);
-        }
-        return null;
-    }
-
-    private static String componentPickerMessage(
-            ComponentAction componentAction,
-            List<List<Map.Entry<String, String>>> optionGroups,
-            int messageIndex,
-            int messageCount) {
-        int firstGroup = messageIndex * MAX_SELECT_MENUS_PER_MESSAGE;
-        int lastGroup = Math.min(firstGroup + MAX_SELECT_MENUS_PER_MESSAGE, optionGroups.size());
-        StringBuilder message = new StringBuilder(
-                componentAction.add() ? "Choose components to ban: " : "Choose components to unban: ");
-        message.append(COMPONENT_TYPES.get(componentAction.componentType()));
-        if (messageCount > 1) {
-            message.append(" (")
-                    .append(messageIndex + 1)
-                    .append("/")
-                    .append(messageCount)
-                    .append(")");
-        }
-        for (int groupIndex = firstGroup; groupIndex < lastGroup; groupIndex++) {
-            message.append("\n- List ")
-                    .append(groupIndex + 1)
-                    .append(": ")
-                    .append(alphabetRange(optionGroups.get(groupIndex)));
-        }
-        return message.toString();
-    }
-
-    private static List<ActionRow> componentPickerRows(
-            ComponentAction componentAction,
-            String prefix,
-            List<List<Map.Entry<String, String>>> optionGroups,
-            int firstGroup) {
-        String mode = componentAction.add() ? "add" : "remove";
-        int lastGroup = Math.min(firstGroup + MAX_SELECT_MENUS_PER_MESSAGE, optionGroups.size());
-        List<ActionRow> rows = new ArrayList<>();
-        for (int groupIndex = firstGroup; groupIndex < lastGroup; groupIndex++) {
-            List<Map.Entry<String, String>> group = optionGroups.get(groupIndex);
-            List<SelectOption> options = group.stream()
-                    .map(entry -> SelectOption.of(entry.getValue(), entry.getKey()))
-                    .toList();
-            String selectId = prefix + "Select~" + mode + "~" + componentAction.componentType() + "~" + groupIndex;
-            StringSelectMenu selectMenu = StringSelectMenu.create(selectId)
-                    .addOptions(options)
-                    .setPlaceholder((componentAction.add() ? "Ban " : "Unban ")
-                            + COMPONENT_TYPES.get(componentAction.componentType()) + " "
-                            + alphabetRange(group))
-                    .setRequiredRange(0, options.size())
-                    .build();
-            rows.add(ActionRow.of(selectMenu));
-        }
-        return rows;
-    }
-
-    private String updateComponentBansFromSelection(GenericInteractionCreateEvent event, String action) {
-        if (!(event instanceof StringSelectInteractionEvent selectEvent)) {
-            return "Unknown Event";
-        }
-
-        ComponentAction componentAction = parseComponentAction(action);
-        if (componentAction == null) {
-            return "Invalid component ban action.";
-        }
-        for (String key : selectEvent.getValues()) {
-            String[] parts = splitComponentKey(key);
-            if (parts.length != 2 || !parts[0].equals(componentAction.componentType())) {
-                continue;
-            }
-            if (componentAction.add()) {
-                bannedComponents.add(key);
-            } else {
-                bannedComponents.remove(key);
-            }
-        }
-        return null;
-    }
-
-    private String clearComponentBans() {
-        bannedComponents.clear();
-        return null;
-    }
-
-    private void appendComponentSummary(StringBuilder sb) {
-        Map<String, Set<String>> banListSources = selectedBanListComponentSources();
-        Set<String> effectiveBans = new HashSet<>(bannedComponents);
-        effectiveBans.addAll(banListSources.keySet());
-        if (effectiveBans.isEmpty()) {
-            sb.append("> No component bans selected.\n");
-            return;
-        }
-
-        List<String> labels = effectiveBans.stream()
-                .map(key -> componentLabel(key, banListSources.getOrDefault(key, Set.of())))
-                .sorted()
-                .toList();
-        List<String> shown = labels.subList(0, Math.min(labels.size(), SUMMARY_LIMIT));
-        for (String label : shown) {
-            sb.append("> ").append(label).append("\n");
-        }
-        if (labels.size() > SUMMARY_LIMIT) {
-            sb.append("> +").append(labels.size() - SUMMARY_LIMIT).append(" more\n");
-        }
-    }
-
-    private Map<String, Set<String>> selectedBanListComponentSources() {
-        Map<String, Set<String>> sources = new LinkedHashMap<>();
-        if (!(parent instanceof FrankenSettings frankenSettings)) {
-            return sources;
-        }
-        for (String type : COMPONENT_TYPES.keySet()) {
-            for (Map.Entry<String, Set<String>> entry :
-                    frankenSettings.selectedBanListSources(type).entrySet()) {
-                sources.put(componentKey(type, entry.getKey()), entry.getValue());
-            }
-        }
-        return sources;
-    }
-
-    private void initializeBannedComponents(JsonNode json) {
-        if (json == null || !json.isArray()) {
-            return;
-        }
-        bannedComponents.clear();
-        json.forEach(node -> {
-            if (!node.isTextual()) {
-                return;
-            }
-            String key = node.asText();
-            String[] parts = splitComponentKey(key);
-            if (parts.length == 2 && isValidComponent(game, parts[0], parts[1])) {
-                bannedComponents.add(key);
-            }
-        });
-    }
-
-    static boolean isValidComponent(Game game, String type, String id) {
-        return switch (type) {
-            case Constants.ABILITY ->
-                Mapper.getAbility(id) != null && playableFactionHasComponent(game, id, FactionModel::getAbilities);
-            case Constants.BREAKTHROUGH ->
-                Mapper.getBreakthrough(id) != null
-                        && playableFactions(game).stream().anyMatch(faction -> id.equals(faction.getBreakthrough()));
-            case Constants.LEADER ->
-                Mapper.getLeader(id) != null && playableFactionHasComponent(game, id, FactionModel::getLeaders);
-            case Constants.PROMISSORY_NOTE_ID ->
-                Mapper.getPromissoryNote(id) != null
-                        && playableFactionHasComponent(game, id, FactionModel::getPromissoryNotes);
-            case Constants.TECH ->
-                Mapper.getTech(id) != null && playableFactionHasComponent(game, id, FactionModel::getFactionTech);
-            case Constants.TILE_NAME -> Mapper.getTileRepresentations().containsKey(id);
-            case Constants.UNIT_ID ->
-                isMechOrFlagship(id) && playableFactionHasComponent(game, id, FactionModel::getUnits);
-            case Constants.BAN_COMMODITIES, Constants.BAN_FLEET, Constants.BAN_HS, Constants.BAN_STARTING_TECH ->
-                playableFactionAliases(game).contains(id);
-            default -> false;
-        };
-    }
-
-    static Set<Entry<String, String>> componentOptions(Game game, String type) {
-        Map<String, String> options = new LinkedHashMap<>();
-        List<FactionModel> factions = playableFactions(game);
-        switch (type) {
-            case Constants.ABILITY ->
-                addFactionComponents(
-                        options, type, factions, FactionModel::getAbilities, FrankenComponentBanSettings::abilityName);
-            case Constants.BREAKTHROUGH ->
-                addFactionComponents(
-                        options,
-                        type,
-                        factions,
-                        FrankenComponentBanSettings::breakthroughIds,
-                        FrankenComponentBanSettings::breakthroughName);
-            case Constants.LEADER ->
-                addFactionComponents(
-                        options, type, factions, FactionModel::getLeaders, FrankenComponentBanSettings::leaderName);
-            case Constants.PROMISSORY_NOTE_ID ->
-                addFactionComponents(
-                        options,
-                        type,
-                        factions,
-                        FactionModel::getPromissoryNotes,
-                        FrankenComponentBanSettings::promissoryName);
-            case Constants.TECH ->
-                addFactionComponents(
-                        options, type, factions, FactionModel::getFactionTech, FrankenComponentBanSettings::techName);
-            case Constants.TILE_NAME ->
-                Mapper.getTileRepresentations().forEach((id, name) -> addOption(options, type, id, name, id));
-            case Constants.UNIT_ID ->
-                addFactionComponents(
-                        options,
-                        type,
-                        factions,
-                        FrankenComponentBanSettings::unitIds,
-                        FrankenComponentBanSettings::unitName);
-            case Constants.BAN_COMMODITIES, Constants.BAN_FLEET, Constants.BAN_HS, Constants.BAN_STARTING_TECH ->
-                addFactionOptions(options, type, factions);
-            default -> {}
-        }
-        return options.entrySet();
-    }
-
-    private static void addFactionComponents(
-            Map<String, String> options,
-            String type,
-            List<FactionModel> factions,
-            Function<FactionModel, List<String>> componentIds,
-            Function<String, String> componentName) {
-        for (FactionModel faction : factions) {
-            List<String> ids = componentIds.apply(faction);
-            if (ids == null) {
-                continue;
-            }
-            for (String id : ids) {
-                addOption(options, type, id, componentName.apply(id), id);
-            }
-        }
-    }
-
-    private static void addFactionOptions(Map<String, String> options, String type, List<FactionModel> factions) {
-        for (FactionModel faction : factions) {
-            addOption(options, type, faction.getAlias(), faction.getFactionName(), faction.getAlias());
-        }
-    }
-
-    private static void addOption(
-            Map<String, String> options, String type, String id, String name, String labelSuffix) {
-        if (id == null || id.isBlank() || name == null || name.isBlank()) {
-            return;
-        }
-        options.put(componentKey(type, id), abbreviate(name + " [" + labelSuffix + "]"));
-    }
-
-    private static List<String> breakthroughIds(FactionModel faction) {
-        String id = faction.getBreakthrough();
-        return id == null || id.isBlank() ? List.of() : List.of(id);
-    }
-
-    private static List<String> unitIds(FactionModel faction) {
-        return faction.getUnits().stream()
-                .filter(FrankenComponentBanSettings::isMechOrFlagship)
-                .toList();
-    }
-
-    private static boolean isMechOrFlagship(String id) {
-        var unit = Mapper.getUnit(id);
-        if (unit == null) {
-            return false;
-        }
-        String baseType = unit.getBaseType();
-        return Constants.MECH_ID.equalsIgnoreCase(baseType) || Constants.FLAGSHIP_ID.equalsIgnoreCase(baseType);
-    }
-
-    private static String abilityName(String id) {
-        var model = Mapper.getAbility(id);
-        return model == null ? null : model.getName();
-    }
-
-    private static String breakthroughName(String id) {
-        var model = Mapper.getBreakthrough(id);
-        return model == null ? null : model.getName();
-    }
-
-    private static String leaderName(String id) {
-        var model = Mapper.getLeader(id);
-        return model == null ? null : model.getName();
-    }
-
-    private static String promissoryName(String id) {
-        var model = Mapper.getPromissoryNote(id);
-        return model == null ? null : model.getName();
-    }
-
-    private static String techName(String id) {
-        var model = Mapper.getTech(id);
-        return model == null ? null : model.getName();
-    }
-
-    private static String unitName(String id) {
-        var model = Mapper.getUnit(id);
-        return model == null ? null : model.getName();
-    }
-
-    private static List<FactionModel> playableFactions(Game game) {
-        return FrankenDraft.getAllFrankenLegalFactions(game);
-    }
-
-    private static Set<String> playableFactionAliases(Game game) {
-        return playableFactions(game).stream().map(FactionModel::getAlias).collect(Collectors.toSet());
-    }
-
-    private static boolean playableFactionHasComponent(
-            Game game, String id, Function<FactionModel, List<String>> componentIds) {
-        return playableFactions(game).stream().map(componentIds).anyMatch(ids -> ids != null && ids.contains(id));
-    }
-
-    private static String componentKey(String type, String id) {
-        return type + KEY_SEPARATOR + id;
-    }
-
-    private static String[] splitComponentKey(String key) {
-        return key.split("\\" + KEY_SEPARATOR, 2);
-    }
-
-    private boolean hasBannedComponentOfType(String type) {
-        return bannedComponents.stream().anyMatch(key -> key.startsWith(type + KEY_SEPARATOR));
-    }
-
-    private static String componentLabel(String key, Set<String> sources) {
-        return FrankenSettings.withSourceLabel(componentLabel(key), sources);
-    }
-
-    private static String componentLabel(String key) {
-        String[] parts = splitComponentKey(key);
-        if (parts.length != 2) {
-            return key;
-        }
-
-        String type = parts[0];
-        String id = parts[1];
-        String name =
-                switch (type) {
-                    case Constants.ABILITY -> labelOrId(abilityName(id), id);
-                    case Constants.BREAKTHROUGH -> labelOrId(breakthroughName(id), id);
-                    case Constants.LEADER -> labelOrId(leaderName(id), id);
-                    case Constants.PROMISSORY_NOTE_ID -> labelOrId(promissoryName(id), id);
-                    case Constants.TECH -> labelOrId(techName(id), id);
-                    case Constants.TILE_NAME -> Mapper.getTileRepresentations().getOrDefault(id, id);
-                    case Constants.UNIT_ID -> labelOrId(unitName(id), id);
-                    case Constants.BAN_COMMODITIES -> FrankenSettings.factionName(id) + " commodities";
-                    case Constants.BAN_FLEET -> FrankenSettings.factionName(id) + " starting fleet";
-                    case Constants.BAN_HS -> FrankenSettings.factionName(id) + " home system";
-                    case Constants.BAN_STARTING_TECH -> FrankenSettings.factionName(id) + " starting tech";
-                    default -> id;
-                };
-
-        return "`" + type + "`: " + name + " [" + id + "]";
-    }
-
-    private static String labelOrId(String label, String id) {
-        return label == null ? id : label;
-    }
-
-    private static ComponentAction parseComponentAction(String action) {
-        String[] parts = action.split("~");
-        if (parts.length < 4) {
-            return null;
-        }
-        boolean add;
-        if ("add".equals(parts[1])) {
-            add = true;
-        } else if ("remove".equals(parts[1])) {
-            add = false;
-        } else {
-            return null;
-        }
-        String componentType = parts[2];
-        if (!COMPONENT_TYPES.containsKey(componentType)) {
-            return null;
-        }
-        int page;
-        try {
-            page = Integer.parseInt(parts[3]);
-        } catch (NumberFormatException e) {
-            page = 0;
-        }
-        return new ComponentAction(add, componentType, page);
-    }
-
-    private static Map<String, String> componentTypes() {
-        Map<String, String> componentTypes = new LinkedHashMap<>();
-        componentTypes.put(Constants.ABILITY, "Ability");
-        componentTypes.put(Constants.BREAKTHROUGH, "Breakthrough");
-        componentTypes.put(Constants.LEADER, "Leader");
-        componentTypes.put(Constants.PROMISSORY_NOTE_ID, "Promissory");
-        componentTypes.put(Constants.TECH, "Tech");
-        componentTypes.put(Constants.TILE_NAME, "Tile");
-        componentTypes.put(Constants.UNIT_ID, "Unit");
-        componentTypes.put(Constants.BAN_COMMODITIES, "Commodities");
-        componentTypes.put(Constants.BAN_FLEET, "Starting Fleet");
-        componentTypes.put(Constants.BAN_HS, "Home System");
-        componentTypes.put(Constants.BAN_STARTING_TECH, "Starting Tech");
-        return componentTypes;
-    }
-
-    private static String abbreviate(String label) {
-        if (label.length() <= 90) {
-            return label;
-        }
-        return label.substring(0, 87) + "...";
-    }
-
-    private static String alphabetRange(List<Map.Entry<String, String>> entries) {
-        if (entries.isEmpty()) {
-            return "";
-        }
-        String first = alphabetStart(entries.getFirst().getValue());
-        String last = alphabetStart(entries.getLast().getValue());
-        return first.equals(last) ? first : first + "-" + last;
-    }
-
-    private static String alphabetStart(String label) {
-        if (label == null || label.isBlank()) {
-            return "#";
-        }
-        char first = Character.toUpperCase(label.trim().charAt(0));
-        return Character.isLetterOrDigit(first) ? String.valueOf(first) : "#";
-    }
-
-    private record ComponentAction(boolean add, String componentType, int page) {}
 }

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
@@ -168,7 +168,7 @@ public class FrankenSettings extends SettingsMenu {
     private static String frankenNotes() {
         return "\n\n"
                 + "**Notes:**\n"
-                + "> Use the game options and homebrew settings above to enable homebrew. DS auto includes BR, if you want to play without them, add the BR ban list.\n"
+                + "> Use the game options and homebrew settings above to enable homebrew. DS auto includes BR, if you want to play without them, add the BR ban list.\n\n"
                 + "> Due to discord message limits, component bans must be handled manually via slash command. The ban list options have popular component bans.";
     }
 

--- a/src/main/java/ti4/service/franken/FrankenBanList.java
+++ b/src/main/java/ti4/service/franken/FrankenBanList.java
@@ -161,7 +161,13 @@ public enum FrankenBanList {
                                     "classified_developments",
                                     "data_recovery",
                                     "honor_bound",
-                                    "prescience"))));
+                                    "prescience")))),
+
+    Blue_Reverie(
+            "Blue Reverie",
+            "Removes BR factions.",
+            Map.ofEntries(Map.entry(
+                    Constants.BAN_FACTION, List.of("atokera", "belkosea", "qhet", "pharadn", "toldar", "uydai"))));
 
     private final String id;
 

--- a/src/main/java/ti4/service/franken/FrankenDraftStartService.java
+++ b/src/main/java/ti4/service/franken/FrankenDraftStartService.java
@@ -1,0 +1,61 @@
+package ti4.service.franken;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import ti4.draft.FrankenDraft;
+import ti4.draft.FrankenDrazDraft;
+import ti4.draft.InauguralSpliceFrankenDraft;
+import ti4.draft.OnePickFrankenDraft;
+import ti4.draft.OverdraftFrankenDraft;
+import ti4.draft.PoweredFrankenDraft;
+import ti4.draft.PoweredOnePickFrankenDraft;
+import ti4.draft.PoweredOverdraftFrankenDraft;
+import ti4.draft.TwilightsFallFrankenDraft;
+import ti4.game.Game;
+import ti4.game.Player;
+
+@UtilityClass
+public class FrankenDraftStartService {
+
+    public String startFrankenDraft(
+            GenericInteractionCreateEvent event, Game game, boolean force, FrankenDraftMode draftMode) {
+        String validationError = validateStartFrankenDraft(game, force);
+        if (validationError != null) return validationError;
+
+        FrankenDraftBagService.setUpFrankenFactions(game, event, force);
+        FrankenDraftBagService.clearPlayerHands(game);
+
+        if (draftMode == null) {
+            game.setBagDraft(new FrankenDraft(game));
+        } else {
+            switch (draftMode) {
+                case POWERED -> game.setBagDraft(new PoweredFrankenDraft(game));
+                case ONEPICK -> game.setBagDraft(new OnePickFrankenDraft(game));
+                case OVERDRAFT -> game.setBagDraft(new OverdraftFrankenDraft(game));
+                case POWEREDONEPICK -> game.setBagDraft(new PoweredOnePickFrankenDraft(game));
+                case POWEREDOVERDRAFT -> game.setBagDraft(new PoweredOverdraftFrankenDraft(game));
+                case FRANKENDRAZ -> game.setBagDraft(new FrankenDrazDraft(game));
+                case TWILIGHTSFALL -> {
+                    game.setupTwilightsFallMode(event);
+                    game.setBagDraft(new TwilightsFallFrankenDraft(game));
+                }
+                case INAUGURALSPLICE -> {
+                    game.setupTwilightsFallMode(event);
+                    game.setBagDraft(new InauguralSpliceFrankenDraft(game));
+                }
+            }
+        }
+
+        FrankenDraftBagService.startDraft(game);
+        return null;
+    }
+
+    public String validateStartFrankenDraft(Game game, boolean force) {
+        if (!force
+                && game.getPlayers().values().stream().anyMatch(Player::isRealPlayer)
+                && !game.isTwilightsFallMode()) {
+            return "There are players that are currently set up already. Please rerun with force enabled to overwrite them.";
+        }
+        return null;
+    }
+}

--- a/src/main/java/ti4/service/game/CreateGameService.java
+++ b/src/main/java/ti4/service/game/CreateGameService.java
@@ -290,6 +290,12 @@ public class CreateGameService {
                 "If you want to start a Twilight's Fall Game (alternate game mode included in Thunder's Edge) use this button",
                 tfOptions);
 
+        Button frankenButton = Buttons.green("frankenSetup", "Start Franken Setup");
+        MessageHelper.sendMessageToChannelWithButton(
+                actionsChannel,
+                "If you want to start a Franken game (alternate homebrew game mode) use this button",
+                frankenButton);
+
         List<Button> buttons = new ArrayList<>();
         buttons.add(Buttons.green("chooseExp_newPoK", "New PoK"));
         buttons.add(Buttons.gray("chooseExp_oldPoK", "Old PoK"));

--- a/src/test/java/ti4/discord/interactions/commands/franken/ban/BanServiceTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/franken/ban/BanServiceTest.java
@@ -30,7 +30,8 @@ class BanServiceTest extends BaseTi4Test {
         banService.applyBanList(game, FrankenBanList.Blue_Reverie);
         banService.applyBanList(game, FrankenBanList.Blue_Reverie);
 
-        List<String> bannedFactions = List.of(game.getStoredValue("bannedFactions").split(Constants.FIN_SEPARATOR));
+        List<String> bannedFactions =
+                List.of(game.getStoredValue("bannedFactions").split(Constants.FIN_SEPARATOR));
         assertThat(bannedFactions)
                 .containsExactly("atokera", "belkosea", "qhet", "pharadn", "toldar", "uydai")
                 .doesNotHaveDuplicates();

--- a/src/test/java/ti4/discord/interactions/commands/franken/ban/BanServiceTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/franken/ban/BanServiceTest.java
@@ -1,0 +1,38 @@
+package ti4.discord.interactions.commands.franken.ban;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.helpers.Constants;
+import ti4.service.franken.FrankenBanList;
+import ti4.testUtils.BaseTi4Test;
+
+class BanServiceTest extends BaseTi4Test {
+
+    private final BanService banService = new BanService();
+
+    @Test
+    void applyOptionDeduplicatesStoredBans() {
+        Game game = new Game();
+
+        banService.applyOption(game, Constants.BAN_FACTION, "atokera");
+        banService.applyOption(game, Constants.BAN_FACTION, "atokera");
+
+        assertThat(game.getStoredValue("bannedFactions")).isEqualTo("atokera");
+    }
+
+    @Test
+    void applyBanListAddsFactionBansOnce() {
+        Game game = new Game();
+
+        banService.applyBanList(game, FrankenBanList.Blue_Reverie);
+        banService.applyBanList(game, FrankenBanList.Blue_Reverie);
+
+        List<String> bannedFactions = List.of(game.getStoredValue("bannedFactions").split(Constants.FIN_SEPARATOR));
+        assertThat(bannedFactions)
+                .containsExactly("atokera", "belkosea", "qhet", "pharadn", "toldar", "uydai")
+                .doesNotHaveDuplicates();
+    }
+}

--- a/src/test/java/ti4/helpers/settingsFramework/menus/FrankenSettingsTest.java
+++ b/src/test/java/ti4/helpers/settingsFramework/menus/FrankenSettingsTest.java
@@ -2,86 +2,23 @@ package ti4.helpers.settingsFramework.menus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import ti4.draft.FrankenDraft;
-import ti4.game.Game;
-import ti4.helpers.Constants;
-import ti4.image.Mapper;
-import ti4.model.FactionModel;
-import ti4.testUtils.BaseTi4Test;
 
-class FrankenSettingsTest extends BaseTi4Test {
+class FrankenSettingsTest {
 
     @Test
     void routesOnlyDeterministicFrankenMenuIds() {
-        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_franken_startFranken")).isTrue();
-        assertThat(FrankenSettings.isFrankenMenuComponent("jmfN_franken.frankenComponents")).isTrue();
-        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_franken.frankenComponents_componentBanPick~add~ability~0"))
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_franken_startFranken"))
+                .isTrue();
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfN_franken.BannedFactions"))
                 .isTrue();
 
-        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_milty_includeBanned_franken")).isFalse();
-        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_frankenish_start")).isFalse();
-        assertThat(FrankenSettings.isFrankenMenuComponent("prefix_jmfA_franken_start")).isFalse();
-        assertThat(FrankenSettings.isFrankenMenuComponent(null)).isFalse();
-    }
-
-    @Test
-    void componentValidationRequiresPlayableFactionComponent() {
-        Game game = new Game();
-        Set<String> legalAbilityIds = componentIds(game, FactionModel::getAbilities);
-        String playableAbilityId = legalAbilityIds.stream().findFirst().orElseThrow();
-        String nonPlayableAbilityId = Mapper.getAbilities().keySet().stream()
-                .filter(id -> !legalAbilityIds.contains(id))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(FrankenComponentBanSettings.isValidComponent(game, Constants.ABILITY, playableAbilityId))
-                .isTrue();
-        assertThat(FrankenComponentBanSettings.isValidComponent(game, Constants.ABILITY, nonPlayableAbilityId))
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_milty_includeBanned_franken"))
                 .isFalse();
-    }
-
-    @Test
-    void componentOptionsOnlyIncludePlayableFactionComponents() {
-        Game game = new Game();
-        Set<String> legalAbilityIds = componentIds(game, FactionModel::getAbilities);
-
-        Set<String> optionIds = FrankenComponentBanSettings.componentOptions(game, Constants.ABILITY).stream()
-                .map(Map.Entry::getKey)
-                .map(FrankenSettingsTest::componentId)
-                .collect(Collectors.toSet());
-
-        assertThat(optionIds).isNotEmpty().allMatch(legalAbilityIds::contains);
-    }
-
-    @Test
-    void factionDerivedComponentOptionsUsePlayableFactions() {
-        Game game = new Game();
-        Set<String> legalFactionIds = FrankenDraft.getAllFrankenLegalFactions(game).stream()
-                .map(FactionModel::getAlias)
-                .collect(Collectors.toSet());
-
-        Set<String> optionIds = FrankenComponentBanSettings.componentOptions(game, Constants.BAN_COMMODITIES).stream()
-                .map(Map.Entry::getKey)
-                .map(FrankenSettingsTest::componentId)
-                .collect(Collectors.toSet());
-
-        assertThat(optionIds).containsExactlyInAnyOrderElementsOf(legalFactionIds);
-    }
-
-    private static Set<String> componentIds(Game game, Function<FactionModel, List<String>> ids) {
-        return FrankenDraft.getAllFrankenLegalFactions(game).stream()
-                .map(ids)
-                .flatMap(List::stream)
-                .collect(Collectors.toSet());
-    }
-
-    private static String componentId(String componentKey) {
-        return componentKey.split("\\|", 2)[1];
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_frankenish_start"))
+                .isFalse();
+        assertThat(FrankenSettings.isFrankenMenuComponent("prefix_jmfA_franken_start"))
+                .isFalse();
+        assertThat(FrankenSettings.isFrankenMenuComponent(null)).isFalse();
     }
 }

--- a/src/test/java/ti4/helpers/settingsFramework/menus/FrankenSettingsTest.java
+++ b/src/test/java/ti4/helpers/settingsFramework/menus/FrankenSettingsTest.java
@@ -1,0 +1,87 @@
+package ti4.helpers.settingsFramework.menus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import ti4.draft.FrankenDraft;
+import ti4.game.Game;
+import ti4.helpers.Constants;
+import ti4.image.Mapper;
+import ti4.model.FactionModel;
+import ti4.testUtils.BaseTi4Test;
+
+class FrankenSettingsTest extends BaseTi4Test {
+
+    @Test
+    void routesOnlyDeterministicFrankenMenuIds() {
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_franken_startFranken")).isTrue();
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfN_franken.frankenComponents")).isTrue();
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_franken.frankenComponents_componentBanPick~add~ability~0"))
+                .isTrue();
+
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_milty_includeBanned_franken")).isFalse();
+        assertThat(FrankenSettings.isFrankenMenuComponent("jmfA_frankenish_start")).isFalse();
+        assertThat(FrankenSettings.isFrankenMenuComponent("prefix_jmfA_franken_start")).isFalse();
+        assertThat(FrankenSettings.isFrankenMenuComponent(null)).isFalse();
+    }
+
+    @Test
+    void componentValidationRequiresPlayableFactionComponent() {
+        Game game = new Game();
+        Set<String> legalAbilityIds = componentIds(game, FactionModel::getAbilities);
+        String playableAbilityId = legalAbilityIds.stream().findFirst().orElseThrow();
+        String nonPlayableAbilityId = Mapper.getAbilities().keySet().stream()
+                .filter(id -> !legalAbilityIds.contains(id))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(FrankenComponentBanSettings.isValidComponent(game, Constants.ABILITY, playableAbilityId))
+                .isTrue();
+        assertThat(FrankenComponentBanSettings.isValidComponent(game, Constants.ABILITY, nonPlayableAbilityId))
+                .isFalse();
+    }
+
+    @Test
+    void componentOptionsOnlyIncludePlayableFactionComponents() {
+        Game game = new Game();
+        Set<String> legalAbilityIds = componentIds(game, FactionModel::getAbilities);
+
+        Set<String> optionIds = FrankenComponentBanSettings.componentOptions(game, Constants.ABILITY).stream()
+                .map(Map.Entry::getKey)
+                .map(FrankenSettingsTest::componentId)
+                .collect(Collectors.toSet());
+
+        assertThat(optionIds).isNotEmpty().allMatch(legalAbilityIds::contains);
+    }
+
+    @Test
+    void factionDerivedComponentOptionsUsePlayableFactions() {
+        Game game = new Game();
+        Set<String> legalFactionIds = FrankenDraft.getAllFrankenLegalFactions(game).stream()
+                .map(FactionModel::getAlias)
+                .collect(Collectors.toSet());
+
+        Set<String> optionIds = FrankenComponentBanSettings.componentOptions(game, Constants.BAN_COMMODITIES).stream()
+                .map(Map.Entry::getKey)
+                .map(FrankenSettingsTest::componentId)
+                .collect(Collectors.toSet());
+
+        assertThat(optionIds).containsExactlyInAnyOrderElementsOf(legalFactionIds);
+    }
+
+    private static Set<String> componentIds(Game game, Function<FactionModel, List<String>> ids) {
+        return FrankenDraft.getAllFrankenLegalFactions(game).stream()
+                .map(ids)
+                .flatMap(List::stream)
+                .collect(Collectors.toSet());
+    }
+
+    private static String componentId(String componentKey) {
+        return componentKey.split("\\|", 2)[1];
+    }
+}


### PR DESCRIPTION
Add Franken Draft Settings Menu

Adds a new settings framework menu for configuring and starting Franken draft games. Features include:

- Draft mode selection (Standard, Powered, Overdraft, etc.)
- Faction banning system with support for pre-defined ban lists
- Force-start option for overwriting existing player setups
- Refactored StartFrankenDraft command logic into reusable FrankenDraftStartService
- Integration with button/modal/selection event handlers for consistent menu routing
- Added "Blue Reverie" ban list for excluding BR factions
- Persistence: Franken settings are now saved and restored with game state