### PR TITLE
Dream agent button fix

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/beans/DreamButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/beans/DreamButtonHandler.java
@@ -257,6 +257,42 @@ public class DreamButtonHandler {
 
     // Xal'thuun, the Dreaming Throne agent
 
+    public static Button getDreamAgentCardsInfoButton(Player dreamPlayer) {
+        return Buttons.gray(
+                dreamPlayer.factionButtonChecker() + "dream_agent_select_player",
+                "Use agent on someone else",
+                FactionEmojis.dream);
+    }
+
+    @ButtonHandler("dream_agent_select_player")
+    public static void offerDreamAgentTargetButtons(ButtonInteractionEvent event, Game game, Player dreamPlayer) {
+        if (!dreamPlayer.hasUnexhaustedLeader("dreamagent")) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "**Xal'thuun** is no longer available.");
+            return;
+        }
+        if (getDreamAgentAnomalyTiles(game).isEmpty()) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "There are no valid non-home anomalies to choose.");
+            return;
+        }
+
+        List<Button> buttons = game.getRealPlayers().stream()
+                .filter(target -> !target.getFaction().equalsIgnoreCase(dreamPlayer.getFaction()))
+                .map(target -> Buttons.gray(
+                        dreamPlayer.factionButtonChecker() + "dream_agent_offer_" + target.getFaction() + "_"
+                                + dreamPlayer.getFaction(),
+                        target.getColorDisplayName(),
+                        target.fogSafeEmoji()))
+                .toList();
+        if (buttons.isEmpty()) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "No eligible players were found for **Xal'thuun**.");
+            return;
+        }
+
+        MessageHelper.sendMessageToEventChannelWithEphemeralButtons(
+                event, dreamPlayer.getRepresentationUnfogged() + ", choose a player for **Xal'thuun**.", buttons);
+    }
+
     public static void offerDreamAgentButtons(Game game, Player activePlayer, Player dreamPlayer) {
         List<Button> buttons = new ArrayList<>();
         buttons.add(Buttons.gray(
@@ -265,11 +301,9 @@ public class DreamButtonHandler {
                 FactionEmojis.dream));
         buttons.add(Buttons.red("deleteButtons", "Decline"));
         MessageHelper.sendMessageToChannelWithButtons(
-                dreamPlayer.getCardsInfoThread(),
+                game.getActionsChannel(),
                 dreamPlayer.getRepresentation()
-                        + " may exhaust **Xal'thuun**, the Dreaming Throne agent, to let "
-                        + activePlayer.getRepresentationNoPing()
-                        + " choose a non-home anomaly to ignore during this tactical action.",
+                        + " you may exhaust **Xal'thuun**, the Dreaming Throne agent, to choose a non-home anomaly to ignore during this tactical action.",
                 buttons);
     }
 
@@ -279,6 +313,10 @@ public class DreamButtonHandler {
         Player activePlayer = game.getPlayerFromColorOrFaction(parts[0]);
         Player dreamPlayer = parts.length > 1 ? game.getPlayerFromColorOrFaction(parts[1]) : player;
         Player dreamAgentOwner = dreamPlayer == null ? player : dreamPlayer;
+        if (!dreamAgentOwner.hasUnexhaustedLeader("dreamagent")) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "**Xal'thuun** is no longer available.");
+            return;
+        }
         if (activePlayer == null) {
             activePlayer = game.getActivePlayer();
         }

--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -829,10 +829,8 @@ public final class ButtonHelperTacticalAction {
         }
         if (!game.isL1Hero()
                 && !DreamButtonHandler.getDreamAgentAnomalyTiles(game).isEmpty()) {
-            for (Player dreamPlayer : game.getRealPlayers()) {
-                if (dreamPlayer.hasUnexhaustedLeader("dreamagent")) {
-                    DreamButtonHandler.offerDreamAgentButtons(game, player, dreamPlayer);
-                }
+            if (player.hasUnexhaustedLeader("dreamagent")) {
+                DreamButtonHandler.offerDreamAgentButtons(game, player, player);
             }
         }
 

--- a/src/main/java/ti4/service/info/CardsInfoService.java
+++ b/src/main/java/ti4/service/info/CardsInfoService.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.DreamButtonHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Netrunners.NetrunnersAbilitiesHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Netrunners.NetrunnersLeadersHandler;
 import ti4.discord.interactions.commands.CommandHelper;
@@ -78,6 +79,10 @@ public class CardsInfoService {
         }
         if (player.hasUnexhaustedLeader("netrunnersagent")) {
             buttons.add(NetrunnersLeadersHandler.getOverclockCardsInfoButton(player));
+        }
+        if (player.hasUnexhaustedLeader("dreamagent")
+                && !DreamButtonHandler.getDreamAgentAnomalyTiles(game).isEmpty()) {
+            buttons.add(DreamButtonHandler.getDreamAgentCardsInfoButton(player));
         }
         if (player.hasAbility("intrigue")) {
             buttons.add(Buttons.blue("startIntrigueCard", "Pay For Intrigue Card", FactionEmojis.xin));


### PR DESCRIPTION
Instead of pinging the Dreaming Throne player each time a tactical action is done, there are now 2 paths:

A button in cards info for players that have the agent u exhausted that allows them to use it on someone else, but not the dreaming throne player.

A button that appears after a system is activated by the dreaming throne player that allows them to exhaust their agent to use on themselves only if they have the u exhausted dream agent.