### PR TITLE
Expose game event log: /events endpoint + eventSequence change signal

### DIFF
--- a/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
@@ -1,5 +1,6 @@
 package ti4.spring.api.webdata;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ti4.game.Game;
 import ti4.spring.context.RequestContext;
+import ti4.spring.service.gameevent.GameEventDto;
+import ti4.spring.service.gameevent.GameEventService;
 import ti4.website.model.WebGameState;
 
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ import ti4.website.model.WebGameState;
 public class GameWebDataController {
 
     private final GameWebDataService gameWebDataService;
+    private final GameEventService gameEventService;
 
     @GetMapping(value = "/web-data", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> get(@PathVariable String gameName) {
@@ -40,5 +44,17 @@ public class GameWebDataController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(WebGameState.fromGame(game));
+    }
+
+    @GetMapping(value = "/events", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<GameEventDto>> getEvents() {
+        Game game = RequestContext.getGame();
+        if (game == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (game.isFowMode()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(gameEventService.getEvents(game));
     }
 }

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
@@ -128,6 +128,7 @@ public class GameWebDataService {
         webData.put("ringCount", game.getRingCount());
         webData.put("vpsToWin", game.getVp());
         webData.put("gameRound", game.getRound());
+        webData.put("eventSequence", game.getEventSequenceCounter());
         webData.put("gameName", game.getName());
         webData.put("gameCustomName", game.getCustomName());
         webData.put("tableTalkJumpLink", game.getTabletalkJumpLink());

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDto.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDto.java
@@ -1,0 +1,6 @@
+package ti4.spring.service.gameevent;
+
+import tools.jackson.databind.JsonNode;
+
+public record GameEventDto(
+        long seq, String archetype, int round, String phase, String faction, long timestamp, JsonNode payload) {}

--- a/src/main/java/ti4/spring/service/gameevent/GameEventService.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventService.java
@@ -51,6 +51,20 @@ public class GameEventService {
         game.setEventSequenceCounter(seq);
     }
 
+    public List<GameEventDto> getEvents(Game game) {
+        if (DatabasePersistenceGate.isDisabled()) return List.of();
+        return getEventsForGame(game).stream()
+                .map(event -> new GameEventDto(
+                        event.getSeq(),
+                        event.getArchetype(),
+                        event.getRound(),
+                        event.getPhase(),
+                        event.getFaction(),
+                        event.getTimestampEpochMillis(),
+                        JsonMapperManager.basic().readTree(event.getPayload())))
+                .toList();
+    }
+
     List<GameEventEntity> getEventsForGame(Game game) {
         return gameEventRepository.findByGameNameAndSeqLessThanEqualOrderBySeqAsc(
                 game.getName(), game.getEventSequenceCounter());


### PR DESCRIPTION
Follow-up to #5339 (merged), adding the read side of the game event log so the web UI can render an event feed.

- `GET /api/public/game/{gameName}/events` — returns the undo-fenced event list as DTOs (`seq, archetype, round, phase, faction, timestamp, payload`), with payload parsed to JSON. Same 404 / fog-of-war guards as `/game-state`, gated by `DatabasePersistenceGate`.
- `buildWebData` gains an `eventSequence` scalar (the game's event counter). Since the websocket stream diffs the full web payload, this one field announces new events to connected clients, which refetch `/events` — no polling.

Verified: full test suite green on current master (407 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)