### PR TITLE
Skip combat-replay DB queries for games without open candidates

### DIFF
--- a/src/main/java/ti4/contest/cron/CombatReplayCron.java
+++ b/src/main/java/ti4/contest/cron/CombatReplayCron.java
@@ -26,7 +26,9 @@ public class CombatReplayCron {
         CombatContestSettings settings = SpringContext.getBean(CombatContestSettings.class);
         if (!shouldRun(settings.getReplayExecution().getReplayIntervalSeconds())) return;
         try {
-            SpringContext.getBean(CombatReplayService.class).finalizeExpiredPendingResolutionCandidates();
+            CombatReplayService replayService = SpringContext.getBean(CombatReplayService.class);
+            replayService.finalizeExpiredPendingResolutionCandidates();
+            replayService.refreshOpenCandidateGames();
             SpringContext.getBean(CombatReplayContestLifecycleService.class).runReplayTick();
         } catch (Exception e) {
             BotLogger.error("**CombatReplayCron failed.**", e);

--- a/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
+++ b/src/main/java/ti4/contest/replay/repository/CombatCandidateRepository.java
@@ -18,6 +18,9 @@ public interface CombatCandidateRepository extends JpaRepository<CombatCandidate
 
     List<CombatCandidateEntity> findByGameNameAndStatusIn(String gameName, Collection<CombatCandidateStatus> statuses);
 
+    @Query("select distinct c.gameName from CombatCandidateEntity c where c.status in :statuses")
+    List<String> findDistinctGameNamesByStatusIn(@Param("statuses") Collection<CombatCandidateStatus> statuses);
+
     CombatCandidateEntity findFirstByGameNameAndTilePositionAndStatusIn(
             String gameName, String tilePosition, Collection<CombatCandidateStatus> statuses);
 

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -61,17 +62,29 @@ public class CombatReplayService {
     private final CombatReplayEventAppender eventAppender;
     private final CombatReplaySideBetTriggerService sideBetTriggerService;
     private final CombatSideBetAvailabilityService availabilityService;
+    // Games that MAY have open candidates; a stale entry costs one query and self-heals in getOpenCandidates.
+    private final Set<String> gamesWithOpenCandidates = ConcurrentHashMap.newKeySet();
     private CombatReplaySelection selection;
 
     @PostConstruct
     void initializeSelectionSnapshot() {
         selection = new CombatReplaySelection(settings);
         refreshSelectionSnapshot();
+        refreshOpenCandidateGames();
+    }
+
+    /**
+     * Add-only on purpose: a replace-style refresh could race with concurrent candidate creation and drop a
+     * just-created game. Removal happens only in getOpenCandidates, once the database proves a game has none open.
+     */
+    public void refreshOpenCandidateGames() {
+        gamesWithOpenCandidates.addAll(candidateRepository.findDistinctGameNamesByStatusIn(OPEN_CANDIDATE_STATUSES));
     }
 
     public PreInteractionSnapshot capturePreInteractionSnapshot(Game game) {
         if (!settings.isEnabled()) return PreInteractionSnapshot.empty();
         if (game == null) return PreInteractionSnapshot.empty();
+        if (!mayHaveOpenCandidates(game)) return PreInteractionSnapshot.empty();
 
         Map<Long, CandidateInitialSnapshot> snapshots = new HashMap<>();
         for (CombatCandidateEntity candidate : getOpenCandidates(game)) {
@@ -116,10 +129,12 @@ public class CombatReplayService {
 
         CombatCandidateEntity candidate = buildCandidate(observation, attacker, defender, tile);
         candidateRepository.save(candidate);
+        gamesWithOpenCandidates.add(candidate.getGameName());
     }
 
     public void onButtonInteractionSettled(Game game, Player player, ButtonInteractionEvent event) {
         if (!settings.isEnabled()) return;
+        if (!mayHaveOpenCandidates(game)) return;
         for (CombatCandidateEntity candidate : getOpenCandidates(game)) {
             if (candidate.getStatus() == CombatCandidateStatus.PENDING_RESOLUTION
                     && !candidate
@@ -892,8 +907,17 @@ public class CombatReplayService {
         return player != null && player.hasTech("asc");
     }
 
+    private boolean mayHaveOpenCandidates(Game game) {
+        return gamesWithOpenCandidates.contains(game.getName());
+    }
+
     private List<CombatCandidateEntity> getOpenCandidates(Game game) {
-        return candidateRepository.findByGameNameAndStatusIn(game.getName(), OPEN_CANDIDATE_STATUSES);
+        List<CombatCandidateEntity> openCandidates =
+                candidateRepository.findByGameNameAndStatusIn(game.getName(), OPEN_CANDIDATE_STATUSES);
+        if (openCandidates.isEmpty()) {
+            gamesWithOpenCandidates.remove(game.getName());
+        }
+        return openCandidates;
     }
 
     private CombatCandidateEntity getTrackingCandidate(Game game, String tilePosition) {

--- a/src/main/java/ti4/contest/replay/service/CombatReplayService.java
+++ b/src/main/java/ti4/contest/replay/service/CombatReplayService.java
@@ -62,7 +62,6 @@ public class CombatReplayService {
     private final CombatReplayEventAppender eventAppender;
     private final CombatReplaySideBetTriggerService sideBetTriggerService;
     private final CombatSideBetAvailabilityService availabilityService;
-    // Games that MAY have open candidates; a stale entry costs one query and self-heals in getOpenCandidates.
     private final Set<String> gamesWithOpenCandidates = ConcurrentHashMap.newKeySet();
     private CombatReplaySelection selection;
 
@@ -73,10 +72,6 @@ public class CombatReplayService {
         refreshOpenCandidateGames();
     }
 
-    /**
-     * Add-only on purpose: a replace-style refresh could race with concurrent candidate creation and drop a
-     * just-created game. Removal happens only in getOpenCandidates, once the database proves a game has none open.
-     */
     public void refreshOpenCandidateGames() {
         gamesWithOpenCandidates.addAll(candidateRepository.findDistinctGameNamesByStatusIn(OPEN_CANDIDATE_STATUSES));
     }

--- a/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
+++ b/src/test/java/ti4/contest/replay/service/CombatReplayServiceTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -253,6 +256,44 @@ class CombatReplayServiceTest {
         service.onSpaceCombatStarted(game, player(game, "rohdhna"), player(game, "khrask"), new Tile("d31", "317"));
 
         verifyNoInteractions(observationRepository, candidateRepository);
+    }
+
+    @Test
+    void capturePreInteractionSnapshotSkipsDatabaseForGameWithoutOpenCandidates() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayService service = service(candidateRepository);
+        Game game = game("pbd-unregistered");
+
+        CombatReplayService.PreInteractionSnapshot snapshot = service.capturePreInteractionSnapshot(game);
+
+        assertEquals(CombatReplayService.PreInteractionSnapshot.empty(), snapshot);
+        verify(candidateRepository, never()).findByGameNameAndStatusIn(any(), any());
+    }
+
+    @Test
+    void onButtonInteractionSettledSkipsDatabaseForGameWithoutOpenCandidates() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayService service = service(candidateRepository);
+        Game game = game("pbd-unregistered");
+
+        service.onButtonInteractionSettled(game, player(game, "sol"), null);
+
+        verifyNoInteractions(candidateRepository);
+    }
+
+    @Test
+    void refreshRegistersOpenCandidateGameAndEmptyQuerySelfHeals() {
+        CombatCandidateRepository candidateRepository = mock(CombatCandidateRepository.class);
+        CombatReplayService service = service(candidateRepository);
+        Game game = game("pbd1");
+        when(candidateRepository.findDistinctGameNamesByStatusIn(any())).thenReturn(List.of("pbd1"));
+        when(candidateRepository.findByGameNameAndStatusIn(any(), any())).thenReturn(List.of());
+
+        service.refreshOpenCandidateGames();
+        service.onButtonInteractionSettled(game, player(game, "sol"), null);
+        service.onButtonInteractionSettled(game, player(game, "sol"), null);
+
+        verify(candidateRepository, times(1)).findByGameNameAndStatusIn(any(), any());
     }
 
     private CombatReplayService service(CombatCandidateRepository candidateRepository) {


### PR DESCRIPTION
## Why

Production logs showed button presses going 1-10s slow in a ~10s window every 30 minutes, starting the exact second MatchmakerCron begins. The app runs SQLite with a single Hikari connection, and with the combat contest enabled **every button press** runs two queries — `CombatReplayService.capturePreInteractionSnapshot()` and `onButtonInteractionSettled()` both call `findByGameNameAndStatusIn` — so presses queue behind whatever cron is holding the connection. #5364 shrank the matchmaker transactions; this PR removes the per-press queries themselves for the overwhelmingly common case: games with no open combat candidates.

## What

Adds an in-memory gate (`ConcurrentHashMap.newKeySet()` of game names) in `CombatReplayService` with "may have open candidates" semantics — it fails toward querying, never away from it:

- **Gate:** `capturePreInteractionSnapshot` returns an empty snapshot and `onButtonInteractionSettled` returns immediately for games not in the set, after their existing early returns. Byte-identical to the "queried and found no open candidates" path today.
- **Register:** `onSpaceCombatStarted` adds the game right after saving a new candidate (same thread, so the combat-starting press's own settle hook is never gated out).
- **Refresh:** new repository query `findDistinctGameNamesByStatusIn` seeds the set at `@PostConstruct` and on every `CombatReplayCron` tick (bounds staleness after a lease failover to ~one replay interval). The refresh is **add-only on purpose** — a replace-style refresh could race with concurrent candidate creation and drop a just-created game.
- **Self-heal:** the single removal point is `getOpenCandidates`: once the DB proves a game has no open candidates, it's dropped from the set. After the last candidate in a game closes, the next press pays one query and unregisters the game.

## Reviewer notes

- The new set field is inline-initialized, not constructor-injected, so the Lombok `@RequiredArgsConstructor` arity stays unchanged.
- A stale positive entry costs exactly one query and then self-heals; a gated-out game behaves identically to "no open candidates found".
- The mirror/roll paths are untouched — they only run in combat contexts and query by tile.

## Testing

- Three new `CombatReplayServiceTest` tests: both button-path methods skip the DB for an unregistered game; refresh registers a game and an empty query self-heals (settled twice → repository queried exactly once).
- `mvn --batch-mode --fail-at-end verify` passes: 515 tests, 0 failures, SpotBugs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
