### PR TITLE
Implement Vyserix/kalora breakthroughs, bug fixes

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/combat/RetreatButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/combat/RetreatButtonHandler.java
@@ -89,10 +89,13 @@ class RetreatButtonHandler {
 
     @ButtonHandler("retreatUnitsFrom_")
     public static void retreatUnitsFrom(ButtonInteractionEvent event, Player player, String buttonID, Game game) {
-        ButtonHelperModifyUnits.retreatSpaceUnits(buttonID, event, game, player);
         String both = buttonID.replace("retreatUnitsFrom_", "");
         String pos1 = both.split("_")[0];
         String pos2 = both.split("_")[1];
+        if (player.hasUnlockedBreakthrough("kalorabt")) {
+            KaloraBreakthroughHandler.bypassOperationsRetreat(player, game, game.getTileByPosition(pos1), event);
+        }
+        ButtonHelperModifyUnits.retreatSpaceUnits(buttonID, event, game, player);
         MessageHelper.sendMessageToChannel(
                 event.getMessageChannel(),
                 player.getRepresentationNoPing() + " retreated all units in space to "
@@ -107,9 +110,6 @@ class RetreatButtonHandler {
         CommanderUnlockCheckService.checkPlayer(player, "kalora");
         if (player.hasAbility("carapace_regeneration")) {
             KaloraAbilityHandler.carapaceRegeneration(player, game.getTileByPosition(pos2), event);
-        }
-        if (player.hasUnlockedBreakthrough("kalorabt")) {
-            KaloraBreakthroughHandler.bypassOperationsRetreat(player, game, game.getTileByPosition(pos1), event);
         }
         FOWCombatThreadMirroring.mirrorMessage(
                 event, game, player.getRepresentationNoPing() + " retreated all units in space.");

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/kalora/KaloraBreakthroughHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/kalora/KaloraBreakthroughHandler.java
@@ -1,13 +1,23 @@
 package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.Tile;
+import ti4.helpers.ButtonHelper;
 import ti4.helpers.CommandCounterHelper;
+import ti4.helpers.Helper;
+import ti4.helpers.Units.UnitType;
 import ti4.message.MessageHelper;
 import ti4.service.RemoveCommandCounterService;
+import ti4.service.unit.MoveUnitService;
 
 @UtilityClass
 public class KaloraBreakthroughHandler {
@@ -20,5 +30,35 @@ public class KaloraBreakthroughHandler {
                 event.getMessageChannel(),
                 player.getFactionEmoji()
                         + " returned 1 command token from the active system to their reinforcements via **Bypass Operations**.");
+    }
+
+    public static void offerCommitInfantryButton(
+            GenericInteractionCreateEvent event, Game game, Player player, Tile tile, String bombardPlanet) {
+        if (bombardPlanet == null || bombardPlanet.isEmpty()) return;
+        if (tile.getSpaceUnitHolder().getUnitCount(UnitType.Infantry, player.getColor()) <= 0) return;
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.green(
+                player.factionButtonChecker() + "kaloraCommitInfantry_" + bombardPlanet,
+                "Commit 1 Infantry to " + Helper.getPlanetRepresentation(bombardPlanet, game)));
+        buttons.add(Buttons.red("deleteButtons", "Decline"));
+        String msg = player.getRepresentation()
+                + ", if you just destroyed the last of the controlling player's ground forces on "
+                + Helper.getPlanetRepresentation(bombardPlanet, game)
+                + ", you may commit 1 infantry from the space area onto that planet using **Bypass Operations**.";
+        MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), msg, buttons);
+    }
+
+    @ButtonHandler("kaloraCommitInfantry_")
+    public static void commitInfantryFromSpace(
+            Player player, String buttonID, Game game, ButtonInteractionEvent event) {
+        String planet = buttonID.replace("kaloraCommitInfantry_", "");
+        Tile tile = game.getTileFromPlanet(planet);
+        if (tile == null) return;
+        MoveUnitService.moveUnits(event, tile, game, player.getColor(), "inf", tile, planet);
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(),
+                player.getRepresentation() + " committed 1 infantry from the space area onto "
+                        + Helper.getPlanetRepresentation(planet, game) + " using **Bypass Operations**.");
+        ButtonHelper.deleteMessage(event);
     }
 }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/vyserix/VyserixBreakthroughHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/whispers/vyserix/VyserixBreakthroughHandler.java
@@ -1,0 +1,46 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.vyserix;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.message.MessageHelper;
+import ti4.service.unit.AddUnitService;
+
+@UtilityClass
+public class VyserixBreakthroughHandler {
+
+    public static void offerMoraySystemButtons(
+            GenericInteractionCreateEvent event, Game game, Player player, Tile tile, int hits) {
+        if (hits <= 0) return;
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.green(
+                player.factionButtonChecker() + "vyserixMoraySystem_" + tile.getPosition(),
+                "Place 1 Fighter in " + tile.getRepresentationForButtons(game, player)));
+        buttons.add(Buttons.red("deleteButtons", "Done"));
+        String msg = player.getRepresentation() + " you could potentially cancel "
+                + (hits == 1 ? "the ANTI-FIGHTER BARRAGE hit" : "some ANTI-FIGHTER BARRAGE hits")
+                + " to place fighters instead due to _M.O.R.A.Y. System_. Use these buttons to do so, and press done when done. The bot did not track how many hits you got.";
+        MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), msg, buttons);
+    }
+
+    @ButtonHandler("vyserixMoraySystem_")
+    public static void placeMoraySystemFighter(
+            Player player, String buttonID, Game game, ButtonInteractionEvent event) {
+        String pos = buttonID.replace("vyserixMoraySystem_", "");
+        Tile tile = game.getTileByPosition(pos);
+        if (tile == null) return;
+        String msg = player.getRepresentation()
+                + " canceled one ANTI-FIGHTER BARRAGE hit to place one fighter in "
+                + tile.getRepresentationForButtons(game, player) + " due to _M.O.R.A.Y. System_.";
+        AddUnitService.addUnits(event, tile, game, player.getColor(), "1 ff");
+        MessageHelper.sendMessageToChannel(event.getMessageChannel(), msg);
+    }
+}

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -4045,6 +4045,7 @@ public class ButtonHelper {
         int numInfNFightersNMechs = 0;
         int numOfCapitalShips = 0;
         int fightersIgnored = 0;
+        int totalPdsInSystem = 0;
         int numFighter2s = 0;
         int numFighter2sFleet = 0;
         int numRiptide2s = 0;
@@ -4117,6 +4118,7 @@ public class ButtonHelper {
                 }
                 if ("pds".equalsIgnoreCase(unit.getBaseType()) && !"space".equalsIgnoreCase(capChecker.getName())) {
                     numPDS += entry.getValue();
+                    totalPdsInSystem += entry.getValue();
                 }
             }
             if (player.getPlanets().contains(capChecker.getName())) {
@@ -4161,6 +4163,9 @@ public class ButtonHelper {
             if ((capChecker instanceof Planet p) && numPDS > 2 && !isLawInPlay(game, "defense_act")) {
                 tooManyPDS = p.getRepresentation(game);
             }
+        }
+        if (player.hasUnlockedBreakthrough("vyserixbt")) {
+            fightersIgnored += 3 * totalPdsInSystem;
         }
         int ignoredFs = 0;
 

--- a/src/main/java/ti4/helpers/CombatModHelper.java
+++ b/src/main/java/ti4/helpers/CombatModHelper.java
@@ -624,7 +624,30 @@ public class CombatModHelper {
                     meetsCondition = true;
                 }
             }
-            case "technotemplar" -> meetsCondition = player.hasUnit("vyserix_mech");
+            case "technotemplar" -> {
+                if (tile != null && player.hasUnit("vyserix_mech")) {
+                    List<Tile> tilesToCheck = new ArrayList<>();
+                    tilesToCheck.add(tile);
+                    if (unitsByQuantity.keySet().stream().anyMatch(UnitModel::getDeepSpaceCannon)) {
+                        for (String adjPos :
+                                FoWHelper.getAdjacentTiles(game, tile.getPosition(), player, false, true)) {
+                            Tile adjTile = game.getTileByPosition(adjPos);
+                            if (adjTile != null) {
+                                tilesToCheck.add(adjTile);
+                            }
+                        }
+                    }
+                    checkTiles:
+                    for (Tile t : tilesToCheck) {
+                        for (UnitHolder uh : t.getPlanetUnitHolders()) {
+                            if (uh.getUnitCount(UnitType.Mech, player.getColor()) > 0) {
+                                meetsCondition = true;
+                                break checkTiles;
+                            }
+                        }
+                    }
+                }
+            }
             case "opponent_strat_cards_exhausted" ->
                 meetsCondition = opponent != null && game.getPlayedSCs().containsAll(opponent.getSCs());
             case "space_dock_on_holder" -> {

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -43,6 +43,7 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunne
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersUnitsHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraLeaderHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraUnitHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.vyserix.VyserixBreakthroughHandler;
 import ti4.discord.interactions.commands.planet.PlanetExhaust;
 import ti4.game.Game;
 import ti4.game.Planet;
@@ -264,17 +265,22 @@ public class CombatRollService {
                 AshenUnitHandler.prepareFlagshipBombardmentContext(game, player, bombardPlanet);
             }
             String assignedUnits = game.getStoredValue("assignedBombardment" + player.getFaction());
-            int count;
+            Map<String, Integer> remainingAssignedByAsyncId = new HashMap<>();
+            for (String assignedUnit : assignedUnits.split(";")) {
+                if (assignedUnit.endsWith(bombardPlanet) && assignedUnit.contains("_")) {
+                    String asyncId = assignedUnit.substring(0, assignedUnit.indexOf('_'));
+                    remainingAssignedByAsyncId.merge(asyncId, 1, Integer::sum);
+                }
+            }
             List<Pair<UnitModel, UnitHolder>> unitMods = new ArrayList<>(playerUnitsByQuantity.keySet());
             for (Pair<UnitModel, UnitHolder> mod : unitMods) {
-                count = 0;
-                for (String assignedUnit : assignedUnits.split(";")) {
-                    if (assignedUnit.endsWith(bombardPlanet)
-                            && assignedUnit.contains(mod.getLeft().getAsyncId() + "_")) {
-                        count++;
-                    }
-                }
+                // The same asyncId can span multiple holders here, so split the assigned total across them
+                // instead of giving every holder the full matched count.
+                String asyncId = mod.getLeft().getAsyncId();
+                int available = remainingAssignedByAsyncId.getOrDefault(asyncId, 0);
+                int count = Math.min(available, playerUnitsByQuantity.get(mod));
                 if (count > 0) {
+                    remainingAssignedByAsyncId.put(asyncId, available - count);
                     playerUnitsByQuantity.put(mod, count);
                 } else {
                     playerUnitsByQuantity.remove(mod);
@@ -773,6 +779,10 @@ public class CombatRollService {
                     + (h == 1 ? "the hit" : "hits") + "."
                     + ButtonHelperModifyUnits.autoAssignSpaceCombatHits(opponent, game, tile, h, event, true, true);
             MessageHelper.sendMessageToChannelWithButtons(channel, msg2, buttons);
+        }
+
+        if (rollType == CombatRollType.AFB && player.hasUnlockedBreakthrough("vyserixbt")) {
+            VyserixBreakthroughHandler.offerMoraySystemButtons(event, game, player, tile, h);
         }
 
         if (rollType == CombatRollType.bombardment) {

--- a/src/main/java/ti4/service/combat/CombatRollService.java
+++ b/src/main/java/ti4/service/combat/CombatRollService.java
@@ -41,6 +41,7 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.crystell
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersAbilitiesHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersLeadersHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunners.NetrunnersUnitsHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraBreakthroughHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraLeaderHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraUnitHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.vyserix.VyserixBreakthroughHandler;
@@ -836,6 +837,9 @@ public class CombatRollService {
                             + (h == 1 ? "the BOMBARDMENT hit" : "some BOMBARDMENT hits")
                             + " to place infantry instead. Use these buttons to do so, and press done when done. The bot did not track how many hits you got. ";
                     MessageHelper.sendMessageToChannelWithButtons(event.getMessageChannel(), msg2, buttons);
+                }
+                if (player.hasUnlockedBreakthrough("kalorabt")) {
+                    KaloraBreakthroughHandler.offerCommitInfantryButton(event, game, player, tile, bombardPlanet);
                 }
             }
             if (player.hasTech("x89c4")) {

--- a/src/main/resources/data/breakthroughs/balacasi_breakthroughs.json
+++ b/src/main/resources/data/breakthroughs/balacasi_breakthroughs.json
@@ -32,7 +32,7 @@
             "CYBERNETIC",
             "WARFARE"
         ],
-        "text": "At the start of a space combat round in a non-home system, your ships in the active system may use their BOMBARDMENT abilities. If they do, you must announce retreat during this combat round. When you retreat during your tactical action, remove 1 of your command tokens from the active system and return it to your reinforcements. After you destroy all the ground forces on a planet, gain control of that planet.",
+        "text": "At the start of a space combat round in a non-home system, your ships in the active system may use their BOMBARDMENT abilities. If they do, you must announce retreat during this combat round. When you retreat during your tactical action, remove 1 of your command tokens from the active system and return it to your reinforcements. After you destroy the last of the controlling player's ground forces on a planet, you may commit 1 infantry from that planet's space area onto that planet.",
         "source": "balacasi"
     },
     {


### PR DESCRIPTION
- Vyserix BT: PDS-scaled fighter capacity exemption, AFB hit-to-fighter conversion
- Fix bombardment assignment counting splitting incorrectly across multiple holders sharing an asyncId (e.g. Kalora Commander's adjacent-system pull), causing unit counts to double
- Fix technotemplar modifier condition checking mech ownership globally instead of on a planet in the active/adjacent system