### PR TITLE
Fix PostgreSQL slash command date parameters

### DIFF
--- a/src/main/java/ti4/spring/service/usage/InteractionCountService.java
+++ b/src/main/java/ti4/spring/service/usage/InteractionCountService.java
@@ -26,7 +26,7 @@ public class InteractionCountService {
     @Transactional
     public synchronized void incrementSlashCommand(String commandName) {
         try {
-            String today = LocalDate.now().toString();
+            LocalDate today = LocalDate.now();
             int updatedRows = repository.incrementExisting(commandName, today);
             if (updatedRows == 0) {
                 repository.insertCount(commandName, today);
@@ -37,12 +37,12 @@ public class InteractionCountService {
     }
 
     public long getTotalSlashCommandCount(@Nullable LocalDate since) {
-        Long total = since == null ? repository.sumAllCounts() : repository.sumCountsSince(since.toString());
+        Long total = since == null ? repository.sumAllCounts() : repository.sumCountsSince(since);
         return total == null ? 0L : total;
     }
 
     public Map<String, Long> getSlashCommandCounts(@Nullable LocalDate since) {
-        List<Object[]> rows = since == null ? repository.sumAllByName() : repository.sumByNameSince(since.toString());
+        List<Object[]> rows = since == null ? repository.sumAllByName() : repository.sumByNameSince(since);
         Map<String, Long> result = new HashMap<>();
         for (Object[] row : rows) {
             result.put((String) row[0], ((Number) row[1]).longValue());

--- a/src/main/java/ti4/spring/service/usage/SlashCommandCountRepository.java
+++ b/src/main/java/ti4/spring/service/usage/SlashCommandCountRepository.java
@@ -1,5 +1,6 @@
 package ti4.spring.service.usage;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,7 +15,7 @@ public interface SlashCommandCountRepository extends JpaRepository<SlashCommandC
                     + "SELECT :name, :date, 1 "
                     + "WHERE NOT EXISTS (SELECT 1 FROM slash_command_count WHERE name = :name AND date = :date)",
             nativeQuery = true)
-    int insertCount(@Param("name") String name, @Param("date") String date);
+    int insertCount(@Param("name") String name, @Param("date") LocalDate date);
 
     @Modifying
     @Query(
@@ -23,7 +24,7 @@ public interface SlashCommandCountRepository extends JpaRepository<SlashCommandC
                             + "SET count = count + 1 "
                             + "WHERE id = (SELECT id FROM slash_command_count WHERE name = :name AND date = :date ORDER BY id LIMIT 1)",
             nativeQuery = true)
-    int incrementExisting(@Param("name") String name, @Param("date") String date);
+    int incrementExisting(@Param("name") String name, @Param("date") LocalDate date);
 
     @Query(
             value = "SELECT name, SUM(day_total) AS total "
@@ -37,7 +38,7 @@ public interface SlashCommandCountRepository extends JpaRepository<SlashCommandC
                     + "FROM (SELECT name, date, MAX(count) AS day_total FROM slash_command_count WHERE date >= :since GROUP BY name, date) grouped_counts "
                     + "GROUP BY name",
             nativeQuery = true)
-    List<Object[]> sumByNameSince(@Param("since") String since);
+    List<Object[]> sumByNameSince(@Param("since") LocalDate since);
 
     @Query(
             value =
@@ -50,5 +51,5 @@ public interface SlashCommandCountRepository extends JpaRepository<SlashCommandC
                     "SELECT SUM(day_total) "
                             + "FROM (SELECT MAX(count) AS day_total FROM slash_command_count WHERE date >= :since GROUP BY name, date)",
             nativeQuery = true)
-    Long sumCountsSince(@Param("since") String since);
+    Long sumCountsSince(@Param("since") LocalDate since);
 }

--- a/src/test/java/ti4/spring/service/usage/InteractionCountServiceTest.java
+++ b/src/test/java/ti4/spring/service/usage/InteractionCountServiceTest.java
@@ -13,39 +13,26 @@ class InteractionCountServiceTest {
     @Test
     void incrementSlashCommandUpdatesExistingRowWithoutInsert() {
         SlashCommandCountRepository repository = mock(SlashCommandCountRepository.class);
-        when(repository.incrementExisting(
-                        "/bothelper list_slash_commands_used", LocalDate.now().toString()))
+        when(repository.incrementExisting("/bothelper list_slash_commands_used", LocalDate.now()))
                 .thenReturn(1);
 
         InteractionCountService service = new InteractionCountService(repository);
         service.incrementSlashCommand("/bothelper list_slash_commands_used");
 
-        verify(repository)
-                .incrementExisting(
-                        "/bothelper list_slash_commands_used", LocalDate.now().toString());
-        verify(repository, never())
-                .insertCount(
-                        "/bothelper list_slash_commands_used", LocalDate.now().toString());
+        verify(repository).incrementExisting("/bothelper list_slash_commands_used", LocalDate.now());
+        verify(repository, never()).insertCount("/bothelper list_slash_commands_used", LocalDate.now());
     }
 
     @Test
     void incrementSlashCommandInsertsWhenNoRowExists() {
         SlashCommandCountRepository repository = mock(SlashCommandCountRepository.class);
-        when(repository.incrementExisting(
-                        "/developer button_processing_statistics",
-                        LocalDate.now().toString()))
+        when(repository.incrementExisting("/developer button_processing_statistics", LocalDate.now()))
                 .thenReturn(0);
 
         InteractionCountService service = new InteractionCountService(repository);
         service.incrementSlashCommand("/developer button_processing_statistics");
 
-        verify(repository)
-                .incrementExisting(
-                        "/developer button_processing_statistics",
-                        LocalDate.now().toString());
-        verify(repository)
-                .insertCount(
-                        "/developer button_processing_statistics",
-                        LocalDate.now().toString());
+        verify(repository).incrementExisting("/developer button_processing_statistics", LocalDate.now());
+        verify(repository).insertCount("/developer button_processing_statistics", LocalDate.now());
     }
 }


### PR DESCRIPTION
## What changed

- Preserve `LocalDate` values through `InteractionCountService` instead of converting them to strings.
- Type all four date-bound native repository parameters as `LocalDate`: insert, increment, total-since, and grouped-total-since.
- Update the existing interaction count mocks for the corrected repository contract.

## Root cause

The PostgreSQL migration created `slash_command_count.date` as a native `date` column, but the service converted dates to strings and Hibernate bound them as `varchar` parameters in native SQL. SQLite allowed those comparisons; PostgreSQL rejects `date = character varying` (and the equivalent range comparisons).

## Impact

Slash command usage increments and date-filtered usage reports now bind PostgreSQL date parameters with the correct JDBC type.

## Validation

- `mvn -q -DskipTests spotless:check`
- `mvn -q -Dtest=InteractionCountServiceTest test` with Java 26