### PR TITLE
Add authoritative movement and retreat state to game events

### DIFF
--- a/src/main/java/ti4/game/GameProperties.java
+++ b/src/main/java/ti4/game/GameProperties.java
@@ -70,6 +70,8 @@ public class GameProperties {
     private String currentACDrawStatusInfo = "";
     // Undo-safe draft of tactical sub-events, persisted as one JSON line; "" means closed.
     private String pendingSubEventsJson = "";
+    // Undo-safe compact movement captured when tactical displacement is committed.
+    private String pendingMovementState = "";
     private String latestCommand = "";
     private String latestOutcomeVotedFor = "";
     private String playersWhoHitPersistentNoAfter = "";

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -663,6 +663,11 @@ class GameLoadService {
                         game.setPendingSubEventsJson(info);
                     }
                 }
+                case Constants.PENDING_MOVEMENT_STATE -> {
+                    if (isNotBlank(info)) {
+                        game.setPendingMovementState(info);
+                    }
+                }
                 case Constants.STARTED_DATE -> {
                     if (isNotBlank(info)) {
                         game.setStartedDate(Long.parseLong(info));

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -426,6 +426,8 @@ class GameSaveService {
         writer.write(System.lineSeparator());
         writer.write(Constants.PENDING_SUB_EVENTS_JSON + " " + game.getPendingSubEventsJson());
         writer.write(System.lineSeparator());
+        writer.write(Constants.PENDING_MOVEMENT_STATE + " " + game.getPendingMovementState());
+        writer.write(System.lineSeparator());
         writer.write(Constants.GAME_CUSTOM_NAME + " " + game.getCustomName());
         writer.write(System.lineSeparator());
 

--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -65,6 +65,7 @@ import ti4.service.unit.ParsedUnit;
 import ti4.service.unit.RemoveUnitService;
 import ti4.service.unit.RemoveUnitService.RemovedUnit;
 import ti4.spring.context.SpringContext;
+import ti4.spring.service.gameevent.GameEventDraft;
 
 public final class ButtonHelperModifyUnits {
 
@@ -1723,9 +1724,12 @@ public final class ButtonHelperModifyUnits {
 
         Tile src = game.getTileByPosition(pos1);
         Tile dest = game.getTileByPosition(pos2);
+        UnitHolder sourceHolder = src.getUnitHolderFromPlanet(planet);
+        Map<UnitKey, List<Integer>> beforeRetreat = GameEventDraft.snapshotRetreatUnits(player, sourceHolder);
         boolean damaged = buttonLabel.toLowerCase().contains("damaged");
         MoveUnitService.moveUnits(
                 event, src, game, player.getColor(), amount + " " + unitType + " " + planet, dest, "space", damaged);
+        GameEventDraft.stageRetreat(game, player, pos1, planet, pos2, Constants.SPACE, beforeRetreat, sourceHolder);
 
         List<Button> systemButtons = getRetreatingGroundTroopsButtons(player, game, pos1, pos2);
         String retreatMessage = player.getFactionEmojiOrColor() + " retreated " + amount + " " + unitType + " on "
@@ -1749,6 +1753,8 @@ public final class ButtonHelperModifyUnits {
         Tile tile1 = game.getTileByPosition(pos1);
         Tile tile2 = game.getTileByPosition(pos2);
         tile2 = FlipTileService.flipTileIfNeeded(event, tile2, game);
+        UnitHolder sourceSpace = tile1.getSpaceUnitHolder();
+        Map<UnitKey, List<Integer>> beforeRetreat = GameEventDraft.snapshotRetreatUnits(player, sourceSpace);
         if (game.playerHasLeaderUnlockedOrAlliance(player, "kollecccommander")
                 && !buttonID.contains("skilled")
                 && !CommandCounterHelper.hasCC(event, player.getColor(), tile1)) {
@@ -1809,6 +1815,8 @@ public final class ButtonHelperModifyUnits {
                         event, tile1, game, player.getColor(), totalUnits + " " + unitName, tile2, "space");
             }
         }
+        GameEventDraft.stageRetreat(
+                game, player, pos1, Constants.SPACE, pos2, Constants.SPACE, beforeRetreat, sourceSpace);
 
         if (tile2 != null && tile2.getPosition().startsWith("frac")) {
             CommanderUnlockCheckService.checkPlayer(player, "obsidian");

--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -447,7 +447,8 @@ public final class ButtonHelperTacticalAction {
         if (!subEvents.isEmpty()) {
             payload.put("subEvents", GameEventDraft.toJsonNode(subEvents));
         }
-        GameEventService.commit(game, GameEventType.TACTICAL_ACTION, player, payload);
+        String movementState = GameEventDraft.drainMovement(game);
+        GameEventService.commit(game, GameEventType.TACTICAL_ACTION, player, payload, movementState);
     }
 
     private static void addIfNotEmpty(Map<String, Object> payload, String key, String value) {

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -148,6 +148,7 @@ public final class Constants {
     public static final String BUTTON_PRESS_COUNT = "button_press_count";
     public static final String EVENT_SEQUENCE_COUNTER = "event_sequence_counter";
     public static final String PENDING_SUB_EVENTS_JSON = "pending_sub_events_json";
+    public static final String PENDING_MOVEMENT_STATE = "pending_movement_state";
     public static final String ABSOL_MODE = "absol_mode";
     public static final String PROMISES_PROMISES = "promises_promises";
     public static final String FLAGSHIPPING = "flagshipping";

--- a/src/main/java/ti4/helpers/thundersedge/TeHelperCommanders.java
+++ b/src/main/java/ti4/helpers/thundersedge/TeHelperCommanders.java
@@ -34,6 +34,7 @@ import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.RemoveUnitService;
+import ti4.spring.service.gameevent.GameEventDraft;
 
 @UtilityClass
 public class TeHelperCommanders {
@@ -152,6 +153,9 @@ public class TeHelperCommanders {
             Tile tile = game.getTileByPosition(matcher.group("pos"));
             HashMap<String, List<String>> ojzMap = TeHelperAbilities.readMoveMap(game.getStoredValue("OjzRetreatMap"));
             for (Map.Entry<String, List<String>> entry : ojzMap.entrySet()) {
+                Tile sourceTile = game.getTileByPosition(entry.getKey());
+                UnitHolder sourceSpace = sourceTile.getSpaceUnitHolder();
+                Map<UnitKey, List<Integer>> beforeRetreat = GameEventDraft.snapshotRetreatUnits(player, sourceSpace);
                 if (entry.getValue().contains("fs space")) movedFlagship = true;
                 List<String> units =
                         entry.getValue().stream().collect(Collectors.groupingBy(s -> s)).entrySet().stream()
@@ -166,9 +170,17 @@ public class TeHelperCommanders {
                         .toList();
                 String unitStrFrom = String.join(", ", units);
                 String unitStrTo = String.join(", ", unitsTo);
-                RemoveUnitService.removeUnits(
-                        event, game.getTileByPosition(entry.getKey()), game, player.getColor(), unitStrFrom);
+                RemoveUnitService.removeUnits(event, sourceTile, game, player.getColor(), unitStrFrom);
                 AddUnitService.addUnits(event, tile, game, player.getColor(), unitStrTo);
+                GameEventDraft.stageRetreat(
+                        game,
+                        player,
+                        entry.getKey(),
+                        Constants.SPACE,
+                        tile.getPosition(),
+                        Constants.SPACE,
+                        beforeRetreat,
+                        sourceSpace);
             }
             if (!player.hasUnit("ralnel_flagship")) movedFlagship = false;
             game.removeStoredValue("OjzRetreatMap");

--- a/src/main/java/ti4/service/fow/FOWPlusService.java
+++ b/src/main/java/ti4/service/fow/FOWPlusService.java
@@ -45,6 +45,7 @@ import ti4.service.option.FOWOptionService.FOWOption;
 import ti4.service.unit.AddUnitService;
 import ti4.service.unit.RemoveUnitService;
 import ti4.service.unit.RemoveUnitService.RemovedUnit;
+import ti4.spring.service.gameevent.GameEventDraft;
 
 /*
  To activate FoW+ mode use /game weird_game_setup fow_plus:True
@@ -229,6 +230,7 @@ public final class FOWPlusService {
         String message = player.getRepresentationUnfoggedNoPing() + " lost " + valueOfUnitsLost + " resources ";
         message += unitEmojis + " to The Void round " + game.getRound() + " turn " + player.getInRoundTurnCount() + ".";
         GMService.logPlayerActivity(game, player, message, null, true);
+        GameEventDraft.stageMovement(game, game.getActiveSystem(), unitsGoingToVoid);
         game.getTacticalActionDisplacement().clear();
     }
 

--- a/src/main/java/ti4/service/tactical/TacticalActionDisplacementService.java
+++ b/src/main/java/ti4/service/tactical/TacticalActionDisplacementService.java
@@ -21,6 +21,7 @@ import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitState;
 import ti4.helpers.Units.UnitType;
 import ti4.service.regex.RegexService;
+import ti4.spring.service.gameevent.GameEventDraft;
 
 @UtilityClass
 public class TacticalActionDisplacementService {
@@ -177,6 +178,7 @@ public class TacticalActionDisplacementService {
     public boolean applyDisplacementToActiveSystem(Game game, Tile tile) {
         boolean moved = false;
         UnitHolder activeSystemSpace = tile.getSpaceUnitHolder();
+        GameEventDraft.stageMovement(game, tile.getPosition(), game.getTacticalActionDisplacement());
         for (Entry<String, Map<UnitKey, List<Integer>>> e :
                 game.getTacticalActionDisplacement().entrySet()) {
             for (Entry<UnitKey, List<Integer>> unit : e.getValue().entrySet()) {

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
@@ -1,12 +1,17 @@
 package ti4.spring.service.gameevent;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.UnitHolder;
 import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitState;
 import ti4.json.JsonMapperManager;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
@@ -100,6 +105,53 @@ public class GameEventDraft {
                         .filter(states -> states != null)
                         .flatMap(List::stream)
                         .anyMatch(count -> count != null && count > 0);
+    }
+
+    /** Snapshot used to calculate exactly which of a player's units a retreat operation removed from its source. */
+    public static Map<UnitKey, List<Integer>> snapshotRetreatUnits(Player player, UnitHolder source) {
+        if (source == null) return Map.of();
+        Map<UnitKey, List<Integer>> snapshot = new HashMap<>();
+        for (UnitKey unitKey : source.getUnitKeys()) {
+            if (player.unitBelongsToPlayer(unitKey)) {
+                snapshot.put(unitKey, new ArrayList<>(source.getUnitStates(unitKey)));
+            }
+        }
+        return snapshot;
+    }
+
+    /** Stages the exact state-count delta removed from a retreat source. */
+    public static boolean stageRetreat(
+            Game game,
+            Player player,
+            String fromTile,
+            String fromHolder,
+            String toTile,
+            String toHolder,
+            Map<UnitKey, List<Integer>> before,
+            UnitHolder sourceAfterRetreat) {
+        Map<String, List<Integer>> units = new TreeMap<>();
+        for (Map.Entry<UnitKey, List<Integer>> entry : before.entrySet()) {
+            List<Integer> after = sourceAfterRetreat == null
+                    ? UnitState.emptyList()
+                    : sourceAfterRetreat.getUnitStates(entry.getKey());
+            List<Integer> moved = new ArrayList<>(UnitState.values().length);
+            int total = 0;
+            for (int i = 0; i < UnitState.values().length; i++) {
+                int beforeCount = stateCount(entry.getValue(), i);
+                int movedCount = Math.max(0, beforeCount - stateCount(after, i));
+                moved.add(movedCount);
+                total += movedCount;
+            }
+            if (total > 0) units.put(entry.getKey().asyncID(), moved);
+        }
+        if (units.isEmpty()) return false;
+        return stage(
+                game, new GameSubEvent.Retreat(player.getFaction(), fromTile, fromHolder, toTile, toHolder, units));
+    }
+
+    private static int stateCount(List<Integer> states, int index) {
+        if (states == null || index >= states.size() || states.get(index) == null) return 0;
+        return states.get(index);
     }
 
     /** Compact JSON (one line, {@code type} discriminators intact) for a list of sub-events. */

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
@@ -83,7 +83,7 @@ public class GameEventDraft {
             Game game, String targetPosition, Map<String, Map<UnitKey, List<Integer>>> displacement) {
         if (!isOpen(game) || !hasMovedUnits(displacement)) return false;
         try {
-            game.setPendingMovementState(CompactMovementState.serialize(targetPosition, displacement));
+            game.setPendingMovementState(CompactMovementState.serialize(game, targetPosition, displacement));
             return true;
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Failed to stage tactical movement state.", e);

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDraft.java
@@ -2,12 +2,15 @@ package ti4.spring.service.gameevent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.StringUtils;
 import ti4.game.Game;
+import ti4.helpers.Units.UnitKey;
 import ti4.json.JsonMapperManager;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
+import ti4.website.model.CompactMovementState;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 
@@ -26,10 +29,12 @@ public class GameEventDraft {
 
     public static void open(Game game) {
         game.setPendingSubEventsJson("[]");
+        game.setPendingMovementState("");
     }
 
     public static void clear(Game game) {
         game.setPendingSubEventsJson("");
+        game.setPendingMovementState("");
     }
 
     public static boolean isOpen(Game game) {
@@ -64,8 +69,37 @@ public class GameEventDraft {
             BotLogger.error(new LogOrigin(game), "Failed to drain tactical sub-event draft.", e);
             subEvents = new ArrayList<>();
         }
-        clear(game);
+        game.setPendingSubEventsJson("");
         return subEvents;
+    }
+
+    /** Captures committed displacement while the enclosing tactical-event draft remains undo-safe. */
+    public static boolean stageMovement(
+            Game game, String targetPosition, Map<String, Map<UnitKey, List<Integer>>> displacement) {
+        if (!isOpen(game) || !hasMovedUnits(displacement)) return false;
+        try {
+            game.setPendingMovementState(CompactMovementState.serialize(targetPosition, displacement));
+            return true;
+        } catch (Exception e) {
+            BotLogger.error(new LogOrigin(game), "Failed to stage tactical movement state.", e);
+            return false;
+        }
+    }
+
+    /** Returns the committed movement payload, if any, and clears only that portion of the draft. */
+    public static String drainMovement(Game game) {
+        String movementState = StringUtils.trimToNull(game.getPendingMovementState());
+        game.setPendingMovementState("");
+        return movementState;
+    }
+
+    private static boolean hasMovedUnits(Map<String, Map<UnitKey, List<Integer>>> displacement) {
+        return displacement != null
+                && displacement.values().stream()
+                        .flatMap(units -> units.values().stream())
+                        .filter(states -> states != null)
+                        .flatMap(List::stream)
+                        .anyMatch(count -> count != null && count > 0);
     }
 
     /** Compact JSON (one line, {@code type} discriminators intact) for a list of sub-events. */

--- a/src/main/java/ti4/spring/service/gameevent/GameEventDto.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventDto.java
@@ -11,4 +11,5 @@ public record GameEventDto(
         String faction,
         long timestamp,
         JsonNode payload,
-        @JsonInclude(JsonInclude.Include.NON_NULL) String mapState) {}
+        @JsonInclude(JsonInclude.Include.NON_NULL) String mapState,
+        @JsonInclude(JsonInclude.Include.NON_NULL) String movementState) {}

--- a/src/main/java/ti4/spring/service/gameevent/GameEventEntity.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventEntity.java
@@ -35,4 +35,7 @@ class GameEventEntity {
 
     @Column(columnDefinition = "TEXT")
     private String mapState;
+
+    @Column(columnDefinition = "TEXT")
+    private String movementState;
 }

--- a/src/main/java/ti4/spring/service/gameevent/GameEventService.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventService.java
@@ -22,16 +22,30 @@ public class GameEventService {
     private final GameEventRepository gameEventRepository;
 
     public static void commit(Game game, String archetype, @Nullable Player player, Map<String, Object> payload) {
+        commit(game, archetype, player, payload, null);
+    }
+
+    public static void commit(
+            Game game,
+            String archetype,
+            @Nullable Player player,
+            Map<String, Object> payload,
+            @Nullable String movementState) {
         try {
             if (DatabasePersistenceGate.isDisabled()) return;
-            SpringContext.getBean(GameEventService.class).commitEvent(game, archetype, player, payload);
+            SpringContext.getBean(GameEventService.class).commitEvent(game, archetype, player, payload, movementState);
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Failed to commit game event.", e);
         }
     }
 
     @Transactional
-    void commitEvent(Game game, String archetype, @Nullable Player player, Map<String, Object> payload) {
+    void commitEvent(
+            Game game,
+            String archetype,
+            @Nullable Player player,
+            Map<String, Object> payload,
+            @Nullable String movementState) {
         long counter = game.getEventSequenceCounter();
         // Undo restores an older counter; rows above it are future events and must not survive the next append.
         gameEventRepository.deleteByGameNameAndSeqGreaterThan(game.getName(), counter);
@@ -56,7 +70,8 @@ public class GameEventService {
                 faction,
                 System.currentTimeMillis(),
                 serializedPayload,
-                serializedMapState);
+                serializedMapState,
+                movementState);
         gameEventRepository.save(record);
         game.setEventSequenceCounter(seq);
     }
@@ -72,7 +87,8 @@ public class GameEventService {
                         event.getFaction(),
                         event.getTimestampEpochMillis(),
                         JsonMapperManager.basic().readTree(event.getPayload()),
-                        event.getMapState()))
+                        event.getMapState(),
+                        event.getMovementState()))
                 .toList();
     }
 

--- a/src/main/java/ti4/spring/service/gameevent/GameSubEvent.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameSubEvent.java
@@ -2,6 +2,7 @@ package ti4.spring.service.gameevent;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -19,6 +20,7 @@ import java.util.Map;
     @JsonSubTypes.Type(value = GameSubEvent.TechExhausted.class, name = "TECH_EXHAUSTED"),
     @JsonSubTypes.Type(value = GameSubEvent.ObjectiveScored.class, name = "OBJECTIVE_SCORED"),
     @JsonSubTypes.Type(value = GameSubEvent.Production.class, name = "PRODUCTION"),
+    @JsonSubTypes.Type(value = GameSubEvent.Retreat.class, name = "RETREAT"),
     @JsonSubTypes.Type(value = GameSubEvent.ManualCommand.class, name = "MANUAL_COMMAND")
 })
 public sealed interface GameSubEvent {
@@ -35,6 +37,15 @@ public sealed interface GameSubEvent {
     record ObjectiveScored(String faction, String objectiveId, String category) implements GameSubEvent {}
 
     record Production(String tile, Map<String, Integer> units, Integer cost) implements GameSubEvent {}
+
+    record Retreat(
+            String faction,
+            String fromTile,
+            String fromHolder,
+            String toTile,
+            String toHolder,
+            Map<String, List<Integer>> units)
+            implements GameSubEvent {}
 
     record ManualCommand(String user, String command) implements GameSubEvent {}
 }

--- a/src/main/java/ti4/spring/service/gameevent/GameSubEventType.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameSubEventType.java
@@ -8,5 +8,6 @@ public enum GameSubEventType {
     TECH_EXHAUSTED,
     OBJECTIVE_SCORED,
     PRODUCTION,
+    RETREAT,
     MANUAL_COMMAND
 }

--- a/src/main/java/ti4/website/model/CompactMovementState.java
+++ b/src/main/java/ti4/website/model/CompactMovementState.java
@@ -1,0 +1,66 @@
+package ti4.website.model;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitState;
+import ti4.json.JsonMapperManager;
+
+/** Deterministic positional JSON describing the units committed by a tactical-action displacement. */
+@UtilityClass
+public class CompactMovementState {
+
+    private static final int FORMAT_VERSION = 1;
+
+    /**
+     * Format: {@code [version,targetPosition,targetHolder,[[sourcePosition,sourceHolder,units],...]]}, where each unit
+     * is {@code [colorId,asyncUnitId,healthy,damaged,galvanized,damagedGalvanized]}.
+     */
+    public static String serialize(String targetPosition, Map<String, Map<UnitKey, List<Integer>>> displacement) {
+        List<Object> state = new ArrayList<>(4);
+        state.add(FORMAT_VERSION);
+        state.add(targetPosition);
+        state.add("space");
+        state.add(displacement.entrySet().stream()
+                .map(CompactMovementState::serializeSource)
+                .filter(source -> !((List<?>) source.get(2)).isEmpty())
+                .sorted(Comparator.comparing(source -> JsonMapperManager.basic().writeValueAsString(source)))
+                .map(source -> (Object) source)
+                .toList());
+        return JsonMapperManager.basic().writeValueAsString(state);
+    }
+
+    private static List<Object> serializeSource(Map.Entry<String, Map<UnitKey, List<Integer>>> entry) {
+        String key = entry.getKey();
+        int separator = key == null ? -1 : key.indexOf('-');
+        String position = separator < 0 ? key : key.substring(0, separator);
+        String holder = separator < 0 ? "" : key.substring(separator + 1);
+
+        List<Object> units = entry.getValue().entrySet().stream()
+                .map(CompactMovementState::serializeUnit)
+                .filter(unit -> unit.subList(2, unit.size()).stream()
+                                .mapToInt(value -> (Integer) value)
+                                .sum()
+                        > 0)
+                .sorted(Comparator.<List<Object>, String>comparing(unit -> (String) unit.get(0))
+                        .thenComparing(unit -> (String) unit.get(1)))
+                .map(unit -> (Object) unit)
+                .toList();
+        return List.of(position, holder, units);
+    }
+
+    private static List<Object> serializeUnit(Map.Entry<UnitKey, List<Integer>> entry) {
+        List<Object> unit = new ArrayList<>(6);
+        unit.add(entry.getKey().colorID());
+        unit.add(entry.getKey().asyncID());
+        List<Integer> states = entry.getValue();
+        for (int i = 0; i < UnitState.values().length; i++) {
+            Integer count = states != null && i < states.size() ? states.get(i) : null;
+            unit.add(count == null ? 0 : count);
+        }
+        return unit;
+    }
+}

--- a/src/main/java/ti4/website/model/CompactMovementState.java
+++ b/src/main/java/ti4/website/model/CompactMovementState.java
@@ -5,6 +5,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
+import ti4.game.Game;
+import ti4.game.Player;
 import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitState;
 import ti4.json.JsonMapperManager;
@@ -13,19 +15,22 @@ import ti4.json.JsonMapperManager;
 @UtilityClass
 public class CompactMovementState {
 
-    private static final int FORMAT_VERSION = 1;
+    private static final int FORMAT_VERSION = 2;
 
     /**
      * Format: {@code [version,targetPosition,targetHolder,[[sourcePosition,sourceHolder,units],...]]}, where each unit
-     * is {@code [colorId,asyncUnitId,healthy,damaged,galvanized,damagedGalvanized]}.
+     * is {@code [colorId,asyncUnitId,healthy,damaged,galvanized,damagedGalvanized,neutral?]}. The final {@code 1} is
+     * emitted only for neutral units because their dynamically assigned plastic color is intentionally absent from the
+     * website's normal player-color map.
      */
-    public static String serialize(String targetPosition, Map<String, Map<UnitKey, List<Integer>>> displacement) {
+    public static String serialize(
+            Game game, String targetPosition, Map<String, Map<UnitKey, List<Integer>>> displacement) {
         List<Object> state = new ArrayList<>(4);
         state.add(FORMAT_VERSION);
         state.add(targetPosition);
         state.add("space");
         state.add(displacement.entrySet().stream()
-                .map(CompactMovementState::serializeSource)
+                .map(entry -> serializeSource(game, entry))
                 .filter(source -> !((List<?>) source.get(2)).isEmpty())
                 .sorted(Comparator.comparing(source -> JsonMapperManager.basic().writeValueAsString(source)))
                 .map(source -> (Object) source)
@@ -33,15 +38,15 @@ public class CompactMovementState {
         return JsonMapperManager.basic().writeValueAsString(state);
     }
 
-    private static List<Object> serializeSource(Map.Entry<String, Map<UnitKey, List<Integer>>> entry) {
+    private static List<Object> serializeSource(Game game, Map.Entry<String, Map<UnitKey, List<Integer>>> entry) {
         String key = entry.getKey();
         int separator = key == null ? -1 : key.indexOf('-');
         String position = separator < 0 ? key : key.substring(0, separator);
         String holder = separator < 0 ? "" : key.substring(separator + 1);
 
         List<Object> units = entry.getValue().entrySet().stream()
-                .map(CompactMovementState::serializeUnit)
-                .filter(unit -> unit.subList(2, unit.size()).stream()
+                .map(unit -> serializeUnit(game, unit))
+                .filter(unit -> unit.subList(2, 6).stream()
                                 .mapToInt(value -> (Integer) value)
                                 .sum()
                         > 0)
@@ -52,8 +57,8 @@ public class CompactMovementState {
         return List.of(position, holder, units);
     }
 
-    private static List<Object> serializeUnit(Map.Entry<UnitKey, List<Integer>> entry) {
-        List<Object> unit = new ArrayList<>(6);
+    private static List<Object> serializeUnit(Game game, Map.Entry<UnitKey, List<Integer>> entry) {
+        List<Object> unit = new ArrayList<>(7);
         unit.add(entry.getKey().colorID());
         unit.add(entry.getKey().asyncID());
         List<Integer> states = entry.getValue();
@@ -61,6 +66,8 @@ public class CompactMovementState {
             Integer count = states != null && i < states.size() ? states.get(i) : null;
             unit.add(count == null ? 0 : count);
         }
+        Player owner = game.getPlayerFromColorOrFaction(entry.getKey().colorID());
+        if (owner != null && "neutral".equals(owner.getFaction())) unit.add(1);
         return unit;
     }
 }


### PR DESCRIPTION
## Summary
- add compact, versioned positional JSON `movementState` to persisted game events and the web event DTO
- capture exact tactical displacement origins, destination, unit async IDs, colors, and all four unit-state counts at commit time
- preserve authoritative neutral-unit ownership with a compact neutral marker, since neutral plastic colors are intentionally absent from the normal player-color map
- add typed `RETREAT` tactical sub-events with faction, source/destination tile and holder, and exact four-state unit counts
- capture standard space retreats, retreating ground forces, and selective Watchful Ojz retreats from the actual before/after unit delta
- persist pending movement and retreat data through the existing save-backed tactical event draft
- capture normal movement and FoW+ Void movement before the displacement buffer is cleared

## Why
Final map snapshots cannot reliably infer movement or distinguish combat casualties from retreats. These independent payloads give the frontend authoritative movement and retreat trajectories while the final `mapState` describes the post-event board. Neutral ownership is explicit so a neutral unit can never be animated as the active player.

## Undo behavior
Movement and retreat information lives in ordinary game-save state until the tactical event commits. Undo before commit restores or clears the pending draft with the save. Undo after commit continues to use the existing event sequence counter and future-row pruning.

## Validation
- `mvn -DskipTests compile`
- Spotless formatting/check
- no backend tests added or run, per request