### PR TITLE
Add game-level whispers enable/disable

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/game/Setup.java
+++ b/src/main/java/ti4/discord/interactions/commands/game/Setup.java
@@ -27,6 +27,8 @@ class Setup extends GameStateSubcommand {
         addOptions(new OptionData(OptionType.BOOLEAN, Constants.TIGL_GAME, "True to mark the game as TIGL"));
         addOptions(new OptionData(
                 OptionType.INTEGER, Constants.AUTO_PING, "Hours between auto pings. Min 1. Enter 0 to turn off."));
+        addOptions(
+                new OptionData(OptionType.BOOLEAN, Constants.WHISPERS_ENABLED, "True to allow whispers in this game."));
     }
 
     @Override
@@ -112,6 +114,16 @@ class Setup extends GameStateSubcommand {
             game.setCustomName(customGameName);
         }
 
+        Boolean whispersEnabled = event.getOption(Constants.WHISPERS_ENABLED, null, OptionMapping::getAsBoolean);
+        if (whispersEnabled != null) {
+            game.setWhispersDisabled(!whispersEnabled);
+            MessageHelper.sendMessageToChannel(
+                    event.getChannel(),
+                    whispersEnabled
+                            ? "Whispers have been reenabled for this game."
+                            : "Whispers have been disabled for this game.");
+        }
+
         if (!setGameMode(event, game)) {
             MessageHelper.sendMessageToChannel(
                     event.getChannel(),
@@ -122,6 +134,7 @@ class Setup extends GameStateSubcommand {
                 && scCountPerPlayer == null
                 && maxSOCount == null
                 && vpOption == null
+                && whispersEnabled == null
                 && playerCount == null) {
             CreateGameService.presentSetupToPlayers(game);
         }

--- a/src/main/java/ti4/discord/interactions/listeners/MessageListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/MessageListener.java
@@ -251,6 +251,14 @@ class MessageListener extends ListenerAdapter {
             return true;
         }
 
+        if (game.isWhispersDisabled()) {
+            MessageHelper.sendMessageToChannel(
+                    event.getChannel(),
+                    "Whispers are disabled in this game. To reenable them, use `/game setup whispers_enabled:true`.");
+            message.delete().queue(Consumers.nop(), BotLogger::catchRestError);
+            return true;
+        }
+
         String messageContent = StringUtils.substringAfter(messageText, " ");
         if (messageContent.isEmpty()) {
             message.reply("No message content?").queue(Consumers.nop(), BotLogger::catchRestError);

--- a/src/main/java/ti4/game/GameProperties.java
+++ b/src/main/java/ti4/game/GameProperties.java
@@ -143,6 +143,7 @@ public class GameProperties {
     private @ExportableField boolean noSwapMode;
     private @ExportableField boolean veiledHeartMode;
     private @ExportableField boolean limitedWhispersMode;
+    private @ExportableField boolean whispersDisabled;
     private @ExportableField boolean ageOfCommerceMode;
     private @ExportableField boolean hiddenAgendaMode;
     private @ExportableField boolean ordinianC1Mode;

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -648,6 +648,7 @@ class GameLoadService {
                 case Constants.NO_SWAP_MODE -> game.setNoSwapMode(parseBooleanOrDefault(info, false));
                 case Constants.VEILED_HEART_MODE -> game.setVeiledHeartMode(parseBooleanOrDefault(info, false));
                 case Constants.LIMITED_WHISPERS_MODE -> game.setLimitedWhispersMode(parseBooleanOrDefault(info, false));
+                case Constants.WHISPERS_DISABLED -> game.setWhispersDisabled(parseBooleanOrDefault(info, false));
                 case Constants.ORDINIAN_C1_MODE -> game.setOrdinianC1Mode(parseBooleanOrDefault(info, false));
                 case Constants.LIBERATION_C4_MODE -> game.setLiberationC4Mode(parseBooleanOrDefault(info, false));
                 case Constants.VOTC_MODE -> game.setVotcMode(parseBooleanOrDefault(info, false));

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -580,6 +580,8 @@ class GameSaveService {
         writer.write(System.lineSeparator());
         writer.write(Constants.LIMITED_WHISPERS_MODE + " " + game.isLimitedWhispersMode());
         writer.write(System.lineSeparator());
+        writer.write(Constants.WHISPERS_DISABLED + " " + game.isWhispersDisabled());
+        writer.write(System.lineSeparator());
         writer.write(Constants.AGE_OF_COMMERCE_MODE + " " + game.isAgeOfCommerceMode());
         writer.write(System.lineSeparator());
         writer.write(Constants.ORDINIAN_C1_MODE + " " + game.isOrdinianC1Mode());

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1274,6 +1274,8 @@ public final class Constants {
     public static final String NO_SWAP_MODE = "no_swap_mode";
     public static final String VEILED_HEART_MODE = "veiled_heart_mode";
     public static final String LIMITED_WHISPERS_MODE = "limited_whispers_mode";
+    public static final String WHISPERS_ENABLED = "whispers_enabled";
+    public static final String WHISPERS_DISABLED = "whispers_disabled";
     public static final String ORDINIAN_C1_MODE = "ordinian_c1_mode";
     public static final String LIBERATION_C4_MODE = "liberation_c4_mode";
     public static final String FAKE_COMMANDERS = "fake_commanders";

--- a/src/main/java/ti4/service/fow/WhisperService.java
+++ b/src/main/java/ti4/service/fow/WhisperService.java
@@ -21,6 +21,13 @@ public class WhisperService {
             String anonY,
             MessageChannel feedbackChannel,
             Guild guild) {
+        if (game.isWhispersDisabled()) {
+            MessageHelper.sendMessageToChannel(
+                    feedbackChannel,
+                    "Whispers are disabled in this game. To reenable them, use `/game setup whispers_enabled:true`.");
+            return;
+        }
+
         String message;
         String realIdentity = player_.getRepresentationUnfogged();
         String player1 = ColorEmojis.getColorEmojiWithName(player.getColor());

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -1010,11 +1010,15 @@ public class StartPhaseService {
             boolean anyoneWantsToBan = false;
             boolean anyoneWantsNoSwaps = false;
             boolean anyoneWantsLimitedWhispers = false;
+            int noWhispersCount = 0;
             Collections.shuffle(randomPlayers);
             for (Player player : randomPlayers) {
                 var userSettings = UserSettingsManager.get(player.getUserID());
                 if (!userSettings.isHasAnsweredSurvey()) {
                     continue;
+                }
+                if ("No Whispers".equalsIgnoreCase(userSettings.getWhisperPref())) {
+                    noWhispersCount++;
                 }
                 question1
                         .append("* ")
@@ -1079,7 +1083,8 @@ public class StartPhaseService {
                         "If you wish to do anything unusual with _Supports For The Thrones_, you can use these buttons.",
                         buttons);
             }
-            if (anyoneWantsLimitedWhispers) {
+            boolean majorityPrefersNoWhispers = noWhispersCount > randomPlayers.size() / 2;
+            if (anyoneWantsLimitedWhispers && !majorityPrefersNoWhispers) {
                 buttons = new ArrayList<>();
                 buttons.add(Buttons.blue("setLimitedWhispers", "Allow Limited Whispers"));
                 buttons.add(Buttons.gray("deleteButtons", "Dismiss these buttons"));
@@ -1090,6 +1095,12 @@ public class StartPhaseService {
                                 + " of your deals/transactions are hidden (redacted), so you can have limited secret communication."
                                 + " Players are not allowed to send more than one hidden deal in a turn.",
                         buttons);
+            }
+            if (majorityPrefersNoWhispers) {
+                game.setWhispersDisabled(true);
+                MessageHelper.sendMessageToChannel(
+                        game.getMainGameChannel(),
+                        "A majority of players indicated that they prefer no whispers, so whispers have been disabled for this game. To reenable them, use `/game setup whispers_enabled:true`.");
             }
             MessageHelper.sendMessageToChannel(
                     game.getTableTalkChannel(),

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -1084,7 +1084,7 @@ public class StartPhaseService {
                         buttons);
             }
             boolean majorityPrefersNoWhispers = noWhispersCount > randomPlayers.size() / 2;
-            if (anyoneWantsLimitedWhispers && !majorityPrefersNoWhispers) {
+            if (anyoneWantsLimitedWhispers) {
                 buttons = new ArrayList<>();
                 buttons.add(Buttons.blue("setLimitedWhispers", "Allow Limited Whispers"));
                 buttons.add(Buttons.gray("deleteButtons", "Dismiss these buttons"));

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -1083,7 +1083,7 @@ public class StartPhaseService {
                         "If you wish to do anything unusual with _Supports For The Thrones_, you can use these buttons.",
                         buttons);
             }
-            boolean majorityPrefersNoWhispers = noWhispersCount > randomPlayers.size() / 2;
+
             if (anyoneWantsLimitedWhispers) {
                 buttons = new ArrayList<>();
                 buttons.add(Buttons.blue("setLimitedWhispers", "Allow Limited Whispers"));
@@ -1096,12 +1096,15 @@ public class StartPhaseService {
                                 + " Players are not allowed to send more than one hidden deal in a turn.",
                         buttons);
             }
+
+            boolean majorityPrefersNoWhispers = noWhispersCount > randomPlayers.size() / 2;
             if (majorityPrefersNoWhispers) {
                 game.setWhispersDisabled(true);
                 MessageHelper.sendMessageToChannel(
                         game.getMainGameChannel(),
                         "A majority of players indicated that they prefer no whispers, so whispers have been disabled for this game. To reenable them, use `/game setup whispers_enabled:true`.");
             }
+
             MessageHelper.sendMessageToChannel(
                     game.getTableTalkChannel(),
                     "You are encouraged to discuss these results if there appears to be any disagreement on questions 1-3,"


### PR DESCRIPTION
Introduce a configurable whispers toggle per game. Adds constants (whispers_enabled/whispers_disabled), a whispersDisabled field on GameProperties, and persistence (save/load). The /game setup command accepts whispers_enabled and updates the game (with feedback). Whisper sending is blocked when disabled (MessageListener and WhisperService) and setup instructions are shown to reenable. StartPhaseService now honors survey majority pref to automatically disable whispers at game start.