### PR TITLE
Ignore Autocomplete errors due to wrong type

### DIFF
--- a/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
+++ b/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
@@ -93,6 +93,8 @@ class AutoCompleteProvider {
     static void handleAutoCompleteEvent(CommandAutoCompleteInteractionEvent event) {
         try {
             resolveAutoCompleteEvent(event);
+        } catch (IllegalArgumentException ignored) {
+            // We don't care about these.
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(event), "Error in handleAutoCompleteEvent", e);
         }

--- a/src/main/java/ti4/helpers/TransactionHelper.java
+++ b/src/main/java/ti4/helpers/TransactionHelper.java
@@ -1353,9 +1353,9 @@ public final class TransactionHelper {
         if (pillagersToPillaged.isEmpty()) return "";
 
         StringBuilder notice = new StringBuilder();
-        notice.append("> This is a surcharge notice from ")
+        notice.append("> This is a surcharge notice from **")
                 .append(getRandomPillageSource())
-                .append(":");
+                .append("**:");
         for (Map.Entry<String, List<String>> pillagerToPillaged : pillagersToPillaged.entrySet()) {
             notice.append("\n> • ")
                     .append(MiscEmojis.tg)

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
@@ -36,7 +36,7 @@ class TrueSkillMatchmakingRatingService {
                 var trueSkillPlayer = userIdToTrueSkillPlayer.computeIfAbsent(
                         gamePlayer.userId(), _ -> new Player<>(gamePlayer.userId()));
                 Rating rating =
-                        trueSkillPlayerToRating.computeIfAbsent(trueSkillPlayer, id -> gameInfo.getDefaultRating());
+                        trueSkillPlayerToRating.computeIfAbsent(trueSkillPlayer, _ -> gameInfo.getDefaultRating());
                 userIdToUsername.put(gamePlayer.userId(), gamePlayer.username());
 
                 var team = new Team();


### PR DESCRIPTION
AutoCompleteProvider: catch and ignore IllegalArgumentException in handleAutoCompleteEvent to avoid noisy/benign errors. TransactionHelper: wrap the pillage source in bold markdown (**source**) in the surcharge notice for clearer formatting. TrueSkillMatchmakingRatingService: rename unused lambda parameter to '_' when computing default rating to clarify it's unused.