### PR TITLE
Add full res map image button

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/Buttons.java
+++ b/src/main/java/ti4/discord/interactions/buttons/Buttons.java
@@ -111,7 +111,7 @@ public final class Buttons {
         if (game != null && !game.isFowMode()) {
             if (AsyncTi4WebsiteHelper.uploadsEnabled()) {
                 String url = "https://asyncti4.com/game/" + game.getName() + "/newui";
-                buttonsWeb.add(Button.link(url, "Website View"));
+                buttonsWeb.add(Button.link(url, "Web View"));
             }
             buttonsWeb.add(PLAYER_INFO);
         }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -143,7 +143,6 @@ import ti4.service.unit.CheckUnitContainmentService;
 import ti4.service.unit.RemoveUnitService;
 import ti4.spring.api.image.GameImageService;
 import ti4.spring.context.SpringContext;
-import ti4.website.AsyncTi4WebsiteHelper;
 
 @UtilityClass
 public class ButtonHelper {
@@ -2422,11 +2421,7 @@ public class ButtonHelper {
             List<Button> buttons,
             Game game,
             @Nullable Consumer<Message> onSuccess) {
-        if (!AsyncTi4WebsiteHelper.uploadsEnabled() || game.isFowMode()) {
-            MessageHelper.sendFileToChannelAndAddLinkToButtons(channel, fileUpload, message, buttons, onSuccess);
-        } else {
-            MessageHelper.sendFileToChannelWithButtonsAfter(channel, fileUpload, message, buttons, onSuccess);
-        }
+        MessageHelper.sendFileToChannelAndAddLinkToButtons(channel, fileUpload, message, buttons, onSuccess);
     }
 
     public static boolean canMoveOutOfLockedSystems(Player player, Game game) {

--- a/src/main/java/ti4/message/MessageHelper.java
+++ b/src/main/java/ti4/message/MessageHelper.java
@@ -420,7 +420,15 @@ public class MessageHelper {
                                 onSuccess.accept(msg);
                             }
                             String link = msg.getAttachments().getFirst().getUrl();
-                            realButtons.add(Button.link(link, "Open in browser"));
+                            Button fullResButton = Button.link(link, "Full Res");
+                            if (!buttons.isEmpty() && "Web View".equals(buttons.getFirst().getLabel())) {
+                                realButtons.add(buttons.getFirst());
+                                realButtons.add(fullResButton);
+                                realButtons.addAll(buttons.subList(1, buttons.size()));
+                                splitAndSent(message, channel, null, realButtons);
+                                return;
+                            }
+                            realButtons.add(fullResButton);
                             realButtons.addAll(buttons);
                             splitAndSent(message, channel, null, realButtons);
                         },


### PR DESCRIPTION
## Summary
- add a Full Res link button for posted map image attachments
- keep the website link button and rename it to Web View
- route map image sends through the attachment-aware helper so both buttons appear together

## Testing
- Not run; prior Maven test command was interrupted before completion.