### PR TITLE
whispers pack refactor and automate

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/arvaxi/ArvaxiAbilityButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/arvaxi/ArvaxiAbilityButtonHandler.java
@@ -13,6 +13,7 @@ import ti4.game.Player;
 import ti4.helpers.ButtonHelper;
 import ti4.message.MessageHelper;
 import ti4.service.actioncard.ForceGiveActionCardService;
+import ti4.service.emoji.FactionEmojis;
 
 @UtilityClass
 public class ArvaxiAbilityButtonHandler {
@@ -52,6 +53,19 @@ public class ArvaxiAbilityButtonHandler {
                 player.getCorrectChannel(),
                 "Sent " + target.getColor() + " the buttons for resolving Underhanded Maneuver.");
         ButtonHelper.deleteMessage(event);
+    }
+
+    public static void offerUndHandManeuver(Player player) {
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.gray(
+                player.factionButtonChecker() + "underhandedManeuverPickNeighbor",
+                "Use Underhanded Maneuver",
+                FactionEmojis.arvaxi));
+        buttons.add(Buttons.red("deleteButtons", "Decline"));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCardsInfoThread(),
+                player.getRepresentationUnfogged() + ", use buttons to resolve _Underhanded Maneuver_.",
+                buttons);
     }
 
     public static void onExplorePlanet(Player player, Game game, String planetName) {

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/kalora/KaloraButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/kalora/KaloraButtonHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.routing.ButtonHandler;
@@ -14,6 +15,7 @@ import ti4.helpers.ButtonHelper;
 import ti4.helpers.Units.UnitType;
 import ti4.message.MessageHelper;
 import ti4.service.emoji.ExploreEmojis;
+import ti4.service.emoji.FactionEmojis;
 import ti4.service.explore.ExploreService;
 import ti4.service.leader.ExhaustLeaderService;
 
@@ -40,6 +42,26 @@ public class KaloraButtonHandler {
         String pos = buttonID.replace("kaloraExploreFront_", "");
         ExploreService.expFront(event, game.getTileByPosition(pos), game, player, true, null);
         ButtonHelper.deleteButtonAndDeleteMessageIfEmpty(event);
+    }
+
+    public static void offerKaloraAgentButtons(Player player, String msg) {
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.gray(
+                player.factionButtonChecker() + "exhaustAgent_kaloraagent",
+                "Use Valzor, the Kalora Agent",
+                FactionEmojis.kalora));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCardsInfoThread(),
+                msg
+                        + ", a reminder that at the end of this space combat, you may exhaust the Kalora agent to allow a participating player to gain 1 command token.",
+                buttons);
+    }
+
+    public static void onEusocialityRetreat(Player player, GenericInteractionCreateEvent event) {
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(),
+                player.getFactionEmoji()
+                        + " did not place a command token in system they retreated to due to **Eusociality**.");
     }
 
     public static void offerMechButtons(Player player, Game game, Tile tile) {

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaUnitButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/onyxxa/OnyxxaUnitButtonHandler.java
@@ -1,0 +1,48 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.UnitHolder;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.Units.UnitType;
+import ti4.message.MessageHelper;
+import ti4.service.emoji.FactionEmojis;
+
+@UtilityClass
+public class OnyxxaUnitButtonHandler {
+
+    public static int getObeliskCombatModifier(Player player, UnitHolder unitHolder) {
+        int totalMechs = unitHolder.getUnitCount(UnitType.Mech, player.getColor());
+        return Math.max(0, totalMechs - 1);
+    }
+
+    public static void offerFlagshipWinButton(Player player, String msg) {
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.gray(
+                player.factionButtonChecker() + "onyxxaFlagshipWin", "Gain 1 Command Token", FactionEmojis.onyxxa));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCardsInfoThread(),
+                msg + ", a reminder that if you win this space combat, you may gain 1 command token.",
+                buttons);
+    }
+
+    @ButtonHandler("onyxxaFlagshipWin")
+    public static void onyxxaFlagshipWin(Player player, Game game, ButtonInteractionEvent event) {
+        List<Button> buttons = ButtonHelper.getGainCCButtons(player);
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                player.getRepresentationUnfogged()
+                        + ", your current command tokens are "
+                        + player.getCCRepresentation()
+                        + ". Use buttons to gain 1 command token.",
+                buttons);
+        ButtonHelper.deleteButtonAndDeleteMessageIfEmpty(event);
+    }
+}

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/tyris/TyrisBreakthroughButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/tyris/TyrisBreakthroughButtonHandler.java
@@ -142,7 +142,7 @@ public class TyrisBreakthroughButtonHandler {
             TechnologyModel m = Mapper.getTech(removed);
             String name = m != null ? "_" + m.getName() + "_" : removed;
             MessageHelper.sendMessageToChannel(
-                    p.getCardsInfoThread(),
+                    p.getCorrectChannel(),
                     p.getRepresentation() + "'s " + name
                             + " was removed from _Non-Linear Time Progression_ because a player passed.");
         } else {

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/tyris/TyrisCommanderButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/tyris/TyrisCommanderButtonHandler.java
@@ -40,6 +40,13 @@ public class TyrisCommanderButtonHandler {
                 buttons);
     }
 
+    public static void addCommanderActionButton(
+            Player p1, String factionChecker, String prefix, List<Button> compButtons) {
+        if (p1.getStrategicCC() <= 0 && !p1.hasRelicReady("emelpar")) return;
+        compButtons.add(Buttons.green(
+                factionChecker + prefix + "ability_tyrisCommanderMech", "Place Mech for 1 Token", FactionEmojis.tyris));
+    }
+
     public static void offerInfantry(Game game, Player player) {
         List<Button> buttons =
                 new ArrayList<>(Helper.getPlanetPlaceUnitButtons(player, game, "gf", "placeOneNDone_skipbuild"));

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/tyris/TyrisHeroButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/tyris/TyrisHeroButtonHandler.java
@@ -13,6 +13,11 @@ import ti4.service.emoji.FactionEmojis;
 @UtilityClass
 public class TyrisHeroButtonHandler {
 
+    public static boolean isHeroActiveThisRound(Game game, Player player) {
+        return !game.getStoredValue("tyrisHeroRound" + game.getRound() + "_" + player.getFaction())
+                .isEmpty();
+    }
+
     public static void offerHeroAtStartOfTurn(Game game, Player player) {
         List<Button> buttons = new ArrayList<>();
         buttons.add(Buttons.green(

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/vyserix/VyserixAbilityButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/vyserix/VyserixAbilityButtonHandler.java
@@ -1,0 +1,25 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.vyserix;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.game.UnitHolder;
+import ti4.helpers.Helper;
+import ti4.message.MessageHelper;
+import ti4.service.unit.AddUnitService;
+
+@UtilityClass
+public class VyserixAbilityButtonHandler {
+
+    public static void onGainPlanetWithTechSpec(
+            Player player, Game game, GenericInteractionCreateEvent event, Tile tile, UnitHolder unitHolder) {
+        MessageHelper.sendMessageToChannel(
+                player.getCorrectChannel(),
+                player.getFactionEmoji() + " placed 1 PDS on "
+                        + Helper.getPlanetRepresentation(unitHolder.getName(), game)
+                        + " due to the Veiled Ember Forge ability. This is optional but was done automatically.");
+        AddUnitService.addUnits(event, tile, game, player.getColor(), "pds " + unitHolder.getName());
+    }
+}

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/xan/XanAbilityButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/xan/XanAbilityButtonHandler.java
@@ -1,0 +1,24 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.xan;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.helpers.Helper;
+import ti4.message.MessageHelper;
+
+@UtilityClass
+public class XanAbilityButtonHandler {
+
+    public static void offerQuantumFabrication(
+            Player player, Game game, GenericInteractionCreateEvent event, Tile tile) {
+        String msg = player.getRepresentationUnfogged()
+                + ", if you placed this space dock via **Construction**, you may use its PRODUCTION ability immediately in "
+                + tile.getRepresentationForButtons(game, player) + " via **Quantum Fabrication**.";
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                msg,
+                Helper.getPlaceUnitButtons(event, player, game, tile, "ministerBuild", "place"));
+    }
+}

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/zephyrion/ZephyrionAgentButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/zephyrion/ZephyrionAgentButtonHandler.java
@@ -75,20 +75,35 @@ public class ZephyrionAgentButtonHandler {
 
         UnitType type = Mapper.getUnitKey(AliasHandler.resolveUnit(unitTypeString), p2.getColorID())
                 .unitType();
-        List<Button> destroyButtons = new ArrayList<>();
+        List<Tile> validTiles = new ArrayList<>();
         for (Tile tile : CheckUnitContainmentService.getTilesContainingPlayersUnits(game, p2, type)) {
             UnitHolder space = tile.getSpaceUnitHolder();
             if (space.getUnitCount(type, p2.getColor()) > 0 && CommandCounterHelper.hasCC(p2, tile)) {
+                validTiles.add(tile);
+            }
+        }
+        if (validTiles.size() == 1) {
+            zephShipDestroy(
+                    "zephShipDestroy_" + faction + "_" + unitTypeString + "_"
+                            + validTiles.getFirst().getPosition(),
+                    event,
+                    game,
+                    player);
+        } else {
+            List<Button> destroyButtons = new ArrayList<>();
+            for (Tile tile : validTiles) {
                 destroyButtons.add(Buttons.red(
                         p2.factionButtonChecker() + "zephShipDestroy_" + faction + "_" + unitTypeString + "_"
                                 + tile.getPosition(),
                         StringUtils.capitalize(unitTypeString) + " in " + tile.getRepresentationForButtons(game, p2)));
             }
+            destroyButtons.add(Buttons.gray("deleteButtons", "Done"));
+            MessageHelper.sendMessageToChannelWithButtons(
+                    game.getMainGameChannel(),
+                    p2.getRepresentation() + ", choose which ship to destroy.",
+                    destroyButtons);
+            ButtonHelper.deleteMessage(event);
         }
-        destroyButtons.add(Buttons.gray("deleteButtons", "Done"));
-        MessageHelper.sendMessageToChannelWithButtons(
-                game.getMainGameChannel(), p2.getRepresentation() + ", choose which ship to destroy.", destroyButtons);
-        ButtonHelper.deleteMessage(event);
     }
 
     @ButtonHandler("zephShipDestroy_")

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/zephyrion/ZephyrionBreakthroughButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/zephyrion/ZephyrionBreakthroughButtonHandler.java
@@ -20,10 +20,24 @@ import ti4.image.Mapper;
 import ti4.message.MessageHelper;
 import ti4.model.LeaderModel;
 import ti4.model.Source.ComponentSource;
+import ti4.service.emoji.FactionEmojis;
 import ti4.service.leader.ExhaustLeaderService;
 
 @UtilityClass
-class ZephyrionBreakthroughButtonHandler {
+public class ZephyrionBreakthroughButtonHandler {
+
+    public static void offerBtCombatButtons(Player player, Player otherPlayer, Game game, String msg) {
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.gray(
+                player.factionButtonChecker() + "zephyrionbtRes_" + otherPlayer.getFaction(),
+                "Resolve Subdue Chancellor (Upon Win)",
+                FactionEmojis.zephyrion));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCardsInfoThread(),
+                msg
+                        + ", a reminder that if you win this space combat, you may resolve _Subdue Chancellor_ to draw an unused agent.",
+                buttons);
+    }
 
     @ButtonHandler("zephyrionbtRes_")
     public static void zephyrionbtRes(String buttonID, ButtonInteractionEvent event, Game game, Player player) {

--- a/src/main/java/ti4/helpers/AgendaHelper.java
+++ b/src/main/java/ti4/helpers/AgendaHelper.java
@@ -31,6 +31,7 @@ import ti4.discord.interactions.buttons.handlers.actioncards.acd2.PublicOutrageA
 import ti4.discord.interactions.buttons.handlers.actioncards.acd2.SettlementsAcd2ButtonHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.DreamButtonHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.ta.TaLeadersHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.xan.XanAbilityButtonHandler;
 import ti4.discord.interactions.commands.planet.PlanetExhaust;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
@@ -3240,13 +3241,7 @@ public final class AgendaHelper {
                     player.getRepresentationNoPing() + " has the opportunity to resolve a Minister of Industry build.");
         }
         if (player.hasAbility("quantum_fabrication") && !tile.isScar(game)) {
-            String msg = player.getRepresentationUnfogged()
-                    + ", if you placed this space dock via **Construction**, you may use its PRODUCTION ability immediately in "
-                    + tile.getRepresentationForButtons(game, player) + " via **Quantum Fabrication**.";
-            MessageHelper.sendMessageToChannelWithButtons(
-                    player.getCorrectChannel(),
-                    msg,
-                    Helper.getPlaceUnitButtons(event, player, game, tile, "ministerBuild", "place"));
+            XanAbilityButtonHandler.offerQuantumFabrication(player, game, event, tile);
         }
     }
 }

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -62,6 +62,7 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.arvax
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraButtonHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.tyris.PhantomEnergyHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.tyris.TyrisBreakthroughButtonHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.tyris.TyrisHeroButtonHandler;
 import ti4.discord.interactions.commands.tokens.AddTokenCommand;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.discord.interactions.selections.selectmenus.SelectFaction;
@@ -5077,8 +5078,7 @@ public class ButtonHelper {
                 && !player.hasPlanet("thundersedge")
                 && !game.playerHasLeaderUnlockedOrAlliance(player, "kelerescommander")
                 && !player.hasAbility("arrow_of_time")
-                && game.getStoredValue("tyrisHeroRound" + game.getRound() + "_" + player.getFaction())
-                        .isEmpty()) {
+                && !TyrisHeroButtonHandler.isHeroActiveThisRound(game, player)) {
             MessageHelper.sendEphemeralMessageToEventChannel(
                     event,
                     "## " + player.getRepresentation()

--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -23,6 +23,7 @@ import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Iron.IronAbilitiesHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Iron.IronLeadersHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.ashen.AshenUnitHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraButtonHandler;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
 import ti4.game.Planet;
@@ -1714,10 +1715,7 @@ public final class ButtonHelperModifyUnits {
                             + " did not place a command token in system they retreated to due to Kado S'mah-Qar, the Kollecc commander.");
         } else {
             if (player.hasAbility("eusociality") && !CommandCounterHelper.hasCC(event, player.getColor(), tile1)) {
-                MessageHelper.sendMessageToChannel(
-                        event.getMessageChannel(),
-                        player.getFactionEmoji()
-                                + " did not place a command token in system they retreated to due to **Eusosociality**.");
+                KaloraButtonHandler.onEusocialityRetreat(player, event);
             } else {
                 if (game.isTwilightsFallMode() && buttonID.contains("skilled") && buttonID.contains("feint")) {
                     MessageHelper.sendMessageToChannel(

--- a/src/main/java/ti4/helpers/ComponentActionHelper.java
+++ b/src/main/java/ti4/helpers/ComponentActionHelper.java
@@ -400,12 +400,8 @@ public class ComponentActionHelper {
                     Buttons.green(factionChecker + prefix + "ability_orbitalDrop", "Orbital Drop", FactionEmojis.Sol);
             compButtons.add(abilityButton);
         }
-        if (game.playerHasLeaderUnlockedOrAlliance(p1, "tyriscommander")
-                && (p1.getStrategicCC() > 0 || p1.hasRelicReady("emelpar"))) {
-            compButtons.add(Buttons.green(
-                    factionChecker + prefix + "ability_tyrisCommanderMech",
-                    "Place Mech for 1 Token",
-                    FactionEmojis.tyris));
+        if (game.playerHasLeaderUnlockedOrAlliance(p1, "tyriscommander")) {
+            TyrisCommanderButtonHandler.addCommanderActionButton(p1, factionChecker, prefix, compButtons);
         }
         if (p1.hasAbility("mutineers")
                 && !ButtonHelperAbilities.getTilesToMutineers(game, p1).isEmpty()

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -38,6 +38,7 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunne
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersLeadersHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersUnitsHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.arvaxi.MobilizationEngineHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaUnitButtonHandler;
 import ti4.discord.interactions.commands.planet.PlanetExhaust;
 import ti4.game.Game;
 import ti4.game.Planet;
@@ -1022,6 +1023,11 @@ public class CombatRollService {
                     && player.hasTech("baconcg")
                     && game.getPlayedSCs().containsAll(opponent.getSCs())) {
                 modifierToHit += 1;
+            }
+            if (rollType == CombatRollType.combatround
+                    && "onyxxa_mech".equalsIgnoreCase(unitModel.getId())
+                    && unitHolder != null) {
+                modifierToHit += OnyxxaUnitButtonHandler.getObeliskCombatModifier(player, unitHolder);
             }
             int numRollsPerUnit = unitModel.getCombatDieCountForAbility(rollType, player);
             if (rollType == CombatRollType.combatround) {

--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -29,7 +29,10 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.crystell
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersAbilitiesHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersUnitsHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.arvaxi.ArvaxiCommanderHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraButtonHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaBreakthroughButtonHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaUnitButtonHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.zephyrion.ZephyrionBreakthroughButtonHandler;
 import ti4.game.Game;
 import ti4.game.Leader;
 import ti4.game.Planet;
@@ -917,20 +920,12 @@ public class StartCombatService {
                         buttons);
             }
             if ("space".equalsIgnoreCase(type) && player.hasUnexhaustedLeader("kaloraagent")) {
-                buttons = new ArrayList<>();
-                buttons.add(Buttons.gray(
-                        player.factionButtonChecker() + "exhaustAgent_kaloraagent",
-                        "Use Valzor, the Kalora Agent",
-                        FactionEmojis.kalora));
-                MessageHelper.sendMessageToChannelWithButtons(
-                        player.getCardsInfoThread(),
-                        msg
-                                + ", a reminder that at the end of this space combat, you may exhaust the Kalora agent to allow a participating player to gain 1 command token.",
-                        buttons);
+                KaloraButtonHandler.offerKaloraAgentButtons(player, msg);
             }
-            if ("space".equalsIgnoreCase(type)
-                    && (player.getLeaderIDs().contains("arvaxicommander")
-                            || game.playerHasLeaderUnlockedOrAlliance(player, "arvaxicommander"))) {
+            if ("space".equalsIgnoreCase(type) && ButtonHelper.doesPlayerHaveFSHere("onyxxa_flagship", player, tile)) {
+                OnyxxaUnitButtonHandler.offerFlagshipWinButton(player, msg);
+            }
+            if ("space".equalsIgnoreCase(type) && game.playerHasLeaderUnlockedOrAlliance(player, "arvaxicommander")) {
                 ArvaxiCommanderHandler.sendCombatButtons(player, otherPlayer, game, msg);
             }
             if (player.hasTechReady("dskortg") && CommandCounterHelper.hasCC(player, tile)) {
@@ -953,16 +948,7 @@ public class StartCombatService {
             if (player.hasUnlockedBreakthrough("zephyrionbt")
                     && "space".equalsIgnoreCase(type)
                     && ButtonHelper.isTileInOrAdjacentToPlayersHome(game, tile, otherPlayer, player)) {
-                buttons = new ArrayList<>();
-                buttons.add(Buttons.gray(
-                        player.factionButtonChecker() + "zephyrionbtRes_" + otherPlayer.getFaction(),
-                        "Resolve Subdue Chancellor (Upon Win)",
-                        FactionEmojis.zephyrion));
-                MessageHelper.sendMessageToChannelWithButtons(
-                        player.getCardsInfoThread(),
-                        msg
-                                + ", a reminder that if you win this space combat, you may resolve _Subdue Chancellor_ to draw an unused agent.",
-                        buttons);
+                ZephyrionBreakthroughButtonHandler.offerBtCombatButtons(player, otherPlayer, game, msg);
             }
             if (player.hasAbility("technological_singularity")
                     && !otherPlayer.isDummy()

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -18,6 +18,7 @@ import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.DreamButtonHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.arvaxi.ArvaxiAbilityButtonHandler;
 import ti4.game.Game;
 import ti4.game.Leader;
 import ti4.game.Planet;
@@ -595,16 +596,7 @@ public class StartPhaseService {
             }
             if (player2.hasAbility("underhanded_maneuver")
                     && !player2.getNeighbouringPlayers(true).isEmpty()) {
-                List<Button> buttons = new ArrayList<>();
-                buttons.add(Buttons.gray(
-                        player2.factionButtonChecker() + "underhandedManeuverPickNeighbor",
-                        "Use Underhanded Maneuver",
-                        FactionEmojis.arvaxi));
-                buttons.add(Buttons.red("deleteButtons", "Decline"));
-                MessageHelper.sendMessageToChannelWithButtons(
-                        player2.getCardsInfoThread(),
-                        player2.getRepresentationUnfogged() + ", use buttons to resolve _Underhanded Maneuver_.",
-                        buttons);
+                ArvaxiAbilityButtonHandler.offerUndHandManeuver(player2);
             }
             for (String pn : player2.getPromissoryNotes().keySet()) {
                 if (!player2.ownsPromissoryNote("scepter") && "scepter".equalsIgnoreCase(pn)) {

--- a/src/main/java/ti4/service/planet/AddPlanetService.java
+++ b/src/main/java/ti4/service/planet/AddPlanetService.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.ta.TaAbilityHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.onyxxa.OnyxxaCommanderButtonHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.vyserix.VyserixAbilityButtonHandler;
 import ti4.game.Game;
 import ti4.game.Planet;
 import ti4.game.Player;
@@ -454,12 +455,7 @@ public class AddPlanetService {
                 && !doubleCheck
                 && !setup
                 && !unitHolder.getTechSpecialities().isEmpty()) {
-            String fac = player.getFactionEmoji();
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    fac + " placed 1 PDS on " + Helper.getPlanetRepresentation(unitHolder.getName(), game)
-                            + " due to the Veiled Ember Forge ability. This is optional but was done automatically.");
-            AddUnitService.addUnits(event, tile, game, player.getColor(), "pds " + unitHolder.getName());
+            VyserixAbilityButtonHandler.onGainPlanetWithTechSpec(player, game, event, tile, unitHolder);
         }
         if ((game.getPhaseOfGame().contains("agenda")
                         || (game.getActivePlayerID() != null && !("".equalsIgnoreCase(game.getActivePlayerID()))))

--- a/src/main/java/ti4/service/turn/StartTurnService.java
+++ b/src/main/java/ti4/service/turn/StartTurnService.java
@@ -465,9 +465,7 @@ public class StartTurnService {
         boolean hadAnyUnplayedSCs = false;
 
         if (doneActionThisTurn
-                && (player.hasTech("fl")
-                        || !game.getStoredValue("tyrisHeroRound" + game.getRound() + "_" + player.getFaction())
-                                .isEmpty())) {
+                && (player.hasTech("fl") || TyrisHeroButtonHandler.isHeroActiveThisRound(game, player))) {
             confirmed2ndAction = true;
         }
         if (!doneActionThisTurn || confirmed2ndAction) {


### PR DESCRIPTION

- Extract Kalora agent reminder, Eusociality retreat msg, Arvaxi underhanded maneuver, Zephyrion BT combat reminder, Xan quantum fabrication, Vyserix veiled ember forge, Tyris commander mech button, Tyris hero active check into faction handler classes
- Fix Arvaxi commander check to use playerHasLeaderUnlockedOrAlliance
- Add OnyxxaUnitButtonHandler: Obelisk mech combat modifier (+1 per other mech on planet) and Igneous Khan flagship post-win CC gain button
- Fix TyrisBreakthroughButtonHandler to send player-passed announcement to main channel