### PR TITLE
Simplify action card play-to-win correlation output

### DIFF
--- a/src/main/java/ti4/service/statistics/ActionCardStatsService.java
+++ b/src/main/java/ti4/service/statistics/ActionCardStatsService.java
@@ -327,52 +327,49 @@ public class ActionCardStatsService {
             return;
         }
 
-        playToWinCorrelationCounts.entrySet().stream()
-                .sorted(Comparator.<Map.Entry<String, PlayToWinCorrelationCount>>comparingInt(entry ->
-                                getImpactScore(entry.getValue().getWins(), expectedDrawsPerCard.get(entry.getKey()))
-                                                != null
-                                        ? 0
-                                        : 1)
-                        .thenComparing(
-                                entry -> {
-                                    Double impactScore = getImpactScore(
-                                            entry.getValue().getWins(), expectedDrawsPerCard.get(entry.getKey()));
-                                    return impactScore != null
-                                            ? impactScore
-                                            : entry.getValue().getWins();
-                                },
-                                Comparator.reverseOrder())
-                        .thenComparing(entry -> entry.getValue().getTotal(), Comparator.reverseOrder())
-                        .thenComparing(Map.Entry::getKey))
-                .forEach(entry -> {
-                    PlayToWinCorrelationCount count = entry.getValue();
-                    message.append("- ")
-                            .append(entry.getKey())
-                            .append(": ")
-                            .append(count.getWins())
-                            .append(" wins, ")
-                            .append(count.getTotal())
-                            .append(" plays (")
-                            .append(String.format("%.1f%%", count.getWinRate() * 100))
-                            .append(")");
-                    Integer expectedDraws = expectedDrawsPerCard.get(entry.getKey());
-                    Double impactScore = getImpactScore(count.getWins(), expectedDraws);
-                    if (impactScore != null) {
-                        message.append(", ")
-                                .append(String.format("%.1f", impactScore))
-                                .append(" Impact Score (wins vs ~draws)");
-                    }
-                    if (expectedDraws != null) {
-                        Double uncancelledImpactScore =
-                                getImpactScore(count.getWins(), expectedDraws - count.getCanceledPlays());
-                        if (uncancelledImpactScore != null) {
-                            message.append(", ")
-                                    .append(String.format("%.1f", uncancelledImpactScore))
-                                    .append(" Uncancelled Impact Score");
-                        }
-                    }
-                    message.append('\n');
-                });
+        List<Map.Entry<String, PlayToWinCorrelationCount>> sortedEntries =
+                playToWinCorrelationCounts.entrySet().stream()
+                        .sorted(Comparator.<Map.Entry<String, PlayToWinCorrelationCount>>comparingInt(
+                                        entry -> getImpactScore(
+                                                                entry.getValue().getWins(),
+                                                                expectedDrawsPerCard.get(entry.getKey()))
+                                                        != null
+                                                ? 0
+                                                : 1)
+                                .thenComparing(
+                                        entry -> {
+                                            Double impactScore = getImpactScore(
+                                                    entry.getValue().getWins(),
+                                                    expectedDrawsPerCard.get(entry.getKey()));
+                                            return impactScore != null
+                                                    ? impactScore
+                                                    : entry.getValue().getWins();
+                                        },
+                                        Comparator.reverseOrder())
+                                .thenComparing(entry -> entry.getValue().getTotal(), Comparator.reverseOrder())
+                                .thenComparing(Map.Entry::getKey))
+                        .toList();
+        for (int i = 0; i < sortedEntries.size(); i++) {
+            Map.Entry<String, PlayToWinCorrelationCount> entry = sortedEntries.get(i);
+            boolean firstEntry = i == 0;
+            PlayToWinCorrelationCount count = entry.getValue();
+            message.append("- ")
+                    .append(entry.getKey())
+                    .append(": ")
+                    .append(count.getWins())
+                    .append(" wins, ")
+                    .append(count.getTotal())
+                    .append(" plays (")
+                    .append(String.format("%.1f%%", count.getWinRate() * 100))
+                    .append(firstEntry ? " win rate)" : ")");
+            Double impactScore = getImpactScore(count.getWins(), expectedDrawsPerCard.get(entry.getKey()));
+            if (impactScore != null) {
+                message.append(", ")
+                        .append(String.format("%.1f", impactScore))
+                        .append(firstEntry ? " Impact Score (wins vs ~draws)" : " Impact Score");
+            }
+            message.append('\n');
+        }
     }
 
     private static Double getImpactScore(int wins, Integer expectedDraws) {
@@ -399,10 +396,6 @@ public class ActionCardStatsService {
 
         double getWinRate() {
             return total == 0 ? 0 : (double) wins / total;
-        }
-
-        int getCanceledPlays() {
-            return playsIncludingCanceled - total;
         }
     }
 }


### PR DESCRIPTION
## What changed

- Removed the Uncancelled Impact Score from the action card play-to-win correlation stats output.
- Only the first entry in the list spells out the full labels; subsequent lines use a compact form:
  - First: `- Overrule: 132 wins, 388 plays (34.0% win rate), 29.8 Impact Score (wins vs ~draws)`
  - Rest: `- Rise of a Messiah: 97 wins, 440 plays (22.0%), 21.9 Impact Score`

## Why

The Uncancelled Impact Score added noise without much value, and repeating the full labels on every line made the list harder to scan.

## Notes for reviewers

The stream forEach was converted to an indexed loop so the first entry can be formatted differently. The `playsIncludingCanceled` counter is still used for the expected-draws calculation; only the now-unused `getCanceledPlays()` helper was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)