### PR TITLE
Relic remove command AND /set order fix for non automated setups 

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/custom/CustomCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/custom/CustomCommand.java
@@ -14,6 +14,7 @@ public class CustomCommand implements ParentCommand {
                     new SoAddToGame(),
                     new AgendaRemoveFromGame(),
                     new ACRemoveFromGame(),
+                    new RelicRemoveFromGame(),
                     new SCAddToGame(),
                     new SCRemoveFromGame(),
                     new PoRemoveFromGame(),

--- a/src/main/java/ti4/discord/interactions/commands/custom/RelicRemoveFromGame.java
+++ b/src/main/java/ti4/discord/interactions/commands/custom/RelicRemoveFromGame.java
@@ -1,0 +1,34 @@
+package ti4.discord.interactions.commands.custom;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.GameStateSubcommand;
+import ti4.helpers.Constants;
+import ti4.message.MessageHelper;
+
+class RelicRemoveFromGame extends GameStateSubcommand {
+
+    RelicRemoveFromGame() {
+        super(Constants.REMOVE_RELIC_FROM_GAME, "Remove a relic from the game", true, true);
+        addOptions(new OptionData(OptionType.STRING, Constants.RELIC, "Relic ID")
+                .setRequired(true)
+                .setAutoComplete(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        boolean removed =
+                getGame().removeRelicFromGame(event.getOption(Constants.RELIC).getAsString());
+        if (removed) {
+            MessageHelper.sendMessageToChannel(event.getChannel(), "Relic removed from game deck.");
+        } else {
+            MessageHelper.sendMessageToChannel(event.getChannel(), "Relic not found in game deck.");
+        }
+    }
+
+    @Override
+    public boolean isSuspicious(SlashCommandInteractionEvent event) {
+        return true;
+    }
+}

--- a/src/main/java/ti4/game/GameProperties.java
+++ b/src/main/java/ti4/game/GameProperties.java
@@ -74,6 +74,7 @@ public class GameProperties {
     private String playersWhoHitPersistentNoWhen = "";
     private String savedMessage;
     private boolean hasHadAStatusPhase;
+    private boolean speakerOrderEstablished;
     private boolean naaluAgent;
     private boolean warfareAction;
     private boolean l1Hero;

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -536,6 +536,8 @@ class GameLoadService {
                 case Constants.BOT_COLOR_REACTS -> game.setBotColorReacts(parseBooleanOrDefault(info, false));
                 case Constants.BOT_STRAT_REACTS -> game.setBotStratReacts(parseBooleanOrDefault(info, false));
                 case Constants.HAS_HAD_A_STATUS_PHASE -> game.setHasHadAStatusPhase(parseBooleanOrDefault(info, false));
+                case Constants.SPEAKER_ORDER_ESTABLISHED ->
+                    game.setSpeakerOrderEstablished(parseBooleanOrDefault(info, false));
                 case Constants.BOT_SHUSHING -> game.setBotShushing(parseBooleanOrDefault(info, false));
                 case Constants.COMMUNITY_MODE -> game.setCommunityMode(parseBooleanOrDefault(info, false));
                 case Constants.ALLIANCE_MODE -> game.setAllianceMode(parseBooleanOrDefault(info, false));

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -609,6 +609,8 @@ class GameSaveService {
         writer.write(System.lineSeparator());
         writer.write(Constants.HAS_HAD_A_STATUS_PHASE + " " + game.isHasHadAStatusPhase());
         writer.write(System.lineSeparator());
+        writer.write(Constants.SPEAKER_ORDER_ESTABLISHED + " " + game.isSpeakerOrderEstablished());
+        writer.write(System.lineSeparator());
         writer.write(Constants.BOT_SHUSHING + " " + game.isBotShushing());
         writer.write(System.lineSeparator());
         writer.write(Constants.HOMEBREW_SC_MODE + " " + game.isHomebrewSCMode());

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -516,6 +516,7 @@ public final class Constants {
     public static final String REMOVE_SO_FROM_GAME = "remove_so_from_game";
     public static final String REMOVE_PO_FROM_GAME = "remove_po_from_game";
     public static final String REMOVE_SC_FROM_GAME = "remove_sc_from_game";
+    public static final String REMOVE_RELIC_FROM_GAME = "remove_relic_from_game";
 
     public static final String SET_PO_DECK = "set_po_deck";
     public static final String SET_PO_DECK_STAGE1_LIST = "stage1_ids";

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1225,6 +1225,7 @@ public final class Constants {
     public static final String BOT_COLOR_REACTS = "bot_color_reacts";
     public static final String BOT_STRAT_REACTS = "bot_strat_reacts";
     public static final String HAS_HAD_A_STATUS_PHASE = "has_had_a_status_phase";
+    public static final String SPEAKER_ORDER_ESTABLISHED = "speaker_order_established";
     public static final String BOT_SHUSHING = "bot_shushing";
     public static final String RELIC_SEND = "send";
     public static final String FOLLOWED_SC = "followed_sc";

--- a/src/main/java/ti4/service/game/SetOrderService.java
+++ b/src/main/java/ti4/service/game/SetOrderService.java
@@ -28,6 +28,7 @@ public class SetOrderService {
                 newPlayerOrder.putAll(players);
             }
             game.setPlayers(newPlayerOrder);
+            game.setSpeakerOrderEstablished(true);
         } catch (Exception e) {
             game.setPlayers(playersBackup);
         }

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -244,7 +244,9 @@ public class StartPhaseService {
             game.setRound(round);
         }
         if (game.getRound() == 1) {
-            Helper.setOrder(game);
+            if (!game.isSpeakerOrderEstablished()) {
+                Helper.setOrder(game);
+            }
             if (game.getActionsChannel() != null) {
                 for (ThreadChannel threadChannel : game.getActionsChannel().getThreadChannels()) {
                     if ((!threadChannel.getName().contains("Cards Info-" + game.getName())


### PR DESCRIPTION
**DOUBLE EYES REQUIRED FOR POINT 2**

1. Simple relic remove command, Often used in custom games and almost all fog games
2. /set Order was overridden by a change in November last year. Where it was moved from dealing SO to first strat phase round.

this made it impossible to properly set order through the command. As noted by many bug reports over the last half year or more.

I tried to patch it through setting a boolean like what was done for has had status phase.

The boolean is set to true if a GM or person hard sets player order through the command. 
This then guards against being overwritten by artificially deciding table order on a non table order map.
completely leaving all other options open
**The only potential issue** left might be some franken draft thing but I believe that hard sets the order in it's own matter

I had this all double checked by me and 2 NN models. But I need double eyes to make sure it does not break 1 of the many draft systems. (I could not find any issues but...

