### PR TITLE
Fix extra rolls and planet labels for units on multiple holders

### DIFF
--- a/src/main/java/ti4/helpers/CombatMessageHelper.java
+++ b/src/main/java/ti4/helpers/CombatMessageHelper.java
@@ -58,6 +58,20 @@ public final class CombatMessageHelper {
             int extraRolls,
             List<Die> resultRolls,
             int numHit) {
+        return displayUnitRoll(
+                unitModel, toHit, modifier, unitQuantity, numRollsPerUnit, extraRolls, resultRolls, numHit, "");
+    }
+
+    public static String displayUnitRoll(
+            UnitModel unitModel,
+            int toHit,
+            int modifier,
+            int unitQuantity,
+            int numRollsPerUnit,
+            int extraRolls,
+            List<Die> resultRolls,
+            int numHit,
+            String holderLabel) {
         String hitsSuffix = "";
         if (numHit > 1) {
             hitsSuffix = "s";
@@ -94,7 +108,11 @@ public final class CombatMessageHelper {
             upgradedUnitName = unitModel.getName();
         }
 
-        List<String> optionalInfoParts = Arrays.asList(upgradedUnitName, unitRollsTextInfo, unitTypeHitsInfo);
+        String holderLabelSep = StringUtils.isNotBlank(holderLabel) && StringUtils.isBlank(unitRollsTextInfo)
+                ? holderLabel + ","
+                : holderLabel;
+        List<String> optionalInfoParts =
+                Arrays.asList(upgradedUnitName, holderLabelSep, unitRollsTextInfo, unitTypeHitsInfo);
         String optionalText =
                 optionalInfoParts.stream().filter(StringUtils::isNotBlank).collect(Collectors.joining(" "));
 

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -2519,8 +2520,11 @@ public class CombatRollService {
             Game game,
             List<UnitModel> playerUnitsList,
             Tile activeSystem) {
+
+        IdentityHashMap<Pair<UnitModel, UnitHolder>, Integer> countByIdentity = new IdentityHashMap<>();
+        playerUnits.forEach(countByIdentity::put);
         Map<String, List<Pair<UnitModel, UnitHolder>>> modelKeys = new LinkedHashMap<>();
-        for (Pair<UnitModel, UnitHolder> key : playerUnits.keySet()) {
+        for (Pair<UnitModel, UnitHolder> key : countByIdentity.keySet()) {
             modelKeys
                     .computeIfAbsent(key.getLeft().getId(), k -> new ArrayList<>())
                     .add(key);
@@ -2531,10 +2535,10 @@ public class CombatRollService {
             List<Pair<UnitModel, UnitHolder>> keys = modelEntry.getValue();
             if (keys.size() == 1) {
                 Pair<UnitModel, UnitHolder> k = keys.get(0);
-                merged.put(k, playerUnits.get(k));
+                merged.put(k, countByIdentity.get(k));
                 continue;
             }
-            Map<Pair<UnitModel, UnitHolder>, Integer> perKeyToHit = new HashMap<>();
+            IdentityHashMap<Pair<UnitModel, UnitHolder>, Integer> perKeyToHit = new IdentityHashMap<>();
             for (Pair<UnitModel, UnitHolder> key : keys) {
                 UnitModel m = key.getLeft();
                 UnitHolder h = key.getRight();
@@ -2545,7 +2549,7 @@ public class CombatRollService {
                 }
                 int mod = CombatModHelper.getCombinedModifierForUnit(
                         m,
-                        playerUnits.get(key),
+                        countByIdentity.get(key),
                         mods,
                         player,
                         opponent,
@@ -2560,9 +2564,9 @@ public class CombatRollService {
             if (distinctToHits.size() > 1) {
                 divergingModels.add(modelEntry.getKey());
                 keys.sort(Comparator.comparingInt(perKeyToHit::get));
-                for (Pair<UnitModel, UnitHolder> k : keys) merged.put(k, playerUnits.get(k));
+                for (Pair<UnitModel, UnitHolder> k : keys) merged.put(k, countByIdentity.get(k));
             } else {
-                int totalCount = keys.stream().mapToInt(playerUnits::get).sum();
+                int totalCount = keys.stream().mapToInt(countByIdentity::get).sum();
                 merged.put(keys.get(0), totalCount);
             }
         }

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -4,8 +4,10 @@ import static org.apache.commons.lang3.StringUtils.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1062,6 +1064,11 @@ public class CombatRollService {
                         Map.of("modifier", Integer.toString(letnevBTBoost))));
             }
         }
+        MergeResult mergeResult = mergeAndDetectDivergence(
+                playerUnits, mods, rollType, player, opponent, game, playerUnitsList, activeSystem);
+        playerUnits = mergeResult.units();
+        Set<String> divergingModels = mergeResult.divergingModels();
+        Set<String> consumedBestMods = new HashSet<>();
         for (Map.Entry<Pair<UnitModel, UnitHolder>, Integer> entry : playerUnits.entrySet()) {
             UnitModel unitModel = entry.getKey().getLeft();
             UnitHolder perUnitHolder = entry.getKey().getRight();
@@ -1080,10 +1087,13 @@ public class CombatRollService {
                     rollType,
                     activeSystem,
                     perUnitHolder);
+            List<NamedCombatModifierModel> availableExtraRolls = extraRolls.stream()
+                    .filter(m -> !consumedBestMods.contains(m.getModifier().getAlias()))
+                    .collect(Collectors.toList());
             int extraRollsForUnit = CombatModHelper.getCombinedModifierForUnit(
                     unitModel,
                     numOfUnit,
-                    extraRolls,
+                    availableExtraRolls,
                     player,
                     opponent,
                     game,
@@ -1091,6 +1101,16 @@ public class CombatRollService {
                     rollType,
                     activeSystem,
                     perUnitHolder);
+            if (extraRollsForUnit > 0) {
+                for (NamedCombatModifierModel m : availableExtraRolls) {
+                    String sc = m.getModifier().getScope();
+                    if (("_best_".equals(sc) || "_bestCap_".equals(sc) || (sc != null && sc.contains("_mostdice_")))
+                            && Boolean.TRUE.equals(m.getModifier()
+                                    .isInScopeForUnit(unitModel, playerUnitsList, rollType, game, player))) {
+                        consumedBestMods.add(m.getModifier().getAlias());
+                    }
+                }
+            }
 
             int numRollsPerUnit = unitModel.getCombatDieCountForAbility(rollType, player);
             if (rollType == CombatRollType.combatround) {
@@ -1390,6 +1410,9 @@ public class CombatRollService {
 
                 totalHits += hitRolls;
 
+                String holderLabel = divergingModels.contains(unitModel.getId()) && perUnitHolder instanceof Planet p
+                        ? "on **" + Helper.getPlanetRepresentationNoResInf(p.getName(), game) + "**"
+                        : "";
                 String unitRoll = CombatMessageHelper.displayUnitRoll(
                         unitModel,
                         toHit,
@@ -1398,7 +1421,8 @@ public class CombatRollService {
                         numRollsPerUnit,
                         extraRollsForUnit,
                         resultRolls,
-                        hitRolls);
+                        hitRolls,
+                        holderLabel);
                 resultBuilder.append(unitRoll);
                 payloadBuilder.addUnitRoll(
                         unitModel,
@@ -2482,6 +2506,67 @@ public class CombatRollService {
         Map<UnitModel, Integer> result = new HashMap<>();
         map.forEach((k, v) -> result.merge(k.getLeft(), v, Integer::sum));
         return result;
+    }
+
+    record MergeResult(Map<Pair<UnitModel, UnitHolder>, Integer> units, Set<String> divergingModels) {}
+
+    static MergeResult mergeAndDetectDivergence(
+            Map<Pair<UnitModel, UnitHolder>, Integer> playerUnits,
+            List<NamedCombatModifierModel> mods,
+            CombatRollType rollType,
+            Player player,
+            Player opponent,
+            Game game,
+            List<UnitModel> playerUnitsList,
+            Tile activeSystem) {
+        Map<String, List<Pair<UnitModel, UnitHolder>>> modelKeys = new LinkedHashMap<>();
+        for (Pair<UnitModel, UnitHolder> key : playerUnits.keySet()) {
+            modelKeys
+                    .computeIfAbsent(key.getLeft().getId(), k -> new ArrayList<>())
+                    .add(key);
+        }
+        Set<String> divergingModels = new HashSet<>();
+        Map<Pair<UnitModel, UnitHolder>, Integer> merged = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Pair<UnitModel, UnitHolder>>> modelEntry : modelKeys.entrySet()) {
+            List<Pair<UnitModel, UnitHolder>> keys = modelEntry.getValue();
+            if (keys.size() == 1) {
+                Pair<UnitModel, UnitHolder> k = keys.get(0);
+                merged.put(k, playerUnits.get(k));
+                continue;
+            }
+            Map<Pair<UnitModel, UnitHolder>, Integer> perKeyToHit = new HashMap<>();
+            for (Pair<UnitModel, UnitHolder> key : keys) {
+                UnitModel m = key.getLeft();
+                UnitHolder h = key.getRight();
+                int toHit = m.getCombatDieHitsOnForAbility(rollType, player);
+                if (rollType == CombatRollType.combatround) {
+                    toHit = CombatStatsService.getCombatRoundProfile(true, m, player, activeSystem, opponent, false)
+                            .hitsOn();
+                }
+                int mod = CombatModHelper.getCombinedModifierForUnit(
+                        m,
+                        playerUnits.get(key),
+                        mods,
+                        player,
+                        opponent,
+                        game,
+                        playerUnitsList,
+                        rollType,
+                        activeSystem,
+                        h);
+                perKeyToHit.put(key, toHit - mod);
+            }
+            Set<Integer> distinctToHits = new HashSet<>(perKeyToHit.values());
+            if (distinctToHits.size() > 1) {
+                divergingModels.add(modelEntry.getKey());
+                keys.sort(Comparator.comparingInt(perKeyToHit::get));
+                for (Pair<UnitModel, UnitHolder> k : keys) merged.put(k, playerUnits.get(k));
+            } else {
+                int totalCount = keys.stream().mapToInt(playerUnits::get).sum();
+                merged.put(keys.get(0), totalCount);
+            }
+        }
+        return new MergeResult(merged, divergingModels);
     }
 
     private static void checkBadUnits(


### PR DESCRIPTION
- Merge same-model entries with identical effective hit thresholds into one display line
- Show planet label only when same unit type has diverging hit values across holders
- Fix _best_-scope extra rolls (e.g. plasma scoring) applying to all same-asyncId units; consumed tracking ensures only the best unit gets it
- Sort diverging entries best-first so the consumed assignment goes to the right unit
- Fix comma punctuation after planet label when no extra rolls are present
- Extract pre-pass into mergeAndDetectDivergence() helper, eliminating duplicate effectiveToHit computation