### PR TITLE
Make SQLite writes safe for pooled connections

### DIFF
--- a/src/main/java/ti4/spring/service/gameevent/GameEventRepository.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventRepository.java
@@ -2,7 +2,10 @@ package ti4.spring.service.gameevent;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 interface GameEventRepository extends CrudRepository<GameEventEntity, Long> {
     List<GameEventEntity> findByGameNameAndSeqLessThanEqualOrderBySeqAsc(String gameName, long seq);
@@ -10,5 +13,7 @@ interface GameEventRepository extends CrudRepository<GameEventEntity, Long> {
     Optional<GameEventEntity> findFirstByGameNameAndSeqLessThanEqualAndMapStateIsNotNullOrderBySeqDesc(
             String gameName, long seq);
 
-    long deleteByGameNameAndSeqGreaterThan(String gameName, long seq);
+    @Modifying
+    @Query("delete from GameEventEntity event where event.gameName = :gameName and event.seq > :seq")
+    int deleteFutureEvents(@Param("gameName") String gameName, @Param("seq") long seq);
 }

--- a/src/main/java/ti4/spring/service/gameevent/GameEventService.java
+++ b/src/main/java/ti4/spring/service/gameevent/GameEventService.java
@@ -33,47 +33,47 @@ public class GameEventService {
             @Nullable String movementState) {
         try {
             if (DatabasePersistenceGate.isDisabled()) return;
-            SpringContext.getBean(GameEventService.class).commitEvent(game, archetype, player, payload, movementState);
+            String serializedPayload = JsonMapperManager.basic().writeValueAsString(payload);
+            String serializedMapState = CompactMapState.serialize(game);
+            GameEventService service = SpringContext.getBean(GameEventService.class);
+            long counter = game.getEventSequenceCounter();
+            String previousMapState = service.getPreviousMapState(game.getName(), counter);
+            if (serializedMapState.equals(previousMapState)) {
+                serializedMapState = null;
+            }
+            long seq = counter + 1;
+            var record = new GameEventEntity(
+                    null,
+                    game.getName(),
+                    seq,
+                    archetype,
+                    game.getRound(),
+                    game.getPhaseOfGame(),
+                    player == null ? null : player.getFaction(),
+                    System.currentTimeMillis(),
+                    serializedPayload,
+                    serializedMapState,
+                    movementState);
+            service.commitEvent(game.getName(), counter, record);
+            game.setEventSequenceCounter(seq);
         } catch (Exception e) {
             BotLogger.error(new LogOrigin(game), "Failed to commit game event.", e);
         }
     }
 
     @Transactional
-    void commitEvent(
-            Game game,
-            String archetype,
-            @Nullable Player player,
-            Map<String, Object> payload,
-            @Nullable String movementState) {
-        long counter = game.getEventSequenceCounter();
+    void commitEvent(String gameName, long counter, GameEventEntity record) {
         // Undo restores an older counter; rows above it are future events and must not survive the next append.
-        gameEventRepository.deleteByGameNameAndSeqGreaterThan(game.getName(), counter);
-        long seq = counter + 1;
-        String faction = player == null ? null : player.getFaction();
-        String serializedPayload = JsonMapperManager.basic().writeValueAsString(payload);
-        String serializedMapState = CompactMapState.serialize(game);
-        String previousMapState = gameEventRepository
-                .findFirstByGameNameAndSeqLessThanEqualAndMapStateIsNotNullOrderBySeqDesc(game.getName(), counter)
+        // This direct DELETE must remain the first SQL statement so SQLite reserves the writer before any later work.
+        gameEventRepository.deleteFutureEvents(gameName, counter);
+        gameEventRepository.save(record);
+    }
+
+    String getPreviousMapState(String gameName, long counter) {
+        return gameEventRepository
+                .findFirstByGameNameAndSeqLessThanEqualAndMapStateIsNotNullOrderBySeqDesc(gameName, counter)
                 .map(GameEventEntity::getMapState)
                 .orElse(null);
-        if (serializedMapState.equals(previousMapState)) {
-            serializedMapState = null;
-        }
-        var record = new GameEventEntity(
-                null,
-                game.getName(),
-                seq,
-                archetype,
-                game.getRound(),
-                game.getPhaseOfGame(),
-                faction,
-                System.currentTimeMillis(),
-                serializedPayload,
-                serializedMapState,
-                movementState);
-        gameEventRepository.save(record);
-        game.setEventSequenceCounter(seq);
     }
 
     public List<GameEventDto> getEvents(Game game) {

--- a/src/main/java/ti4/spring/service/messagecache/BotDiscordMessageEntityRepository.java
+++ b/src/main/java/ti4/spring/service/messagecache/BotDiscordMessageEntityRepository.java
@@ -1,7 +1,33 @@
 package ti4.spring.service.messagecache;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 interface BotDiscordMessageEntityRepository extends CrudRepository<BotDiscordMessageEntity, Long> {
-    long deleteByCreatedAtEpochMillisLessThan(long cutoffEpochMillis);
+
+    @Transactional
+    @Modifying
+    @Query(value = """
+                    insert into bot_discord_message (message_id, content, created_at_epoch_millis)
+                    values (:messageId, :content, :createdAt)
+                    on conflict (message_id) do update set
+                        content = excluded.content,
+                        created_at_epoch_millis = excluded.created_at_epoch_millis
+                    """, nativeQuery = true)
+    void upsert(
+            @Param("messageId") long messageId,
+            @Param("content") String content,
+            @Param("createdAt") long createdAtEpochMillis);
+
+    @Modifying
+    @Query("delete from BotDiscordMessageEntity message where message.createdAtEpochMillis < :cutoff")
+    int deleteExpired(@Param("cutoff") long cutoffEpochMillis);
+
+    @Transactional
+    @Modifying
+    @Query("delete from BotDiscordMessageEntity message where message.messageId = :messageId")
+    void deleteMessage(@Param("messageId") long messageId);
 }

--- a/src/main/java/ti4/spring/service/messagecache/SavedBotMessagesService.java
+++ b/src/main/java/ti4/spring/service/messagecache/SavedBotMessagesService.java
@@ -24,8 +24,7 @@ public class SavedBotMessagesService {
         if (!isImportantMessage(message)) return;
 
         long createdAtEpochMillis = message.getTimeCreated().toInstant().toEpochMilli();
-        var record = new BotDiscordMessageEntity(message.getIdLong(), message.getContentRaw(), createdAtEpochMillis);
-        botDiscordMessageEntityRepository.save(record);
+        botDiscordMessageEntityRepository.upsert(message.getIdLong(), message.getContentRaw(), createdAtEpochMillis);
     }
 
     public static boolean isImportantMessage(Message message) {
@@ -57,13 +56,13 @@ public class SavedBotMessagesService {
             return;
         }
         long cutoff = System.currentTimeMillis() - RETENTION_MILLIS;
-        long deletedRowCount = botDiscordMessageEntityRepository.deleteByCreatedAtEpochMillisLessThan(cutoff);
+        long deletedRowCount = botDiscordMessageEntityRepository.deleteExpired(cutoff);
         BotLogger.info("Deleted " + deletedRowCount + " rows from the `bot_discord_message` table.");
     }
 
     public void remove(long messageId) {
         if (DatabasePersistenceGate.isDisabled()) return;
-        botDiscordMessageEntityRepository.deleteById(messageId);
+        botDiscordMessageEntityRepository.deleteMessage(messageId);
     }
 
     public static SavedBotMessagesService getBean() {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakerService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakerService.java
@@ -39,7 +39,6 @@ public class MatchmakerService {
         return queueStore.partyMemberIds(userId);
     }
 
-    @Transactional
     public Optional<String> formGroup(String creatorId, List<String> memberIds) {
         if (DatabasePersistenceGate.isDisabled()) return Optional.of("Queueing is currently disabled.");
 
@@ -62,7 +61,6 @@ public class MatchmakerService {
         return Optional.empty();
     }
 
-    @Transactional
     public Optional<String> queue(String queuerId, boolean tigl) {
         if (DatabasePersistenceGate.isDisabled()) return Optional.of("Queueing is currently disabled.");
 
@@ -90,7 +88,6 @@ public class MatchmakerService {
         return Optional.empty();
     }
 
-    @Transactional
     public boolean leaveQueue(String userId) {
         if (DatabasePersistenceGate.isDisabled()) return false;
 
@@ -102,13 +99,11 @@ public class MatchmakerService {
         return true;
     }
 
-    @Transactional
     public long clearQueue() {
         if (DatabasePersistenceGate.isDisabled()) return 0;
         return queueStore.clearAll();
     }
 
-    @Transactional
     public List<String> removePlayer(String userId) {
         if (DatabasePersistenceGate.isDisabled()) return List.of();
 

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueMemberRepository.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueMemberRepository.java
@@ -4,7 +4,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface MatchmakingQueueMemberRepository extends JpaRepository<MatchmakingQueueMember, Long> {
 
@@ -16,9 +18,15 @@ interface MatchmakingQueueMemberRepository extends JpaRepository<MatchmakingQueu
 
     List<MatchmakingQueueMember> findAllByPartyIdIn(Collection<Long> partyIds);
 
-    @Transactional
-    long deleteByPartyId(long partyId);
+    @Modifying
+    @Query("delete from MatchmakingQueueMember member where member.id = :memberId")
+    int deleteMember(@Param("memberId") long memberId);
 
-    @Transactional
-    void deleteAllByPartyIdIn(Collection<Long> partyIds);
+    @Modifying
+    @Query("delete from MatchmakingQueueMember member where member.partyId in :partyIds")
+    int deleteAllForParties(@Param("partyIds") Collection<Long> partyIds);
+
+    @Modifying
+    @Query("delete from MatchmakingQueueMember")
+    int deleteAllMembers();
 }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueuePartyRepository.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueuePartyRepository.java
@@ -1,9 +1,37 @@
 package ti4.spring.service.statistics.matchmaking.queue;
 
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface MatchmakingQueuePartyRepository extends JpaRepository<MatchmakingQueueParty, Long> {
 
     List<MatchmakingQueueParty> findAllByQueuedTrueOrderByQueuedAtAsc();
+
+    @Modifying
+    @Query("""
+            update MatchmakingQueueParty party
+            set party.leaderId = :leaderId,
+                party.queued = true,
+                party.tigl = :tigl,
+                party.queuedAt = :queuedAt
+            where party.id = :partyId
+            """)
+    int markQueued(
+            @Param("partyId") long partyId,
+            @Param("leaderId") String leaderId,
+            @Param("tigl") boolean tigl,
+            @Param("queuedAt") Instant queuedAt);
+
+    @Modifying
+    @Query("delete from MatchmakingQueueParty party where party.id in :partyIds")
+    int deleteAllByIds(@Param("partyIds") Collection<Long> partyIds);
+
+    @Modifying
+    @Query("delete from MatchmakingQueueParty")
+    int deleteAllParties();
 }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchRepository.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchRepository.java
@@ -1,13 +1,49 @@
 package ti4.spring.service.statistics.matchmaking.queue;
 
-import java.util.Optional;
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 interface MatchmakingQueueSearchRepository extends JpaRepository<MatchmakingQueueSearch, Long> {
 
-    Optional<MatchmakingQueueSearch> findByThreadId(String threadId);
+    @Transactional
+    @Modifying
+    @Query(value = """
+                    insert into matchmaking_queue_search (
+                        thread_id, message_id, player_counts, victory_point_goals, expansions,
+                        paces, restrictions, tigl, tigl_ranks, created_at
+                    ) values (
+                        :threadId, :messageId, :playerCounts, :victoryPointGoals, :expansions,
+                        :paces, :restrictions, :tigl, :tiglRanks, :createdAt
+                    )
+                    on conflict (thread_id) do update set
+                        message_id = excluded.message_id,
+                        player_counts = excluded.player_counts,
+                        victory_point_goals = excluded.victory_point_goals,
+                        expansions = excluded.expansions,
+                        paces = excluded.paces,
+                        restrictions = excluded.restrictions,
+                        tigl = excluded.tigl,
+                        tigl_ranks = excluded.tigl_ranks,
+                        created_at = excluded.created_at
+                    """, nativeQuery = true)
+    void upsert(
+            @Param("threadId") String threadId,
+            @Param("messageId") String messageId,
+            @Param("playerCounts") String playerCounts,
+            @Param("victoryPointGoals") String victoryPointGoals,
+            @Param("expansions") String expansions,
+            @Param("paces") String paces,
+            @Param("restrictions") String restrictions,
+            @Param("tigl") boolean tigl,
+            @Param("tiglRanks") String tiglRanks,
+            @Param("createdAt") Instant createdAt);
 
     @Transactional
-    void deleteByThreadId(String threadId);
+    @Modifying
+    @Query("delete from MatchmakingQueueSearch search where search.threadId = :threadId")
+    void deleteByThreadId(@Param("threadId") String threadId);
 }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchService.java
@@ -9,7 +9,6 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.buttons.handlers.game.CreateGameButtonHandler;
 import ti4.service.persistence.DatabasePersistenceGate;
@@ -25,24 +24,21 @@ public class MatchmakingQueueSearchService {
         return SpringContext.getBean(MatchmakingQueueSearchService.class);
     }
 
-    @Transactional
     public void register(String threadId, String messageId, PlayerSearchCriteria criteria) {
         if (DatabasePersistenceGate.isDisabled()) return;
-        MatchmakingQueueSearch search = repository.findByThreadId(threadId).orElseGet(MatchmakingQueueSearch::new);
-        search.setThreadId(threadId);
-        search.setMessageId(messageId);
-        search.setPlayerCounts(join(criteria.playerCounts()));
-        search.setVictoryPointGoals(join(criteria.victoryPointGoals()));
-        search.setExpansions(join(criteria.expansions()));
-        search.setPaces(join(criteria.paces()));
-        search.setRestrictions(join(criteria.restrictions()));
-        search.setTigl(criteria.tigl());
-        search.setTiglRanks(join(criteria.tiglRanks()));
-        search.setCreatedAt(Instant.now());
-        repository.save(search);
+        repository.upsert(
+                threadId,
+                messageId,
+                join(criteria.playerCounts()),
+                join(criteria.victoryPointGoals()),
+                join(criteria.expansions()),
+                join(criteria.paces()),
+                join(criteria.restrictions()),
+                criteria.tigl(),
+                join(criteria.tiglRanks()),
+                Instant.now());
     }
 
-    @Transactional
     public void remove(String threadId) {
         if (DatabasePersistenceGate.isDisabled()) return;
         repository.deleteByThreadId(threadId);

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueStore.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueStore.java
@@ -31,8 +31,9 @@ public class MatchmakingQueueStore {
         return partyRepository.findById(partyId);
     }
 
+    @Transactional
     void deleteMember(MatchmakingQueueMember member) {
-        memberRepository.delete(member);
+        memberRepository.deleteMember(member.getId());
     }
 
     boolean isUserQueued(String userId) {
@@ -53,6 +54,7 @@ public class MatchmakingQueueStore {
                 .orElse(List.of(userId));
     }
 
+    @Transactional
     void createUnqueuedGroup(List<String> userIds) {
         MatchmakingQueueParty party = new MatchmakingQueueParty();
         party.setQueued(false);
@@ -60,14 +62,12 @@ public class MatchmakingQueueStore {
         saveMembers(userIds, partyId);
     }
 
+    @Transactional
     void markQueued(MatchmakingQueueParty party, String leaderId, boolean tigl) {
-        party.setLeaderId(leaderId);
-        party.setQueued(true);
-        party.setTigl(tigl);
-        party.setQueuedAt(Instant.now());
-        partyRepository.save(party);
+        partyRepository.markQueued(party.getId(), leaderId, tigl, Instant.now());
     }
 
+    @Transactional
     void createSoloQueuedParty(String leaderId, boolean tigl) {
         MatchmakingQueueParty party = new MatchmakingQueueParty();
         party.setQueued(true);
@@ -93,15 +93,14 @@ public class MatchmakingQueueStore {
     @Transactional
     void deleteParties(Collection<Long> partyIds) {
         if (partyIds.isEmpty()) return;
-        memberRepository.deleteAllByPartyIdIn(partyIds);
-        partyRepository.deleteAllById(partyIds);
+        memberRepository.deleteAllForParties(partyIds);
+        partyRepository.deleteAllByIds(partyIds);
     }
 
+    @Transactional
     long clearAll() {
-        long clearedParties = partyRepository.count();
-        memberRepository.deleteAll();
-        partyRepository.deleteAll();
-        return clearedParties;
+        memberRepository.deleteAllMembers();
+        return partyRepository.deleteAllParties();
     }
 
     List<QueuedParty> loadQueuedParties() {

--- a/src/main/java/ti4/spring/service/tournamentwinner/TournamentWinnerRepository.java
+++ b/src/main/java/ti4/spring/service/tournamentwinner/TournamentWinnerRepository.java
@@ -1,6 +1,9 @@
 package ti4.spring.service.tournamentwinner;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 interface TournamentWinnerRepository extends JpaRepository<TournamentWinner, Long> {
@@ -8,5 +11,7 @@ interface TournamentWinnerRepository extends JpaRepository<TournamentWinner, Lon
     boolean existsByUserId(String userId);
 
     @Transactional
-    void deleteByUserIdAndTourneyName(String userId, String tourneyName);
+    @Modifying
+    @Query("delete from TournamentWinner winner where winner.userId = :userId and winner.tourneyName = :tourneyName")
+    void deleteWinner(@Param("userId") String userId, @Param("tourneyName") String tourneyName);
 }

--- a/src/main/java/ti4/spring/service/tournamentwinner/TourneyWinnerService.java
+++ b/src/main/java/ti4/spring/service/tournamentwinner/TourneyWinnerService.java
@@ -25,7 +25,7 @@ public class TourneyWinnerService {
 
     public void remove(String userId, String tourneyName) {
         if (DatabasePersistenceGate.isDisabled()) return;
-        tournamentWinnerRepository.deleteByUserIdAndTourneyName(userId, tourneyName);
+        tournamentWinnerRepository.deleteWinner(userId, tourneyName);
     }
 
     public String allWinnersToString() {

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -12,12 +12,15 @@ spring:
     url: "jdbc:sqlite:${DB_PATH:./}/tibot.db"
     driver-class-name: org.sqlite.JDBC
     hikari:
-      # SQLite permits only one writer at a time; extra pooled connections increase lock contention.
-      maximum-pool-size: 1
-      connection-init-sql: |
-        PRAGMA journal_mode=WAL;
-        PRAGMA busy_timeout=30000;
-        PRAGMA synchronous=NORMAL;
+      # WAL permits concurrent readers while SQLite continues to serialize writers.
+      maximum-pool-size: 4
+      connection-timeout: 30000
+      # Xerial applies these properties to every connection. A multi-statement
+      # connection-init-sql only executes its first PRAGMA.
+      data-source-properties:
+        journal_mode: "WAL"
+        busy_timeout: "30000"
+        synchronous: "NORMAL"
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## What changed

- configure WAL, busy timeout, and synchronous mode as Xerial data-source properties so every pooled connection receives them
- expand Hikari from one connection to four after restructuring unsafe write paths
- serialize and compare game-event state before opening the write transaction
- make the game-event transaction begin with a direct bulk delete, then insert the prepared event
- replace entity-loading derived deletes with direct modifying queries
- move matchmaking reads and validation outside short persistence transactions, using direct updates/deletes and upserts where appropriate
- keep the existing read-only service transactions unchanged; that later cleanup is intentionally not included

## Why

SQLite deferred transactions can establish a read snapshot and then fail with `SQLITE_BUSY_SNAPSHOT` if the lease heartbeat commits before that transaction upgrades to a writer. Spring Data derived deletes made this possible because they selected matching entities before deleting them. The previous multi-connection change therefore exposed a real read-to-write upgrade race.

The updated write paths perform expensive preparation before their transaction and make direct DML the first SQL inside each explicit write transaction. That obtains SQLite's single writer position immediately, so competing writers wait under `busy_timeout` instead of invalidating a stale snapshot. WAL still permits readers on the other pooled connections.

## Validation

- `mvn -q spotless:apply -DskipTests compile` with Java 26
- `mvn test` with Java 26: 525 tests passed, 0 failures, 18 skipped

No new tests are included.