### PR TITLE
Two new helpful Frankendraz subcommands

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazCommand.java
@@ -13,6 +13,8 @@ public class FrankenDrazCommand implements ParentCommand {
                     new FrankenDrazAddFaction(),
                     new FrankenDrazRemoveFaction(),
                     new FrankenDrazSwapFaction(),
+                    new FrankenDrazSetKeptComponentLimit(),
+                    new FrankenDrazFactionLimit(),
                     new FrankenDrazHelp())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazFactionLimit.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazFactionLimit.java
@@ -1,0 +1,38 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.GameStateSubcommand;
+import ti4.draft.FrankenDrazDraft;
+import ti4.game.Game;
+import ti4.message.MessageHelper;
+
+class FrankenDrazFactionLimit extends GameStateSubcommand {
+    private static final String LIMIT = "limit";
+
+    FrankenDrazFactionLimit() {
+        super("faction_limit", "Set the number of factions each player drafts", true, false);
+        addOptions(new OptionData(OptionType.INTEGER, LIMIT, "Faction draft limit").setRequired(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getGame();
+        if (game.getActiveBagDraft() != null && !(game.getActiveBagDraft() instanceof FrankenDrazDraft)) {
+            MessageHelper.sendMessageToEventChannel(
+                    event, "This command can only be used before a draft starts or in a FrankenDraz draft.");
+            return;
+        }
+
+        int limit = event.getOption(LIMIT).getAsInt();
+        if (limit < 1) {
+            MessageHelper.sendMessageToEventChannel(event, "Faction limit must be at least 1.");
+            return;
+        }
+
+        game.setStoredValue(FrankenDrazDraft.FACTION_LIMIT_KEY, String.valueOf(limit));
+        MessageHelper.sendMessageToEventChannel(
+                event, "FrankenDraz faction draft limit set to " + limit + " per player.");
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazHelp.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazHelp.java
@@ -20,10 +20,12 @@ class FrankenDrazHelp extends Subcommand {
 
                 After the draft is complete, each player gets category buttons in their cards info thread. Open a category to view the drafted components and choose which ones to add to the faction. Home systems and starting fleets are informational and must still be set up manually (for now).
 
-                The limits for components follow powered franken limits. (4 abilities, 3 faction techs, 1 of everything else)
+                The limits for components follow powered franken limits by default. (4 abilities, 3 faction techs, 1 of everything else)
 
                 Use the following post-draft commands in case of any issues:
 
+                `/frankendraz faction_limit`
+                `/frankendraz set_kept_component_limit`
                 `/frankendraz add_faction`
                 `/frankendraz remove_faction`
                 `/frankendraz swap_faction`

--- a/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazSetKeptComponentLimit.java
+++ b/src/main/java/ti4/discord/interactions/commands/frankendraz/FrankenDrazSetKeptComponentLimit.java
@@ -1,0 +1,43 @@
+package ti4.discord.interactions.commands.frankendraz;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.GameStateSubcommand;
+import ti4.draft.FrankenDrazDraft;
+import ti4.game.Game;
+import ti4.message.MessageHelper;
+
+class FrankenDrazSetKeptComponentLimit extends GameStateSubcommand {
+    private static final String UNLIMITED = "unlimited";
+
+    FrankenDrazSetKeptComponentLimit() {
+        super("set_kept_component_limit", "Set whether FrankenDraz kept components are unlimited", true, false);
+        addOptions(new OptionData(
+                        OptionType.BOOLEAN,
+                        UNLIMITED,
+                        "True to remove kept component limits; false to use powered franken limits")
+                .setRequired(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Game game = getGame();
+        if (!(game.getActiveBagDraft() instanceof FrankenDrazDraft)) {
+            MessageHelper.sendMessageToEventChannel(
+                    event, "This command can only be used in a FrankenDraz draft. Please run after draft has begun.");
+            return;
+        }
+
+        boolean unlimited = event.getOption(UNLIMITED, Boolean.FALSE, OptionMapping::getAsBoolean);
+        if (unlimited) {
+            game.setStoredValue(FrankenDrazDraft.UNLIMITED_KEPT_COMPONENTS_KEY, "true");
+            MessageHelper.sendMessageToEventChannel(event, "FrankenDraz kept component limits removed.");
+        } else {
+            game.removeStoredValue(FrankenDrazDraft.UNLIMITED_KEPT_COMPONENTS_KEY);
+            MessageHelper.sendMessageToEventChannel(
+                    event, "FrankenDraz kept component limits now use powered franken limits.");
+        }
+    }
+}

--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -39,6 +39,10 @@ import ti4.service.milty.MiltyDraftHelper;
 import ti4.service.milty.MiltyDraftManager;
 
 public class FrankenDrazDraft extends FrankenDraft {
+    public static final String UNLIMITED_KEPT_COMPONENTS_KEY = "frankenDrazUnlimitedKeptComponents";
+    public static final String FACTION_LIMIT_KEY = "frankenDrazFactionLimit";
+
+    private static final int DEFAULT_FACTION_LIMIT = 6;
     private static final List<String> AUTO_BANNED_FACTIONS = List.of("obsidian", "firmament");
     private static final List<DraftCategory> POST_DRAFT_COMPONENT_CATEGORIES = List.of(
             DraftCategory.ABILITY,
@@ -62,7 +66,7 @@ public class FrankenDrazDraft extends FrankenDraft {
     @Override
     public int getItemLimitForCategory(DraftCategory category) {
         return switch (category) {
-            case FACTION -> 6;
+            case FACTION -> getFactionLimit(getOwner());
             case BLUETILE -> 3;
             case REDTILE -> 2;
             case DRAFTORDER -> 1;
@@ -72,15 +76,32 @@ public class FrankenDrazDraft extends FrankenDraft {
 
     @Override
     public int getKeptItemLimitForCategory(DraftCategory category) {
-        return switch (category) {
-            case ABILITY -> 4;
-            case TECH, BLUETILE -> 3;
-            case REDTILE -> 2;
-            case COMMODITIES, FLAGSHIP, MECH, PN -> 1;
-            case HERO, COMMANDER, AGENT, BREAKTHROUGH -> 1;
-            case DRAFTORDER, STARTINGFLEET, STARTINGTECH, HOMESYSTEM -> 1;
-            case FACTION, UNIT, PLOT, MAHACTKING -> 0;
-        };
+        int limit =
+                switch (category) {
+                    case ABILITY -> 4;
+                    case TECH, BLUETILE -> 3;
+                    case REDTILE -> 2;
+                    case COMMODITIES, FLAGSHIP, MECH, PN -> 1;
+                    case HERO, COMMANDER, AGENT, BREAKTHROUGH -> 1;
+                    case DRAFTORDER, STARTINGFLEET, STARTINGTECH, HOMESYSTEM -> 1;
+                    case FACTION, UNIT, PLOT, MAHACTKING -> 0;
+                };
+        if (limit > 0 && hasUnlimitedKeptComponents(getOwner())) {
+            return Integer.MAX_VALUE;
+        }
+        return limit;
+    }
+
+    public static boolean hasUnlimitedKeptComponents(Game game) {
+        return "true".equals(game.getStoredValue(UNLIMITED_KEPT_COMPONENTS_KEY));
+    }
+
+    public static int getFactionLimit(Game game) {
+        String storedLimit = game.getStoredValue(FACTION_LIMIT_KEY);
+        if (!storedLimit.isEmpty()) {
+            return Integer.parseInt(storedLimit);
+        }
+        return DEFAULT_FACTION_LIMIT;
     }
 
     @Override
@@ -317,7 +338,7 @@ public class FrankenDrazDraft extends FrankenDraft {
 
     @Override
     public int getBagSize() {
-        return 12;
+        return getFactionLimit(getOwner()) + 6;
     }
 
     private List<Player> getOwnerPlayers() {

--- a/src/test/java/ti4/draft/FrankenDrazDraftTest.java
+++ b/src/test/java/ti4/draft/FrankenDrazDraftTest.java
@@ -67,6 +67,36 @@ class FrankenDrazDraftTest extends BaseTi4Test {
     }
 
     @Test
+    void factionLimitChangesFactionPackageCountAndBagSize() {
+        Game game = setupGame(6);
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+        game.setBagDraft(draft);
+        game.setStoredValue(FrankenDrazDraft.FACTION_LIMIT_KEY, "4");
+
+        List<DraftBag> bags = assertDoesNotThrow(() -> draft.generateBags(game));
+
+        assertEquals(4, draft.getItemLimitForCategory(DraftCategory.FACTION));
+        assertEquals(10, draft.getBagSize());
+        assertEquals(10, game.getFrankenBagSize());
+        assertNotNull(bags);
+        for (DraftBag bag : bags) {
+            assertEquals(4, bag.getCategoryCount(DraftCategory.FACTION));
+            assertEquals(10, bag.Contents.size());
+        }
+    }
+
+    @Test
+    void factionLimitCanBeConfiguredBeforeDraftStarts() {
+        Game game = new Game();
+        game.setStoredValue(FrankenDrazDraft.FACTION_LIMIT_KEY, "5");
+
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+
+        assertEquals(5, draft.getItemLimitForCategory(DraftCategory.FACTION));
+        assertEquals(11, draft.getBagSize());
+    }
+
+    @Test
     void generateBagsAutoBansObsidianAndFirmament() {
         Game game = setupGame(6);
         FrankenDrazDraft draft = new FrankenDrazDraft(game);
@@ -133,6 +163,21 @@ class FrankenDrazDraftTest extends BaseTi4Test {
         addMapSetupItems(player.getDraftHand());
 
         assertFalse(draft.isDraftStageComplete());
+    }
+
+    @Test
+    void unlimitedKeptComponentsRemovesPositiveFrankenDrazLimits() {
+        Game game = new Game();
+        FrankenDrazDraft draft = new FrankenDrazDraft(game);
+
+        assertEquals(4, draft.getKeptItemLimitForCategory(DraftCategory.ABILITY));
+        assertEquals(0, draft.getKeptItemLimitForCategory(DraftCategory.FACTION));
+
+        game.setStoredValue(FrankenDrazDraft.UNLIMITED_KEPT_COMPONENTS_KEY, "true");
+
+        assertEquals(Integer.MAX_VALUE, draft.getKeptItemLimitForCategory(DraftCategory.ABILITY));
+        assertEquals(Integer.MAX_VALUE, draft.getKeptItemLimitForCategory(DraftCategory.TECH));
+        assertEquals(0, draft.getKeptItemLimitForCategory(DraftCategory.FACTION));
     }
 
     private static Game setupGame(int players) {


### PR DESCRIPTION
Adds the following commands:

/frankendraz set_kept_component_limit

This removes the limits on kept components to allow for easy implementation of various point-buy or overpowered modes being used in concurrence with FrankenDraz.

/frankendraz faction_limit

Allows setting the drafted faction limit to a custom limit (at least 1).