### PR TITLE
Franken Mahact Y-set errata

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/commandcounter/CommandCounterButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/commandcounter/CommandCounterButtonHandler.java
@@ -288,7 +288,7 @@ public class CommandCounterButtonHandler {
     @ButtonHandler("confirm_cc")
     public static void confirmCC(ButtonInteractionEvent event, Game game, Player player) {
         String message = "Confirmed command tokens: " + player.getTacticalCC() + "/" + player.getFleetCC();
-        if (!player.getMahactCC().isEmpty()) {
+        if (player.hasAbility("edict") || player.hasAbility("edict_y")) {
             message += "(+" + player.getMahactCC().size() + ")";
         }
         message += "/" + player.getStrategicCC();

--- a/src/main/java/ti4/draft/DraftItem.java
+++ b/src/main/java/ti4/draft/DraftItem.java
@@ -2,6 +2,7 @@ package ti4.draft;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import lombok.Getter;
@@ -152,6 +153,10 @@ public abstract class DraftItem {
         items.addAll(MahactKingDraftItem.buildAllItems());
         items.addAll(BreakthroughDraftItem.buildAllItems(factions));
         items.addAll(PlotDraftItem.buildAllItems());
+        Mapper.getFrankenErrata().keySet().stream()
+                .map(DraftItem::generateFromAlias)
+                .forEach(items::add);
+        items = new ArrayList<>(new LinkedHashSet<>(items));
         return items;
     }
 

--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -4121,7 +4121,7 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
 
         // check if player has Imperia and if any of the stolen CCs are owned by players
         // that have the leader unlocked
-        if (player.hasAbility("imperia")) {
+        if (player.hasAbility("imperia") || player.hasAbility("imperia_y")) {
             for (Player player_ : getRealPlayersNDummies()) {
                 if (player_.getFaction().equalsIgnoreCase(player.getFaction())) continue;
                 if (player.getMahactCC().contains(player_.getColor()) && player_.hasLeaderUnlocked(leaderID)) {
@@ -4156,7 +4156,7 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
 
         // check if player has Imperia and if any of the stolen CCs are owned by players
         // that have the leader unlocked
-        if (player.hasAbility("imperia")) {
+        if (player.hasAbility("imperia") || player.hasAbility("imperia_y")) {
             for (Player otherPlayer : getRealPlayers()) {
                 if (otherPlayer.equals(player)) continue;
                 if (player.getMahactCC().contains(otherPlayer.getColor())) {

--- a/src/main/java/ti4/game/Player.java
+++ b/src/main/java/ti4/game/Player.java
@@ -2010,7 +2010,10 @@ public class Player extends PlayerProperties implements StoredValueHelper {
     }
 
     public int getEffectiveFleetCC() {
-        return getFleetCC() + getMahactCC().size();
+        return getFleetCC()
+                + ((hasAbility("edict") || hasAbility("edict_y"))
+                        ? getMahactCC().size()
+                        : 0);
     }
 
     @Override

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -1924,15 +1924,16 @@ public class ButtonHelper {
                             buttons);
                 }
             }
-            if (nonActivePlayer.hasUnit("mahact_mech")
+            if (nonActivePlayer.hasAnyUnit("mahact_mech", "mahact_mech_y")
                     && nonActivePlayer.hasMechInSystem(activeSystem)
                     && nonActivePlayer.getMahactCC().contains(player.getColor())
                     && !isLawInPlay(game, "articles_war")) {
+                String mechName = nonActivePlayer.hasUnit("mahact_mech_y") ? "Starlancer Y" : "Starlancer";
+                String tokenLocation = nonActivePlayer.hasAbility("primacy") ? "Primacy ability" : "fleet pool";
                 if (justChecking) {
                     if (!game.isFowMode()) {
                         MessageHelper.sendMessageToChannel(
-                                channel,
-                                "Warning: this would provide an opportunity for a Starlancer (Mahact mech) to trigger.");
+                                channel, "Warning: this would provide an opportunity for " + mechName + " to trigger.");
                     }
                     numberOfAbilities++;
                 } else {
@@ -1946,7 +1947,8 @@ public class ButtonHelper {
                             nonActivePlayer.getCorrectChannel(),
                             ident
                                     + ", you may use the buttons to remove the " + player.getColor()
-                                    + " command token from your fleet pool to end their turn by using the Starlancer (Mahact mech) in the active system.",
+                                    + " command token from your " + tokenLocation
+                                    + " to end their turn by using " + mechName + " in the active system.",
                             buttons);
                 }
             }
@@ -3210,6 +3212,7 @@ public class ButtonHelper {
 
     public static void resolveMahactMechAbilityUse(
             Player mahact, Player target, Game game, Tile tile, ButtonInteractionEvent event) {
+        String mechName = mahact.hasUnit("mahact_mech_y") ? "Starlancer Y" : "Starlancer";
         mahact.removeMahactCC(target.getColor());
         if (!game.isNaaluAgent() && !game.isWarfareAction()) {
             if (!game.getStoredValue("absolLux").isEmpty()) {
@@ -3222,7 +3225,8 @@ public class ButtonHelper {
         MessageHelper.sendMessageToChannel(
                 mahact.getCorrectChannel(),
                 mahact.getRepresentationUnfogged() + " the " + target.getColor()
-                        + " command token has been removed from your fleet pool");
+                        + " command token has been removed from your "
+                        + (mahact.hasAbility("primacy") ? "Primacy ability" : "fleet pool"));
         checkFleetInEveryTile(mahact, game);
         List<Button> conclusionButtons = new ArrayList<>();
         conclusionButtons.add(getEndTurnButton(game, target));
@@ -3237,7 +3241,7 @@ public class ButtonHelper {
                 target.getRepresentation(true, true)
                         + " You've been hit by"
                         + (RandomHelper.isOneInX(1000) ? ", you've been struck by," : "")
-                        + " the Starlancer (Mahact mech) ability. You gain 1 command token to any command pool. "
+                        + " " + mechName + ". You gain 1 command token to any command pool. "
                         + "Then, use the buttons to resolve \"end of turn\" abilities and then end turn.",
                 conclusionButtons);
         deleteMessage(event);
@@ -4018,7 +4022,9 @@ public class ButtonHelper {
         String tooManyPDS = "";
         int fleetCap = (player.getFleetCC()
                         + armadaValue
-                        + player.getMahactCC().size()
+                        + ((player.hasAbility("edict") || player.hasAbility("edict_y"))
+                                ? player.getMahactCC().size()
+                                : 0)
                         + tile.getFleetSupplyBonusForPlayer(player))
                 * 2;
         // fleetCap is double to more easily deal with half-capacity, e.g., Naalu Fighter II
@@ -4254,13 +4260,11 @@ public class ButtonHelper {
             message += player.getRepresentationUnfogged() + ", you are violating fleet pool limits in the system "
                     + tile.getRepresentation()
                     + ". Specifically, you have "
-                    + (player.getFleetCC() + player.getMahactCC().size())
+                    + player.getEffectiveFleetCC()
                     + " command tokens in your fleet pool,"
-                    + (fleetCap / 2 - player.getFleetCC() - player.getMahactCC().size() > 0
+                    + (fleetCap / 2 - player.getEffectiveFleetCC() > 0
                             ? "plus the ability to hold"
-                                    + (fleetCap / 2
-                                            - player.getFleetCC()
-                                            - player.getMahactCC().size())
+                                    + (fleetCap / 2 - player.getEffectiveFleetCC())
                                     + "additional ships, for a total of " + (fleetCap / 2)
                             : "")
                     + " and you currently are filling "

--- a/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
+++ b/src/main/java/ti4/helpers/ButtonHelperFactionSpecific.java
@@ -1105,15 +1105,18 @@ public final class ButtonHelperFactionSpecific {
     public static void mahactStealCC(Game game, Player player, ButtonInteractionEvent event, String buttonID) {
         String color = buttonID.replace("mahactStealCC_", "");
         String ident = player.getRepresentation(true, false);
+
+        String location = player.hasAbility("primacy") ? "Primacy ability" : "fleet pool";
         if (!player.getMahactCC().contains(color)) {
             player.addMahactCC(color);
             Helper.isCCCountCorrect(game, color);
             MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(), ident + " added a " + color + " command token to their fleet pool.");
+                    player.getCorrectChannel(),
+                    ident + " added a " + color + " command token to their " + location + ".");
         } else {
             MessageHelper.sendMessageToChannel(
                     player.getCorrectChannel(),
-                    ident + " already had a " + color + " command token in their fleet pool.");
+                    ident + " already had a " + color + " command token in their " + location + ".");
         }
         CommanderUnlockCheckService.checkPlayer(player, "mahact");
 

--- a/src/main/java/ti4/helpers/ComponentActionHelper.java
+++ b/src/main/java/ti4/helpers/ComponentActionHelper.java
@@ -276,7 +276,9 @@ public class ComponentActionHelper {
                 }
             }
         }
-        if (game.playerHasLeaderUnlockedOrAlliance(p1, "mahactcommander")
+        boolean hasMahactCommander = game.playerHasLeaderUnlockedOrAlliance(p1, "mahactcommander")
+                || game.playerHasLeaderUnlockedOrAlliance(p1, "mahactcommander_y");
+        if (hasMahactCommander
                 && p1.getTacticalCC() > 0
                 && !ButtonHelper.getTilesWithYourCC(p1, game, event).isEmpty()) {
 

--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -2755,7 +2755,11 @@ public final class Helper {
                 ccCount += player_.getStrategicCC();
                 ccCount += player_.getTacticalCC();
                 ccCount += player_.getFleetCC();
-            } else if (player_.hasAbility("imperia") || player_.hasAbility("edict")) {
+            } else if (player_.hasAbility("primacy")
+                    || player_.hasAbility("edict")
+                    || player_.hasAbility("edict_y")
+                    || player_.hasAbility("imperia")
+                    || player_.hasAbility("imperia_y")) {
                 for (String color_ : player_.getMahactCC()) {
                     ColorModel ccColor = Mapper.getColor(color_);
                     if (player.getColor().equalsIgnoreCase(ccColor.getName())) {

--- a/src/main/java/ti4/image/MapGenerator.java
+++ b/src/main/java/ti4/image/MapGenerator.java
@@ -1788,8 +1788,10 @@ public class MapGenerator implements AutoCloseable {
         // Additional FS
         int additionalFleetSupply = 0;
         String addFS = "";
-        if (player.hasAbility("edict"))
+
+        if (player.hasAbility("edict") || player.hasAbility("edict_y")) {
             additionalFleetSupply += player.getMahactCC().size();
+        }
         if (player.hasAbility("armada")) additionalFleetSupply += 2;
         if (additionalFleetSupply > 0) addFS = "*";
 
@@ -2103,7 +2105,8 @@ public class MapGenerator implements AutoCloseable {
         int ccCount = player.getFleetCC();
         boolean hasArmada = player.hasAbility("armada");
         List<String> mahactCC = player.getMahactCC();
-        boolean hasMahactCCs = !player.getMahactCC().isEmpty() && player.hasAbility("edict");
+        boolean hasMahactCCs =
+                !player.getMahactCC().isEmpty() && (player.hasAbility("edict") || player.hasAbility("edict_y"));
 
         try {
             BufferedImage ccImage = ImageHelper.read(ccPath);

--- a/src/main/java/ti4/image/PlayerAreaGenerator.java
+++ b/src/main/java/ti4/image/PlayerAreaGenerator.java
@@ -297,7 +297,7 @@ public class PlayerAreaGenerator {
 
         // Additional Fleet Supply
         int additionalFleetSupply = 0;
-        if (player.hasAbility("edict")) {
+        if (player.hasAbility("edict") || player.hasAbility("edict_y")) {
             additionalFleetSupply += player.getMahactCC().size();
         }
         if (player.hasAbility("armada")) {
@@ -1360,7 +1360,7 @@ public class PlayerAreaGenerator {
                     graphics, x, y, VeiledHeartService.VeiledCardType.PARADIGM, deltaX, player);
         }
 
-        if (player.hasAbility("imperia")) {
+        if (player.hasAbility("imperia") || player.hasAbility("imperia_y")) {
             deltaX += 5;
             List<String> mahactCCs = player.getMahactCC();
             Collection<Player> players = game.getRealPlayersNDummies();
@@ -1573,7 +1573,6 @@ public class PlayerAreaGenerator {
                     }
                     drawRectWithOverlay(g2, x + deltaX - 2, y - 2, 44, 152, abilityModel);
                 }
-
                 deltaX += 48;
                 addedAbilities = true;
             }

--- a/src/main/java/ti4/service/abilities/MahactTokenService.java
+++ b/src/main/java/ti4/service/abilities/MahactTokenService.java
@@ -18,7 +18,9 @@ public class MahactTokenService {
 
     public void removeFleetCC(Game game, Player player, String reason) {
         String message = player.getRepresentation();
-        if (!player.getMahactCC().isEmpty()) {
+        if (!(player.hasAbility("primacy"))
+                && (player.hasAbility("edict") || player.hasAbility("imperia"))
+                && !player.getMahactCC().isEmpty()) {
             if (player.getFleetCC() == 0 && player.getMahactCC().size() == 1) {
                 // exactly 1 token in fleet
                 String color = player.getMahactCC().getFirst();
@@ -44,6 +46,9 @@ public class MahactTokenService {
 
     public List<Button> removeFleetTokenOptions(Game game, Player player, boolean includeSelf, boolean keepButtons) {
         List<Button> buttons = new ArrayList<>();
+        if (player.hasAbility("primacy") || (!player.hasAbility("edict") && !player.hasAbility("imperia"))) {
+            return buttons;
+        }
         String prefix = player.factionButtonChecker() + "loseMahactCC_";
         String suffix = keepButtons ? "_keep" : "";
         String label = "Lose your own token";

--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -859,19 +859,25 @@ public class StartCombatService {
                         buttons2);
             }
 
-            if ((player.hasAbility("edict") || player.hasAbility("imperia"))
+            if ((player.hasAbility("primacy")
+                            || player.hasAbility("edict")
+                            || player.hasAbility("edict_y")
+                            || player.hasAbility("imperia")
+                            || player.hasAbility("imperia_y"))
                     && !player.getMahactCC().contains(otherPlayer.getColor())
                     && !"neutral".equalsIgnoreCase(otherPlayer.getFaction())) {
                 buttons = new ArrayList<>();
                 String factionChecker = player.factionButtonChecker();
+                String location = player.hasAbility("primacy") ? "Primacy" : "Fleet";
                 buttons.add(Buttons.gray(
                         factionChecker + "mahactStealCC_" + otherPlayer.getColor(),
-                        "Add " + otherPlayer.getColor() + " Token to Fleet",
+                        "Add " + otherPlayer.getColor() + " Token to " + location,
                         FactionEmojis.Mahact));
                 MessageHelper.sendMessageToChannelWithButtons(
                         player.getCardsInfoThread(),
                         msg + ", a reminder that if you win this combat, you may add the opponents ("
-                                + otherPlayer.getColor() + ") command token to your fleet pool.",
+                                + otherPlayer.getColor() + ") command token to your "
+                                + (player.hasAbility("primacy") ? "Primacy ability." : "fleet pool."),
                         buttons);
             }
             if (player.hasUnlockedBreakthrough("sardakkbt")) {

--- a/src/main/java/ti4/service/emoji/LeaderEmojis.java
+++ b/src/main/java/ti4/service/emoji/LeaderEmojis.java
@@ -315,6 +315,9 @@ public enum LeaderEmojis implements TI4Emoji {
             case "voicehero" -> XxchaHero;
             case "witchinghero" -> KeleresHeroOdlynn;
 
+            // Franken
+            case "mahactcommander_y" -> MahactCommander;
+
             default -> TI4Emoji.getRandomGoodDog(leader.toLowerCase());
         };
     }

--- a/src/main/java/ti4/service/info/LeaderInfoService.java
+++ b/src/main/java/ti4/service/info/LeaderInfoService.java
@@ -86,7 +86,7 @@ public class LeaderInfoService {
 
         // ADD MAHACT IMPERIA REFERENCE
         List<MessageEmbed> imperiaEmbeds = new ArrayList<>();
-        if (player.hasAbility("imperia")) {
+        if (player.hasAbility("imperia") || player.hasAbility("imperia_y")) {
             for (Player otherPlayer : game.getPlayers().values()) {
                 if (otherPlayer != player) {
                     if (player.getMahactCC().contains(otherPlayer.getColor())) {

--- a/src/main/java/ti4/service/leader/CommanderUnlockCheckService.java
+++ b/src/main/java/ti4/service/leader/CommanderUnlockCheckService.java
@@ -29,16 +29,22 @@ public class CommanderUnlockCheckService {
 
     public static void checkPlayer(Player player, String... factionsToCheck) {
         for (String factionToCheck : factionsToCheck) {
-            if (player != null
-                    && player.isRealPlayer()
-                    && player.hasLeader(factionToCheck + "commander")
+            if (player == null || !player.isRealPlayer()) {
+                continue;
+            }
+            if (player.hasLeader(factionToCheck + "commander")
                     && !player.hasLeaderUnlocked(factionToCheck + "commander")) {
-                checkConditionsAndUnlock(player, factionToCheck);
+                checkConditionsAndUnlock(player, factionToCheck, factionToCheck + "commander");
+            }
+            if ("mahact".equals(factionToCheck)
+                    && player.hasLeader("mahactcommander_y")
+                    && !player.hasLeaderUnlocked("mahactcommander_y")) {
+                checkConditionsAndUnlock(player, "mahact_y", "mahactcommander_y");
             }
         }
     }
 
-    private static void checkConditionsAndUnlock(Player player, String faction) {
+    private static void checkConditionsAndUnlock(Player player, String faction, String leaderId) {
         Game game = player.getGame();
         boolean shouldBeUnlocked = false;
         switch (faction) {
@@ -142,6 +148,7 @@ public class CommanderUnlockCheckService {
                 shouldBeUnlocked =
                         (player.getNeighbourCount() >= (game.getRealPlayers().size() - 1));
             case "mahact" -> shouldBeUnlocked = (player.getMahactCC().size() >= 2);
+            case "mahact_y" -> shouldBeUnlocked = (player.getMahactCC().size() >= 3);
             case "naaz" ->
                 shouldBeUnlocked =
                         (CheckUnitContainmentService.getTilesContainingPlayersUnits(game, player, UnitType.Mech)
@@ -281,7 +288,7 @@ public class CommanderUnlockCheckService {
                 shouldBeUnlocked = (ButtonHelper.getNumberOfUnitsOnTheBoard(game, player, "pds", false) >= 4);
         }
         if (shouldBeUnlocked) {
-            UnlockLeaderService.unlockLeader(faction + "commander", game, player);
+            UnlockLeaderService.unlockLeader(leaderId, game, player);
         }
     }
 }

--- a/src/main/java/ti4/service/turn/StartTurnService.java
+++ b/src/main/java/ti4/service/turn/StartTurnService.java
@@ -533,7 +533,8 @@ public class StartTurnService {
                                 startButtons.add(lButton);
                             }
                         }
-                    } else if ("mahactcommander".equalsIgnoreCase(leaderID)
+                    } else if (("mahactcommander".equalsIgnoreCase(leaderID)
+                                    || "mahactcommander_y".equalsIgnoreCase(leaderID))
                             && player.getTacticalCC() > 0
                             && !ButtonHelper.getTilesWithYourCC(player, game, event)
                                     .isEmpty()) {

--- a/src/main/java/ti4/website/model/WebPlayerArea.java
+++ b/src/main/java/ti4/website/model/WebPlayerArea.java
@@ -524,8 +524,7 @@ public class WebPlayerArea {
         }
         webPlayerArea.nombox = nomboxData;
 
-        // Mahact edict: only applies if the player is mahact and loads the mahact's "stolen" fleet supply
-        if (player.hasAbility("edict")) {
+        if (player.hasAbility("edict") || player.hasAbility("edict_y")) {
             webPlayerArea.mahactEdict = player.getMahactCC();
         } else {
             webPlayerArea.mahactEdict = new ArrayList<>();

--- a/src/main/resources/data/abilities/franken.json
+++ b/src/main/resources/data/abilities/franken.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "primacy",
+        "name": "Primacy",
+        "faction": "mahact",
+        "window": "When you win a combat",
+        "windowEffect": "Place 1 owner token from your opponent on this ability if it does not already contain 1 of that player's tokens.",
+        "source": "franken"
+    },
+    {
+        "id": "edict_y",
+        "name": "Edict Y",
+        "faction": "mahact",
+        "permanentEffect": "Each owner token on your Primacy ability increases your fleet limit by 1.",
+        "source": "franken"
+    },
+    {
+        "id": "imperia_y",
+        "name": "Imperia Y",
+        "faction": "mahact",
+        "permanentEffect": "While another player's owner token is on your Primacy ability, you can use the abilities of that player's commanders, if they are unlocked.",
+        "source": "franken"
+    }
+]

--- a/src/main/resources/data/franken_errata/pok.json
+++ b/src/main/resources/data/franken_errata/pok.json
@@ -144,12 +144,14 @@
     {
         "itemCategory": "ABILITY",
         "itemId": "edict",
+        "undraftable": true,
         "alternateText": "When you win a combat, place 1 command token from your opponent's reinforcements in your fleet pool if it does not already contain 1 of that player's tokens; other players' tokens in your fleet pool increase your fleet limit but cannot be redistributed.",
         "source": "pok"
     },
     {
         "itemCategory": "ABILITY",
         "itemId": "imperia",
+        "undraftable": true,
         "alternateText": "[Franken only] When you win a combat, place 1 command token from your opponent's reinforcements in your fleet pool if it does not already contain 1 of that player's tokens; other players' tokens in your fleet pool do not increase your fleet limit and cannot be redistributed. While another player's command token is on your command sheet, you can use the ability of that player's commander, if it is unlocked.",
         "source": "pok"
     },
@@ -158,6 +160,60 @@
         "itemId": "hubris",
         "undraftable": true,
         "source": "pok"
+    },
+    {
+        "itemCategory": "COMMANDER",
+        "itemId": "mahactcommander",
+        "undraftable": true,
+        "source": "pok"
+    },
+    {
+        "itemCategory": "MECH",
+        "itemId": "mahact_mech",
+        "undraftable": true,
+        "source": "pok"
+    },
+    {
+        "itemCategory": "ABILITY",
+        "itemId": "primacy",
+        "undraftable": true,
+        "source": "franken"
+    },
+    {
+        "itemCategory": "ABILITY",
+        "itemId": "edict_y",
+        "additionalComponents": [
+            "ABILITY:primacy"
+        ],
+        "alwaysAddToPool": true,
+        "source": "franken"
+    },
+    {
+        "itemCategory": "ABILITY",
+        "itemId": "imperia_y",
+        "additionalComponents": [
+            "ABILITY:primacy"
+        ],
+        "alwaysAddToPool": true,
+        "source": "franken"
+    },
+    {
+        "itemCategory": "COMMANDER",
+        "itemId": "mahactcommander_y",
+        "additionalComponents": [
+            "ABILITY:primacy"
+        ],
+        "alwaysAddToPool": true,
+        "source": "franken"
+    },
+    {
+        "itemCategory": "MECH",
+        "itemId": "mahact_mech_y",
+        "additionalComponents": [
+            "ABILITY:primacy"
+        ],
+        "alwaysAddToPool": true,
+        "source": "franken"
     },
     {
         "itemCategory": "ABILITY",

--- a/src/main/resources/data/leaders/franken.json
+++ b/src/main/resources/data/leaders/franken.json
@@ -1,0 +1,15 @@
+[
+    {
+        "id": "mahactcommander_y",
+        "faction": "mahact",
+        "type": "commander",
+        "name": "Il Na Viroset Y",
+        "shortName": "Il Na Viroset Y",
+        "title": "Archon of Virtue",
+        "abilityWindow": "During your tactical actions:",
+        "abilityText": "You can activate systems that contain your command tokens. If you do, return both command tokens to your reinforcements and end your turn.",
+        "notes": "This is not really a tactical action and does not trigger any on activation effects. It's really a component action in effect, and the bot treats it as such. You can find it under component actions.",
+        "unlockCondition": "Have an owner token from 3 other players on your Primacy ability.",
+        "source": "franken"
+    }
+]

--- a/src/main/resources/data/units/franken.json
+++ b/src/main/resources/data/units/franken.json
@@ -1,0 +1,32 @@
+[
+    {
+        "id": "mahact_mech_y",
+        "baseType": "mech",
+        "asyncId": "mf",
+        "name": "Starlancer Y",
+        "source": "franken",
+        "faction": "mahact",
+        "capacityUsed": 1,
+        "cost": 2,
+        "combatHitsOn": 6,
+        "combatDieCount": 1,
+        "afbHitsOn": 0,
+        "afbDieCount": 0,
+        "bombardHitsOn": 0,
+        "bombardDieCount": 0,
+        "spaceCannonHitsOn": 0,
+        "spaceCannonDieCount": 0,
+        "deepSpaceCannon": false,
+        "planetaryShield": false,
+        "sustainDamage": true,
+        "disablesPlanetaryShield": false,
+        "canBeDirectHit": false,
+        "isStructure": false,
+        "isMonument": false,
+        "isGroundForce": true,
+        "isShip": false,
+        "isSpaceOnly": false,
+        "isPlanetOnly": false,
+        "ability": "After a player activates this system, you may spend their owner token from your Primacy ability to have them end their turn and they gain 1 command token."
+    }
+]


### PR DESCRIPTION
This adds Luminous' Mahact franken-only rework to franken modes.

This replaces the normal Mahact counterparts for franken-only.
The franken-only check is done via the franken-errata JSON.

Due to commander unlock being different for Franken version, I had to slightly change the commander unlock service. shouldBeUnlocked now checks wether it is "mahact" before going through the rest of logic. If it is "mahact" then there is special logic for it, if not it goes through the normal logic.

Mainly lots of additions to files with ability gates/message text. The actual mahact automation is untouched, just routed differently for the franken components.