### PR TITLE
Structured tactical-action sub-events, phase markers, and manual-command logging

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/other/DeleteButtonsButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/other/DeleteButtonsButtonHandler.java
@@ -191,16 +191,21 @@ class DeleteButtonsButtonHandler {
                     String unitId = entry.getKey().split("_")[0];
                     unitsMap.merge(unitId, entry.getValue(), Integer::sum);
                 }
-                GameSubEvent.Production produced =
-                        new GameSubEvent.Production(tile == null ? null : tile.getPosition(), unitsMap, cost);
-                if (!GameEventDraft.stage(game, produced) && buttonID.contains("tacticalAction")) {
-                    Map<String, Object> payload = new HashMap<>();
-                    if (produced.tile() != null) {
-                        payload.put("tile", produced.tile());
+                // Only tactical-action builds belong to the tactical draft; the draft is game-global, so an
+                // unscoped stage would swallow other players' warfare/construction builds into the active
+                // player's tactical action.
+                if (buttonID.contains("tacticalAction")) {
+                    GameSubEvent.Production produced =
+                            new GameSubEvent.Production(tile == null ? null : tile.getPosition(), unitsMap, cost);
+                    if (!GameEventDraft.stage(game, produced)) {
+                        Map<String, Object> payload = new HashMap<>();
+                        if (produced.tile() != null) {
+                            payload.put("tile", produced.tile());
+                        }
+                        payload.put("units", produced.units());
+                        payload.put("cost", produced.cost());
+                        GameEventService.commit(game, GameEventType.PRODUCTION, player, payload);
                     }
-                    payload.put("units", produced.units());
-                    payload.put("cost", produced.cost());
-                    GameEventService.commit(game, GameEventType.PRODUCTION, player, payload);
                 }
                 game.setStoredValue("producedUnitCostFor" + player.getFaction(), "" + cost);
                 player.setTotalExpenses(

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/other/DeleteButtonsButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/other/DeleteButtonsButtonHandler.java
@@ -188,12 +188,7 @@ class DeleteButtonsButtonHandler {
                 Map<String, Integer> unitsMap = new HashMap<>();
                 for (Map.Entry<String, Integer> entry :
                         player.getCurrentProducedUnits().entrySet()) {
-                    String producedUnit = entry.getKey();
-                    int lastSeparator = producedUnit.lastIndexOf('_');
-                    int middleSeparator = lastSeparator < 0 ? -1 : producedUnit.lastIndexOf('_', lastSeparator - 1);
-                    String unitId = middleSeparator < 0
-                            ? producedUnit.split("_")[0]
-                            : producedUnit.substring(0, middleSeparator);
+                    String unitId = entry.getKey().split("_")[0];
                     unitsMap.merge(unitId, entry.getValue(), Integer::sum);
                 }
                 GameSubEvent.Production produced =

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/other/DeleteButtonsButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/other/DeleteButtonsButtonHandler.java
@@ -1,6 +1,7 @@
 package ti4.discord.interactions.buttons.handlers.other;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
@@ -40,6 +41,10 @@ import ti4.service.emoji.FactionEmojis;
 import ti4.service.emoji.TechEmojis;
 import ti4.service.fow.LoreService;
 import ti4.service.turn.StartTurnService;
+import ti4.spring.service.gameevent.GameEventDraft;
+import ti4.spring.service.gameevent.GameEventService;
+import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 @UtilityClass
 class DeleteButtonsButtonHandler {
@@ -180,6 +185,28 @@ class DeleteButtonsButtonHandler {
                 TheIconService.checkAndSendIconButton(event, game, player, buttonID);
                 EidolonMaximumService.sendEidolonMaximumFlipButtons(game, player);
                 int cost = Helper.calculateCostOfProducedUnits(player, game, true);
+                Map<String, Integer> unitsMap = new HashMap<>();
+                for (Map.Entry<String, Integer> entry :
+                        player.getCurrentProducedUnits().entrySet()) {
+                    String producedUnit = entry.getKey();
+                    int lastSeparator = producedUnit.lastIndexOf('_');
+                    int middleSeparator = lastSeparator < 0 ? -1 : producedUnit.lastIndexOf('_', lastSeparator - 1);
+                    String unitId = middleSeparator < 0
+                            ? producedUnit.split("_")[0]
+                            : producedUnit.substring(0, middleSeparator);
+                    unitsMap.merge(unitId, entry.getValue(), Integer::sum);
+                }
+                GameSubEvent.Production produced =
+                        new GameSubEvent.Production(tile == null ? null : tile.getPosition(), unitsMap, cost);
+                if (!GameEventDraft.stage(game, produced) && buttonID.contains("tacticalAction")) {
+                    Map<String, Object> payload = new HashMap<>();
+                    if (produced.tile() != null) {
+                        payload.put("tile", produced.tile());
+                    }
+                    payload.put("units", produced.units());
+                    payload.put("cost", produced.cost());
+                    GameEventService.commit(game, GameEventType.PRODUCTION, player, payload);
+                }
                 game.setStoredValue("producedUnitCostFor" + player.getFaction(), "" + cost);
                 player.setTotalExpenses(
                         player.getTotalExpenses() + Helper.calculateCostOfProducedUnits(player, game, true));

--- a/src/main/java/ti4/discord/interactions/commands/CommandGameState.java
+++ b/src/main/java/ti4/discord/interactions/commands/CommandGameState.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.persistence.GameManager;
-import ti4.helpers.Constants;
 import ti4.logging.RollbarManager;
 import ti4.service.event.EventAuditService;
 import ti4.service.game.GameNameService;
@@ -56,8 +55,6 @@ record CommandGameState(boolean saveGame, boolean playerCommand) {
 
     private static void logManualCommand(SlashCommandInteractionEvent event, Game game) {
         if (game == null) return;
-        // Undo events would be invalidated immediately; skip them.
-        if (Constants.UNDO.equals(event.getSubcommandName())) return;
 
         String commandString = event.getCommandString();
         Member member = event.getMember();

--- a/src/main/java/ti4/discord/interactions/commands/CommandGameState.java
+++ b/src/main/java/ti4/discord/interactions/commands/CommandGameState.java
@@ -1,13 +1,21 @@
 package ti4.discord.interactions.commands;
 
+import java.util.HashMap;
+import java.util.Map;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.jetbrains.annotations.NotNull;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.persistence.GameManager;
+import ti4.helpers.Constants;
 import ti4.logging.RollbarManager;
 import ti4.service.event.EventAuditService;
 import ti4.service.game.GameNameService;
+import ti4.spring.service.gameevent.GameEventDraft;
+import ti4.spring.service.gameevent.GameEventService;
+import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 record CommandGameState(boolean saveGame, boolean playerCommand) {
 
@@ -39,9 +47,36 @@ record CommandGameState(boolean saveGame, boolean playerCommand) {
     void postExecute(SlashCommandInteractionEvent event) {
         if (saveGame) {
             Game game = CommandGameState.game.get();
+            // Emit the manual-command event BEFORE the save so its counter increment is persisted with the game.
+            logManualCommand(event, game);
             GameManager.save(game, EventAuditService.getReason(event));
         }
         clear();
+    }
+
+    private static void logManualCommand(SlashCommandInteractionEvent event, Game game) {
+        if (game == null) return;
+        // Undo events would be invalidated immediately; skip them.
+        if (Constants.UNDO.equals(event.getSubcommandName())) return;
+
+        String commandString = event.getCommandString();
+        Member member = event.getMember();
+        String userName = member == null ? null : member.getEffectiveName();
+
+        // Nest under an open tactical-action draft when present; otherwise emit a top-level event.
+        if (GameEventDraft.stage(game, new GameSubEvent.ManualCommand(userName, commandString))) {
+            return;
+        }
+
+        // Attribute to the invoking user's player (not any target-player option) when resolvable.
+        Player player =
+                CommandHelper.getPlayerFromGame(game, member, event.getUser().getId());
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("command", commandString);
+        if (userName != null) {
+            payload.put("user", userName);
+        }
+        GameEventService.commit(game, GameEventType.MANUAL_COMMAND, player, payload);
     }
 
     void clear() {

--- a/src/main/java/ti4/game/GameProperties.java
+++ b/src/main/java/ti4/game/GameProperties.java
@@ -68,6 +68,8 @@ public class GameProperties {
     private String activeSystem;
     private String currentAgendaInfo = "";
     private String currentACDrawStatusInfo = "";
+    // Undo-safe draft of tactical sub-events, persisted as one JSON line; "" means closed.
+    private String pendingSubEventsJson = "";
     private String latestCommand = "";
     private String latestOutcomeVotedFor = "";
     private String playersWhoHitPersistentNoAfter = "";

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -658,6 +658,11 @@ class GameLoadService {
                         game.setEventSequenceCounter(Long.parseLong(info));
                     }
                 }
+                case Constants.PENDING_SUB_EVENTS_JSON -> {
+                    if (isNotBlank(info)) {
+                        game.setPendingSubEventsJson(info);
+                    }
+                }
                 case Constants.STARTED_DATE -> {
                     if (isNotBlank(info)) {
                         game.setStartedDate(Long.parseLong(info));

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -424,6 +424,8 @@ class GameSaveService {
         writer.write(System.lineSeparator());
         writer.write(Constants.EVENT_SEQUENCE_COUNTER + " " + game.getEventSequenceCounter());
         writer.write(System.lineSeparator());
+        writer.write(Constants.PENDING_SUB_EVENTS_JSON + " " + game.getPendingSubEventsJson());
+        writer.write(System.lineSeparator());
         writer.write(Constants.GAME_CUSTOM_NAME + " " + game.getCustomName());
         writer.write(System.lineSeparator());
 

--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -54,8 +54,10 @@ import ti4.service.leader.CommanderUnlockCheckService;
 import ti4.service.turn.StartTurnService;
 import ti4.service.unit.AddUnitService;
 import ti4.spring.context.SpringContext;
+import ti4.spring.service.gameevent.GameEventDraft;
 import ti4.spring.service.gameevent.GameEventService;
 import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 @UtilityClass
 public class ActionCardHelper {
@@ -753,8 +755,14 @@ public class ActionCardHelper {
             }
         }
         recordTrackedActionCardPlay(game, player, actionCardTitle);
-        GameEventService.commit(
-                game, GameEventType.CARD_PLAY_ACTION_CARD, player, Map.of("cardId", acID, "cardName", actionCardTitle));
+        if (!GameEventDraft.stage(
+                game, new GameSubEvent.ActionCardPlayed(player.getFaction(), acID, actionCardTitle))) {
+            GameEventService.commit(
+                    game,
+                    GameEventType.CARD_PLAY_ACTION_CARD,
+                    player,
+                    Map.of("cardId", acID, "cardName", actionCardTitle));
+        }
 
         boolean hasUnyieldingWill = player.hasTech("baarvag");
         boolean actionCardIsCancelable = isActionCardCancelable(actionCard) && !twinned && !hasUnyieldingWill;

--- a/src/main/java/ti4/helpers/ButtonHelperAgents.java
+++ b/src/main/java/ti4/helpers/ButtonHelperAgents.java
@@ -60,8 +60,10 @@ import ti4.service.unit.GalvanizeService;
 import ti4.service.unit.ParsedUnit;
 import ti4.service.unit.RemoveUnitService;
 import ti4.spring.context.SpringContext;
+import ti4.spring.service.gameevent.GameEventDraft;
 import ti4.spring.service.gameevent.GameEventService;
 import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 public final class ButtonHelperAgents {
 
@@ -602,7 +604,9 @@ public final class ButtonHelperAgents {
         if (playerLeader == null) {
             return;
         }
-        GameEventService.commit(game, GameEventType.CARD_PLAY_AGENT, player, Map.of("cardId", agent));
+        if (!GameEventDraft.stage(game, new GameSubEvent.LeaderPlayed(player.getFaction(), "AGENT", agent))) {
+            GameEventService.commit(game, GameEventType.CARD_PLAY_AGENT, player, Map.of("cardId", agent));
+        }
 
         ExhaustLeaderService.exhaustLeader(game, player, playerLeader);
         playerLeader.getLeaderModel().ifPresent(agentModel -> SpringContext.getBean(CombatReplayService.class)

--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -29,6 +29,7 @@ import ti4.helpers.Units.UnitType;
 import ti4.helpers.thundersedge.TeHelperAbilities;
 import ti4.helpers.thundersedge.TeHelperPromissories;
 import ti4.image.Mapper;
+import ti4.json.JsonMapperManager;
 import ti4.message.MessageHelper;
 import ti4.model.UnitModel;
 import ti4.service.agenda.IsPlayerElectedService;
@@ -48,8 +49,10 @@ import ti4.service.tactical.TacticalActionService;
 import ti4.service.turn.StartTurnService;
 import ti4.service.unit.CheckUnitContainmentService;
 import ti4.settings.users.UserSettingsManager;
+import ti4.spring.service.gameevent.GameEventDraft;
 import ti4.spring.service.gameevent.GameEventService;
 import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 public final class ButtonHelperTacticalAction {
 
@@ -420,6 +423,7 @@ public final class ButtonHelperTacticalAction {
         game.removeStoredValue("mentakHero");
         game.removeStoredValue("ghostagent_active");
         DreamButtonHandler.clearDreamAgentAnomaly(game);
+        GameEventDraft.clear(game);
 
         game.getTacticalActionDisplacement().clear();
     }
@@ -430,6 +434,12 @@ public final class ButtonHelperTacticalAction {
         addIfNotEmpty(payload, "planetsTaken", game.getStoredValue("planetsTakenThisRound"));
         addIfNotEmpty(payload, "combat", game.getStoredValue("factionsInCombat"));
         addIfNotEmpty(payload, "summary", game.getStoredValue("currentActionSummary" + player.getFaction()));
+        List<GameSubEvent> subEvents = GameEventDraft.drain(game);
+        if (!subEvents.isEmpty()) {
+            // Embed as a pre-typed JsonNode: serializing the list inside the Object-valued payload map would otherwise
+            // drop the polymorphic "type" discriminator that the frontend relies on.
+            payload.put("subEvents", JsonMapperManager.basic().readTree(GameEventDraft.serialize(subEvents)));
+        }
         GameEventService.commit(game, GameEventType.TACTICAL_ACTION, player, payload);
     }
 
@@ -587,6 +597,7 @@ public final class ButtonHelperTacticalAction {
                 "currentActionSummary" + player.getFaction(),
                 game.getStoredValue("currentActionSummary" + player.getFaction()) + " Activated "
                         + tile.getRepresentationForButtons(game, player) + ".");
+        GameEventDraft.open(game);
         if ((game.playerHasLeaderUnlockedOrAlliance(player, "celdauricommander") || player.hasTech("tf-starbasewebway"))
                 && CheckUnitContainmentService.getTilesContainingPlayersUnits(game, player, UnitType.Spacedock)
                         .contains(tile)) {

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -117,6 +117,7 @@ public final class Constants {
     public static final String SPIN_MODE = "spin_mode";
     public static final String BUTTON_PRESS_COUNT = "button_press_count";
     public static final String EVENT_SEQUENCE_COUNTER = "event_sequence_counter";
+    public static final String PENDING_SUB_EVENTS_JSON = "pending_sub_events_json";
     public static final String ABSOL_MODE = "absol_mode";
     public static final String PROMISES_PROMISES = "promises_promises";
     public static final String FLAGSHIPPING = "flagshipping";

--- a/src/main/java/ti4/helpers/StatusHelper.java
+++ b/src/main/java/ti4/helpers/StatusHelper.java
@@ -51,6 +51,8 @@ import ti4.service.objectives.ScorePublicObjectiveService;
 import ti4.service.planet.EronousPlanetService;
 import ti4.service.turn.StartTurnService;
 import ti4.settings.users.UserSettingsManager;
+import ti4.spring.service.gameevent.GameEventService;
+import ti4.spring.service.gameevent.GameEventType;
 
 @UtilityClass
 public final class StatusHelper {
@@ -155,6 +157,7 @@ public final class StatusHelper {
 
     public static void beginScoring(GenericInteractionCreateEvent event, Game game, MessageChannel gameChannel) {
         game.setPhaseOfGame("statusScoring");
+        GameEventService.commit(game, GameEventType.PHASE_STARTED, null, Map.of("phase", "status"));
         game.setStoredValue("startTimeOfRound" + game.getRound() + "StatusScoring", System.currentTimeMillis() + "");
         GMService.logActivity(game, "**StatusScoring** Phase for Round " + game.getRound() + " started.", true);
         for (Player player : game.getRealPlayers()) {

--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -72,6 +72,8 @@ import ti4.service.tech.BastionTechService;
 import ti4.service.turn.StartTurnService;
 import ti4.service.unit.CheckUnitContainmentService;
 import ti4.spring.context.SpringContext;
+import ti4.spring.service.gameevent.GameEventDraft;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 @UtilityClass
 public class StartCombatService {
@@ -183,7 +185,10 @@ public class StartCombatService {
             game.setStoredValue(
                     "currentActionSummary" + player.getFaction(),
                     game.getStoredValue("currentActionSummary" + player.getFaction()) + " Had a space combat in "
-                            + tile.getRepresentationForButtons() + " against " + player2.getFactionEmoji() + ".");
+                            + tile.getRepresentationForButtons() + " against " + player2.getFactionNameOrColor()
+                            + ".");
+            GameEventDraft.stage(
+                    game, new GameSubEvent.Combat("space", tile.getPosition(), null, player2.getFaction()));
             return;
         }
         findOrCreateCombatThread(
@@ -224,7 +229,10 @@ public class StartCombatService {
                 "currentActionSummary" + player.getFaction(),
                 game.getStoredValue("currentActionSummary" + player.getFaction()) + " Had a ground combat on "
                         + Helper.getPlanetRepresentation(unitHolder.getName(), game) + " against "
-                        + player2.getFactionEmoji() + ".");
+                        + player2.getFactionNameOrColor() + ".");
+        GameEventDraft.stage(
+                game,
+                new GameSubEvent.Combat("ground", tile.getPosition(), unitHolder.getName(), player2.getFaction()));
         if (!game.isFowMode()) {
             findOrCreateCombatThread(
                     game,

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -74,6 +75,8 @@ import ti4.service.planet.PlanetService;
 import ti4.service.strategycard.PickStrategyCardService;
 import ti4.service.turn.StartTurnService;
 import ti4.settings.users.UserSettingsManager;
+import ti4.spring.service.gameevent.GameEventService;
+import ti4.spring.service.gameevent.GameEventType;
 
 @UtilityClass
 public class StartPhaseService {
@@ -85,6 +88,7 @@ public class StartPhaseService {
             case "shuffleDecks" -> game.shuffleDecks();
             case "agenda" -> {
                 game.setPhaseOfGame("agenda");
+                GameEventService.commit(game, GameEventType.PHASE_STARTED, null, Map.of("phase", "agenda"));
                 Button flipAgenda = Buttons.blue("flip_agenda", "Flip Agenda");
                 List<Button> buttons = List.of(flipAgenda);
                 MessageHelper.sendMessageToChannelWithButtons(
@@ -243,6 +247,7 @@ public class StartPhaseService {
         if (game.isHasHadAStatusPhase()) {
             round++;
             game.setRound(round);
+            GameEventService.commit(game, GameEventType.ROUND_STARTED, null, Map.of("round", round));
         }
         if (game.getRound() == 1 && !game.isFowMode()) {
             Helper.setOrder(game);
@@ -546,6 +551,7 @@ public class StartPhaseService {
         String message = firstSCPicker.getRepresentationUnfogged() + " is up to pick a strategy card.";
         game.updateActivePlayer(firstSCPicker);
         game.setPhaseOfGame("strategy");
+        GameEventService.commit(game, GameEventType.PHASE_STARTED, null, Map.of("phase", "strategy"));
         GMService.logActivity(game, "**Strategy** Phase for Round " + game.getRound() + " started.", true);
         FowCommunicationThreadService.checkAllCommThreads(game);
         SpinService.executeSpinsForTrigger(game, SpinService.AutoTrigger.STRATEGY);
@@ -1127,6 +1133,7 @@ public class StartPhaseService {
         boolean isFowPrivateGame = game.isFowMode();
         game.setStoredValue("willRevolution", "");
         game.setPhaseOfGame("action");
+        GameEventService.commit(game, GameEventType.PHASE_STARTED, null, Map.of("phase", "action"));
         GMService.logActivity(game, "**Action** Phase for Round " + game.getRound() + " started.", true);
         for (Player p2 : game.getRealPlayers()) {
             ButtonHelperActionCards.checkForAssigningExtremeDuress(game, p2);

--- a/src/main/java/ti4/service/leader/PlayHeroService.java
+++ b/src/main/java/ti4/service/leader/PlayHeroService.java
@@ -67,8 +67,10 @@ import ti4.service.tech.ListTechService;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.CheckUnitContainmentService;
 import ti4.spring.context.SpringContext;
+import ti4.spring.service.gameevent.GameEventDraft;
 import ti4.spring.service.gameevent.GameEventService;
 import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 @UtilityClass
 public class PlayHeroService {
@@ -100,7 +102,10 @@ public class PlayHeroService {
 
     public static void playHero(GenericInteractionCreateEvent event, Game game, Player player, Leader playerLeader) {
         LeaderModel leaderModel = playerLeader.getLeaderModel().orElse(null);
-        GameEventService.commit(game, GameEventType.CARD_PLAY_HERO, player, Map.of("cardId", playerLeader.getId()));
+        if (!GameEventDraft.stage(
+                game, new GameSubEvent.LeaderPlayed(player.getFaction(), "HERO", playerLeader.getId()))) {
+            GameEventService.commit(game, GameEventType.CARD_PLAY_HERO, player, Map.of("cardId", playerLeader.getId()));
+        }
         boolean showFlavourText = Constants.VERBOSITY_VERBOSE.equals(game.getOutputVerbosity());
         StringBuilder sb = new StringBuilder();
         if (leaderModel != null) {

--- a/src/main/java/ti4/service/planet/AddPlanetService.java
+++ b/src/main/java/ti4/service/planet/AddPlanetService.java
@@ -47,8 +47,10 @@ import ti4.service.leader.CommanderUnlockCheckService;
 import ti4.service.leader.UnlockLeaderService;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.CheckUnitContainmentService;
+import ti4.spring.service.gameevent.GameEventDraft;
 import ti4.spring.service.gameevent.GameEventService;
 import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 @UtilityClass
 public class AddPlanetService {
@@ -414,6 +416,7 @@ public class AddPlanetService {
                 "currentActionSummary" + player.getFaction(),
                 game.getStoredValue("currentActionSummary" + player.getFaction()) + " Established control of "
                         + Helper.getPlanetRepresentation(planet, game) + ".");
+        GameEventDraft.stage(game, new GameSubEvent.ControlEstablished(planet));
         if ((game.getPhaseOfGame().contains("agenda")
                         || (game.getActivePlayerID() != null && !("".equalsIgnoreCase(game.getActivePlayerID()))))
                 && player.hasAbility("scavenge")

--- a/src/main/java/ti4/service/tech/PlayerTechService.java
+++ b/src/main/java/ti4/service/tech/PlayerTechService.java
@@ -66,8 +66,10 @@ import ti4.service.unit.AddUnitService;
 import ti4.service.unit.CheckUnitContainmentService;
 import ti4.settings.users.UserSettingsManager;
 import ti4.spring.context.SpringContext;
+import ti4.spring.service.gameevent.GameEventDraft;
 import ti4.spring.service.gameevent.GameEventService;
 import ti4.spring.service.gameevent.GameEventType;
+import ti4.spring.service.gameevent.GameSubEvent;
 
 @UtilityClass
 public class PlayerTechService {
@@ -230,7 +232,9 @@ public class PlayerTechService {
         }
 
         player.exhaustTech(tech);
-        GameEventService.commit(game, GameEventType.CARD_PLAY_TECH_EXHAUST, player, Map.of("cardId", tech));
+        if (!GameEventDraft.stage(game, new GameSubEvent.TechExhausted(player.getFaction(), tech))) {
+            GameEventService.commit(game, GameEventType.CARD_PLAY_TECH_EXHAUST, player, Map.of("cardId", tech));
+        }
 
         // Handle Ignis Aurora Techs
         if (tech.startsWith("baldrick_")) {

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
@@ -1,0 +1,70 @@
+package ti4.spring.service.gameevent;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+import ti4.game.Game;
+import ti4.json.JsonMapperManager;
+import ti4.logging.BotLogger;
+import ti4.logging.LogOrigin;
+import tools.jackson.core.type.TypeReference;
+
+/**
+ * Undo-safe, strictly ordered draft of tactical sub-events. The draft lives as ONE JSON line in the game save file via
+ * {@link Game#getPendingSubEventsJson()} so that undo (which restores the save file byte-for-byte) rolls it back for
+ * free. This utility operates ONLY on that field and never touches the database.
+ *
+ * <p>Serialization goes through an explicit {@code List<GameSubEvent>} type so Jackson emits the polymorphic
+ * {@code type} discriminator; serializing the list via a raw {@code Object}/collection reference drops it.
+ */
+@UtilityClass
+public class GameEventDraft {
+
+    private static final TypeReference<List<GameSubEvent>> LIST_TYPE = new TypeReference<>() {};
+
+    public static void open(Game game) {
+        game.setPendingSubEventsJson("[]");
+    }
+
+    public static void clear(Game game) {
+        game.setPendingSubEventsJson("");
+    }
+
+    public static boolean isOpen(Game game) {
+        return StringUtils.isNotBlank(game.getPendingSubEventsJson());
+    }
+
+    /**
+     * Appends a sub-event to the draft. Returns false (no-op) when the draft is not open or on parse error; callers use
+     * the return value to decide whether to fall back to a top-level event.
+     */
+    public static boolean stage(Game game, GameSubEvent subEvent) {
+        if (!isOpen(game)) return false;
+        try {
+            List<GameSubEvent> subEvents = parse(game.getPendingSubEventsJson());
+            subEvents.add(subEvent);
+            game.setPendingSubEventsJson(serialize(subEvents));
+            return true;
+        } catch (Exception e) {
+            BotLogger.error(new LogOrigin(game), "Failed to stage tactical sub-event.", e);
+            return false;
+        }
+    }
+
+    /** Returns the staged sub-events (empty when closed/empty) and clears the draft. */
+    public static List<GameSubEvent> drain(Game game) {
+        List<GameSubEvent> subEvents = isOpen(game) ? parse(game.getPendingSubEventsJson()) : new ArrayList<>();
+        clear(game);
+        return subEvents;
+    }
+
+    /** Compact JSON (one line, {@code type} discriminators intact) for a list of sub-events. */
+    public static String serialize(List<GameSubEvent> subEvents) {
+        return JsonMapperManager.basic().writerFor(LIST_TYPE).writeValueAsString(subEvents);
+    }
+
+    private static List<GameSubEvent> parse(String json) {
+        return JsonMapperManager.basic().readValue(json, LIST_TYPE);
+    }
+}

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
@@ -54,7 +54,15 @@ public class GameEventDraft {
 
     /** Returns the staged sub-events (empty when closed/empty) and clears the draft. */
     public static List<GameSubEvent> drain(Game game) {
-        List<GameSubEvent> subEvents = isOpen(game) ? parse(game.getPendingSubEventsJson()) : new ArrayList<>();
+        List<GameSubEvent> subEvents;
+        try {
+            subEvents = isOpen(game) ? parse(game.getPendingSubEventsJson()) : new ArrayList<>();
+        } catch (Exception e) {
+            // An unparseable draft (e.g. staged by a newer bot version, then rolled back) must not break
+            // the tactical action's end buttons; the text summary still carries the information.
+            BotLogger.error(new LogOrigin(game), "Failed to drain tactical sub-event draft.", e);
+            subEvents = new ArrayList<>();
+        }
         clear(game);
         return subEvents;
     }

--- a/src/main/java/ti4/spring/service/gameevent/GameEventType.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventType.java
@@ -21,4 +21,8 @@ public class GameEventType {
     public static final String AGENDA_RESOLVED = "AGENDA_RESOLVED";
     public static final String TRANSACTION = "TRANSACTION";
     public static final String GAME_ENDED = "GAME_ENDED";
+    public static final String PRODUCTION = "PRODUCTION";
+    public static final String MANUAL_COMMAND = "MANUAL_COMMAND";
+    public static final String PHASE_STARTED = "PHASE_STARTED";
+    public static final String ROUND_STARTED = "ROUND_STARTED";
 }

--- a/src/main/java/ti4/spring/service/gameevent/GameSubEvent.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameSubEvent.java
@@ -1,0 +1,37 @@
+package ti4.spring.service.gameevent;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.Map;
+
+/**
+ * Structured sub-event collected during a tactical action and embedded in the TACTICAL_ACTION event payload.
+ *
+ * <p>The {@code type} discriminator values are EXACTLY the {@link GameSubEventType} constant names; this is the wire
+ * contract with the React frontend and must not drift.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = GameSubEvent.Combat.class, name = "COMBAT"),
+    @JsonSubTypes.Type(value = GameSubEvent.ControlEstablished.class, name = "CONTROL_ESTABLISHED"),
+    @JsonSubTypes.Type(value = GameSubEvent.ActionCardPlayed.class, name = "ACTION_CARD_PLAYED"),
+    @JsonSubTypes.Type(value = GameSubEvent.LeaderPlayed.class, name = "LEADER_PLAYED"),
+    @JsonSubTypes.Type(value = GameSubEvent.TechExhausted.class, name = "TECH_EXHAUSTED"),
+    @JsonSubTypes.Type(value = GameSubEvent.Production.class, name = "PRODUCTION"),
+    @JsonSubTypes.Type(value = GameSubEvent.ManualCommand.class, name = "MANUAL_COMMAND")
+})
+public sealed interface GameSubEvent {
+    record Combat(String kind, String tile, String planet, String vsFaction) implements GameSubEvent {}
+
+    record ControlEstablished(String planet) implements GameSubEvent {}
+
+    record ActionCardPlayed(String faction, String cardId, String cardName) implements GameSubEvent {}
+
+    record LeaderPlayed(String faction, String leaderType, String leaderId) implements GameSubEvent {}
+
+    record TechExhausted(String faction, String techId) implements GameSubEvent {}
+
+    record Production(String tile, Map<String, Integer> units, Integer cost) implements GameSubEvent {}
+
+    record ManualCommand(String user, String command) implements GameSubEvent {}
+}

--- a/src/main/java/ti4/spring/service/gameevent/GameSubEventType.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameSubEventType.java
@@ -1,0 +1,11 @@
+package ti4.spring.service.gameevent;
+
+public enum GameSubEventType {
+    COMBAT,
+    CONTROL_ESTABLISHED,
+    ACTION_CARD_PLAYED,
+    LEADER_PLAYED,
+    TECH_EXHAUSTED,
+    PRODUCTION,
+    MANUAL_COMMAND
+}

--- a/src/test/java/ti4/spring/service/gameevent/GameEventDraftTest.java
+++ b/src/test/java/ti4/spring/service/gameevent/GameEventDraftTest.java
@@ -1,0 +1,88 @@
+package ti4.spring.service.gameevent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.json.JsonMapperManager;
+
+class GameEventDraftTest {
+
+    @Test
+    void stageWhenClosedReturnsFalseAndStoresNothing() {
+        Game game = new Game();
+
+        boolean staged = GameEventDraft.stage(game, new GameSubEvent.ControlEstablished("18"));
+
+        assertThat(staged).isFalse();
+        assertThat(GameEventDraft.isOpen(game)).isFalse();
+        assertThat(game.getPendingSubEventsJson()).isEmpty();
+    }
+
+    @Test
+    void openThenStageThenDrainReturnsTypedOrderedListAndClears() {
+        Game game = new Game();
+        GameEventDraft.open(game);
+
+        assertThat(GameEventDraft.isOpen(game)).isTrue();
+        assertThat(GameEventDraft.stage(game, new GameSubEvent.ControlEstablished("18")))
+                .isTrue();
+        assertThat(GameEventDraft.stage(game, new GameSubEvent.Combat("space", "18", null, "hacan")))
+                .isTrue();
+        assertThat(GameEventDraft.stage(game, new GameSubEvent.TechExhausted("hacan", "gs")))
+                .isTrue();
+
+        List<GameSubEvent> drained = GameEventDraft.drain(game);
+
+        assertThat(drained)
+                .containsExactly(
+                        new GameSubEvent.ControlEstablished("18"),
+                        new GameSubEvent.Combat("space", "18", null, "hacan"),
+                        new GameSubEvent.TechExhausted("hacan", "gs"));
+        assertThat(GameEventDraft.isOpen(game)).isFalse();
+        assertThat(game.getPendingSubEventsJson()).isEmpty();
+    }
+
+    @Test
+    void drainWhenClosedReturnsEmpty() {
+        Game game = new Game();
+
+        assertThat(GameEventDraft.drain(game)).isEmpty();
+    }
+
+    @Test
+    void serializedDraftContainsTypeDiscriminatorsAndNoNewlines() {
+        Game game = new Game();
+        GameEventDraft.open(game);
+        GameEventDraft.stage(game, new GameSubEvent.ControlEstablished("18"));
+        GameEventDraft.stage(game, new GameSubEvent.LeaderPlayed("hacan", "agent", "hacanagent"));
+
+        String json = game.getPendingSubEventsJson();
+
+        assertThat(json).doesNotContain("\n").doesNotContain("\r");
+        assertThat(json).contains("\"type\":\"CONTROL_ESTABLISHED\"");
+        assertThat(json).contains("\"type\":\"LEADER_PLAYED\"");
+    }
+
+    @Test
+    void drainedListReserializesWithTypeIntact() {
+        Game game = new Game();
+        GameEventDraft.open(game);
+        GameEventDraft.stage(game, new GameSubEvent.ActionCardPlayed("hacan", "ac1", "Sabotage"));
+
+        List<GameSubEvent> drained = GameEventDraft.drain(game);
+
+        // This is what lands in the event payload; the typed serialize keeps the polymorphic discriminator, whereas a
+        // raw writeValueAsString(list) through an Object reference would drop it.
+        String payloadJson = GameEventDraft.serialize(drained);
+        assertThat(payloadJson).contains("\"type\":\"ACTION_CARD_PLAYED\"");
+
+        // And it survives being embedded (as a JsonNode) into the Object-valued payload map the committer serializes.
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("subEvents", JsonMapperManager.basic().readTree(payloadJson));
+        assertThat(JsonMapperManager.basic().writeValueAsString(payload)).contains("\"type\":\"ACTION_CARD_PLAYED\"");
+    }
+}

--- a/src/test/java/ti4/spring/service/gameevent/GameEventDraftTest.java
+++ b/src/test/java/ti4/spring/service/gameevent/GameEventDraftTest.java
@@ -2,6 +2,8 @@ package ti4.spring.service.gameevent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +60,7 @@ class GameEventDraftTest {
         Game game = new Game();
         GameEventDraft.open(game);
         GameEventDraft.stage(game, new GameSubEvent.ControlEstablished("18"));
-        GameEventDraft.stage(game, new GameSubEvent.LeaderPlayed("hacan", "agent", "hacanagent"));
+        GameEventDraft.stage(game, new GameSubEvent.LeaderPlayed("hacan", "AGENT", "hacanagent"));
 
         String json = game.getPendingSubEventsJson();
 
@@ -84,5 +86,19 @@ class GameEventDraftTest {
         Map<String, Object> payload = new HashMap<>();
         payload.put("subEvents", JsonMapperManager.basic().readTree(payloadJson));
         assertThat(JsonMapperManager.basic().writeValueAsString(payload)).contains("\"type\":\"ACTION_CARD_PLAYED\"");
+    }
+
+    @Test
+    void subEventTypeEnumMatchesJsonDiscriminators() {
+        // GameSubEventType documents the wire contract; keep it structurally tied to the @JsonSubTypes names.
+        List<String> discriminators = Arrays.stream(
+                        GameSubEvent.class.getAnnotation(JsonSubTypes.class).value())
+                .map(JsonSubTypes.Type::name)
+                .toList();
+        List<String> enumNames =
+                Arrays.stream(GameSubEventType.values()).map(Enum::name).toList();
+
+        assertThat(discriminators).containsExactlyInAnyOrderElementsOf(enumNames);
+        assertThat(GameSubEvent.class.getPermittedSubclasses()).hasSameSizeAs(discriminators);
     }
 }


### PR DESCRIPTION
## Summary

Replaces the blur of tactical-action summary sentences with structured, enum-discriminated sub-events, rendered by the website as proper line items (text summary remains the fallback for old events).

- **Sub-event draft**: a pending JSON draft lives as one line in the game save file (`GameProperties.pendingSubEventsJson`), opened at system activation (`ringTile_`), drained into the `TACTICAL_ACTION` event payload as `subEvents`, cleared at tactical reset. Because it rides the save file, it is undo-safe (rolls back byte-for-byte with the file-copy undo) and strictly ordered — no new tables.
- **DTOs**: sealed `GameSubEvent` interface with records (`Combat`, `ControlEstablished`, `ActionCardPlayed`, `LeaderPlayed`, `TechExhausted`, `Production`, `ManualCommand`), Jackson-polymorphic on a `type` discriminator sourced from the `GameSubEventType` enum (drift-tested). Note: serialization goes through a typed `List<GameSubEvent>` writer + `JsonNode` embed because Jackson 3 drops `@JsonSubTypes` discriminators when serializing from `Object`-typed contexts.
- **Nesting priority**: sites that previously committed top-level events (action cards, agents, heroes, tech exhausts) now stage into an open tactical draft instead — nested XOR top-level, never duplicated. Action cards/leaders/techs by *any* player nest under the active tactical action.
- **Builds**: production sub-events carry tile, per-unit counts, and cost. Agency Supply Network builds nest when they finish before the tactical action concludes; afterwards they become a standalone top-level `PRODUCTION` event. Nesting is scoped to `tacticalAction` buttons so other players' Warfare/Construction builds don't bleed into the active player's action.
- **Emoji fix**: combat summaries now say the faction name (`getFactionNameOrColor()`) instead of raw `<:Sardakk:1345…>` emoji markup.
- **New marker events**: `PHASE_STARTED` (strategy / action / status / agenda, emitted at the single choke point of each transition) and `ROUND_STARTED` at the round increment.
- **`MANUAL_COMMAND`**: every game-mutating slash command logs its raw command string — nested under an open tactical draft, else top-level — emitted just before `GameManager.save` so the undo fence holds.

Companion frontend PR: AsyncTI4/ti4_web_new (structured rendering with text fallback).

## Test plan

- `mvn compile` clean; `GameEventDraftTest` (6 tests) covers draft lifecycle, ordering, discriminator preservation through the real payload path, newline-free save-file serialization, and enum↔`@JsonSubTypes` drift.
- Old save files load unchanged (field defaults to empty); old events keep their text summary.
- Reviewed end-to-end (spec + quality per task, plus an independent second-opinion review of the full diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)