### PR TITLE
Pair map refactor

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/combat/BombardmentButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/combat/BombardmentButtonHandler.java
@@ -98,7 +98,8 @@ class BombardmentButtonHandler {
         if (tile == null) {
             return buttons;
         }
-        Map<UnitModel, Integer> bombardUnits = CombatRollService.getUnitsInBombardment(tile, player, null);
+        Map<UnitModel, Integer> bombardUnits =
+                CombatRollService.flattenUnitMap(CombatRollService.getUnitsInBombardment(tile, player, null));
         String assignedUnits = game.getStoredValue("assignedBombardment" + player.getFaction());
         List<String> usedLabels = new ArrayList<>();
         for (Map.Entry<UnitModel, Integer> entry : bombardUnits.entrySet()) {

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/beans/ashen/AshenLeadersHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/beans/ashen/AshenLeadersHandler.java
@@ -543,7 +543,8 @@ public class AshenLeadersHandler {
     private static String buildHeroBombardmentAssignment(
             Player player, Game game, Tile sourceTile, String targetPlanet) {
         StringBuilder assignment = new StringBuilder();
-        Map<UnitModel, Integer> bombardUnits = CombatRollService.getUnitsInBombardment(sourceTile, player, null);
+        Map<UnitModel, Integer> bombardUnits =
+                CombatRollService.flattenUnitMap(CombatRollService.getUnitsInBombardment(sourceTile, player, null));
         for (Map.Entry<UnitModel, Integer> entry : bombardUnits.entrySet()) {
             for (int x = 0; x < entry.getValue(); x++) {
                 assignment

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/kalora/KaloraCommanderHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/kalora/KaloraCommanderHandler.java
@@ -2,8 +2,10 @@ package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalo
 
 import java.util.Map;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.tuple.Pair;
 import ti4.game.Player;
 import ti4.game.Tile;
+import ti4.game.UnitHolder;
 import ti4.helpers.FoWHelper;
 import ti4.model.UnitModel;
 import ti4.service.combat.CombatRollService;
@@ -11,7 +13,8 @@ import ti4.service.combat.CombatRollService;
 @UtilityClass
 public class KaloraCommanderHandler {
 
-    public static void addCommanderBombardmentUnits(Player player, Tile tile, Map<UnitModel, Integer> units) {
+    public static void addCommanderBombardmentUnits(
+            Player player, Tile tile, Map<Pair<UnitModel, UnitHolder>, Integer> units) {
         var game = player.getGame();
         if (game == null) return;
         String guardKey = "kaloraCommanderBombardResolving_" + player.getFaction();
@@ -21,8 +24,9 @@ public class KaloraCommanderHandler {
             for (String adjacentPos : FoWHelper.getAdjacentTiles(game, tile.getPosition(), player, false, false)) {
                 Tile adjacentTile = game.getTileByPosition(adjacentPos);
                 if (adjacentTile == null) continue;
-                CombatRollService.getUnitsInBombardment(adjacentTile, player, null)
-                        .forEach((unit, count) -> units.merge(unit, count, Integer::sum));
+                Map<Pair<UnitModel, UnitHolder>, Integer> adjacentUnits =
+                        CombatRollService.getUnitsInBombardment(adjacentTile, player, null);
+                adjacentUnits.forEach((pair, count) -> units.merge(pair, count, Integer::sum));
             }
         } finally {
             game.setStoredValue(guardKey, "");

--- a/src/main/java/ti4/service/combat/BombardmentService.java
+++ b/src/main/java/ti4/service/combat/BombardmentService.java
@@ -35,7 +35,8 @@ public class BombardmentService {
         if (tile == null) {
             return;
         }
-        Map<UnitModel, Integer> bombardUnits = CombatRollService.getUnitsInBombardment(tile, player, null);
+        Map<UnitModel, Integer> bombardUnits =
+                CombatRollService.flattenUnitMap(CombatRollService.getUnitsInBombardment(tile, player, null));
         String planet = getBestBombardablePlanet(player, game, tile);
         for (Map.Entry<UnitModel, Integer> entry : bombardUnits.entrySet()) {
             for (int x = 0; x < entry.getValue(); x++) {

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -16,9 +16,9 @@ import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
-import net.dv8tion.jda.internal.utils.tuple.ImmutablePair;
-import net.dv8tion.jda.internal.utils.tuple.Pair;
 import org.apache.commons.collections4.IterableUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import ti4.contest.replay.core.CombatRollPayload;
 import ti4.contest.replay.core.CombatRollPayload.CombatRollNotePlacement;
 import ti4.contest.replay.core.CombatRollPayload.CombatRollNoteType;
@@ -203,13 +203,13 @@ public class CombatRollService {
         }
         Player opponent = null;
 
-        Map<UnitModel, Integer> playerUnitsByQuantity =
-                getUnitsInCombat(tile, combatOnHolder, player, event, rollType, game);
+        Map<Pair<UnitModel, UnitHolder>, Integer> playerUnitsByQuantity =
+                getUnitsInCombatByHolder(tile, combatOnHolder, player, event, rollType, game);
         if (rollType == CombatRollType.AFB && player.hasRelic("metalivoidarmaments")) {
-            playerUnitsByQuantity.put(getMetaliAFBUnit(player), 1);
+            playerUnitsByQuantity.put(new ImmutablePair<>(getMetaliAFBUnit(player), combatOnHolder), 1);
         }
         if (rollType == CombatRollType.AFB && player.hasTech("tf-projectionofpow")) {
-            playerUnitsByQuantity.put(getProjectionUnit(player, true), 1);
+            playerUnitsByQuantity.put(new ImmutablePair<>(getProjectionUnit(player, true), combatOnHolder), 1);
         }
         if (player.hasAbility("projection_of_power")) {
             boolean adj = false;
@@ -221,7 +221,7 @@ public class CombatRollService {
                 }
             }
             if (adj) {
-                playerUnitsByQuantity.put(getProjectionUnit(player, false), 1);
+                playerUnitsByQuantity.put(new ImmutablePair<>(getProjectionUnit(player, false), combatOnHolder), 1);
             }
         }
         if (rollType == CombatRollType.combatround && player.hasActiveBreakthrough("zelianbt")) {
@@ -231,7 +231,10 @@ public class CombatRollService {
                                 || uH.getName().equalsIgnoreCase(unitHolderName))) {
                     int resource = Helper.getPlanetResources(uH.getName(), game);
                     playerUnitsByQuantity.put(
-                            getZelianPlanetUnit(player, Helper.getPlanetName(uH.getName()), 10 - resource), 1);
+                            new ImmutablePair<>(
+                                    getZelianPlanetUnit(player, Helper.getPlanetName(uH.getName()), 10 - resource),
+                                    combatOnHolder),
+                            1);
                 }
             }
         }
@@ -242,7 +245,10 @@ public class CombatRollService {
                 if (player.getPlanetsAllianceMode().contains(uH.getName())) {
                     int resource = Helper.getPlanetResources(uH.getName(), game);
                     playerUnitsByQuantity.put(
-                            getZelianPlanetUnit(player, Helper.getPlanetName(uH.getName()), 10 - resource), 1);
+                            new ImmutablePair<>(
+                                    getZelianPlanetUnit(player, Helper.getPlanetName(uH.getName()), 10 - resource),
+                                    combatOnHolder),
+                            1);
                 }
             }
         }
@@ -256,11 +262,12 @@ public class CombatRollService {
             }
             String assignedUnits = game.getStoredValue("assignedBombardment" + player.getFaction());
             int count;
-            List<UnitModel> unitMods = new ArrayList<>(playerUnitsByQuantity.keySet());
-            for (UnitModel mod : unitMods) {
+            List<Pair<UnitModel, UnitHolder>> unitMods = new ArrayList<>(playerUnitsByQuantity.keySet());
+            for (Pair<UnitModel, UnitHolder> mod : unitMods) {
                 count = 0;
                 for (String assignedUnit : assignedUnits.split(";")) {
-                    if (assignedUnit.endsWith(bombardPlanet) && assignedUnit.contains(mod.getAsyncId() + "_")) {
+                    if (assignedUnit.endsWith(bombardPlanet)
+                            && assignedUnit.contains(mod.getLeft().getAsyncId() + "_")) {
                         count++;
                     }
                 }
@@ -279,18 +286,22 @@ public class CombatRollService {
         }
 
         if (ButtonHelper.isLawInPlay(game, "articles_war")) {
-            if (playerUnitsByQuantity.keySet().stream().anyMatch(unit -> "naaz_mech_space".equals(unit.getAlias()))) {
+            if (playerUnitsByQuantity.keySet().stream()
+                    .anyMatch(pair -> "naaz_mech_space".equals(pair.getLeft().getAlias()))) {
                 playerUnitsByQuantity = new HashMap<>(playerUnitsByQuantity.entrySet().stream()
-                        .filter(e -> !"naaz_mech_space".equals(e.getKey().getAlias()))
+                        .filter(e ->
+                                !"naaz_mech_space".equals(e.getKey().getLeft().getAlias()))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
                 MessageHelper.sendMessageToChannel(
                         event.getMessageChannel(),
                         "Skipping Z-Grav Eidolon (Naaz-Rokha mech) combat rolls due to _Articles of War_.");
             }
             if (rollType == CombatRollType.SpaceCannonDefence || rollType == CombatRollType.SpaceCannonOffence) {
-                if (playerUnitsByQuantity.keySet().stream().anyMatch(unit -> "xxcha_mech".equals(unit.getAlias()))) {
+                if (playerUnitsByQuantity.keySet().stream()
+                        .anyMatch(pair -> "xxcha_mech".equals(pair.getLeft().getAlias()))) {
                     playerUnitsByQuantity = new HashMap<>(playerUnitsByQuantity.entrySet().stream()
-                            .filter(e -> !"xxcha_mech".equals(e.getKey().getAlias()))
+                            .filter(e ->
+                                    !"xxcha_mech".equals(e.getKey().getLeft().getAlias()))
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
                     MessageHelper.sendMessageToChannel(
                             event.getMessageChannel(),
@@ -298,9 +309,11 @@ public class CombatRollService {
                 }
             }
             if (rollType == CombatRollType.bombardment) {
-                if (playerUnitsByQuantity.keySet().stream().anyMatch(unit -> "l1z1x_mech".equals(unit.getAlias()))) {
+                if (playerUnitsByQuantity.keySet().stream()
+                        .anyMatch(pair -> "l1z1x_mech".equals(pair.getLeft().getAlias()))) {
                     playerUnitsByQuantity = new HashMap<>(playerUnitsByQuantity.entrySet().stream()
-                            .filter(e -> !"l1z1x_mech".equals(e.getKey().getAlias()))
+                            .filter(e ->
+                                    !"l1z1x_mech".equals(e.getKey().getLeft().getAlias()))
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
                     MessageHelper.sendMessageToChannel(
                             event.getMessageChannel(),
@@ -341,10 +354,12 @@ public class CombatRollService {
                 getUnitsInCombat(tile, combatOnHolder, opponent, event, rollType, game);
 
         TileModel tileModel = TileHelper.getTileById(tile.getTileID());
+        Map<UnitModel, Integer> playerUnitsFlat = new HashMap<>();
+        playerUnitsByQuantity.forEach((k, v) -> playerUnitsFlat.merge(k.getLeft(), v, Integer::sum));
         List<NamedCombatModifierModel> modifiers = CombatModHelper.getModifiers(
                 player,
                 opponent,
-                playerUnitsByQuantity,
+                playerUnitsFlat,
                 opponentUnitsByQuantity,
                 tileModel,
                 game,
@@ -355,7 +370,7 @@ public class CombatRollService {
         List<NamedCombatModifierModel> extraRolls = CombatModHelper.getModifiers(
                 player,
                 opponent,
-                playerUnitsByQuantity,
+                playerUnitsFlat,
                 opponentUnitsByQuantity,
                 tileModel,
                 game,
@@ -873,7 +888,7 @@ public class CombatRollService {
     }
 
     public static String rollForUnits(
-            Map<UnitModel, Integer> playerUnits,
+            Map<UnitModel, Integer> playerUnitsFlat,
             List<NamedCombatModifierModel> extraRolls,
             List<NamedCombatModifierModel> autoMods,
             List<NamedCombatModifierModel> tempMods,
@@ -884,6 +899,8 @@ public class CombatRollService {
             GenericInteractionCreateEvent event,
             Tile activeSystem,
             UnitHolder unitHolder) {
+        Map<Pair<UnitModel, UnitHolder>, Integer> playerUnits = new HashMap<>();
+        playerUnitsFlat.forEach((model, count) -> playerUnits.put(new ImmutablePair<>(model, unitHolder), count));
         return rollForUnitsWithResult(
                         playerUnits,
                         extraRolls,
@@ -900,7 +917,7 @@ public class CombatRollService {
     }
 
     static CombatRollResult rollForUnitsWithResult(
-            Map<UnitModel, Integer> playerUnits,
+            Map<Pair<UnitModel, UnitHolder>, Integer> playerUnits,
             List<NamedCombatModifierModel> extraRolls,
             List<NamedCombatModifierModel> autoMods,
             List<NamedCombatModifierModel> tempMods,
@@ -924,9 +941,11 @@ public class CombatRollService {
         modAndExtraRolls.addAll(extraRolls);
         Set<NamedCombatModifierModel> set = new HashSet<>(modAndExtraRolls);
         List<NamedCombatModifierModel> uniqueList = new ArrayList<>(set);
-        result += CombatMessageHelper.displayModifiers("With modifiers: \n", playerUnits, uniqueList);
+        Map<UnitModel, Integer> playerUnitsFlat = new HashMap<>();
+        playerUnits.forEach((k, v) -> playerUnitsFlat.merge(k.getLeft(), v, Integer::sum));
+        result += CombatMessageHelper.displayModifiers("With modifiers: \n", playerUnitsFlat, uniqueList);
         payloadBuilder.addModifierDisplays(
-                uniqueList, playerUnits, player, opponent, game, rollType, activeSystem, unitHolder);
+                uniqueList, playerUnitsFlat, player, opponent, game, rollType, activeSystem, unitHolder);
 
         // Actually roll for each unit
         int totalHits = 0;
@@ -935,7 +954,8 @@ public class CombatRollService {
         double chanceOfAllMiss = Math.nextDown(100.0);
         int maximumHits = 0;
 
-        List<UnitModel> playerUnitsList = new ArrayList<>(playerUnits.keySet());
+        List<UnitModel> playerUnitsList =
+                playerUnits.keySet().stream().map(Pair::getLeft).collect(Collectors.toList());
         List<UnitType> playerUnitTypes =
                 playerUnitsList.stream().map(UnitModel::getUnitType).toList();
         boolean hacanFlagship = player.hasUnit("hacan_flagship") && playerUnitTypes.contains(UnitType.Flagship);
@@ -990,8 +1010,9 @@ public class CombatRollService {
                         || (player.hasUnlockedBreakthrough("letnevbt")
                                 && "space".equalsIgnoreCase(unitHolder.getName())))) {
             int max = 0;
-            for (Map.Entry<UnitModel, Integer> entry : playerUnits.entrySet()) {
-                UnitModel unitModel = entry.getKey();
+            for (Map.Entry<Pair<UnitModel, UnitHolder>, Integer> entry : playerUnits.entrySet()) {
+                UnitModel unitModel = entry.getKey().getLeft();
+                UnitHolder perUnitHolder = entry.getKey().getRight();
                 int numOfUnit = entry.getValue();
                 int extraRollsForUnit = CombatModHelper.getCombinedModifierForUnit(
                         unitModel,
@@ -1003,7 +1024,7 @@ public class CombatRollService {
                         playerUnitsList,
                         CombatRollType.combatround,
                         activeSystem,
-                        unitHolder);
+                        perUnitHolder);
                 unitModel.getCombatDieCountForAbility(CombatRollType.combatround, player);
                 int numRollsPerUnit;
                 CombatStatsService.CombatRoundProfile combatRoundProfile = CombatStatsService.getCombatRoundProfile(
@@ -1041,8 +1062,9 @@ public class CombatRollService {
                         Map.of("modifier", Integer.toString(letnevBTBoost))));
             }
         }
-        for (Map.Entry<UnitModel, Integer> entry : playerUnits.entrySet()) {
-            UnitModel unitModel = entry.getKey();
+        for (Map.Entry<Pair<UnitModel, UnitHolder>, Integer> entry : playerUnits.entrySet()) {
+            UnitModel unitModel = entry.getKey().getLeft();
+            UnitHolder perUnitHolder = entry.getKey().getRight();
             int numOfUnit = entry.getValue();
             UnitType unitType = unitModel.getUnitType();
 
@@ -1057,7 +1079,7 @@ public class CombatRollService {
                     playerUnitsList,
                     rollType,
                     activeSystem,
-                    unitHolder);
+                    perUnitHolder);
             int extraRollsForUnit = CombatModHelper.getCombinedModifierForUnit(
                     unitModel,
                     numOfUnit,
@@ -1068,7 +1090,7 @@ public class CombatRollService {
                     playerUnitsList,
                     rollType,
                     activeSystem,
-                    unitHolder);
+                    perUnitHolder);
 
             int numRollsPerUnit = unitModel.getCombatDieCountForAbility(rollType, player);
             if (rollType == CombatRollType.combatround) {
@@ -2068,6 +2090,33 @@ public class CombatRollService {
         return opponent;
     }
 
+    public static Map<Pair<UnitModel, UnitHolder>, Integer> getUnitsInCombatByHolder(
+            Tile tile,
+            UnitHolder unitHolder,
+            Player player,
+            GenericInteractionCreateEvent event,
+            CombatRollType roleType,
+            Game game) {
+        Planet unitHolderPlanet = unitHolder instanceof Planet p ? p : null;
+        return switch (roleType) {
+            case combatround -> {
+                Map<Pair<UnitModel, UnitHolder>, Integer> result = new HashMap<>();
+                getCombatRoundUnits(tile, unitHolder, player, event)
+                        .forEach((model, count) -> result.put(new ImmutablePair<>(model, unitHolder), count));
+                yield result;
+            }
+            case SpaceCannonDefence -> {
+                Map<Pair<UnitModel, UnitHolder>, Integer> result = new HashMap<>();
+                getUnitsInSpaceCannonDefence(unitHolderPlanet, player, event)
+                        .forEach((model, count) -> result.put(new ImmutablePair<>(model, unitHolder), count));
+                yield result;
+            }
+            case AFB -> getUnitsInAFB(tile, player, event);
+            case bombardment -> getUnitsInBombardment(tile, player, event);
+            case SpaceCannonOffence -> getUnitsInSpaceCannonOffense(tile, player, event, game);
+        };
+    }
+
     public static Map<UnitModel, Integer> getUnitsInCombat(
             Tile tile,
             UnitHolder unitHolder,
@@ -2075,17 +2124,10 @@ public class CombatRollService {
             GenericInteractionCreateEvent event,
             CombatRollType roleType,
             Game game) {
-        Planet unitHolderPlanet = null;
-        if (unitHolder instanceof Planet) {
-            unitHolderPlanet = (Planet) unitHolder;
-        }
-        return switch (roleType) {
-            case combatround -> getCombatRoundUnits(tile, unitHolder, player, event);
-            case AFB -> getUnitsInAFB(tile, player, event);
-            case bombardment -> getUnitsInBombardment(tile, player, event);
-            case SpaceCannonOffence -> getUnitsInSpaceCannonOffense(tile, player, event, game);
-            case SpaceCannonDefence -> getUnitsInSpaceCannonDefence(unitHolderPlanet, player, event);
-        };
+        Map<UnitModel, Integer> result = new HashMap<>();
+        getUnitsInCombatByHolder(tile, unitHolder, player, event, roleType, game)
+                .forEach((key, value) -> result.merge(key.getLeft(), value, Integer::sum));
+        return result;
     }
 
     private static Map<UnitModel, Integer> getCombatRoundUnits(
@@ -2097,24 +2139,31 @@ public class CombatRollService {
         return output;
     }
 
-    private static Map<UnitModel, Integer> getUnitsInAFB(
+    static Map<Pair<UnitModel, UnitHolder>, Integer> getUnitsInAFB(
             Tile tile, Player player, GenericInteractionCreateEvent event) {
         String colorID = Mapper.getColorID(player.getColor());
+        UnitHolder spaceHolder = tile.getUnitHolders().get("space");
 
         Map<String, Integer> unitsByAsyncId = new HashMap<>();
+        Map<Pair<UnitModel, UnitHolder>, Integer> output = new HashMap<>();
         for (UnitHolder unitHolder : tile.getUnitHolders().values()) {
-            getUnitsOnHolderByAsyncId(colorID, unitsByAsyncId, unitHolder);
+            Map<String, Integer> holderUnits = new HashMap<>();
+            getUnitsOnHolderByAsyncId(colorID, holderUnits, unitHolder);
+            holderUnits.forEach((k, v) -> unitsByAsyncId.merge(k, v, Integer::sum));
+            for (var entry : holderUnits.entrySet()) {
+                UnitModel model = player.getPriorityUnitByAsyncID(entry.getKey(), null);
+                if (model != null && model.getAfbDieCount(player) > 0) {
+                    output.merge(new ImmutablePair<>(model, unitHolder), entry.getValue(), Integer::sum);
+                }
+            }
         }
-
-        Map<UnitModel, Integer> unitsInCombat = getUnitsInCombat(player, unitsByAsyncId);
-
-        Map<UnitModel, Integer> output = new HashMap<>(unitsInCombat.entrySet().stream()
-                .filter(entry -> entry.getKey() != null && entry.getKey().getAfbDieCount(player) > 0)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
         if (player.hasUnit("iron_flagship")) {
-            output.putAll(IronUnitsHandler.getIronFlagshipAfbUnits(player, tile));
+            IronUnitsHandler.getIronFlagshipAfbUnits(player, tile)
+                    .forEach((model, count) -> output.put(new ImmutablePair<>(model, spaceHolder), count));
         }
-        checkBadUnits(player, event, unitsByAsyncId, output);
+        Map<UnitModel, Integer> flatOutput = new HashMap<>();
+        output.forEach((k, v) -> flatOutput.merge(k.getLeft(), v, Integer::sum));
+        checkBadUnits(player, event, unitsByAsyncId, flatOutput);
 
         return output;
     }
@@ -2175,19 +2224,23 @@ public class CombatRollService {
         return Map.of(proximaFakeUnit, 1);
     }
 
-    public static Map<UnitModel, Integer> getUnitsInBombardment(
+    public static Map<Pair<UnitModel, UnitHolder>, Integer> getUnitsInBombardment(
             Tile tile, Player player, GenericInteractionCreateEvent event) {
         String colorID = Mapper.getColorID(player.getColor());
+        UnitHolder spaceHolder = tile.getUnitHolders().get("space");
         Map<String, Integer> unitsByAsyncId = new HashMap<>();
         for (UnitHolder unitHolder : tile.getUnitHolders().values()) {
             getUnitsOnHolderByAsyncId(colorID, unitsByAsyncId, unitHolder);
         }
         Map<UnitModel, Integer> unitsInCombat = getUnitsInCombat(player, unitsByAsyncId);
 
-        Map<UnitModel, Integer> output = new HashMap<>(unitsInCombat.entrySet().stream()
+        Map<Pair<UnitModel, UnitHolder>, Integer> output = new HashMap<>(unitsInCombat.entrySet().stream()
                 .filter(entry -> entry.getKey() != null && entry.getKey().getBombardDieCount(player) > 0)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-        checkBadUnits(player, event, unitsByAsyncId, output);
+                .collect(Collectors.toMap(
+                        entry -> new ImmutablePair<>(entry.getKey(), spaceHolder), Map.Entry::getValue)));
+        Map<UnitModel, Integer> flatOutput = new HashMap<>();
+        output.forEach((k, v) -> flatOutput.merge(k.getLeft(), v, Integer::sum));
+        checkBadUnits(player, event, unitsByAsyncId, flatOutput);
         if (player.getGame() != null && player.getGame().playerHasLeaderUnlockedOrAlliance(player, "kaloracommander")) {
             KaloraCommanderHandler.addCommanderBombardmentUnits(player, tile, output);
         }
@@ -2247,18 +2300,28 @@ public class CombatRollService {
         return output;
     }
 
-    private static Map<UnitModel, Integer> getUnitsInSpaceCannonOffense(
+    static Map<Pair<UnitModel, UnitHolder>, Integer> getUnitsInSpaceCannonOffense(
             Tile tile, Player player, GenericInteractionCreateEvent event, Game game) {
         String colorID = Mapper.getColorID(player.getColor());
+        UnitHolder spaceHolder = tile.getUnitHolders().get("space");
 
         Map<String, Integer> unitsByAsyncId = new HashMap<>();
+        Map<Pair<UnitModel, UnitHolder>, Integer> unitsOnTile = new HashMap<>();
 
         Collection<UnitHolder> unitHolders = tile.getUnitHolders().values();
         for (UnitHolder unitHolder : unitHolders) {
-            getUnitsOnHolderByAsyncIdForSpaceCannon(colorID, unitsByAsyncId, unitHolder, player);
+            Map<String, Integer> holderUnits = new HashMap<>();
+            getUnitsOnHolderByAsyncIdForSpaceCannon(colorID, holderUnits, unitHolder, player);
+            holderUnits.forEach((k, v) -> unitsByAsyncId.merge(k, v, Integer::sum));
+            for (var entry : holderUnits.entrySet()) {
+                UnitModel model = player.getPriorityUnitByAsyncID(entry.getKey(), null);
+                if (model != null)
+                    unitsOnTile.merge(new ImmutablePair<>(model, unitHolder), entry.getValue(), Integer::sum);
+            }
         }
 
         Map<String, Integer> adjacentUnitsByAsyncId = new HashMap<>();
+        Map<Pair<UnitModel, UnitHolder>, Integer> unitsOnAdjacentTiles = new HashMap<>();
         Set<String> adjTiles = FoWHelper.getAdjacentTiles(game, tile.getPosition(), player, false);
         for (String adjacentTilePosition : adjTiles) {
             if (adjacentTilePosition.equals(tile.getPosition())) {
@@ -2268,20 +2331,18 @@ public class CombatRollService {
             if (TeHelperUnits.affectedByQuietus(game, player, adjTile) || adjTile.isScar(game)) {
                 continue;
             }
-
             for (UnitHolder unitHolder : adjTile.getUnitHolders().values()) {
-                getUnitsOnHolderByAsyncIdForSpaceCannon(colorID, adjacentUnitsByAsyncId, unitHolder, player);
+                Map<String, Integer> holderUnits = new HashMap<>();
+                getUnitsOnHolderByAsyncIdForSpaceCannon(colorID, holderUnits, unitHolder, player);
+                holderUnits.forEach((k, v) -> adjacentUnitsByAsyncId.merge(k, v, Integer::sum));
+                for (var entry : holderUnits.entrySet()) {
+                    UnitModel model = player.getPriorityUnitByAsyncID(entry.getKey(), null);
+                    if (model != null)
+                        unitsOnAdjacentTiles.merge(
+                                new ImmutablePair<>(model, unitHolder), entry.getValue(), Integer::sum);
+                }
             }
         }
-
-        Map<UnitModel, Integer> unitsOnTile = unitsByAsyncId.entrySet().stream()
-                .map(entry ->
-                        new ImmutablePair<>(player.getPriorityUnitByAsyncID(entry.getKey(), null), entry.getValue()))
-                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
-        Map<UnitModel, Integer> unitsOnAdjacentTiles = adjacentUnitsByAsyncId.entrySet().stream()
-                .map(entry ->
-                        new ImmutablePair<>(player.getPriorityUnitByAsyncID(entry.getKey(), null), entry.getValue()))
-                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
 
         // Check for space cannon die on planets
 
@@ -2304,7 +2365,7 @@ public class CombatRollService {
                     planetFakeUnit.setId(planet.getName() + "pds");
                     planetFakeUnit.setBaseType("pds");
                     planetFakeUnit.setFaction(player.getFaction());
-                    unitsOnTile.put(planetFakeUnit, 1);
+                    unitsOnTile.put(new ImmutablePair<>(planetFakeUnit, unitHolder), 1);
                 }
                 boolean spaceStation =
                         (player.hasUnlockedBreakthrough("gledgebt") || player.hasTech("tf-mantlecracking"))
@@ -2321,7 +2382,7 @@ public class CombatRollService {
                         planetFakeUnit.setId(planet.getName() + "pds");
                         planetFakeUnit.setBaseType("pds");
                         planetFakeUnit.setFaction(player.getFaction());
-                        unitsOnTile.put(planetFakeUnit, 1);
+                        unitsOnTile.put(new ImmutablePair<>(planetFakeUnit, unitHolder), 1);
                     }
                     if (player.hasTech("tf-deepinstallations")) {
                         UnitModel planetFakeUnit = new UnitModel();
@@ -2333,7 +2394,7 @@ public class CombatRollService {
                         planetFakeUnit.setId(planet.getName() + "pds");
                         planetFakeUnit.setBaseType("pds");
                         planetFakeUnit.setFaction(player.getFaction());
-                        unitsOnTile.put(planetFakeUnit, 1);
+                        unitsOnTile.put(new ImmutablePair<>(planetFakeUnit, unitHolder), 1);
                     }
                 }
             }
@@ -2350,7 +2411,7 @@ public class CombatRollService {
                     starfallFakeUnit.setId("starfallpds");
                     starfallFakeUnit.setBaseType("pds");
                     starfallFakeUnit.setFaction(player.getFaction());
-                    unitsOnTile.put(starfallFakeUnit, count);
+                    unitsOnTile.put(new ImmutablePair<>(starfallFakeUnit, spaceHolder), count);
                 }
             } else {
                 MessageHelper.sendMessageToChannel(
@@ -2373,48 +2434,54 @@ public class CombatRollService {
                     starfallFakeUnit.setId("starfallpds");
                     starfallFakeUnit.setBaseType("pds");
                     starfallFakeUnit.setFaction(player.getFaction());
-                    unitsOnTile.put(starfallFakeUnit, count);
+                    unitsOnTile.put(new ImmutablePair<>(starfallFakeUnit, spaceHolder), count);
                 }
             }
         }
 
-        HashMap<UnitModel, Integer> output = new HashMap<>(unitsOnTile.entrySet().stream()
-                .filter(entry -> entry.getKey() != null && entry.getKey().getSpaceCannonDieCount(player) > 0)
+        Map<Pair<UnitModel, UnitHolder>, Integer> output = new HashMap<>(unitsOnTile.entrySet().stream()
+                .filter(entry -> entry.getKey().getLeft() != null
+                        && entry.getKey().getLeft().getSpaceCannonDieCount(player) > 0)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
-        Map<UnitModel, Integer> adjacentOutput = new HashMap<>(unitsOnAdjacentTiles.entrySet().stream()
-                .filter(entry -> entry.getKey() != null
-                        && entry.getKey().getSpaceCannonDieCount(player) > 0
-                        && (entry.getKey().getDeepSpaceCannon(player)
-                                || game.playerHasLeaderUnlockedOrAlliance(player, "mirvedacommander")
-                                || ("spacedock".equalsIgnoreCase(entry.getKey().getBaseType()))))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        Map<Pair<UnitModel, UnitHolder>, Integer> adjacentOutput =
+                new HashMap<>(unitsOnAdjacentTiles.entrySet().stream()
+                        .filter(entry -> entry.getKey().getLeft() != null
+                                && entry.getKey().getLeft().getSpaceCannonDieCount(player) > 0
+                                && (entry.getKey().getLeft().getDeepSpaceCannon(player)
+                                        || game.playerHasLeaderUnlockedOrAlliance(player, "mirvedacommander")
+                                        || "spacedock"
+                                                .equalsIgnoreCase(
+                                                        entry.getKey().getLeft().getBaseType())))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
         int limit = 0;
         for (var entry : adjacentOutput.entrySet()) {
-            if (entry.getKey().getDeepSpaceCannon(player)) {
-                if (output.containsKey(entry.getKey())) {
-                    output.put(entry.getKey(), entry.getValue() + output.get(entry.getKey()));
-                } else {
-                    output.put(entry.getKey(), entry.getValue());
-                }
+            if (entry.getKey().getLeft().getDeepSpaceCannon(player)) {
+                output.merge(entry.getKey(), entry.getValue(), Integer::sum);
             } else {
                 if (limit < 1) {
                     limit = 1;
-                    if (output.containsKey(entry.getKey())) {
-                        output.put(entry.getKey(), 1 + output.get(entry.getKey()));
-                    } else {
-                        output.put(entry.getKey(), 1);
-                    }
+                    output.merge(entry.getKey(), 1, Integer::sum);
                 }
             }
         }
         if (game.playerHasLeaderUnlockedOrAlliance(player, "netrunnerscommander")) {
-            output.putAll(NetrunnersLeadersHandler.getCommanderSpaceCannonUnits(game, player, tile));
+            NetrunnersLeadersHandler.getCommanderSpaceCannonUnits(game, player, tile)
+                    .forEach((model, count) ->
+                            output.merge(new ImmutablePair<>(model, spaceHolder), count, Integer::sum));
         }
 
-        checkBadUnits(player, event, unitsByAsyncId, output);
+        Map<UnitModel, Integer> flatOutput = new HashMap<>();
+        output.forEach((k, v) -> flatOutput.merge(k.getLeft(), v, Integer::sum));
+        checkBadUnits(player, event, unitsByAsyncId, flatOutput);
 
         return output;
+    }
+
+    public static Map<UnitModel, Integer> flattenUnitMap(Map<Pair<UnitModel, UnitHolder>, Integer> map) {
+        Map<UnitModel, Integer> result = new HashMap<>();
+        map.forEach((k, v) -> result.merge(k.getLeft(), v, Integer::sum));
+        return result;
     }
 
     private static void checkBadUnits(

--- a/src/test/java/ti4/service/combat/CombatRollPayloadRendererParityTest.java
+++ b/src/test/java/ti4/service/combat/CombatRollPayloadRendererParityTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
@@ -260,15 +261,16 @@ class CombatRollPayloadRendererParityTest extends BaseTi4Test {
     private RenderedRoll assertRollBodyParity(
             Harness harness, Player player, Player opponent, Tile tile, CombatRollType rollType) {
         UnitHolder space = tile.getUnitHolders().get(Constants.SPACE);
-        Map<UnitModel, Integer> playerUnits =
-                CombatRollService.getUnitsInCombat(tile, space, player, null, rollType, harness.game);
+        Map<Pair<UnitModel, UnitHolder>, Integer> playerUnits =
+                CombatRollService.getUnitsInCombatByHolder(tile, space, player, null, rollType, harness.game);
+        Map<UnitModel, Integer> playerUnitsFlat = CombatRollService.flattenUnitMap(playerUnits);
         Map<UnitModel, Integer> opponentUnits =
                 CombatRollService.getUnitsInCombat(tile, space, opponent, null, rollType, harness.game);
         TileModel tileModel = tile.getTileModel();
         List<NamedCombatModifierModel> modifiers = CombatModHelper.getModifiers(
                 player,
                 opponent,
-                playerUnits,
+                playerUnitsFlat,
                 opponentUnits,
                 tileModel,
                 harness.game,
@@ -277,7 +279,7 @@ class CombatRollPayloadRendererParityTest extends BaseTi4Test {
         List<NamedCombatModifierModel> extraRolls = CombatModHelper.getModifiers(
                 player,
                 opponent,
-                playerUnits,
+                playerUnitsFlat,
                 opponentUnits,
                 tileModel,
                 harness.game,


### PR DESCRIPTION
carry per-holder context through combat roll pipeline: getUnitsInAFB, getUnitsInBombardment, getUnitsInSpaceCannonOffense now return Map<Pair<UnitModel, UnitHolder>, Integer> so each unit carries its actual UnitHolder into rollForUnitsWithResult. This lets mechs_on_planet scaling (Vyserix Technotemplar) correctly read the planet holder for AFB and SpaceCannonOffence rolls instead of always seeing spaceHolder.