### PR TITLE
Migrate law elections when a player changes color

### DIFF
--- a/src/main/java/ti4/helpers/ColorChangeHelper.java
+++ b/src/main/java/ti4/helpers/ColorChangeHelper.java
@@ -92,6 +92,16 @@ public class ColorChangeHelper {
         }
         player.setPromissoryNotesOwned(ownedPromissoryNotesChanged);
 
+        // Law elections. IsPlayerElectedService matches the recorded election against either the
+        // player's faction or their color, so an election recorded by color silently stops
+        // matching once that color changes - the player quietly loses the law's effect, and the
+        // election can never be matched again since no player holds the old color.
+        for (Map.Entry<String, String> law : game.getLawsInfo().entrySet()) {
+            if (oldColor.equalsIgnoreCase(law.getValue())) {
+                law.setValue(newColor);
+            }
+        }
+
         // Convert all unitholders
         game.getTileMap().values().stream()
                 .flatMap(t -> t.getUnitHolders().values().stream())


### PR DESCRIPTION
Law elections are stored in lawsInfo as free text - either the elected player's faction or their color, and IsPlayerElectedService matches against both. changePlayerColor already migrates promissory notes, Mahact CCs, debt tokens, units, control tokens and CCs, but never touched lawsInfo, so a color-recorded election silently stopped matching the moment that player changed color.

The player quietly loses the law's effect - isPlayerElected gates 64 call sites across agenda, combat and phase handling - and the election can never match again, since no player holds the old color anymore.

Note this only fixes future color changes; games that already changed color need their lawsInfo repaired separately.