### PR TITLE
feat: log state-modifying slash commands as COMMAND game events

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/CommandGameState.java
+++ b/src/main/java/ti4/discord/interactions/commands/CommandGameState.java
@@ -1,5 +1,6 @@
 package ti4.discord.interactions.commands;
 
+import java.util.Map;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.jetbrains.annotations.NotNull;
 import ti4.game.Game;
@@ -8,6 +9,8 @@ import ti4.game.persistence.GameManager;
 import ti4.logging.RollbarManager;
 import ti4.service.event.EventAuditService;
 import ti4.service.game.GameNameService;
+import ti4.spring.service.gameevent.GameEventService;
+import ti4.spring.service.gameevent.GameEventType;
 
 record CommandGameState(boolean saveGame, boolean playerCommand) {
 
@@ -39,6 +42,16 @@ record CommandGameState(boolean saveGame, boolean playerCommand) {
     void postExecute(SlashCommandInteractionEvent event) {
         if (saveGame) {
             Game game = CommandGameState.game.get();
+            // Log the raw command before the save so the bumped event-sequence counter is persisted with the game.
+            GameEventService.commit(
+                    game,
+                    GameEventType.COMMAND,
+                    player.get(),
+                    Map.of(
+                            "command",
+                            event.getCommandString(),
+                            "user",
+                            event.getUser().getName()));
             GameManager.save(game, EventAuditService.getReason(event));
         }
         clear();

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
@@ -1,5 +1,6 @@
 package ti4.spring.api.webdata;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ti4.game.Game;
 import ti4.spring.context.RequestContext;
+import ti4.spring.service.gameevent.GameEventDto;
+import ti4.spring.service.gameevent.GameEventService;
 import ti4.website.model.WebGameState;
 
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ import ti4.website.model.WebGameState;
 public class GameWebDataController {
 
     private final GameWebDataService gameWebDataService;
+    private final GameEventService gameEventService;
 
     @GetMapping(value = "/web-data", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> get(@PathVariable String gameName) {
@@ -40,5 +44,17 @@ public class GameWebDataController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(WebGameState.fromGame(game));
+    }
+
+    @GetMapping(value = "/events", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<GameEventDto>> getEvents() {
+        Game game = RequestContext.getGame();
+        if (game == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (game.isFowMode()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(gameEventService.getEvents(game));
     }
 }

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
@@ -128,6 +128,7 @@ public class GameWebDataService {
         webData.put("ringCount", game.getRingCount());
         webData.put("vpsToWin", game.getVp());
         webData.put("gameRound", game.getRound());
+        webData.put("eventSequence", game.getEventSequenceCounter());
         webData.put("gameName", game.getName());
         webData.put("gameCustomName", game.getCustomName());
         webData.put("tableTalkJumpLink", game.getTabletalkJumpLink());

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDto.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDto.java
@@ -1,0 +1,6 @@
+package ti4.spring.service.gameevent;
+
+import tools.jackson.databind.JsonNode;
+
+public record GameEventDto(
+        long seq, String archetype, int round, String phase, String faction, long timestamp, JsonNode payload) {}

--- a/src/main/java/ti4/spring/service/gameevent/GameEventService.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventService.java
@@ -51,6 +51,20 @@ public class GameEventService {
         game.setEventSequenceCounter(seq);
     }
 
+    public List<GameEventDto> getEvents(Game game) {
+        if (DatabasePersistenceGate.isDisabled()) return List.of();
+        return getEventsForGame(game).stream()
+                .map(event -> new GameEventDto(
+                        event.getSeq(),
+                        event.getArchetype(),
+                        event.getRound(),
+                        event.getPhase(),
+                        event.getFaction(),
+                        event.getTimestampEpochMillis(),
+                        JsonMapperManager.basic().readTree(event.getPayload())))
+                .toList();
+    }
+
     List<GameEventEntity> getEventsForGame(Game game) {
         return gameEventRepository.findByGameNameAndSeqLessThanEqualOrderBySeqAsc(
                 game.getName(), game.getEventSequenceCounter());

--- a/src/main/java/ti4/spring/service/gameevent/GameEventType.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventType.java
@@ -21,4 +21,7 @@ public class GameEventType {
     public static final String AGENDA_RESOLVED = "AGENDA_RESOLVED";
     public static final String TRANSACTION = "TRANSACTION";
     public static final String GAME_ENDED = "GAME_ENDED";
+    // Raw record of a state-modifying slash command; carries the unparsed command string. Not deduped against
+    // the typed events above, and prunes on undo like any other event.
+    public static final String COMMAND = "COMMAND";
 }


### PR DESCRIPTION
## What

Adds a new `COMMAND` game-event type that records every state-modifying slash command as a raw, unparsed entry in the game event log.

## How

The whole feature hinges on one existing chokepoint: **`CommandGameState.postExecute`**. Every state-modifying slash command (`GameStateSubcommand` and `GameStateCommand`) already flows through it, and it already knows:

- `saveGame == true` — the definition of "this command changed the game"
- the `SlashCommandInteractionEvent`, whose `getCommandString()` yields the raw command (the same call `EventAuditService` already uses for the save reason)

So we emit a `COMMAND` event right there, **before** `GameManager.save(...)`, so the bumped `eventSequenceCounter` is persisted in the same save (mirroring how existing typed events commit during `execute()` and rely on the surrounding save).

```java
GameEventService.commit(
    game, GameEventType.COMMAND, player.get(),
    Map.of("command", event.getCommandString(), "user", event.getUser().getName()));
```

## Notes / design decisions

- **Zero per-command wiring** — every current and future save-game slash command is captured automatically.
- **Scoped to manual commands** — button-driven actions don't route through `CommandGameState`, so this stays a "what was typed" trail.
- **Reuses the existing undo-fenced `commit` path** — `COMMAND` rows prune on undo like any other event and surface through the existing `/events` endpoint. No schema change.
- **No dedup** — the handful of slash commands that also emit a typed event during `execute()` will produce two rows (the typed event + a `COMMAND` row). Left intentionally, since the log is meant to be the raw command trail. Overlap is small because typed events are overwhelmingly button-driven.
- **No parsing** — payload carries the raw command string and username as-is.

## Heads up on base

This branch descends from the unmerged `/events` endpoint commit `b6a6088ea`, so this PR includes that commit as well as the `COMMAND` change. The `game-events-endpoint` branch is gone from origin, so `master` is the base.

## Frontend

The `ti4_web_new` structured event UI needs a matching `COMMAND` render case (type union + `EventBody` case + CSS) — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)