### PR TITLE
Onyxxa BT and commander unlock (#5224)

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaBreakthroughButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaBreakthroughButtonHandler.java
@@ -21,6 +21,7 @@ import ti4.message.MessageHelper;
 import ti4.service.emoji.DiceEmojis;
 import ti4.service.emoji.FactionEmojis;
 import ti4.service.map.FractureService;
+import ti4.service.unit.MoveUnitService;
 
 @UtilityClass
 public class OnyxxaBreakthroughButtonHandler {
@@ -136,9 +137,8 @@ public class OnyxxaBreakthroughButtonHandler {
 
         List<Button> buttons = new ArrayList<>();
         buttons.add(Buttons.green(
-                player.factionButtonChecker() + "mitoMechPlacement_" + tile.getPosition() + "_" + planetName
-                        + "_onyxxabt",
-                "Replace 1 Infantry with 1 Mech"));
+                player.factionButtonChecker() + "onyxxabtMechPlacement_" + tile.getPosition() + "_" + planetName,
+                "Replace 1 Infantry with 1 Mech (" + infantryCount + " available)"));
         buttons.add(Buttons.red("deleteButtons", "Done"));
         MessageHelper.sendMessageToChannelWithButtons(
                 player.getCorrectChannel(),
@@ -147,5 +147,32 @@ public class OnyxxaBreakthroughButtonHandler {
                         + Helper.getPlanetRepresentation(planetName, game)
                         + " (_Styx and Stones_). Click the button once per infantry.",
                 buttons);
+    }
+
+    @ButtonHandler("onyxxabtMechPlacement_")
+    public static void handleMechPlacement(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        String[] parts = buttonID.replace("onyxxabtMechPlacement_", "").split("_", 2);
+        String pos = parts[0];
+        String planetName = parts[1];
+        Tile tile = game.getTileByPosition(pos);
+        UnitHolder unitHolder = tile.getUnitHolders().get(planetName);
+
+        MoveUnitService.replaceUnit(event, game, player, tile, unitHolder, UnitType.Infantry, UnitType.Mech);
+        MessageHelper.sendMessageToChannel(
+                player.getCorrectChannel(),
+                player.getRepresentation(false, false) + " replaced 1 infantry with 1 mech on "
+                        + Helper.getPlanetRepresentation(planetName, game) + " (_Styx and Stones_).");
+
+        int remaining = unitHolder.getUnitCount(UnitType.Infantry, player.getColorID());
+        if (remaining == 0) {
+            ButtonHelper.deleteMessage(event);
+        } else {
+            List<Button> buttons = new ArrayList<>();
+            buttons.add(Buttons.green(
+                    player.factionButtonChecker() + "onyxxabtMechPlacement_" + pos + "_" + planetName,
+                    "Replace 1 Infantry with 1 Mech (" + remaining + " remaining)"));
+            buttons.add(Buttons.red("deleteButtons", "Done"));
+            MessageHelper.editMessageButtons(event, buttons);
+        }
     }
 }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaBreakthroughButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaBreakthroughButtonHandler.java
@@ -1,0 +1,151 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.game.UnitHolder;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.Constants;
+import ti4.helpers.DiceHelper;
+import ti4.helpers.FoWHelper;
+import ti4.helpers.Helper;
+import ti4.helpers.Units.UnitType;
+import ti4.message.MessageHelper;
+import ti4.service.emoji.DiceEmojis;
+import ti4.service.emoji.FactionEmojis;
+import ti4.service.map.FractureService;
+
+@UtilityClass
+public class OnyxxaBreakthroughButtonHandler {
+
+    public static void offerSCRollButton(Game game, Player player) {
+        Button rollButton = Buttons.green(
+                player.factionButtonChecker() + "onyxxabtRoll", "Roll for Styx and Stones", FactionEmojis.onyxxa);
+        MessageHelper.sendMessageToChannelWithButton(
+                player.getCardsInfoThread(),
+                player.getRepresentationUnfogged()
+                        + ", only click if you resolved the primary ability of the strategy card: you may roll for _Styx and Stones_.",
+                rollButton);
+    }
+
+    @ButtonHandler("onyxxabtRoll")
+    public static void handleRoll(ButtonInteractionEvent event, Game game, Player player) {
+        int result = new DiceHelper.Die(0).getResult();
+        DiceEmojis diceEmoji = result == 1 ? DiceEmojis.d10blue_1 : (result == 10 ? DiceEmojis.d10blue_0 : null);
+        String diceStr = diceEmoji != null
+                ? diceEmoji.toString()
+                : DiceEmojis.getGrayDieEmoji(result).toString();
+
+        if (result == 1 || result == 10) {
+            if (!FractureService.isFractureInPlay(game)) {
+                MessageHelper.sendMessageToChannel(
+                        player.getCorrectChannel(),
+                        player.getRepresentation(false, false) + " rolled a " + diceStr
+                                + "! The Fracture is now in play!");
+                FractureService.spawnFracture(event, game);
+                FractureService.spawnIngressTokens(event, game, player, "onyxxabt");
+            } else {
+                MessageHelper.sendMessageToChannel(
+                        player.getCorrectChannel(),
+                        player.getRepresentation(false, false) + " rolled a " + diceStr
+                                + "! The Fracture is already in play — move an ingress token to a system that contains your units.");
+                offerMoveIngressFromButtons(game, player);
+            }
+        } else {
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    player.getRepresentation(true, false) + " rolled a " + DiceEmojis.getGrayDieEmoji(result)
+                            + ", no effect.");
+        }
+        ButtonHelper.deleteButtonAndDeleteMessageIfEmpty(event);
+    }
+
+    @ButtonHandler("onyxxaMoveIngressFrom_")
+    public static void handleMoveIngressFrom(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        String fromPos = buttonID.replace("onyxxaMoveIngressFrom_", "");
+        Tile fromTile = game.getTileByPosition(fromPos);
+        fromTile.getSpaceUnitHolder().removeToken(Constants.TOKEN_INGRESS);
+        MessageHelper.sendMessageToChannel(
+                player.getCorrectChannel(),
+                "Removed ingress token from " + fromTile.getRepresentationForButtons(game, player) + ".");
+
+        List<Button> buttons = new ArrayList<>();
+        for (Tile tile : game.getTileMap().values()) {
+            if (FoWHelper.playerHasUnitsInSystem(player, tile)) {
+                buttons.add(Buttons.green(
+                        player.factionButtonChecker() + "onyxxaMoveIngressTo_" + tile.getPosition(),
+                        tile.getRepresentationForButtons(game, player)));
+            }
+        }
+        buttons.add(Buttons.red("deleteButtons", "Cancel"));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                player.getRepresentationUnfogged() + ", choose the system to move the ingress token to.",
+                buttons);
+        ButtonHelper.deleteMessage(event);
+    }
+
+    @ButtonHandler("onyxxaMoveIngressTo_")
+    public static void handleMoveIngressTo(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        String toPos = buttonID.replace("onyxxaMoveIngressTo_", "");
+        Tile toTile = game.getTileByPosition(toPos);
+        toTile.addToken(Constants.TOKEN_INGRESS, "space");
+        MessageHelper.sendMessageToChannel(
+                player.getCorrectChannel(),
+                player.getRepresentation(false, false) + " moved an ingress token to "
+                        + toTile.getRepresentationForButtons(game, player) + ".");
+        ButtonHelper.deleteMessage(event);
+    }
+
+    private static void offerMoveIngressFromButtons(Game game, Player player) {
+        List<Button> buttons = new ArrayList<>();
+        for (Tile tile : game.getTileMap().values()) {
+            UnitHolder space = tile.getSpaceUnitHolder();
+            if (space.getTokenList().contains(Constants.TOKEN_INGRESS)) {
+                buttons.add(Buttons.red(
+                        player.factionButtonChecker() + "onyxxaMoveIngressFrom_" + tile.getPosition(),
+                        tile.getRepresentationForButtons(game, player)));
+            }
+        }
+        if (buttons.isEmpty()) {
+            MessageHelper.sendMessageToChannel(player.getCorrectChannel(), "No ingress tokens found to move.");
+            return;
+        }
+        buttons.add(Buttons.gray("deleteButtons", "Cancel"));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                player.getRepresentationUnfogged() + ", choose an ingress token to move.",
+                buttons);
+    }
+
+    public static void offerGroundCombatMechButtons(Game game, Player player, UnitHolder unitHolder, Tile tile) {
+        String planetName = unitHolder.getName();
+        int infantryCount = unitHolder.getUnitCount(UnitType.Infantry, player.getColorID());
+        if (infantryCount < 1) return;
+
+        boolean inFracture = tile.getPosition().startsWith("frac");
+        boolean inNexus = "82b".equals(tile.getTileID()) || "82bh".equals(tile.getTileID());
+        if (!inFracture && !inNexus) return;
+
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.green(
+                player.factionButtonChecker() + "mitoMechPlacement_" + tile.getPosition() + "_" + planetName
+                        + "_onyxxabt",
+                "Replace 1 Infantry with 1 Mech"));
+        buttons.add(Buttons.red("deleteButtons", "Done"));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                player.getRepresentationUnfogged()
+                        + ", you may replace any number of your infantry with mechs on "
+                        + Helper.getPlanetRepresentation(planetName, game)
+                        + " (_Styx and Stones_). Click the button once per infantry.",
+                buttons);
+    }
+}

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaCommanderButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaCommanderButtonHandler.java
@@ -1,0 +1,41 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.ButtonHelper;
+import ti4.message.MessageHelper;
+import ti4.service.emoji.FactionEmojis;
+import ti4.service.leader.UnlockLeaderService;
+
+@UtilityClass
+public class OnyxxaCommanderButtonHandler {
+
+    // Commander: Strategist Kreel — unlock condition:
+    // "Resolve the primary ability of a strategy card in 1 of your neighbors' play areas."
+    public static void offerCommanderUnlockButton(Player player) {
+        Button button = Buttons.gray(
+                player.factionButtonChecker() + "onyxxaCommanderUnlock",
+                "Unlock Strategist Kreel",
+                FactionEmojis.onyxxa);
+        MessageHelper.sendMessageToChannelWithButton(
+                player.getCardsInfoThread(),
+                player.getRepresentationUnfogged()
+                        + ", only click if you resolved the primary of a strategy card in a neighbor's play area.",
+                button);
+    }
+
+    @ButtonHandler("onyxxaCommanderUnlock")
+    public static void handleCommanderUnlock(ButtonInteractionEvent event, Game game, Player player) {
+        UnlockLeaderService.unlockLeader("onyxxacommander", game, player);
+        ButtonHelper.deleteButtonAndDeleteMessageIfEmpty(event);
+    }
+
+    // TODO: implement commander ability (Strategist Kreel):
+    // After you draw a relic: gain 1 command token.
+    // After you gain control of a planet in The Fracture that was controlled by another player: gain 1 relic.
+}

--- a/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
+++ b/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
@@ -10,6 +10,8 @@ import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaBreakthroughButtonHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaCommanderButtonHandler;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
 import ti4.game.Planet;
@@ -318,6 +320,12 @@ public class TeHelperActionCards {
         buttons.add(Buttons.red("deleteButtons", "Done Resolving"));
         MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), message, buttons);
         MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg2);
+        if (player.hasUnlockedBreakthrough("onyxxabt")) {
+            OnyxxaBreakthroughButtonHandler.offerSCRollButton(game, player);
+        }
+        if (!player.hasLeaderUnlocked("onyxxacommander") && "onyxxa".equals(player.getFaction())) {
+            OnyxxaCommanderButtonHandler.offerCommanderUnlockButton(player);
+        }
         ButtonHelper.deleteMessage(event);
     }
 

--- a/src/main/java/ti4/model/LeaderModel.java
+++ b/src/main/java/ti4/model/LeaderModel.java
@@ -242,7 +242,8 @@ public class LeaderModel implements ModelInterface, EmbeddableModel {
         String abilityName = useTwilightsFallText ? " " : getAbilityName().orElse(" ");
         String abilityWindow =
                 useTwilightsFallText ? getTFAbilityWindow().orElse(this.abilityWindow) : this.abilityWindow;
-        String fieldTitle = abilityName + "\n**" + abilityWindow + "**";
+        String fieldTitle =
+                abilityName + (abilityWindow == null || abilityWindow.isBlank() ? "" : "\n**" + abilityWindow + "**");
         String fieldContent = useTwilightsFallText ? getTFAbilityText().orElse(abilityText) : abilityText;
         if (useTwilightsFallText && (tfNotes != null)) {
             fieldContent += "\n-# [" + tfNotes + "]";

--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -27,6 +27,7 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Iron.Iro
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersAbilitiesHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersUnitsHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.arvaxi.ArvaxiCommanderHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaBreakthroughButtonHandler;
 import ti4.game.Game;
 import ti4.game.Leader;
 import ti4.game.Planet;
@@ -240,6 +241,11 @@ public class StartCombatService {
                     continue;
                 }
                 createSpectatorThread(game, player3, threadName, tile, event, "ground");
+            }
+        }
+        for (Player p : List.of(player, player2)) {
+            if (p.hasUnlockedBreakthrough("onyxxabt")) {
+                OnyxxaBreakthroughButtonHandler.offerGroundCombatMechButtons(game, p, unitHolder, tile);
             }
         }
     }

--- a/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
+++ b/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
@@ -15,6 +15,8 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaBreakthroughButtonHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaCommanderButtonHandler;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.Tile;
@@ -445,6 +447,16 @@ public class PlayStrategyCardService {
             String message2 = player.getRepresentationUnfogged() + " please gain or flip 1 balance token.";
             List<Button> buttons2 = ButtonHelper.getBalanceButtons(player);
             MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), message2, buttons2);
+        }
+        if (player.hasUnlockedBreakthrough("onyxxabt")) {
+            OnyxxaBreakthroughButtonHandler.offerSCRollButton(game, player);
+        }
+        for (Player p : game.getRealPlayers()) {
+            if (p != player
+                    && !p.hasLeaderUnlocked("onyxxacommander")
+                    && p.getLeaderIDs().contains("onyxxacommander")) {
+                OnyxxaCommanderButtonHandler.offerCommanderUnlockButton(p);
+            }
         }
         if (scModel.usesAutomationForSCID("anarchy8")) {
             MessageHelper.sendMessageToChannel(

--- a/src/main/resources/data/breakthroughs/balacasi_breakthroughs.json
+++ b/src/main/resources/data/breakthroughs/balacasi_breakthroughs.json
@@ -53,8 +53,8 @@
         "shortName": "Styx and\nStones",
         "faction": "onyxxa",
         "synergy": [
-            "CYBERNETIC",
-            "BIOTIC"
+            "BIOTIC",
+            "CYBERNETIC"
         ],
         "text": "When you resolve the primary ability of a strategy card, roll a die. On a result of 1 or 10, put The Fracture into play if it is not already; if it is, move an ingress token into a system that contains your units. At the start of a ground combat on a planet in The Fracture or in the wormhole nexus, you may choose any number of your infantry on that planet; replace each of those infantry with 1 mech from your reinforcements.",
         "source": "balacasi"

--- a/src/main/resources/data/leaders/balacasi.json
+++ b/src/main/resources/data/leaders/balacasi.json
@@ -152,8 +152,8 @@
         "type": "commander",
         "name": "Strategist Kreel",
         "title": "The Judicial",
-        "abilityWindow": "After you draw a relic:",
-        "abilityText": "Gain 1 command token. After you gain control of a planet in The Fracture that was controlled by another player, gain 1 relic.",
+        "abilityWindow": "",
+        "abilityText": "After you draw a relic, gain 1 command token. After you gain control of a planet in The Fracture that was controlled by another player, gain 1 relic.",
         "unlockCondition": "Resolve the primary ability of a strategy card in 1 of your neighbors' play areas.",
         "source": "balacasi"
     },


### PR DESCRIPTION
- Implement Styx and Stones BT: offer roll button on SC primary, spawn/move Fracture ingress on 1/10, offer infantry→mech replacement at start of ground combat in The Fracture or wormhole nexus
- Add commander unlock button (Strategist Kreel) in private channel when a neighbor plays an SC
- Fix empty abilityWindow showing as ** in leader embeds
- Fix Onyxxa BT synergy order and commander JSON