### PR TITLE
Fix persistence deletion order

### DIFF
--- a/src/main/java/ti4/spring/service/persistence/PersistAllEntitiesService.java
+++ b/src/main/java/ti4/spring/service/persistence/PersistAllEntitiesService.java
@@ -26,14 +26,21 @@ public class PersistAllEntitiesService {
     private final UserEntityRepository userEntityRepository;
 
     public void persistAll() {
+        deleteAllPersistedEntities();
         Map<String, UserEntity> userCache = persistAllUsers();
         persistAllGames(userCache);
     }
 
+    void deleteAllPersistedEntities() {
+        titleEntityRepository.deleteAllInBatch();
+        playerEntityRepository.deleteAllInBatch();
+        gameEntityRepository.deleteAllInBatch();
+        userEntityRepository.deleteAllInBatch();
+        BotLogger.info("Deleted all persisted entities.");
+    }
+
     private Map<String, UserEntity> persistAllUsers() {
         BotLogger.info("Starting persistAllUsers.");
-        userEntityRepository.deleteAllInBatch();
-        BotLogger.info("Deleted all persisted users.");
 
         List<UserEntity> userEntities = GameManager.getManagedPlayers().stream()
                 .map(player -> new UserEntity(player.getId(), player.getName()))
@@ -49,10 +56,6 @@ public class PersistAllEntitiesService {
 
     private void persistAllGames(Map<String, UserEntity> userCache) {
         BotLogger.info("Starting persistAllGames.");
-        titleEntityRepository.deleteAllInBatch();
-        playerEntityRepository.deleteAllInBatch();
-        gameEntityRepository.deleteAllInBatch();
-        BotLogger.info("Deleted all persisted games.");
 
         List<GameEntity> gameEntities = new ArrayList<>();
         List<TitleEntity> titleEntities = new ArrayList<>();

--- a/src/test/java/ti4/spring/service/persistence/PersistAllEntitiesServiceTest.java
+++ b/src/test/java/ti4/spring/service/persistence/PersistAllEntitiesServiceTest.java
@@ -1,0 +1,29 @@
+package ti4.spring.service.persistence;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class PersistAllEntitiesServiceTest {
+
+    @Test
+    void deletesPersistedEntitiesInForeignKeyOrder() {
+        GameEntityRepository gameEntityRepository = mock(GameEntityRepository.class);
+        PlayerEntityRepository playerEntityRepository = mock(PlayerEntityRepository.class);
+        TitleEntityRepository titleEntityRepository = mock(TitleEntityRepository.class);
+        UserEntityRepository userEntityRepository = mock(UserEntityRepository.class);
+        PersistAllEntitiesService service = new PersistAllEntitiesService(
+                gameEntityRepository, playerEntityRepository, titleEntityRepository, userEntityRepository);
+
+        service.deleteAllPersistedEntities();
+
+        InOrder deletionOrder =
+                inOrder(titleEntityRepository, playerEntityRepository, gameEntityRepository, userEntityRepository);
+        deletionOrder.verify(titleEntityRepository).deleteAllInBatch();
+        deletionOrder.verify(playerEntityRepository).deleteAllInBatch();
+        deletionOrder.verify(gameEntityRepository).deleteAllInBatch();
+        deletionOrder.verify(userEntityRepository).deleteAllInBatch();
+    }
+}


### PR DESCRIPTION
## Summary

- delete persisted titles, players, games, and users in foreign-key dependency order
- complete all deletions before repopulating users and games
- add a regression test for the deletion sequence

## Root cause

`PersistAllEntitiesService` deleted `discord_user` rows before deleting the `player` and `title` rows that referenced them. PostgreSQL correctly rejected the user deletion with a foreign-key constraint violation, causing `PersistToSqlCron` to fail before the refill phase.

## Impact

The scheduled SQL snapshot can replace persisted entities without violating the existing foreign keys.

## Validation

- `JAVA_HOME=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home PATH=/Users/jstrong/Library/Java/JavaVirtualMachines/corretto-26.0.1/Contents/Home/bin:$PATH mvn -Dtest=PersistAllEntitiesServiceTest test`
- Maven production and test compilation passed under JDK 26
- Spotless check passed