### PR TITLE
Fow web UI

### DIFF
--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -493,6 +493,7 @@ public class JdaService {
         adminRoles.add(jda.getRoleById("1487725249398308884")); // Balacasi's server
         adminRoles.add(jda.getRoleById("1500012691224395906")); // BEANS's server
         adminRoles.add(jda.getRoleById("1516450864376578238")); // Stabar's Server
+        adminRoles.add(jda.getRoleById("1527947707518423150")); // niugnip's Server
 
         adminRoles.removeIf(Objects::isNull);
 
@@ -532,6 +533,7 @@ public class JdaService {
         developerRoles.add(jda.getRoleById("1487725369766449173")); // Balacasi's server
         developerRoles.add(jda.getRoleById("1500012939326001263")); // BEANS's server
         developerRoles.add(jda.getRoleById("1516450864376578238")); // Stabar's Server
+        developerRoles.add(jda.getRoleById("1527947972615209041")); // niugnip's Server
 
         developerRoles.removeIf(Objects::isNull);
 
@@ -575,6 +577,7 @@ public class JdaService {
         bothelperRoles.add(jda.getRoleById("1487725393673719950")); // Balacasi's server
         bothelperRoles.add(jda.getRoleById("1500013009492246558")); // BEANS's server
         bothelperRoles.add(jda.getRoleById("1516450864376578238")); // Stabar's Server
+        bothelperRoles.add(jda.getRoleById("1527947912108183686")); // niugnip's Server
 
         bothelperRoles.removeIf(Objects::isNull);
     }

--- a/src/main/java/ti4/discord/JdaService.java
+++ b/src/main/java/ti4/discord/JdaService.java
@@ -557,7 +557,7 @@ public class JdaService {
         bothelperRoles.add(jda.getRoleById("1458845770672377993")); // Async Tredenary (Planetary Duck System)
         bothelperRoles.add(jda.getRoleById("1458845518393246036")); // Async Quadrodenary (Dannel's Camp Ground)
         bothelperRoles.add(jda.getRoleById("1088532690803884052")); // FoW Server
-        bothelperRoles.add(jda.getRoleById("1063464689218105354")); // FoW Server Game Admin
+        bothelperRoles.add(jda.getRoleById("1063464689218105354")); // FoW Server Game Supervisor
         bothelperRoles.add(jda.getRoleById("1429853811891241128")); // FoW Server Chapter 2 Bothelper
         bothelperRoles.add(jda.getRoleById("1429853811891241129")); // FoW Server Chapter 2 Game Supervisor
         bothelperRoles.add(jda.getRoleById("1248693989193023519")); // Community Server
@@ -623,6 +623,32 @@ public class JdaService {
 
     public static boolean isProduction() {
         return Constants.ASYNCTI4_HUB_SERVER_ID.equals(guildPrimaryID);
+    }
+
+    /**
+     * Whether a user holds any of the given roles, by user and role ID. Unlike CommandHelper#hasRole
+     * this needs no interaction event, so it also works from the web API where all we have is a
+     * Discord user ID. Reads straight from JDA's cache (see the MemberCachePolicy.ALL /
+     * ChunkingFilter.ALL setup above), so it stays a synchronous lookup rather than a REST call.
+     *
+     * <p>Roles that can't be resolved are skipped, and the result is false if none matched - callers
+     * gating access on a role should fail closed rather than treat "couldn't check" as a pass.
+     */
+    public static boolean hasAnyRole(String userId, String... roleIds) {
+        if (jda == null || userId == null) {
+            return false;
+        }
+        for (String roleId : roleIds) {
+            Role role = roleId == null ? null : jda.getRoleById(roleId);
+            if (role == null) {
+                continue;
+            }
+            Member member = role.getGuild().getMemberById(userId);
+            if (member != null && member.getRoles().contains(role)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean isWhitelistedGuild(Guild guild) {

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
@@ -59,10 +59,7 @@ public class GameWebDataController {
                     .body("Authentication required to view Fog of War games");
         }
 
-        boolean isGm = userId.equals(game.getOwnerID())
-                || game.getPlayersWithGMRole().stream().anyMatch(p -> userId.equals(p.getUserID()));
-
-        if (isGm) {
+        if (isGm(game, userId)) {
             if (asPlayer == null || asPlayer.isBlank()) {
                 return withViewerIsGmHeader(gameWebDataService.getOrCompute(gameName), true);
             }
@@ -93,6 +90,11 @@ public class GameWebDataController {
                 .body(body);
     }
 
+    private boolean isGm(Game game, String userId) {
+        return userId.equals(game.getOwnerID())
+                || game.getPlayersWithGMRole().stream().anyMatch(p -> userId.equals(p.getUserID()));
+    }
+
     private Player resolvePlayer(Game game, String idOrFaction) {
         Player byUserId = game.getPlayer(idOrFaction);
         if (byUserId != null) {
@@ -121,6 +123,11 @@ public class GameWebDataController {
         return ResponseEntity.ok(WebGameState.fromGame(game));
     }
 
+    /**
+     * The event log's compact-map-state snapshots and movement/retreat diffs are built from the
+     * full, unfiltered game state - there's no fogged variant of "what changed," so this stays
+     * blocked for FoW games except for the GM/owner, who already sees the unfiltered view.
+     */
     @GetMapping(value = "/events", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<GameEventDto>> getEvents() {
         Game game = RequestContext.getGame();
@@ -128,7 +135,10 @@ public class GameWebDataController {
             return ResponseEntity.notFound().build();
         }
         if (game.isFowMode()) {
-            return ResponseEntity.notFound().build();
+            String userId = getOptionalUserId();
+            if (userId == null || !isGm(game, userId)) {
+                return ResponseEntity.notFound().build();
+            }
         }
         return ResponseEntity.ok(gameEventService.getEvents(game));
     }

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
@@ -2,13 +2,19 @@ package ti4.spring.api.webdata;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import ti4.game.Game;
+import ti4.game.Player;
 import ti4.spring.context.RequestContext;
 import ti4.spring.service.gameevent.GameEventDto;
 import ti4.spring.service.gameevent.GameEventService;
@@ -32,6 +38,75 @@ public class GameWebDataController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(gameWebDataService.getOrCompute(gameName));
+    }
+
+    /**
+     * Fog-of-War aware web-data endpoint. GM/owner gets the full unfiltered payload (or,
+     * with {@code asPlayer}, a preview of another player's fogged view for debugging).
+     * Participants always get their own fogged view. Everyone else is forbidden.
+     */
+    @GetMapping(value = "/web-data-fow", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> getFow(
+            @PathVariable String gameName, @RequestParam(required = false) String asPlayer) {
+        Game game = RequestContext.getGame();
+        if (game == null || !game.isFowMode()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        String userId = getOptionalUserId();
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("Authentication required to view Fog of War games");
+        }
+
+        boolean isGm = userId.equals(game.getOwnerID())
+                || game.getPlayersWithGMRole().stream().anyMatch(p -> userId.equals(p.getUserID()));
+
+        if (isGm) {
+            if (asPlayer == null || asPlayer.isBlank()) {
+                return withViewerIsGmHeader(gameWebDataService.getOrCompute(gameName), true);
+            }
+            Player target = resolvePlayer(game, asPlayer);
+            if (target == null) {
+                return ResponseEntity.notFound().build();
+            }
+            return withViewerIsGmHeader(gameWebDataService.computeFiltered(game, target), true);
+        }
+
+        Player viewer = game.getPlayer(userId);
+        if (viewer == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body("You must be participating in this game to view it");
+        }
+        return withViewerIsGmHeader(gameWebDataService.computeFiltered(game, viewer), false);
+    }
+
+    /**
+     * Whether the requesting user is GM/owner can't be derived from the response body alone: a GM
+     * previewing another player's view and that player's own real view are shaped identically. Callers
+     * that need to distinguish them (e.g. to keep showing "view as" controls while previewing) read this
+     * header instead.
+     */
+    private ResponseEntity<String> withViewerIsGmHeader(String body, boolean isGm) {
+        return ResponseEntity.ok()
+                .header("X-Viewer-Is-Gm", String.valueOf(isGm))
+                .body(body);
+    }
+
+    private Player resolvePlayer(Game game, String idOrFaction) {
+        Player byUserId = game.getPlayer(idOrFaction);
+        if (byUserId != null) {
+            return byUserId;
+        }
+        return game.getPlayerFromColorOrFaction(idOrFaction);
+    }
+
+    private String getOptionalUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken)) {
+            return auth.getName();
+        }
+        return null;
     }
 
     @GetMapping(value = "/game-state", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import ti4.discord.JdaService;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.spring.context.RequestContext;
@@ -27,6 +28,29 @@ public class GameWebDataController {
 
     private final GameWebDataService gameWebDataService;
     private final GameEventService gameEventService;
+
+    /**
+     * TEMPORARY: while the new FoW web UI is in limited testing, production access is restricted to
+     * FoW server staff. Deliberately scoped to that server's own roles rather than JdaService's
+     * bothelperRoles, which spans every Async and community server plus all admins/developers -
+     * far wider than this gate is meant to be. Applies to GMs too: most hold one of these anyway,
+     * and exempting them would leave nearly every FoW game reachable. Remove this and its two call
+     * sites to open the UI up.
+     */
+    private static final String[] FOW_WEB_UI_TESTER_ROLE_IDS = {
+        "1088532690803884052", // FoW Server
+        "1063464689218105354", // FoW Server Game Supervisor
+        "1429853811891241128", // FoW Server Chapter 2 Bothelper
+        "1429853811891241129", // FoW Server Chapter 2 Game Supervisor
+    };
+
+    private static final String FOW_WEB_UI_RESTRICTED_MESSAGE =
+            "The new Fog of War web UI is in limited testing and is currently restricted to Fog of War server staff.";
+
+    private boolean canUseFowWebUi(String userId) {
+        // Only gated on production; local/dev bots keep working without the role.
+        return !JdaService.isProduction() || JdaService.hasAnyRole(userId, FOW_WEB_UI_TESTER_ROLE_IDS);
+    }
 
     @GetMapping(value = "/web-data", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> get(@PathVariable String gameName) {
@@ -57,6 +81,10 @@ public class GameWebDataController {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body("Authentication required to view Fog of War games");
+        }
+
+        if (!canUseFowWebUi(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(FOW_WEB_UI_RESTRICTED_MESSAGE);
         }
 
         if (isGm(game, userId)) {
@@ -136,7 +164,7 @@ public class GameWebDataController {
         }
         if (game.isFowMode()) {
             String userId = getOptionalUserId();
-            if (userId == null || !isGm(game, userId)) {
+            if (userId == null || !isGm(game, userId) || !canUseFowWebUi(userId)) {
                 return ResponseEntity.notFound().build();
             }
         }

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
@@ -127,6 +127,7 @@ public class GameWebDataService {
         Map<String, WebTileUnitData> tileUnitData = (Map<String, WebTileUnitData>) webData.get("tileUnitData");
         WebTileUnitData.redactControlIdentities(tileUnitData, game, viewer);
         WebTileUnitData.redactUnitIdentities(tileUnitData, game, viewer);
+        WebTileUnitData.redactProduction(tileUnitData, game, viewer);
     }
 
     /**
@@ -139,7 +140,10 @@ public class GameWebDataService {
         List<WebPlayerArea> playerDataList = new ArrayList<>();
         Map<String, WebScoreBreakdown> scoreBreakdowns = new HashMap<>();
         for (Player player : game.getRealPlayersNNeutral()) {
-            boolean canSeeStats = FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+            // The neutral (Dicecord) player represents public neutral forces, not a hidden real
+            // opponent, and FoWHelper#canSeeStatsOfPlayer always returns false for it (it isn't a
+            // "real player") - so it's always included here rather than treated as unidentified.
+            boolean canSeeStats = player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
             if (canSeeStats) {
                 playerDataList.add(WebPlayerArea.fromPlayer(player, game));
             }

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
@@ -133,7 +133,7 @@ public class GameWebDataService {
      * Mirrors MapGenerator's private-FoW rendering: a player area is only included at all if the
      * viewer can see that player's stats (FoWHelper#canSeeStatsOfPlayer). Score breakdowns are kept
      * for everyone but trimmed to SCORED entries only for hidden players - scored objectives/relics
-     * are visible on the physical board regardless of fog, unlike hand/resource stats.
+     * stay visible regardless of fog, unlike hand/resource stats.
      */
     private static void applyStatRedaction(Map<String, Object> webData, Game game, Player viewer) {
         List<WebPlayerArea> playerDataList = new ArrayList<>();

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -94,10 +95,24 @@ public class GameWebDataService {
         applyPlayerNameRedaction(webData, game);
         applyExploreDeckRedaction(webData, game);
         applyControlIdentityRedaction(webData, game, viewer);
-        applyObjectiveProgressRedaction(webData, viewer);
+        applyObjectiveProgressRedaction(webData, game, viewer);
         applyLawRedaction(webData, game, viewer);
+        applyStrategyCardRedaction(webData, game, viewer);
+        applyStatTileRedaction(webData, game, viewer);
         applyGhostTileMetadata(webData, viewer, visible);
         return webData;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applyStrategyCardRedaction(Map<String, Object> webData, Game game, Player viewer) {
+        List<WebStrategyCard> strategyCards = (List<WebStrategyCard>) webData.get("strategyCards");
+        WebStrategyCard.redactPickers(strategyCards, game, viewer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applyStatTileRedaction(Map<String, Object> webData, Game game, Player viewer) {
+        Map<String, List<String>> statTilePositions = (Map<String, List<String>>) webData.get("statTilePositions");
+        WebStatTilePositions.redact(statTilePositions, game, viewer);
     }
 
     private static void applyLawRedaction(Map<String, Object> webData, Game game, Player viewer) {
@@ -117,9 +132,10 @@ public class GameWebDataService {
         WebTileUnitData.markGhostTiles(tileUnitData, visible, viewer);
     }
 
-    private static void applyObjectiveProgressRedaction(Map<String, Object> webData, Player viewer) {
+    private static void applyObjectiveProgressRedaction(Map<String, Object> webData, Game game, Player viewer) {
         WebObjectives objectives = (WebObjectives) webData.get("objectives");
         WebObjectives.redactFactionProgress(objectives, viewer);
+        WebObjectives.redactScorers(objectives, game, viewer);
     }
 
     private static void applyControlIdentityRedaction(Map<String, Object> webData, Game game, Player viewer) {
@@ -132,13 +148,18 @@ public class GameWebDataService {
 
     /**
      * Mirrors MapGenerator's private-FoW rendering: a player area is only included at all if the
-     * viewer can see that player's stats (FoWHelper#canSeeStatsOfPlayer). Score breakdowns are kept
-     * for everyone but trimmed to SCORED entries only for hidden players - scored objectives/relics
-     * stay visible regardless of fog, unlike hand/resource stats.
+     * viewer can see that player's stats (FoWHelper#canSeeStatsOfPlayer).
+     *
+     * <p>Hidden players are left out of scoreBreakdowns entirely - keying them by faction would
+     * publish both their identity and which objectives they scored, neither of which survives the
+     * fog. Their score-track position is public though, so their totals go into hiddenPlayerVps as
+     * bare numbers: enough to place an anonymous token on the track, with nothing to tie it to a
+     * faction. Sorted so the order can't be used to correlate a player across requests.
      */
     private static void applyStatRedaction(Map<String, Object> webData, Game game, Player viewer) {
         List<WebPlayerArea> playerDataList = new ArrayList<>();
         Map<String, WebScoreBreakdown> scoreBreakdowns = new HashMap<>();
+        List<Integer> hiddenPlayerVps = new ArrayList<>();
         for (Player player : game.getRealPlayersNNeutral()) {
             // The neutral (Dicecord) player represents public neutral forces, not a hidden real
             // opponent, and FoWHelper#canSeeStatsOfPlayer always returns false for it (it isn't a
@@ -146,15 +167,15 @@ public class GameWebDataService {
             boolean canSeeStats = player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
             if (canSeeStats) {
                 playerDataList.add(WebPlayerArea.fromPlayer(player, game));
+                scoreBreakdowns.put(player.getFaction(), WebScoreBreakdown.fromPlayer(player, game));
+            } else {
+                hiddenPlayerVps.add(player.getTotalVictoryPoints());
             }
-            scoreBreakdowns.put(
-                    player.getFaction(),
-                    canSeeStats
-                            ? WebScoreBreakdown.fromPlayer(player, game)
-                            : WebScoreBreakdown.redacted(player, game));
         }
+        Collections.sort(hiddenPlayerVps);
         webData.put("playerData", playerDataList);
         webData.put("scoreBreakdowns", scoreBreakdowns);
+        webData.put("hiddenPlayerVps", hiddenPlayerVps);
     }
 
     private static void applyPlayerNameRedaction(Map<String, Object> webData, Game game) {

--- a/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
+++ b/src/main/java/ti4/spring/api/webdata/GameWebDataService.java
@@ -8,12 +8,17 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.stereotype.Service;
 import ti4.cache.CacheManager;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.game.Tile;
 import ti4.game.persistence.GameManager;
+import ti4.helpers.FoWHelper;
 import ti4.json.JsonMapperManager;
+import ti4.service.fow.FOWPlusService;
+import ti4.service.option.FOWOptionService.FOWOption;
 import ti4.website.model.WebBorderAnomalies;
 import ti4.website.model.WebCardPool;
 import ti4.website.model.WebExpeditions;
@@ -66,6 +71,122 @@ public class GameWebDataService {
         return cache;
     }
 
+    /**
+     * Builds the fogged view of {@code game} as seen by {@code viewer}: tiles outside
+     * {@link FoWHelper#fowFilter} are replaced with the viewer's remembered "ghost" tile (or
+     * omitted if never seen); other players' stats/scores are redacted per
+     * {@link FoWHelper#canSeeStatsOfPlayer}; names are redacted if the game's HIDE_PLAYER_NAMES
+     * option is set; the explore/relic card pool is omitted if HIDE_EXPLORES (or FoW+) is active.
+     */
+    public String computeFiltered(Game game, Player viewer) {
+        try {
+            return JsonMapperManager.basic().writeValueAsString(buildFilteredWebData(game, viewer));
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not serialize filtered web data for game " + game.getName(), e);
+        }
+    }
+
+    public static Map<String, Object> buildFilteredWebData(Game game, Player viewer) {
+        Set<String> visible = FoWHelper.fowFilter(game, viewer);
+        Map<String, Object> webData = buildWebData(game, buildFogSubstitutedTileMap(game, viewer, visible));
+        webData.put("viewingAsPlayerId", viewer.getUserID());
+        applyStatRedaction(webData, game, viewer);
+        applyPlayerNameRedaction(webData, game);
+        applyExploreDeckRedaction(webData, game);
+        applyControlIdentityRedaction(webData, game, viewer);
+        applyObjectiveProgressRedaction(webData, viewer);
+        applyLawRedaction(webData, game, viewer);
+        applyGhostTileMetadata(webData, viewer, visible);
+        return webData;
+    }
+
+    private static void applyLawRedaction(Map<String, Object> webData, Game game, Player viewer) {
+        @SuppressWarnings("unchecked")
+        List<WebLaw> lawsInPlay = (List<WebLaw>) webData.get("lawsInPlay");
+        WebLaw.redactElectedFaction(lawsInPlay, game, viewer);
+    }
+
+    /**
+     * Flags positions outside the viewer's current vision as remembered "ghost" tiles, mirroring the
+     * greyed-out fog tile with a "last seen" label the Discord PNG already draws for these same
+     * positions (see WebTileUnitData#markGhostTiles).
+     */
+    private static void applyGhostTileMetadata(Map<String, Object> webData, Player viewer, Set<String> visible) {
+        @SuppressWarnings("unchecked")
+        Map<String, WebTileUnitData> tileUnitData = (Map<String, WebTileUnitData>) webData.get("tileUnitData");
+        WebTileUnitData.markGhostTiles(tileUnitData, visible, viewer);
+    }
+
+    private static void applyObjectiveProgressRedaction(Map<String, Object> webData, Player viewer) {
+        WebObjectives objectives = (WebObjectives) webData.get("objectives");
+        WebObjectives.redactFactionProgress(objectives, viewer);
+    }
+
+    private static void applyControlIdentityRedaction(Map<String, Object> webData, Game game, Player viewer) {
+        @SuppressWarnings("unchecked")
+        Map<String, WebTileUnitData> tileUnitData = (Map<String, WebTileUnitData>) webData.get("tileUnitData");
+        WebTileUnitData.redactControlIdentities(tileUnitData, game, viewer);
+        WebTileUnitData.redactUnitIdentities(tileUnitData, game, viewer);
+    }
+
+    /**
+     * Mirrors MapGenerator's private-FoW rendering: a player area is only included at all if the
+     * viewer can see that player's stats (FoWHelper#canSeeStatsOfPlayer). Score breakdowns are kept
+     * for everyone but trimmed to SCORED entries only for hidden players - scored objectives/relics
+     * are visible on the physical board regardless of fog, unlike hand/resource stats.
+     */
+    private static void applyStatRedaction(Map<String, Object> webData, Game game, Player viewer) {
+        List<WebPlayerArea> playerDataList = new ArrayList<>();
+        Map<String, WebScoreBreakdown> scoreBreakdowns = new HashMap<>();
+        for (Player player : game.getRealPlayersNNeutral()) {
+            boolean canSeeStats = FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+            if (canSeeStats) {
+                playerDataList.add(WebPlayerArea.fromPlayer(player, game));
+            }
+            scoreBreakdowns.put(
+                    player.getFaction(),
+                    canSeeStats
+                            ? WebScoreBreakdown.fromPlayer(player, game)
+                            : WebScoreBreakdown.redacted(player, game));
+        }
+        webData.put("playerData", playerDataList);
+        webData.put("scoreBreakdowns", scoreBreakdowns);
+    }
+
+    private static void applyPlayerNameRedaction(Map<String, Object> webData, Game game) {
+        if (!game.hideUserNames()) return;
+        @SuppressWarnings("unchecked")
+        List<WebPlayerArea> playerDataList = (List<WebPlayerArea>) webData.get("playerData");
+        for (WebPlayerArea area : playerDataList) {
+            area.setUserName(null);
+            area.setDisplayName(null);
+            area.setDiscordId(null);
+        }
+    }
+
+    private static void applyExploreDeckRedaction(Map<String, Object> webData, Game game) {
+        boolean hideExplores = FOWPlusService.isActive(game) || game.getFowOption(FOWOption.HIDE_EXPLORES);
+        if (hideExplores) {
+            webData.put("cardPool", null);
+        }
+    }
+
+    private static Map<String, Tile> buildFogSubstitutedTileMap(Game game, Player viewer, Set<String> visible) {
+        Map<String, Tile> substituted = new LinkedHashMap<>();
+        for (Map.Entry<String, Tile> entry : game.getTileMap().entrySet()) {
+            String position = entry.getKey();
+            if (visible.contains(position)) {
+                substituted.put(position, entry.getValue());
+                continue;
+            }
+            Tile fogTile = viewer.buildFogTile(position, viewer);
+            if (fogTile != null) {
+                substituted.put(position, fogTile);
+            }
+        }
+        return substituted;
+    }
+
     private static String serialize(Game game) {
         try {
             return JsonMapperManager.basic().writeValueAsString(buildWebData(game));
@@ -75,13 +196,17 @@ public class GameWebDataService {
     }
 
     public static Map<String, Object> buildWebData(Game game) {
+        return buildWebData(game, game.getTileMap());
+    }
+
+    public static Map<String, Object> buildWebData(Game game, Map<String, Tile> tileMap) {
         List<WebPlayerArea> playerDataList = new ArrayList<>();
         for (Player player : game.getRealPlayersNNeutral()) {
             playerDataList.add(WebPlayerArea.fromPlayer(player, game));
         }
 
-        WebTilePositions webTilePositions = WebTilePositions.fromGame(game);
-        Map<String, WebTileUnitData> tileUnitData = WebTileUnitData.fromGame(game);
+        WebTilePositions webTilePositions = WebTilePositions.fromTileMap(tileMap);
+        Map<String, WebTileUnitData> tileUnitData = WebTileUnitData.fromTileMap(game, tileMap);
         WebStatTilePositions webStatTilePositions = WebStatTilePositions.fromGame(game);
         WebObjectives webObjectives = WebObjectives.fromGame(game);
         WebCardPool webCardPool = WebCardPool.fromGame(game);
@@ -141,6 +266,8 @@ public class GameWebDataService {
                         ? webBorderAnomalies.getBorderAnomalies()
                         : null);
         webData.put("isTwilightsFallMode", game.isTwilightsFallMode());
+        webData.put("isFowMode", game.isFowMode());
+        webData.put("hidePlayerInfos", game.isFowMode() && game.getFowOption(FOWOption.HIDE_PLAYER_INFOS));
         return webData;
     }
 }

--- a/src/main/java/ti4/spring/websocket/WebSocketNotifier.java
+++ b/src/main/java/ti4/spring/websocket/WebSocketNotifier.java
@@ -71,8 +71,13 @@ public class WebSocketNotifier {
                 // Sole writer of the web-data cache: if anything else wrote it, the diff
                 // baseline would drift from what clients last received.
                 if (game.isFowMode()) {
+                    // FoW views differ per-viewer, so don't stream a single patch like non-FoW
+                    // games. Refresh the (unfiltered) cache backing the GM's REST view and tell
+                    // clients to refetch web-data-fow, which re-applies each viewer's fog
+                    // server-side.
                     gameWebDataService.put(gameId, MAPPER.writeValueAsString(current));
-                    return; // cache refreshed for REST, but FoW games never stream
+                    notifyGameRefresh(gameId);
+                    return;
                 }
                 String previousJson = gameWebDataService.getIfCached(gameId);
                 JsonNode previous = previousJson == null ? null : MAPPER.readTree(previousJson);

--- a/src/main/java/ti4/website/model/WebLaw.java
+++ b/src/main/java/ti4/website/model/WebLaw.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.FoWHelper;
 import ti4.image.Mapper;
 import ti4.model.AgendaModel;
 
@@ -32,6 +34,26 @@ public class WebLaw {
     // Additional metadata
     private boolean displaysElectedFaction;
 
+    /**
+     * Obscures which faction was elected by a law for players the viewer can't identify
+     * (FoWHelper#canSeeStatsOfPlayer), substituting the same "fow:&lt;color&gt;" sentinel used for
+     * control tokens and units (see WebTileUnitData#redactControlIdentities). Which color got
+     * elected is announced publicly, so it stays visible - only the faction behind it is hidden.
+     * electedInfo is dropped outright since it's the raw elected string and would leak the faction.
+     */
+    public static void redactElectedFaction(List<WebLaw> lawsInPlay, Game game, Player viewer) {
+        for (WebLaw law : lawsInPlay) {
+            if (!"player".equals(law.electedType) || law.electedFaction == null) {
+                continue;
+            }
+            Player electedPlayer = game.getPlayerFromColorOrFaction(law.electedFaction);
+            if (electedPlayer != null && !FoWHelper.canSeeStatsOfPlayer(game, electedPlayer, viewer)) {
+                law.electedFaction = WebTileUnitData.UNKNOWN_FACTION_PREFIX + electedPlayer.getColor();
+                law.electedInfo = null;
+            }
+        }
+    }
+
     public static WebLaw fromGameLaw(String lawId, Integer uniqueId, Game game) {
         WebLaw webLaw = new WebLaw();
 
@@ -56,8 +78,20 @@ public class WebLaw {
         webLaw.electedInfo = electedInfo;
 
         if (electedInfo != null && !electedInfo.isEmpty()) {
-            // Check if it's a player faction
-            if (Mapper.isValidFaction(electedInfo)) {
+            // Check if it's a player - elections are recorded as either the faction or the
+            // color (see IsPlayerElectedService, which checks both), so resolve via
+            // getPlayerFromColorOrFaction rather than only matching a faction string.
+            Player electedPlayer = game.getPlayerFromColorOrFaction(electedInfo);
+            if (electedPlayer != null) {
+                webLaw.electedType = "player";
+                webLaw.electedFaction = electedPlayer.getFaction();
+            }
+            // The election named a faction that no current player resolves to - it's still a
+            // player election, so keep showing it rather than falling through to "other".
+            // getPlayerFromColorOrFaction only matches players presently in the game, whereas a
+            // recorded election can outlive them (a player leaving, or a stale color recorded
+            // before a /player change_color, which doesn't rewrite lawsInfo).
+            else if (Mapper.isValidFaction(electedInfo)) {
                 webLaw.electedType = "player";
                 webLaw.electedFaction = electedInfo;
             }

--- a/src/main/java/ti4/website/model/WebObjectives.java
+++ b/src/main/java/ti4/website/model/WebObjectives.java
@@ -15,6 +15,13 @@ import ti4.image.Mapper;
 import ti4.model.PublicObjectiveModel;
 import ti4.service.info.ListPlayerInfoService;
 
+/*
+ * Note on FoW: {@code scoredFactions} intentionally stays untouched by redaction - whether a
+ * faction has scored an objective is public knowledge (visible via the scored token on the
+ * physical board). Numeric {@code factionProgress} is private (derived from hand/resources), so
+ * {@link #redactFactionProgress} strips it down to only the viewer's own entry.
+ */
+
 @Data
 public class WebObjectives {
 
@@ -59,6 +66,22 @@ public class WebObjectives {
     private List<ObjectiveInfo> stage2Objectives;
     private List<ObjectiveInfo> customObjectives;
     private List<ObjectiveInfo> allObjectives;
+
+    /**
+     * Strips numeric factionProgress down to just {@code viewer}'s own entry. allObjectives holds
+     * the same ObjectiveInfo instances referenced by the stage1/stage2/custom lists, so mutating
+     * through it updates all of them.
+     */
+    public static void redactFactionProgress(WebObjectives objectives, Player viewer) {
+        String ownFaction = viewer.getFaction();
+        for (ObjectiveInfo info : objectives.allObjectives) {
+            Integer ownProgress = info.factionProgress.get(ownFaction);
+            info.factionProgress.clear();
+            if (ownProgress != null) {
+                info.factionProgress.put(ownFaction, ownProgress);
+            }
+        }
+    }
 
     public static WebObjectives fromGame(Game game) {
         WebObjectives webObjectives = new WebObjectives();

--- a/src/main/java/ti4/website/model/WebObjectives.java
+++ b/src/main/java/ti4/website/model/WebObjectives.java
@@ -17,8 +17,8 @@ import ti4.service.info.ListPlayerInfoService;
 
 /*
  * Note on FoW: {@code scoredFactions} intentionally stays untouched by redaction - whether a
- * faction has scored an objective is public knowledge (visible via the scored token on the
- * physical board). Numeric {@code factionProgress} is private (derived from hand/resources), so
+ * faction has scored an objective is public knowledge (visible via the scored token). Numeric
+ * {@code factionProgress} is private (derived from hand/resources), so
  * {@link #redactFactionProgress} strips it down to only the viewer's own entry.
  */
 

--- a/src/main/java/ti4/website/model/WebObjectives.java
+++ b/src/main/java/ti4/website/model/WebObjectives.java
@@ -73,11 +73,9 @@ public class WebObjectives {
     private List<ObjectiveInfo> customObjectives;
     private List<ObjectiveInfo> allObjectives;
 
-    /**
-     * Strips numeric factionProgress down to just {@code viewer}'s own entry. allObjectives holds
-     * the same ObjectiveInfo instances referenced by the stage1/stage2/custom lists, so mutating
-     * through it updates all of them.
-     */
+    // The redactions below mutate through allObjectives, which holds the same ObjectiveInfo
+    // instances referenced by the stage1/stage2/custom lists - so updating it updates all of them.
+
     /**
      * Replaces scorers the viewer can't identify with a count, and drops them from the peeking list.
      * The frontend renders {@code unidentifiedScorerCount} anonymous tokens, which carry no faction
@@ -96,9 +94,11 @@ public class WebObjectives {
     private static boolean canIdentify(Game game, Player viewer, String faction) {
         Player player = game.getPlayerFromColorOrFaction(faction);
         // Neutral forces are public, and canSeeStatsOfPlayer is false for any non-real player.
-        return player == null || player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+        // An unresolvable faction fails closed - better an extra anonymous token than a leak.
+        return player != null && (player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer));
     }
 
+    /** Strips numeric factionProgress down to just {@code viewer}'s own entry. */
     public static void redactFactionProgress(WebObjectives objectives, Player viewer) {
         String ownFaction = viewer.getFaction();
         for (ObjectiveInfo info : objectives.allObjectives) {

--- a/src/main/java/ti4/website/model/WebObjectives.java
+++ b/src/main/java/ti4/website/model/WebObjectives.java
@@ -11,15 +11,18 @@ import lombok.Data;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.Constants;
+import ti4.helpers.FoWHelper;
 import ti4.image.Mapper;
 import ti4.model.PublicObjectiveModel;
 import ti4.service.info.ListPlayerInfoService;
 
 /*
- * Note on FoW: {@code scoredFactions} intentionally stays untouched by redaction - whether a
- * faction has scored an objective is public knowledge (visible via the scored token). Numeric
- * {@code factionProgress} is private (derived from hand/resources), so
- * {@link #redactFactionProgress} strips it down to only the viewer's own entry.
+ * Note on FoW: under fog you learn that *someone* scored an objective, not who. So
+ * {@link #redactScorers} drops unidentified factions out of {@code scoredFactions} entirely and
+ * replaces them with a bare count - sending the real faction strings and hiding them client-side
+ * would leave the answer sitting in the payload. Numeric {@code factionProgress} is private too
+ * (derived from hand/resources), so {@link #redactFactionProgress} strips it down to only the
+ * viewer's own entry.
  */
 
 @Data
@@ -35,6 +38,9 @@ public class WebObjectives {
         private boolean hasRedTape;
         private List<String> scoredFactions;
         private List<String> peekingFactions;
+        // How many scorers were dropped from scoredFactions because the viewer can't identify them
+        // (see #redactScorers). Always 0 in the unfiltered view.
+        private int unidentifiedScorerCount;
         private Map<String, Integer> factionProgress;
         private int progressThreshold;
 
@@ -72,6 +78,27 @@ public class WebObjectives {
      * the same ObjectiveInfo instances referenced by the stage1/stage2/custom lists, so mutating
      * through it updates all of them.
      */
+    /**
+     * Replaces scorers the viewer can't identify with a count, and drops them from the peeking list.
+     * The frontend renders {@code unidentifiedScorerCount} anonymous tokens, which carry no faction
+     * string at all - so there is nothing to correlate across objectives, and nothing recoverable
+     * from the raw payload.
+     */
+    public static void redactScorers(WebObjectives objectives, Game game, Player viewer) {
+        for (ObjectiveInfo info : objectives.allObjectives) {
+            int before = info.scoredFactions.size();
+            info.scoredFactions.removeIf(faction -> !canIdentify(game, viewer, faction));
+            info.unidentifiedScorerCount = before - info.scoredFactions.size();
+            info.peekingFactions.removeIf(faction -> !canIdentify(game, viewer, faction));
+        }
+    }
+
+    private static boolean canIdentify(Game game, Player viewer, String faction) {
+        Player player = game.getPlayerFromColorOrFaction(faction);
+        // Neutral forces are public, and canSeeStatsOfPlayer is false for any non-real player.
+        return player == null || player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+    }
+
     public static void redactFactionProgress(WebObjectives objectives, Player viewer) {
         String ownFaction = viewer.getFaction();
         for (ObjectiveInfo info : objectives.allObjectives) {

--- a/src/main/java/ti4/website/model/WebScoreBreakdown.java
+++ b/src/main/java/ti4/website/model/WebScoreBreakdown.java
@@ -22,6 +22,9 @@ import ti4.service.info.ListPlayerInfoService;
 @Data
 public class WebScoreBreakdown {
     private List<ScoreBreakdownEntry> entries;
+    // Total VP is always public (visible on the physical score track regardless of fog), so it's
+    // sent for every player, including ones whose player area/entries are otherwise redacted.
+    private Integer totalVps;
 
     @Data
     public static class ScoreBreakdownEntry {
@@ -109,11 +112,29 @@ public class WebScoreBreakdown {
 
         WebScoreBreakdown breakdown = new WebScoreBreakdown();
         breakdown.entries = new ArrayList<>();
+        breakdown.totalVps = player.getTotalVictoryPoints();
 
         addScoredEntries(player, game, breakdown.entries);
         addQualifiesAndPotentialEntries(player, game, breakdown.entries);
         addUnscoredEntries(player, game, breakdown.entries);
 
+        return breakdown;
+    }
+
+    /**
+     * Minimal score breakdown for a viewer who can't see this player's stats. Scored entries are
+     * kept (public knowledge - visible via scored objective/relic tokens on the physical board);
+     * QUALIFIES/POTENTIAL/UNSCORED entries are dropped since they reveal hand/resource information
+     * that requires seeing the player's home system. Total VP stays visible - it's the score track
+     * position, public regardless of fog.
+     */
+    public static WebScoreBreakdown redacted(Player player, Game game) {
+        WebScoreBreakdown full = fromPlayer(player, game);
+        WebScoreBreakdown breakdown = new WebScoreBreakdown();
+        breakdown.totalVps = full.totalVps;
+        breakdown.entries = full.entries.stream()
+                .filter(entry -> entry.getState() == EntryState.SCORED)
+                .toList();
         return breakdown;
     }
 

--- a/src/main/java/ti4/website/model/WebScoreBreakdown.java
+++ b/src/main/java/ti4/website/model/WebScoreBreakdown.java
@@ -123,10 +123,10 @@ public class WebScoreBreakdown {
 
     /**
      * Minimal score breakdown for a viewer who can't see this player's stats. Scored entries are
-     * kept (public knowledge - visible via scored objective/relic tokens on the physical board);
-     * QUALIFIES/POTENTIAL/UNSCORED entries are dropped since they reveal hand/resource information
-     * that requires seeing the player's home system. Total VP stays visible - it's the score track
-     * position, public regardless of fog.
+     * kept (public knowledge - visible via scored objective/relic tokens); QUALIFIES/POTENTIAL/
+     * UNSCORED entries are dropped since they reveal hand/resource information that requires
+     * seeing the player's home system. Total VP stays visible - it's the score track position,
+     * public regardless of fog.
      */
     public static WebScoreBreakdown redacted(Player player, Game game) {
         WebScoreBreakdown full = fromPlayer(player, game);

--- a/src/main/java/ti4/website/model/WebScoreBreakdown.java
+++ b/src/main/java/ti4/website/model/WebScoreBreakdown.java
@@ -22,8 +22,9 @@ import ti4.service.info.ListPlayerInfoService;
 @Data
 public class WebScoreBreakdown {
     private List<ScoreBreakdownEntry> entries;
-    // Total VP is always public (visible on the physical score track regardless of fog), so it's
-    // sent for every player, including ones whose player area/entries are otherwise redacted.
+    // Score-track position, which isn't fogged. Under FoW a hidden player has no breakdown at all
+    // (see GameWebDataService#applyStatRedaction) - their total travels in hiddenPlayerVps instead,
+    // detached from any faction.
     private Integer totalVps;
 
     @Data
@@ -118,23 +119,6 @@ public class WebScoreBreakdown {
         addQualifiesAndPotentialEntries(player, game, breakdown.entries);
         addUnscoredEntries(player, game, breakdown.entries);
 
-        return breakdown;
-    }
-
-    /**
-     * Minimal score breakdown for a viewer who can't see this player's stats. Scored entries are
-     * kept (public knowledge - visible via scored objective/relic tokens); QUALIFIES/POTENTIAL/
-     * UNSCORED entries are dropped since they reveal hand/resource information that requires
-     * seeing the player's home system. Total VP stays visible - it's the score track position,
-     * public regardless of fog.
-     */
-    public static WebScoreBreakdown redacted(Player player, Game game) {
-        WebScoreBreakdown full = fromPlayer(player, game);
-        WebScoreBreakdown breakdown = new WebScoreBreakdown();
-        breakdown.totalVps = full.totalVps;
-        breakdown.entries = full.entries.stream()
-                .filter(entry -> entry.getState() == EntryState.SCORED)
-                .toList();
         return breakdown;
     }
 

--- a/src/main/java/ti4/website/model/WebStatTilePositions.java
+++ b/src/main/java/ti4/website/model/WebStatTilePositions.java
@@ -8,11 +8,25 @@ import java.util.Set;
 import lombok.Data;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.helpers.FoWHelper;
 import ti4.helpers.PlayerStatsHelper;
 
 @Data
 public class WebStatTilePositions {
     private Map<String, List<String>> statTilePositions;
+
+    /**
+     * Drops stat-tile positions for players whose stats the viewer can't see. The tiles sit beside a
+     * player's home system, so publishing them keyed by faction would give away both who is in the
+     * game and roughly where they are - exactly what {@link FoWHelper#canSeeStatsOfPlayer} (which
+     * bottoms out in "is their home system in view") is there to gate.
+     */
+    public static void redact(Map<String, List<String>> statTilePositions, Game game, Player viewer) {
+        statTilePositions.keySet().removeIf(faction -> {
+            Player player = game.getPlayerFromColorOrFaction(faction);
+            return player != null && !FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+        });
+    }
 
     public static WebStatTilePositions fromGame(Game game) {
         WebStatTilePositions webStatTilePositions = new WebStatTilePositions();

--- a/src/main/java/ti4/website/model/WebStatTilePositions.java
+++ b/src/main/java/ti4/website/model/WebStatTilePositions.java
@@ -22,9 +22,10 @@ public class WebStatTilePositions {
      * bottoms out in "is their home system in view") is there to gate.
      */
     public static void redact(Map<String, List<String>> statTilePositions, Game game, Player viewer) {
+        // An unresolvable faction fails closed: dropping its entry is safe, keeping it could leak.
         statTilePositions.keySet().removeIf(faction -> {
             Player player = game.getPlayerFromColorOrFaction(faction);
-            return player != null && !FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+            return player == null || !FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
         });
     }
 

--- a/src/main/java/ti4/website/model/WebStrategyCard.java
+++ b/src/main/java/ti4/website/model/WebStrategyCard.java
@@ -1,7 +1,10 @@
 package ti4.website.model;
 
+import java.util.List;
 import lombok.Data;
 import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.FoWHelper;
 import ti4.model.StrategyCardModel;
 
 @Data
@@ -14,6 +17,32 @@ public class WebStrategyCard {
     private boolean exhausted;
     private int tradeGoods;
     private String pickedByFaction;
+
+    /**
+     * Hides who holds which strategy card. Playing a card is announced, so {@code played} stays
+     * visible along with the pick it implies - but until then, whether a card has been taken is
+     * itself private, and who took it is only visible to someone who can already see that player's
+     * stats (FoWHelper#canSeeStatsOfPlayer).
+     *
+     * <p>Trade goods are cleared alongside, because they'd otherwise give the picks away by
+     * elimination: unpicked cards accumulate trade goods, and picking one takes them, so a nonzero
+     * count marks a card as definitely still unpicked. Blanking every unplayed card leaves them
+     * indistinguishable from each other rather than merely unlabelled.
+     */
+    public static void redactPickers(List<WebStrategyCard> strategyCards, Game game, Player viewer) {
+        for (WebStrategyCard card : strategyCards) {
+            Player picker =
+                    card.pickedByFaction == null ? null : game.getPlayerFromColorOrFaction(card.pickedByFaction);
+            if (picker != null && FoWHelper.canSeeStatsOfPlayer(game, picker, viewer)) {
+                continue;
+            }
+            card.pickedByFaction = null;
+            if (!card.played) {
+                card.picked = false;
+                card.tradeGoods = 0;
+            }
+        }
+    }
 
     public static WebStrategyCard fromGameStrategyCard(int scNumber, Game game) {
         WebStrategyCard webSC = new WebStrategyCard();

--- a/src/main/java/ti4/website/model/WebTilePositions.java
+++ b/src/main/java/ti4/website/model/WebTilePositions.java
@@ -12,11 +12,15 @@ public class WebTilePositions {
     private List<String> tilePositions;
 
     public static WebTilePositions fromGame(Game game) {
+        return fromTileMap(game.getTileMap());
+    }
+
+    public static WebTilePositions fromTileMap(Map<String, Tile> tileMap) {
         WebTilePositions webTilePositions = new WebTilePositions();
 
         List<String> tilePositions = new ArrayList<>();
 
-        for (Map.Entry<String, Tile> entry : game.getTileMap().entrySet()) {
+        for (Map.Entry<String, Tile> entry : tileMap.entrySet()) {
             String position = entry.getKey();
             Tile tile = entry.getValue();
 

--- a/src/main/java/ti4/website/model/WebTileUnitData.java
+++ b/src/main/java/ti4/website/model/WebTileUnitData.java
@@ -19,6 +19,7 @@ import ti4.helpers.Units.UnitKey;
 import ti4.helpers.Units.UnitType;
 import ti4.image.DrawingUtil;
 import ti4.image.TileGenerator;
+import ti4.service.map.CustomHyperlaneService;
 import ti4.website.WebPdsCoverage;
 
 @Data
@@ -29,6 +30,9 @@ public final class WebTileUnitData {
     private boolean isAnomaly;
     private Map<String, Integer> production;
     private Map<String, WebPdsCoverage> pds; // PDS coverage data per faction
+    // Connection matrix (6x6 binary, "i,j,...;..." rows) for hyperlane tiles; null if not a
+    // hyperlane or no connection data is configured. See CustomHyperlaneService for the format.
+    private String hyperlaneMatrix;
 
     private WebTileUnitData() {
         space = new HashMap<>();
@@ -69,6 +73,9 @@ public final class WebTileUnitData {
 
         // Set anomaly status
         tileData.isAnomaly = tile.isAnomaly(game, null);
+
+        // Hyperlane connection matrix, if applicable
+        tileData.hyperlaneMatrix = CustomHyperlaneService.getHyperlaneDataForTile(tile, game);
 
         // Extract command tokens from space
         UnitHolder spaceHolder = tile.getUnitHolders().get(Constants.SPACE);

--- a/src/main/java/ti4/website/model/WebTileUnitData.java
+++ b/src/main/java/ti4/website/model/WebTileUnitData.java
@@ -118,7 +118,7 @@ public final class WebTileUnitData {
 
     private static boolean canSeeStatsByColor(Game game, Player viewer, String color) {
         Player player = game.getPlayerFromColorOrFaction(color);
-        return player == null || player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+        return player == null || FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
     }
 
     /**
@@ -235,9 +235,8 @@ public final class WebTileUnitData {
             }
         }
 
-        // Calculate production for each player, including the neutral (Dicecord) player so e.g. a
-        // neutral space dock's production still shows up.
-        for (Player player : game.getRealPlayersNNeutral()) {
+        // Calculate production for each player
+        for (Player player : game.getRealPlayers()) {
             String color = player.getColor();
 
             int productionValue = Helper.getProductionValue(player, game, tile, false);

--- a/src/main/java/ti4/website/model/WebTileUnitData.java
+++ b/src/main/java/ti4/website/model/WebTileUnitData.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 import ti4.game.Game;
 import ti4.game.Planet;
@@ -12,6 +13,7 @@ import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.helpers.ActionCardHelper;
 import ti4.helpers.Constants;
+import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
 import ti4.helpers.PdsCoverage;
 import ti4.helpers.PdsCoverageHelper;
@@ -33,6 +35,13 @@ public final class WebTileUnitData {
     // Connection matrix (6x6 binary, "i,j,...;..." rows) for hyperlane tiles; null if not a
     // hyperlane or no connection data is configured. See CustomHyperlaneService for the format.
     private String hyperlaneMatrix;
+    // True if this position is outside the viewer's current vision and the tile/unit data above
+    // is a remembered "ghost" snapshot rather than the live tile (see #markGhostTiles). Always
+    // false in the unfiltered (GM/non-FoW) view.
+    private boolean isGhost;
+    // The viewer's last-seen label for this position (e.g. "Rnd 4"), same string shown on the
+    // Discord PNG fog overlay (Player#getFogLabels). Null unless isGhost is true.
+    private String fogLabel;
 
     private WebTileUnitData() {
         space = new HashMap<>();
@@ -43,10 +52,105 @@ public final class WebTileUnitData {
         pds = null; // Only populated if there is PDS coverage
     }
 
+    // Marks a player the viewer can't identify: the real color is kept so the frontend can still
+    // render it, but the faction behind it is withheld. Shared with WebLaw#redactElectedFaction.
+    public static final String UNKNOWN_FACTION_PREFIX = "fow:";
+
     public static Map<String, WebTileUnitData> fromGame(Game game) {
+        return fromTileMap(game, game.getTileMap());
+    }
+
+    /**
+     * Redacts control-token/CC faction identity in place for players the viewer can't identify
+     * (FoWHelper#canSeeStatsOfPlayer), substituting "fow:&lt;color&gt;" so the frontend can still
+     * render the colored token without the faction seal - matching how DrawingUtil#drawControlToken
+     * always draws the real-colored base token on Discord but skips the faction icon overlay.
+     */
+    public static void redactControlIdentities(Map<String, WebTileUnitData> tileUnitData, Game game, Player viewer) {
+        for (WebTileUnitData tileData : tileUnitData.values()) {
+            for (WebTilePlanet planet : tileData.planets.values()) {
+                if (planet.getControlledBy() != null) {
+                    planet.setControlledBy(obscureIfHidden(game, viewer, planet.getControlledBy()));
+                }
+            }
+            tileData.ccs.replaceAll(faction -> obscureIfHidden(game, viewer, faction));
+        }
+    }
+
+    /**
+     * Flags positions outside the viewer's current vision as ghost tiles and stamps them with the
+     * viewer's remembered last-seen label, mirroring the greyed-out "Rnd N" fog tile the Discord PNG
+     * draws (TileGenerator#createTileImage, Player#getFogLabels). The tile/unit data at these
+     * positions is already the remembered snapshot (see GameWebDataService#buildFogSubstitutedTileMap)
+     * - this only adds the metadata the frontend needs to render it distinctly from a live tile.
+     */
+    public static void markGhostTiles(
+            Map<String, WebTileUnitData> tileUnitData, Set<String> visiblePositions, Player viewer) {
+        Map<String, String> fogLabels = viewer.getFogLabels();
+        for (Map.Entry<String, WebTileUnitData> entry : tileUnitData.entrySet()) {
+            if (visiblePositions.contains(entry.getKey())) {
+                continue;
+            }
+            WebTileUnitData tileData = entry.getValue();
+            tileData.isGhost = true;
+            tileData.fogLabel = fogLabels.get(entry.getKey());
+        }
+    }
+
+    private static String obscureIfHidden(Game game, Player viewer, String faction) {
+        Player player = game.getPlayerFromColorOrFaction(faction);
+        if (player == null || player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer)) {
+            return faction;
+        }
+        return UNKNOWN_FACTION_PREFIX + player.getColor();
+    }
+
+    /**
+     * Strips production entries for players the viewer can't identify - unlike control
+     * tokens/units, there's no meaningful "unidentified" placeholder for this number, so
+     * unidentified entries are removed outright rather than obscured.
+     */
+    public static void redactProduction(Map<String, WebTileUnitData> tileUnitData, Game game, Player viewer) {
+        for (WebTileUnitData tileData : tileUnitData.values()) {
+            tileData.production.keySet().removeIf(color -> !canSeeStatsByColor(game, viewer, color));
+        }
+    }
+
+    private static boolean canSeeStatsByColor(Game game, Player viewer, String color) {
+        Player player = game.getPlayerFromColorOrFaction(color);
+        return player == null || player.isNeutral() || FoWHelper.canSeeStatsOfPlayer(game, player, viewer);
+    }
+
+    /**
+     * Redacts unit/token faction identity in place for players the viewer can't identify, the same
+     * way {@link #redactControlIdentities} does for control tokens/CC: the real faction key is
+     * replaced with "fow:&lt;color&gt;" so the frontend can still render the correct unit color
+     * without exposing which faction it belongs to (which would otherwise also leak faction-specific
+     * unit upgrades/tech via the unit tooltip).
+     */
+    public static void redactUnitIdentities(Map<String, WebTileUnitData> tileUnitData, Game game, Player viewer) {
+        for (WebTileUnitData tileData : tileUnitData.values()) {
+            tileData.space = obscureEntityFactionKeys(tileData.space, game, viewer);
+            for (WebTilePlanet planet : tileData.planets.values()) {
+                planet.setEntities(obscureEntityFactionKeys(planet.getEntities(), game, viewer));
+            }
+        }
+    }
+
+    private static Map<String, List<WebEntityData>> obscureEntityFactionKeys(
+            Map<String, List<WebEntityData>> entities, Game game, Player viewer) {
+        Map<String, List<WebEntityData>> result = new HashMap<>();
+        for (Map.Entry<String, List<WebEntityData>> entry : entities.entrySet()) {
+            String obscured = obscureIfHidden(game, viewer, entry.getKey());
+            result.computeIfAbsent(obscured, _ -> new ArrayList<>()).addAll(entry.getValue());
+        }
+        return result;
+    }
+
+    public static Map<String, WebTileUnitData> fromTileMap(Game game, Map<String, Tile> tileMap) {
         Map<String, WebTileUnitData> tileUnitData = new HashMap<>();
 
-        for (Map.Entry<String, Tile> entry : game.getTileMap().entrySet()) {
+        for (Map.Entry<String, Tile> entry : tileMap.entrySet()) {
             String position = entry.getKey();
             Tile tile = entry.getValue();
 
@@ -117,17 +221,25 @@ public final class WebTileUnitData {
                     }
                     planetData.setControlledBy(controllingFaction);
 
+                    // Exhausted status is visible to everyone with vision of this tile regardless
+                    // of faction identification (it doesn't reveal who controls the planet, only
+                    // that a visible planet is exhausted), so it's set here unconditionally rather
+                    // than sourced from the viewer-filtered per-player WebPlayerArea data.
+                    Player controllingPlayer = game.getPlayerFromColorOrFaction(controllingFaction);
+                    planetData.setExhausted(controllingPlayer != null
+                            && controllingPlayer.getExhaustedPlanets().contains(holderName));
+
                     // Update metadata (commodities, shields)
                     updatePlanetMetadata(game, planet, planetData);
                 }
             }
         }
 
-        // Calculate production and capacity for each player
-        for (Player player : game.getRealPlayers()) {
+        // Calculate production for each player, including the neutral (Dicecord) player so e.g. a
+        // neutral space dock's production still shows up.
+        for (Player player : game.getRealPlayersNNeutral()) {
             String color = player.getColor();
 
-            // Calculate production value for this player in this tile
             int productionValue = Helper.getProductionValue(player, game, tile, false);
             if (productionValue > 0) {
                 tileData.production.put(color, productionValue);


### PR DESCRIPTION
Adds Fog of War support to the backend payload that feeds the new web UI, so FoW games can be viewed in it at all. Until now the new UI was hard-blocked for FoW games and players were sent to the old image-based view.

**Pairs with AsyncTI4/ti4_web_new#138— this needs to merge first**, or the frontend reads fields that don't exist yet.

## What it does

`/web-data-fow` serves a per-viewer filtered payload:

- Tiles outside current vision are replaced with the viewer's remembered "ghost" snapshot, flagged with the same "last seen" label the Discord PNG already draws.
- Unit and control-token faction identity is obscured behind a `fow:<color>` sentinel — the real color still renders (matching `DrawingUtil#drawControlToken`, which draws the colored token but skips the faction seal), but the faction behind it doesn't.
- Player stats, score breakdowns, objective progress, elected laws and expedition completers are redacted for players the viewer can't identify.
- Hidden players' identity never reaches the client at all: objective scorers they can't be tied to are collapsed into a bare `unidentifiedScorerCount`, their score breakdowns are omitted entirely (score-track totals travel as faction-less `hiddenPlayerVps`), strategy-card picks are cleared unless the viewer can see that player's stats (with trade goods blanked so unpicked cards can't be identified by elimination), and stat-tile positions are dropped for them.
- Per-planet `exhausted` is now populated for on-tile planets. The web UI previously derived this from each player's `exhaustedPlanets` list, which isn't available for unidentified players, so exhausted planets in visible systems rendered as ready.

The GM/owner gets the unfiltered payload, and can preview any player's fogged view via `?asPlayer=` for debugging. `X-Viewer-Is-Gm` distinguishes "GM previewing a player" from "that player's own view", which are otherwise identical in shape.

FoW games stream only a `"refresh"` signal over the websocket rather than a patch — the payload differs per viewer, so clients refetch and the fog is re-applied server-side.

## Commits

Reviewable in order; each builds standalone.

1. **Send the hyperlane connection matrix in the web tile payload** — unrelated to FoW; the web map couldn't draw custom hyperlane tiles without it.
2. **Add Fog of War support for the new web UI** — the bulk of the change.
3. **Let the GM see the event log in FoW games**
4. **Stop treating the neutral player as a hidden FoW opponent** — the neutral (Dicecord) player isn't a "real player" per `FoWHelper#canSeeStatsOfPlayer`, so it was failing every identity check as though it were a hidden opponent. Also counts neutral production, which affects non-FoW games too, where it simply wasn't counted before.
5. **Add niugnip's server roles** — unrelated to the rest; separated so it can be judged on its own.
6. **Restrict the FoW web UI to FoW server staff in production** — temporary rollout gate, see below.
7. **Withhold hidden players' identity from the FoW payload** — the earlier redaction still sent every scorer's real faction and left the client to render the unidentifiable ones anonymously; the answer was sitting in the JSON. This moves all of that server-side (see the fourth bullet above).
8. **Fail closed on unresolvable factions in the FoW redaction** — review follow-up: a faction string that can't be resolved to a player is now redacted rather than passed through, matching the rollout gate's fail-closed policy.

## The rollout gate

The gate commit limits the FoW web-data and event endpoints to holders of one of the FoW server's staff roles (server, Game Supervisor, and the Chapter 2 bothelper/supervisor equivalents), in production only (`JdaService#isProduction()`), so dev bots are unaffected. GMs are not exempt — most hold one of these already, and exempting them would leave nearly every FoW game reachable.

Deliberately scoped to that server's own roles rather than reusing `bothelperRoles`, which spans every Async and community server plus all admins and developers — far wider than this gate is meant to be.

It fails closed: unresolvable roles are skipped and access is denied rather than treating "couldn't check" as a pass. **Revert that single commit to lift the restriction** — nothing else depends on it.

This also adds `JdaService#hasAnyRole(userId, roleIds...)`, since the existing role checks need an interaction event and the web API only has a Discord user ID. It reads JDA's member cache, which is populated eagerly (`MemberCachePolicy.ALL` / `ChunkingFilter.ALL`), so it stays a synchronous lookup rather than a REST call on the request thread.

It also relabels role `1063464689218105354` from "FoW Server Game Admin" to "FoW Server Game Supervisor", matching what that role is actually called now.

## Testing

Full `mvn install` clean: 327 tests, 0 failures, 0 errors, SpotBugs and Spotless clean. Exercised manually against a local FoW save as GM, as a participant, and via GM preview-as-player. The identity withholding was additionally verified against a running bot with a player forced unidentifiable: their faction no longer appears anywhere in the fogged payload.

The gate itself was exercised against a running bot by temporarily forcing it on and substituting a role this test bot can see: a user holding the role got the payload, while a user without it — including an actual participant in the game — got a 403. That confirms the lookup resolves a role from a non-primary guild, hits the member cache synchronously rather than making a REST call, and sits above the participant check rather than only the GM branch.

**Not verified:** that the four production role IDs themselves resolve, since this bot isn't in the FoW server. The mechanism is proven; only those specific IDs aren't. Worth a look at the first deploy, given it fails closed.