### PR TITLE
Mahact commander yin BT franken fix

### DIFF
--- a/src/main/java/ti4/helpers/UnusedCommanderHelper.java
+++ b/src/main/java/ti4/helpers/UnusedCommanderHelper.java
@@ -30,6 +30,7 @@ public class UnusedCommanderHelper {
                 commanderName = "kelerescommander";
             }
             if (game.getFactions().contains(faction.getAlias())
+                    || (game.isFrankenGame() && "mahactcommander".equalsIgnoreCase(commanderName))
                     || ("obsidian".equalsIgnoreCase(faction.getAlias())
                             && game.getFactions().contains("firmament"))
                     || ("firmament".equalsIgnoreCase(faction.getAlias())


### PR DESCRIPTION
This removes the normal mahact commander from being an option in franken games through anything that draws unused commanders.