### PR TITLE
Base game setup button rework

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/milty/SettingMenuButtonHandlers.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/milty/SettingMenuButtonHandlers.java
@@ -4,6 +4,7 @@ import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
+import ti4.helpers.settingsFramework.menus.BaseGameMiniMiltySettings;
 import ti4.helpers.settingsFramework.menus.FrankenSettings;
 
 @UtilityClass
@@ -16,6 +17,10 @@ class SettingMenuButtonHandlers {
         String draftSystemNavPart = ".*_draft[._].*";
         if (event.getCustomId().matches(draftSystemNavPart)) {
             game.initializeDraftSystemSettings().parseButtonInput(event);
+            return;
+        }
+        if (BaseGameMiniMiltySettings.isBaseGameMiniMiltyMenuComponent(event.getCustomId())) {
+            game.initializeBaseGameMiniMiltySettings().parseButtonInput(event);
             return;
         }
         if (FrankenSettings.isFrankenMenuComponent(event.getCustomId())) {

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/options/GameOptionButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/options/GameOptionButtonHandler.java
@@ -101,12 +101,6 @@ final class GameOptionButtonHandler {
 
     @ButtonHandler("setupBaseGameMode")
     public static void setupBaseGameMode(ButtonInteractionEvent event, Game game) {
-        game.setBaseGameMode(true);
-        game.setAcDeckID("action_cards_basegame");
-        game.setAgendaDeckID("agendas_base_game");
-        game.setScSetID("pok");
-        MessageHelper.sendMessageToChannel(
-                event.getMessageChannel(),
-                "Set game to Base Game mode with Base Game Action Cards, Base Game Agendas, and PoK strategy cards.");
+        game.initializeBaseGameMiniMiltySettings().postMessageAndButtons(event);
     }
 }

--- a/src/main/java/ti4/discord/interactions/commands/game/WeirdGameSetup.java
+++ b/src/main/java/ti4/discord/interactions/commands/game/WeirdGameSetup.java
@@ -19,7 +19,7 @@ import ti4.service.fow.FOWPlusService;
 import ti4.service.fow.RiftSetModeService;
 import ti4.service.option.FOWOptionService.FOWOption;
 
-class WeirdGameSetup extends GameStateSubcommand {
+public class WeirdGameSetup extends GameStateSubcommand {
 
     WeirdGameSetup() {
         super(Constants.WEIRD_GAME_SETUP, "Game Setup for Weird Games", true, false);
@@ -290,8 +290,7 @@ class WeirdGameSetup extends GameStateSubcommand {
             if (!game.validateAndSetPublicObjectivesStage2Deck(event, Mapper.getDeck("public_stage_2_objectives_base")))
                 return false;
             if (!game.validateAndSetSecretObjectiveDeck(event, Mapper.getDeck("secret_objectives_base"))) return false;
-            if (!game.validateAndSetActionCardDeck(event, Mapper.getDeck("action_cards_basegame_and_codex1")))
-                return false;
+            if (!game.validateAndSetActionCardDeck(event, Mapper.getDeck("action_cards_basegame"))) return false;
             if (!game.validateAndSetRelicDeck(Mapper.getDeck("relics_base"))) return false;
             if (!game.validateAndSetExploreDeck(event, Mapper.getDeck("explores_base"))) return false;
 
@@ -430,5 +429,16 @@ class WeirdGameSetup extends GameStateSubcommand {
         }
 
         return true;
+    }
+
+    public static boolean applyBaseGameMode(GenericInteractionCreateEvent event, Game game) {
+        game.setThundersEdge(false);
+        game.setTwilightsFallMode(false);
+        game.removeStoredValue("useOldPok");
+        boolean success = setGameMode(event, game, true, false, false, false, false, false);
+        if (success) {
+            game.setStrategyCardSet("pok");
+        }
+        return success;
     }
 }

--- a/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
+++ b/src/main/java/ti4/discord/interactions/listeners/ModalListener.java
@@ -14,6 +14,7 @@ import ti4.discord.interactions.routing.ModalHandler;
 import ti4.executors.ExecutionLockType;
 import ti4.executors.ExecutorServiceManager;
 import ti4.game.Game;
+import ti4.helpers.settingsFramework.menus.BaseGameMiniMiltySettings;
 import ti4.helpers.settingsFramework.menus.FrankenSettings;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
@@ -113,6 +114,10 @@ public final class ModalListener extends ListenerAdapter {
             String draftSystemNavPart = ".*_draft[._].*";
             if (modalID.matches(draftSystemNavPart)) {
                 game.initializeDraftSystemSettings().parseInput(context);
+                return;
+            }
+            if (BaseGameMiniMiltySettings.isBaseGameMiniMiltyMenuComponent(modalID)) {
+                game.initializeBaseGameMiniMiltySettings().parseInput(context);
                 return;
             }
             if (FrankenSettings.isFrankenMenuComponent(modalID)) {

--- a/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
+++ b/src/main/java/ti4/discord/interactions/selections/SelectionMenuProcessor.java
@@ -12,6 +12,7 @@ import ti4.discord.interactions.routing.SelectionHandler;
 import ti4.executors.ExecutionLockType;
 import ti4.executors.ExecutorServiceManager;
 import ti4.game.Game;
+import ti4.helpers.settingsFramework.menus.BaseGameMiniMiltySettings;
 import ti4.helpers.settingsFramework.menus.FrankenSettings;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
@@ -104,6 +105,11 @@ public final class SelectionMenuProcessor {
         String draftSystemNavPart = ".*_draft[._].*";
         if (event.getCustomId().matches(draftSystemNavPart)) {
             game.initializeDraftSystemSettings().parseSelectionInput(event);
+            deleteMsg(event);
+            return;
+        }
+        if (BaseGameMiniMiltySettings.isBaseGameMiniMiltyMenuComponent(event.getCustomId())) {
+            game.initializeBaseGameMiniMiltySettings().parseSelectionInput(event);
             deleteMsg(event);
             return;
         }

--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -67,6 +67,7 @@ import ti4.helpers.TIGLHelper;
 import ti4.helpers.TIGLHelper.TIGLRank;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.omega_phase.VoiceOfTheCouncilHelper;
+import ti4.helpers.settingsFramework.menus.BaseGameMiniMiltySettings;
 import ti4.helpers.settingsFramework.menus.DeckSettings;
 import ti4.helpers.settingsFramework.menus.DraftSystemSettings;
 import ti4.helpers.settingsFramework.menus.FrankenSettings;
@@ -264,6 +265,10 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
 
     @Setter
     @Getter
+    private String baseGameMiniMiltySettingsJson;
+
+    @Setter
+    @Getter
     private String draftString;
 
     @Setter
@@ -274,6 +279,9 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
 
     @Setter
     private FrankenSettings frankenSettings;
+
+    @Setter
+    private BaseGameMiniMiltySettings baseGameMiniMiltySettings;
 
     @Getter
     @Setter
@@ -483,6 +491,8 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
         draftSystemSettingsJson = null;
         frankenSettings = null;
         frankenSettingsJson = null;
+        baseGameMiniMiltySettings = null;
+        baseGameMiniMiltySettingsJson = null;
     }
 
     @NotNull
@@ -522,6 +532,10 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
         return frankenSettings;
     }
 
+    public BaseGameMiniMiltySettings getBaseGameMiniMiltySettingsUnsafe() {
+        return baseGameMiniMiltySettings;
+    }
+
     public MiltySettings initializeMiltySettings() {
         if (miltySettings == null) {
             miltySettings = initializeSetting(
@@ -552,6 +566,18 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
                     getActionsChannel());
         }
         return frankenSettings;
+    }
+
+    public BaseGameMiniMiltySettings initializeBaseGameMiniMiltySettings() {
+        if (baseGameMiniMiltySettings == null) {
+            baseGameMiniMiltySettings = initializeSetting(
+                    baseGameMiniMiltySettingsJson,
+                    BaseGameMiniMiltySettings::new,
+                    "base game Mini-Milty settings",
+                    Constants.jabberwockyPing(),
+                    getActionsChannel());
+        }
+        return baseGameMiniMiltySettings;
     }
 
     private <T> T initializeSetting(

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -686,6 +686,8 @@ class GameLoadService {
                 case Constants.DRAFT_SYSTEM_SETTINGS ->
                     game.setDraftSystemSettingsJson(info); // We will parse this later
                 case Constants.FRANKEN_DRAFT_SETTINGS -> game.setFrankenSettingsJson(info); // We will parse this later
+                case Constants.BASE_GAME_MINI_MILTY_SETTINGS ->
+                    game.setBaseGameMiniMiltySettingsJson(info); // We will parse this later
                 case Constants.GAME_TAGS -> game.setTags(getCardList(info));
                 case Constants.TIGL_RANK -> {
                     TIGLHelper.TIGLRank rank = TIGLHelper.TIGLRank.fromString(info);

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -34,6 +34,7 @@ import ti4.helpers.Storage;
 import ti4.helpers.StringHelper;
 import ti4.helpers.Units;
 import ti4.helpers.Units.UnitKey;
+import ti4.helpers.settingsFramework.menus.BaseGameMiniMiltySettings;
 import ti4.helpers.settingsFramework.menus.DraftSystemSettings;
 import ti4.helpers.settingsFramework.menus.FrankenSettings;
 import ti4.helpers.settingsFramework.menus.MiltySettings;
@@ -680,6 +681,15 @@ class GameSaveService {
             writer.write(System.lineSeparator());
         } else if (game.getFrankenSettingsJson() != null) {
             writer.write(Constants.FRANKEN_DRAFT_SETTINGS + " " + game.getFrankenSettingsJson());
+            writer.write(System.lineSeparator());
+        }
+
+        BaseGameMiniMiltySettings baseGameMiniMiltySettings = game.getBaseGameMiniMiltySettingsUnsafe();
+        if (baseGameMiniMiltySettings != null) {
+            writer.write(Constants.BASE_GAME_MINI_MILTY_SETTINGS + " " + baseGameMiniMiltySettings.json());
+            writer.write(System.lineSeparator());
+        } else if (game.getBaseGameMiniMiltySettingsJson() != null) {
+            writer.write(Constants.BASE_GAME_MINI_MILTY_SETTINGS + " " + game.getBaseGameMiniMiltySettingsJson());
             writer.write(System.lineSeparator());
         }
 

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1072,6 +1072,7 @@ public final class Constants {
     public static final String DRAFT_MANAGER = "draft_manager";
     public static final String DRAFT_SYSTEM_SETTINGS = "draft_system_settings";
     public static final String FRANKEN_DRAFT_SETTINGS = "franken_draft_settings";
+    public static final String BASE_GAME_MINI_MILTY_SETTINGS = "base_game_mini_milty_settings";
     public static final String DRAFT = "draft";
 
     // groups

--- a/src/main/java/ti4/helpers/settingsFramework/menus/BaseGameMiniMiltyFactionSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/BaseGameMiniMiltyFactionSettings.java
@@ -1,0 +1,90 @@
+package ti4.helpers.settingsFramework.menus;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import ti4.game.Game;
+import ti4.helpers.settingsFramework.settings.IntegerSetting;
+import ti4.helpers.settingsFramework.settings.ListSetting;
+import ti4.helpers.settingsFramework.settings.SettingInterface;
+import ti4.image.Mapper;
+import ti4.model.FactionModel;
+import ti4.model.Source.ComponentSource;
+import tools.jackson.databind.JsonNode;
+
+@Getter
+@JsonIgnoreProperties("messageId")
+public class BaseGameMiniMiltyFactionSettings extends SettingsMenu {
+
+    private static final String MENU_ID = "dsFaction";
+    private static final List<ComponentSource> FACTION_SOURCES = List.of(ComponentSource.base);
+
+    private final IntegerSetting numFactions;
+    private final ListSetting<FactionModel> banFactions;
+    private final ListSetting<FactionModel> priFactions;
+
+    public BaseGameMiniMiltyFactionSettings(Game game, JsonNode json, BaseGameMiniMiltySettings parent) {
+        super(MENU_ID, "Faction Settings", "Control faction draft options.", parent);
+
+        int players = parent.getPlayerUserIds().size();
+        numFactions = new IntegerSetting("#Factions", "Number of Factions", players + 1, 2, 30, 1);
+
+        Set<String> empty = new HashSet<>();
+        Set<Entry<String, FactionModel>> allFactions = new HashSet<>();
+        banFactions = new ListSetting<>(
+                "BanFactions", "Banned factions", "Ban faction", "Unban faction", allFactions, empty, empty);
+        priFactions = new ListSetting<>(
+                "PriFactions",
+                "Prioritized factions",
+                "Prioritize faction",
+                "Unprioritize faction",
+                allFactions,
+                empty,
+                empty);
+
+        banFactions.setGetEmoji(FactionModel::getFactionEmoji);
+        priFactions.setGetEmoji(FactionModel::getFactionEmoji);
+
+        banFactions.setShow(FactionModel::getAlias);
+        priFactions.setShow(FactionModel::getAlias);
+        priFactions.setExtraInfo("These factions will be included in the draft first!");
+
+        if (!(json == null
+                || !json.has("menuId")
+                || !MENU_ID.equals(json.get("menuId").asString("")))) {
+            numFactions.initialize(json.get("numFactions"));
+            banFactions.initialize(json.get("banFactions"));
+            priFactions.initialize(json.get("priFactions"));
+        }
+
+        updateTransientSettings();
+    }
+
+    @Override
+    public List<SettingInterface> settings() {
+        List<SettingInterface> ls = new ArrayList<>();
+        ls.add(numFactions);
+        ls.add(banFactions);
+        ls.add(priFactions);
+        return ls;
+    }
+
+    @Override
+    protected void updateTransientSettings() {
+        Map<String, FactionModel> allFactions = getAvailableBaseFactions();
+        banFactions.setAllValues(allFactions);
+        priFactions.setAllValues(allFactions);
+    }
+
+    private static Map<String, FactionModel> getAvailableBaseFactions() {
+        return Mapper.getFactionsValues().stream()
+                .filter(model -> FACTION_SOURCES.contains(model.getSource()))
+                .collect(Collectors.toMap(FactionModel::getAlias, f -> f));
+    }
+}

--- a/src/main/java/ti4/helpers/settingsFramework/menus/BaseGameMiniMiltySettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/BaseGameMiniMiltySettings.java
@@ -1,0 +1,181 @@
+package ti4.helpers.settingsFramework.menus;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.modals.Modal;
+import org.apache.commons.lang3.function.Consumers;
+import org.jetbrains.annotations.NotNull;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.game.Game;
+import ti4.helpers.settingsFramework.settings.ReadOnlyTextSetting;
+import ti4.helpers.settingsFramework.settings.SettingInterface;
+import ti4.image.Mapper;
+import ti4.logging.BotLogger;
+import ti4.model.MapTemplateModel;
+import ti4.model.Source.ComponentSource;
+import ti4.service.draft.BaseGameMiniMiltyService;
+import tools.jackson.databind.JsonNode;
+
+@Getter
+@JsonIgnoreProperties({"messageId", "mapTemplateStatus", "customMapStatus"})
+public class BaseGameMiniMiltySettings extends SettingsMenu {
+    private static final String MENU_ID = "baseGameMiniMilty";
+
+    private final ReadOnlyTextSetting mapTemplateStatus;
+    private final ReadOnlyTextSetting customMapStatus;
+    private final BaseGameMiniMiltyFactionSettings factionSettings;
+
+    @JsonIgnore
+    private final Game game;
+
+    private String customMapString;
+
+    public BaseGameMiniMiltySettings(@NotNull Game game, JsonNode json) {
+        super(MENU_ID, "Base Game Mini-Milty", "Set up a standalone base-game faction and speaker-order draft.", null);
+        this.game = game;
+
+        mapTemplateStatus = new ReadOnlyTextSetting("Template", "Map Template");
+        customMapStatus = new ReadOnlyTextSetting("CustomMap", "Custom Map String");
+
+        if (json != null
+                && json.has("menuId")
+                && MENU_ID.equals(json.get("menuId").asText(""))) {
+            customMapString = json.hasNonNull("customMapString")
+                    ? json.get("customMapString").asText(null)
+                    : null;
+        }
+
+        factionSettings =
+                new BaseGameMiniMiltyFactionSettings(game, json != null ? json.get("factionSettings") : null, this);
+
+        if (json != null && json.has("messageId")) {
+            setMessageId(json.get("messageId").asText(null));
+        }
+        updateTransientSettings();
+    }
+
+    @Override
+    protected List<SettingsMenu> categories() {
+        return List.of(factionSettings);
+    }
+
+    @Override
+    protected List<SettingInterface> settings() {
+        return List.of(mapTemplateStatus, customMapStatus);
+    }
+
+    @Override
+    protected List<Button> specialButtons() {
+        String prefix = menuAction + "_" + navId() + "_";
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.blue(prefix + "customMapString~MDL", "Insert Map String"));
+        if (hasCustomMapString()) {
+            buttons.add(Buttons.red(prefix + "clearCustomMapString", "Clear Map String"));
+        }
+        buttons.add(Buttons.green(prefix + "startMiniMilty", "Start Mini-Milty!"));
+        return buttons;
+    }
+
+    @Override
+    public String menuSummaryString(String lastSettingTouched) {
+        return super.menuSummaryString(lastSettingTouched) + menuNotes();
+    }
+
+    @Override
+    protected String handleSpecialButtonAction(GenericInteractionCreateEvent event, String action) {
+        return switch (action) {
+            case "customMapString~MDL" -> {
+                String error = handleCustomMapString(event);
+                yield error == null ? "success" : error;
+            }
+            case "customMapString" -> {
+                String error = handleCustomMapString(event);
+                yield error == null ? "success" : error;
+            }
+            case "clearCustomMapString" -> {
+                clearCustomMapString();
+                yield "success";
+            }
+            case "startMiniMilty" -> {
+                String error = BaseGameMiniMiltyService.startFromSettings(event, this);
+                yield error == null ? "success" : error;
+            }
+            default -> null;
+        };
+    }
+
+    @Override
+    protected void updateTransientSettings() {
+        MapTemplateModel template = getResolvedMapTemplate();
+        mapTemplateStatus.setDisplay(template == null ? "No standard template available" : template.getAlias());
+        customMapStatus.setDisplay(
+                hasCustomMapString() ? "Stored (" + customMapString.length() + " chars)" : "Not set");
+    }
+
+    public static boolean isBaseGameMiniMiltyMenuComponent(String componentId) {
+        return componentId != null
+                && (componentId.contains("_" + MENU_ID + "_") || componentId.contains("_" + MENU_ID + "."));
+    }
+
+    public List<String> getPlayerUserIds() {
+        return new ArrayList<>(game.getPlayerIDs());
+    }
+
+    public List<ComponentSource> getFactionSources() {
+        return List.of(ComponentSource.base);
+    }
+
+    public MapTemplateModel getResolvedMapTemplate() {
+        MapTemplateModel template =
+                Mapper.getDefaultMapTemplateForPlayerCount(getPlayerUserIds().size());
+        if (template == null || template.isNucleusTemplate()) {
+            return null;
+        }
+        if (template.bluePerPlayer() != 3 || template.redPerPlayer() != 2) {
+            return null;
+        }
+        return template;
+    }
+
+    public boolean hasCustomMapString() {
+        return customMapString != null && !customMapString.isBlank();
+    }
+
+    public void setCustomMapString(String customMapString) {
+        this.customMapString = customMapString;
+    }
+
+    private String clearCustomMapString() {
+        customMapString = null;
+        return null;
+    }
+
+    private String handleCustomMapString(GenericInteractionCreateEvent event) {
+        if (event instanceof ButtonInteractionEvent buttonEvent) {
+            Modal modal = BaseGameMiniMiltyService.buildMapStringModal(game, navId(), customMapString);
+            buttonEvent.replyModal(modal).queue(Consumers.nop(), BotLogger::catchRestError);
+            return null;
+        }
+        if (event instanceof ModalInteractionEvent modalEvent) {
+            return BaseGameMiniMiltyService.applyMapStringFromModal(modalEvent, this);
+        }
+        return "Unknown event type";
+    }
+
+    private static String menuNotes() {
+        return """
+
+
+            **Notes:**
+            > When the draft is complete, please manually remove the wormhole nexus.
+
+            > If you don't use a custom map string, the draft will try to generate a balanced map.""";
+    }
+}

--- a/src/main/java/ti4/service/draft/BaseGameMiniMiltyService.java
+++ b/src/main/java/ti4/service/draft/BaseGameMiniMiltyService.java
@@ -1,0 +1,251 @@
+package ti4.service.draft;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.label.Label;
+import net.dv8tion.jda.api.components.textinput.TextInput;
+import net.dv8tion.jda.api.components.textinput.TextInputStyle;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.interactions.modals.ModalMapping;
+import net.dv8tion.jda.api.modals.Modal;
+import ti4.discord.interactions.commands.game.WeirdGameSetup;
+import ti4.game.Game;
+import ti4.game.Tile;
+import ti4.game.persistence.GameManager;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.MapTemplateHelper;
+import ti4.helpers.settingsFramework.menus.BaseGameMiniMiltySettings;
+import ti4.logging.BotLogger;
+import ti4.logging.LogOrigin;
+import ti4.model.MapTemplateModel;
+import ti4.model.MapTemplateModel.MapTemplateTile;
+import ti4.model.Source.ComponentSource;
+import ti4.service.draft.draftables.FactionDraftable;
+import ti4.service.draft.draftables.SpeakerOrderDraftable;
+import ti4.service.draft.orchestrators.PublicSnakeDraftOrchestrator;
+import ti4.service.map.AddTileListService;
+import ti4.service.map.MapStringMapper;
+import ti4.service.milty.MiltyDraftTile;
+
+@UtilityClass
+public class BaseGameMiniMiltyService {
+    private static final String MAP_STRING_FIELD = "mapString";
+    private static final int BLUE_TILES_PER_SLICE = 3;
+    private static final int RED_TILES_PER_SLICE = 2;
+
+    public static Modal buildMapStringModal(Game game, String navId, String currentMapString) {
+        TextInput.Builder mapString = TextInput.create(MAP_STRING_FIELD, TextInputStyle.PARAGRAPH)
+                .setPlaceholder("Paste the map string here.")
+                .setRequired(true);
+        if (currentMapString != null && !currentMapString.isBlank()) {
+            mapString.setValue(currentMapString.substring(0, Math.min(currentMapString.length(), 4000)));
+        }
+        return Modal.create("jmfA_" + navId + "_customMapString", "Add Map String for " + game.getName())
+                .addComponents(Label.of("Enter Map String", mapString.build()))
+                .build();
+    }
+
+    public static String applyMapStringFromModal(ModalInteractionEvent event, BaseGameMiniMiltySettings settings) {
+        ModalMapping mapping = event.getValue(MAP_STRING_FIELD);
+        if (mapping == null) {
+            return "No map string provided.";
+        }
+        String mapString = mapping.getAsString().trim();
+        if (mapString.isEmpty()) {
+            settings.setCustomMapString(null);
+            return null;
+        }
+        if (MapStringMapper.getMappedTilesToPosition(mapString, settings.getGame())
+                .isEmpty()) {
+            return "Could not map the provided map string to tile positions.";
+        }
+        settings.setCustomMapString(mapString);
+        return null;
+    }
+
+    public static String startFromSettings(GenericInteractionCreateEvent event, BaseGameMiniMiltySettings settings) {
+        Game game = settings.getGame();
+        MapTemplateModel template = settings.getResolvedMapTemplate();
+        if (template == null) {
+            return "No standard map template is available for this player count.";
+        }
+        if (settings.getPlayerUserIds().isEmpty()) {
+            return "Mini-Milty needs at least 1 player.";
+        }
+        if (MapTemplateHelper.getPlayerHomeSystemLocation(1, template.getAlias()) == null) {
+            return "The selected map template does not define valid home system locations.";
+        }
+        if (template.bluePerPlayer() != 3 || template.redPerPlayer() != 2) {
+            return "Mini-Milty currently requires a map template with exactly 3 blue and 2 red tiles per slice.";
+        }
+
+        if (!WeirdGameSetup.applyBaseGameMode(event, game)) {
+            return "Could not switch the game into base game mode.";
+        }
+        game.setMapTemplateID(template.getAlias());
+
+        DraftManager draftManager = game.getDraftManager();
+        draftManager.resetForNewDraft();
+        draftManager.setPlayers(settings.getPlayerUserIds());
+
+        FactionDraftable factionDraftable = new FactionDraftable();
+        factionDraftable.initialize(
+                settings.getFactionSettings().getNumFactions().getVal(),
+                settings.getFactionSources(),
+                new ArrayList<>(settings.getFactionSettings().getPriFactions().getKeys()),
+                new ArrayList<>(settings.getFactionSettings().getBanFactions().getKeys()));
+        draftManager.addDraftable(factionDraftable);
+
+        SpeakerOrderDraftable speakerOrderDraftable = new SpeakerOrderDraftable();
+        speakerOrderDraftable.initialize(settings.getPlayerUserIds().size());
+        draftManager.addDraftable(speakerOrderDraftable);
+
+        PublicSnakeDraftOrchestrator orchestrator = new PublicSnakeDraftOrchestrator();
+        orchestrator.initialize(draftManager, null);
+        draftManager.setOrchestrator(orchestrator);
+
+        game.clearTileMap();
+        String mapError = prepareDraftMap(event, game, settings);
+        if (mapError != null) {
+            return mapError;
+        }
+
+        ButtonHelper.updateMap(game, event, "Base Game Mini-Milty map preview");
+        game.setPhaseOfGame("miltydraft");
+        draftManager.tryStartDraft();
+        GameManager.save(game, "Base Game Mini-Milty");
+        return null;
+    }
+
+    private static String prepareDraftMap(
+            GenericInteractionCreateEvent event, Game game, BaseGameMiniMiltySettings settings) {
+        MapTemplateModel template = settings.getResolvedMapTemplate();
+        if (template == null) {
+            return "No standard map template is available for this player count.";
+        }
+
+        if (settings.hasCustomMapString()) {
+            return applyCustomMapString(game, settings, template);
+        }
+
+        PartialMapService.placeFromTemplate(template, game);
+        return applyRandomBaseGameTiles(game, template);
+    }
+
+    private static String applyCustomMapString(
+            Game game, BaseGameMiniMiltySettings settings, MapTemplateModel template) {
+        Map<String, String> mappedTiles =
+                new HashMap<>(MapStringMapper.getMappedTilesToPosition(settings.getCustomMapString(), game));
+        if (mappedTiles.isEmpty()) {
+            return "Could not map the stored custom map string to tile positions.";
+        }
+
+        for (Integer homePosition : template.getSortedHomeSystemLocations()) {
+            mappedTiles.remove(homePosition.toString());
+        }
+
+        try {
+            AddTileListService.addTileMapToGame(game, mappedTiles);
+            PartialMapService.placeFromTemplate(template, game);
+        } catch (Exception e) {
+            BotLogger.error(new LogOrigin(game), "Could not apply base game Mini-Milty custom map string", e);
+            return "Could not apply the custom map string. Check the map string and try again.";
+        }
+
+        if (MapTemplateHelper.getPlayerHomeSystemLocation(1, game.getMapTemplateID()) == null) {
+            return "The selected map template does not define valid home system locations.";
+        }
+        return null;
+    }
+
+    private static String applyRandomBaseGameTiles(Game game, MapTemplateModel template) {
+        DraftTileManager tileManager = game.getDraftTileManager();
+        tileManager.clear();
+        tileManager.addAllDraftTiles(List.of(ComponentSource.base));
+
+        List<MiltyDraftTile> blueTiles = new ArrayList<>(tileManager.getBlue());
+        List<MiltyDraftTile> redTiles = new ArrayList<>(tileManager.getRed());
+        Collections.shuffle(blueTiles);
+        Collections.shuffle(redTiles);
+
+        Map<Integer, List<MiltyDraftTile>> tilesByPlayer = new HashMap<>();
+        int bluePointer = 0;
+        int redPointer = 0;
+        for (Integer playerNumber : getSlicePlayerNumbers(template)) {
+            if (bluePointer + BLUE_TILES_PER_SLICE > blueTiles.size()
+                    || redPointer + RED_TILES_PER_SLICE > redTiles.size()) {
+                return "Could not generate enough base-game tiles for the selected map template.";
+            }
+
+            List<MiltyDraftTile> sliceTiles = buildSliceTiles(
+                    blueTiles.subList(bluePointer, bluePointer + BLUE_TILES_PER_SLICE),
+                    redTiles.subList(redPointer, redPointer + RED_TILES_PER_SLICE));
+
+            tilesByPlayer.put(playerNumber, sliceTiles);
+            bluePointer += BLUE_TILES_PER_SLICE;
+            redPointer += RED_TILES_PER_SLICE;
+        }
+        placeSliceTiles(game, template, tilesByPlayer);
+        return null;
+    }
+
+    private static List<Integer> getSlicePlayerNumbers(MapTemplateModel template) {
+        List<Integer> playerNumbers = new ArrayList<>();
+        for (MapTemplateTile templateTile : template.getTemplateTiles()) {
+            Integer playerNumber = templateTile.getPlayerNumber();
+            if (templateTile.getPos() == null || playerNumber == null || templateTile.getMiltyTileIndex() == null) {
+                continue;
+            }
+            if (Boolean.TRUE.equals(templateTile.getHome())) {
+                continue;
+            }
+            if (!playerNumbers.contains(playerNumber)) {
+                playerNumbers.add(playerNumber);
+            }
+        }
+        Collections.sort(playerNumbers);
+        return playerNumbers;
+    }
+
+    private static List<MiltyDraftTile> buildSliceTiles(List<MiltyDraftTile> blueTiles, List<MiltyDraftTile> redTiles) {
+        List<MiltyDraftTile> shuffledBlueTiles = new ArrayList<>(blueTiles);
+        List<MiltyDraftTile> shuffledRedTiles = new ArrayList<>(redTiles);
+        Collections.shuffle(shuffledBlueTiles);
+        Collections.shuffle(shuffledRedTiles);
+
+        List<MiltyDraftTile> sliceTiles = new ArrayList<>(shuffledBlueTiles.size() + shuffledRedTiles.size());
+        sliceTiles.addAll(shuffledBlueTiles);
+        sliceTiles.addAll(shuffledRedTiles);
+        Collections.shuffle(sliceTiles);
+        return sliceTiles;
+    }
+
+    private static void placeSliceTiles(
+            Game game, MapTemplateModel template, Map<Integer, List<MiltyDraftTile>> tilesByPlayer) {
+        for (MapTemplateTile templateTile : template.getTemplateTiles()) {
+            if (templateTile.getPos() == null || templateTile.getPlayerNumber() == null) {
+                continue;
+            }
+            if (Boolean.TRUE.equals(templateTile.getHome()) || templateTile.getMiltyTileIndex() == null) {
+                continue;
+            }
+
+            List<MiltyDraftTile> tiles = tilesByPlayer.get(templateTile.getPlayerNumber());
+            if (tiles == null) {
+                continue;
+            }
+            int tileIndex = templateTile.getMiltyTileIndex();
+            if (tileIndex < 0 || tileIndex >= tiles.size()) {
+                continue;
+            }
+
+            String tileId = tiles.get(tileIndex).getTile().getTileID();
+            game.setTile(new Tile(tileId, templateTile.getPos()));
+        }
+    }
+}

--- a/src/main/java/ti4/service/draft/PlayerSetupService.java
+++ b/src/main/java/ti4/service/draft/PlayerSetupService.java
@@ -32,6 +32,7 @@ import ti4.message.MessageHelper;
 import ti4.model.FactionModel;
 import ti4.model.Source;
 import ti4.model.TechnologyModel;
+import ti4.model.UnitModel;
 import ti4.service.emoji.MiscEmojis;
 import ti4.service.info.AbilityInfoService;
 import ti4.service.info.CardsInfoService;
@@ -278,6 +279,12 @@ public class PlayerSetupService {
         // STARTING OWNED UNITS
         Set<String> playerOwnedUnits = new HashSet<>(factionModel.getUnits());
         player.setUnitsOwned(playerOwnedUnits);
+        if (game.isBaseGameMode()) {
+            UnitModel mech = player.getUnitByBaseType("mech");
+            if (mech != null) {
+                player.removeOwnedUnitByID(mech.getId());
+            }
+        }
 
         // Don't do special stuff if Franken Faction
         if (faction.startsWith("franken")) {

--- a/src/main/java/ti4/service/game/CreateGameService.java
+++ b/src/main/java/ti4/service/game/CreateGameService.java
@@ -309,10 +309,10 @@ public class CreateGameService {
 
                 -# Please realize that these are broad overviews and that some small components may not fit perfectly into these categories.""";
         MessageHelper.sendMessageToChannelWithButtons(actionsChannel, expMsg, buttons);
-        Button baseGameModeButton = Buttons.green("setupBaseGameMode", "Setup Base Game Only");
+        Button baseGameModeButton = Buttons.green("setupBaseGameMode", "Start Base Game Only Setup");
         MessageHelper.sendMessageToChannelWithButton(
                 actionsChannel,
-                "Use the below button to set the game to the base game with PoK strategy cards.\n\n**NOTE: Do not press the button below unless you intend to play the base game only, no expansions.**",
+                "## Use this button to setup a base mode game of TI4.\n\n-# This will set the game to base game with no expansions, and PoK strategy cards.",
                 baseGameModeButton);
     }
 


### PR DESCRIPTION
Button opens a menu that gives:

Map string button, faction settings, and start draft.

I call it Mini-Milty because there is no slice drafting, only faction and speaker order. This is to simplify. If no custom map string is entered, the game generates slices and places them randomly, selecting from the base game tiles only.