### PR TITLE
Muaat starting fleet franken automation

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -429,6 +429,9 @@ public final class ButtonHelperTwilightsFall {
         Tile tile = FrankenHomeService.getPlayerHs(player);
         if (tile != null) {
             String unitList = Mapper.getFaction(factionFleet).getStartingFleet();
+            if (game.isFrankenGame() && "muaat".equalsIgnoreCase(factionFleet) && !hasFactionWarsunUpgrade(player)) {
+                unitList = unitList.replaceFirst("\\bws\\b", "flagship");
+            }
             AddUnitService.addUnitsToDefaultLocations(event, tile, game, player.getColor(), unitList);
 
             String succ = player.getRepresentation() + ", you've set your starting units successfully.";
@@ -439,6 +442,16 @@ public final class ButtonHelperTwilightsFall {
         }
 
         ButtonHelper.deleteMessage(event);
+    }
+
+    private static boolean hasFactionWarsunUpgrade(Player player) {
+        return player.getFactionTechs().stream()
+                .map(Mapper::getTech)
+                .filter(Objects::nonNull)
+                .filter(TechnologyModel::isUnitUpgrade)
+                .map(tech -> Mapper.getUnitModelByTechUpgrade(tech.getAlias()))
+                .filter(Objects::nonNull)
+                .anyMatch(unit -> "warsun".equalsIgnoreCase(unit.getBaseType()));
     }
 
     // @ButtonHandler("initiateASplice_")


### PR DESCRIPTION
Automates starting fleet for Muaat in franken games.

Checks for warsun faction tech and adds a flagship instead of none are present.