### PR TITLE
Stop homebrew replacement promissory notes from leaking, fix games with leaking

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -1,102 +1,19 @@
 package ti4.discord.interactions.commands.developer;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
 import ti4.game.Player;
-import ti4.game.Tile;
 import ti4.game.persistence.ConsumeGameUtility;
 import ti4.game.persistence.GameManager;
-import ti4.helpers.AliasHandler;
-import ti4.image.Mapper;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
-import ti4.model.FactionModel;
-import ti4.model.Source.ComponentSource;
 
 class RunAgainstAllGames extends Subcommand {
-
-    // The 5 removed Eronous factions and their component ids; the models no longer exist, so ids are hardcoded here.
-    private static final Set<String> ERONOUS_FACTIONS = Set.of("canto", "eidolon", "shadows", "mechi", "saera");
-    private static final Map<String, String> ERONOUS_HOME_TILES =
-            Map.of("canto", "as01", "eidolon", "as02", "shadows", "as03", "mechi", "as04", "saera", "as05");
-    private static final Set<String> ERONOUS_PLANETS = Set.of(
-            "thyolcian", "voyd", "etyr", "ecconv", "tyriaprime", "akredrite", "meccna", "gaia", "gensis", "aeva");
-    private static final Set<String> ERONOUS_TECHS = Set.of(
-            "cantoy",
-            "cantor",
-            "eidolonff",
-            "eidolonb",
-            "shadowssd",
-            "shadowsy",
-            "mechig",
-            "mechiy",
-            "saeracr",
-            "saeray");
-    private static final Set<String> ERONOUS_PNS = Set.of("cantopn", "eidolonpn", "shadowspn", "mechipn", "saerapn");
-    private static final Set<String> ERONOUS_LEADERS = Set.of(
-            "cantoagent",
-            "cantocommander",
-            "cantohero",
-            "eidolonagent",
-            "eidoloncommander",
-            "eidolonhero",
-            "shadowsagent",
-            "shadowscommander",
-            "shadowshero",
-            "mechiagent",
-            "mechicommander",
-            "mechihero",
-            "saeraagentprosperity",
-            "saeraagentwarning",
-            "saeraagentprotection",
-            "saeracommander",
-            "saerahero");
-    private static final Set<String> ERONOUS_ABILITIES = Set.of(
-            "enslave",
-            "dominate",
-            "seamless_integration",
-            "void_tap",
-            "dark_weaver",
-            "abyssal_propagation",
-            "creeping_shades",
-            "silent_growth",
-            "tomb_worlds",
-            "protocols",
-            "machine_cult",
-            "protocol_distribution",
-            "protocol_command",
-            "protocol_excavation",
-            "protocol_espionage",
-            "protocol_conflict",
-            "angelic_hosts",
-            "guidance",
-            "celestial_being");
-    private static final Set<String> ERONOUS_UNITS = Set.of(
-            "canto_flagship",
-            "canto_mech",
-            "eidolon_flagship",
-            "eidolon_mech",
-            "eidolon_fighter",
-            "eidolon_fighter2",
-            "shadows_flagship",
-            "shadows_mech",
-            "shadows_spacedock",
-            "shadows_spacedock2",
-            "mechi_flagship",
-            "mechi_mech",
-            "saera_flagship",
-            "saera_mech",
-            "saera_cruiser",
-            "saera_cruiser2");
 
     RunAgainstAllGames() {
         super("run_against_all_games", "Runs this custom code against all games.");
@@ -109,10 +26,10 @@ class RunAgainstAllGames extends Subcommand {
         Set<String> changedGames = new HashSet<>();
         ConsumeGameUtility.consumeAllGames(
                 game -> {
-                    boolean changed = removeEronousFactions(game);
+                    boolean changed = removeBlackSpectrumGenericPNs(game);
                     if (changed) {
                         changedGames.add(game.getName());
-                        GameManager.save(game, "Removed Eronous factions from game state.");
+                        GameManager.save(game, "Removed Black Spectrum generic PN duplicates from game state.");
                     }
                 },
                 ExecutionLockType.WRITE);
@@ -122,109 +39,26 @@ class RunAgainstAllGames extends Subcommand {
                 + " games: " + String.join(", ", changedGames));
     }
 
-    static boolean removeEronousFactions(Game game) {
+    // Black Spectrum's colorable Political Secret/Support for the Throne replacements were dealt
+    // to every player in every game, since nothing gated them behind an actual "is Black Spectrum
+    // enabled" check. Strip any stray copies out of every player's hand and owned-PN pool, wherever
+    // they ended up (including after being traded away from whoever originally received them).
+    static boolean removeBlackSpectrumGenericPNs(Game game) {
         boolean changed = false;
-
-        // Swap any player playing a removed Eronous faction to a random official faction
         for (Player player : game.getPlayers().values()) {
-            String oldFaction = player.getFaction();
-            if (oldFaction == null || !ERONOUS_FACTIONS.contains(oldFaction)) continue;
-            changed = true;
-
-            FactionModel replacement = pickReplacementFaction(game);
-            if (replacement == null) {
-                BotLogger.warning("removeEronousFactions: no replacement faction available in game " + game.getName()
-                        + " for player " + player.getUserName());
-                continue;
-            }
-
-            Tile oldHomeTile = null;
-            String oldHomeTileId = ERONOUS_HOME_TILES.get(oldFaction);
-            for (Tile tile : game.getTileMap().values()) {
-                if (oldHomeTileId.equals(tile.getTileID())) {
-                    oldHomeTile = tile;
-                    break;
-                }
-            }
-
-            player.setFaction(game, replacement.getAlias());
-            player.setFactionEmoji(null);
-            player.setFactionTechs(new ArrayList<>(replacement.getFactionTech()));
-            player.setUnitsOwned(new HashSet<>(replacement.getUnits()));
-
-            Set<String> ownedNotes = new HashSet<>(player.getPromissoryNotesOwned());
-            ownedNotes.removeAll(ERONOUS_PNS);
-            ownedNotes.addAll(replacement.getPromissoryNotes());
-            player.setPromissoryNotesOwned(ownedNotes);
-
-            if (oldHomeTile != null) {
-                String newHomeTileId = AliasHandler.resolveTile(replacement.getHomeSystem());
-                Tile newHomeTile = new Tile(newHomeTileId, oldHomeTile.getPosition(), oldHomeTile.getSpaceUnitHolder());
-                game.setTile(newHomeTile);
-                for (String planet : replacement.getHomePlanets()) {
-                    String planetId = AliasHandler.resolvePlanet(planet.toLowerCase());
-                    if (!player.getPlanets().contains(planetId)) {
-                        player.getPlanets().add(planetId);
-                    }
-                }
-            }
-            player.setCommoditiesBase(replacement.getCommodities());
-            int commoditiesTotal = player.getCommoditiesTotal();
-            if (player.getCommodities() > commoditiesTotal) {
-                player.setCommodities(commoditiesTotal);
-            }
-
-            BotLogger.info("removeEronousFactions: in game " + game.getName() + ", swapped " + player.getUserName()
-                    + " from " + oldFaction + " to " + replacement.getAlias());
-        }
-
-        // Scrub stray Eronous component ids from every player (covers franken drafts and traded PNs)
-        for (Player player : game.getPlayers().values()) {
-            changed |= player.getLeaders().removeIf(leader -> ERONOUS_LEADERS.contains(leader.getId()));
-            changed |= player.getAbilities().removeAll(ERONOUS_ABILITIES);
-            changed |= player.getExhaustedAbilities().removeAll(ERONOUS_ABILITIES);
-            // direct list ops on purpose: removeTech() side effects can NPE on ids with no model
-            changed |= player.getTechs().removeAll(ERONOUS_TECHS);
-            changed |= player.getExhaustedTechs().removeAll(ERONOUS_TECHS);
-            changed |= player.getPurgedTechs().removeAll(ERONOUS_TECHS);
-            changed |= player.getFactionTechs().removeAll(ERONOUS_TECHS);
-            changed |= player.getUnitsOwned().removeAll(ERONOUS_UNITS);
-            changed |= player.getPromissoryNotesOwned().removeAll(ERONOUS_PNS);
-            changed |= player.getPromissoryNotesInPlayArea().removeAll(ERONOUS_PNS);
-            for (String pn : ERONOUS_PNS) {
-                if (player.getPromissoryNotes().containsKey(pn)) {
-                    player.removePromissoryNote(pn);
+            for (String pnID : new ArrayList<>(player.getPromissoryNotes().keySet())) {
+                if (pnID.endsWith("_bsp_ps") || pnID.endsWith("_bsp_sftt")) {
+                    player.removePromissoryNote(pnID);
                     changed = true;
                 }
             }
-            changed |= player.getPlanets().removeAll(ERONOUS_PLANETS);
-            changed |= player.getExhaustedPlanets().removeAll(ERONOUS_PLANETS);
-            changed |= player.getExhaustedPlanetsAbilities().removeAll(ERONOUS_PLANETS);
-        }
-
-        changed |= game.getPurgedPN().removeAll(ERONOUS_PNS);
-
-        // Remove any Eronous home system tiles left on the map (e.g. from an abandoned setup)
-        for (Tile tile : new ArrayList<>(game.getTileMap().values())) {
-            if (ERONOUS_HOME_TILES.containsValue(tile.getTileID())) {
-                game.removeTile(tile.getPosition());
-                changed = true;
+            for (String pnID : new ArrayList<>(player.getPromissoryNotesOwned())) {
+                if (pnID.endsWith("_bsp_ps") || pnID.endsWith("_bsp_sftt")) {
+                    player.removeOwnedPromissoryNoteByID(pnID);
+                    changed = true;
+                }
             }
         }
-
         return changed;
-    }
-
-    private static FactionModel pickReplacementFaction(Game game) {
-        List<FactionModel> pool = Mapper.getFactionsValues().stream()
-                .filter(f -> f.getSource().isOfficial())
-                .filter(f -> game.isTwilightsFallMode() == (f.getSource() == ComponentSource.twilights_fall))
-                .filter(f -> !"neutral".equals(f.getAlias()) && !"keleres".equals(f.getAlias()))
-                .filter(f -> game.getPlayerFromColorOrFaction(f.getAlias()) == null)
-                .filter(f -> game.getTile(AliasHandler.resolveTile(f.getHomeSystem())) == null)
-                .collect(Collectors.toCollection(ArrayList::new));
-        if (pool.isEmpty()) return null;
-        Collections.shuffle(pool);
-        return pool.getFirst();
     }
 }

--- a/src/main/java/ti4/image/Mapper.java
+++ b/src/main/java/ti4/image/Mapper.java
@@ -999,17 +999,18 @@ public class Mapper {
         if (isValidColor(color)) {
             for (PromissoryNoteModel pn : promissoryNotes.values()) {
                 if (pn.getColor().isPresent() && color.equals(pn.getColor().get())) {
-                    if ("agendas_absol".equals(game.getAgendaDeckID())
-                            && pn.getAlias().endsWith("_ps")
-                            && pn.getSource() != ComponentSource.absol) {
-                        continue;
-                    }
-                    if (!"agendas_absol".equals(game.getAgendaDeckID())
-                            && pn.getAlias().endsWith("_ps")
-                            && pn.getSource() == ComponentSource.absol) {
+                    if (pn.getAlias().endsWith("_ps") && "agendas_absol".equals(game.getAgendaDeckID())) {
+                        // Absol's agenda deck is active: only its own Political Secret variant is dealt.
+                        if (pn.getSource() == ComponentSource.absol) {
+                            pnList.add(pn.getAlias());
+                        }
                         continue;
                     }
                     if (pn.getAlias().startsWith("wekkerabsol_") && !"g14".equals(game.getName())) {
+                        continue;
+                    }
+                    if (pn.getHomebrewReplacesID().isPresent()) {
+                        // Any other homebrew replacement PN is opt-in only; nothing has turned it on yet.
                         continue;
                     }
                     pnList.add(pn.getAlias());

--- a/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
@@ -2,120 +2,38 @@ package ti4.discord.interactions.commands.developer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import ti4.game.Game;
-import ti4.game.Leader;
 import ti4.game.Player;
-import ti4.game.Tile;
-import ti4.game.persistence.GameManager;
-import ti4.game.persistence.TestGameHarness;
-import ti4.helpers.AliasHandler;
-import ti4.helpers.Constants;
-import ti4.helpers.Storage;
-import ti4.image.Mapper;
-import ti4.model.FactionModel;
-import ti4.testUtils.BaseTi4Test;
 
-class RunAgainstAllGamesTest extends BaseTi4Test {
+class RunAgainstAllGamesTest {
 
     @Test
-    void shouldSwapRemovedEronousFactionToRandomOfficialFaction() throws IOException {
-        try (var harness = TestGameHarness.forDefaultMap()) {
-            plantEronousFaction(harness.getGameName());
-            Game game = harness.load();
+    void removeBlackSpectrumGenericPNsStripsOnlyTheBlackSpectrumDuplicates() {
+        Game game = new Game();
+        Player player = new Player("user-id", "user/name", game);
+        player.setColor("red");
+        game.setPlayers(new LinkedHashMap<>(Map.of("user-id", player)));
 
-            Player swapped = game.getPlayers().values().stream()
-                    .filter(p -> "canto".equals(p.getFaction()))
-                    .findFirst()
-                    .orElseThrow();
-            String swappedUserId = swapped.getUserID();
+        player.setPromissoryNote("red_ps");
+        player.setPromissoryNote("red_bsp_ps");
+        player.setPromissoryNote("red_sftt");
+        player.setPromissoryNote("red_bsp_sftt");
+        player.setPromissoryNotesOwned(new HashSet<>(List.of("red_ps", "red_bsp_ps", "red_sftt", "red_bsp_sftt")));
 
-            boolean changed = RunAgainstAllGames.removeEronousFactions(game);
+        boolean changed = RunAgainstAllGames.removeBlackSpectrumGenericPNs(game);
 
-            assertThat(changed).isTrue();
-            String newFaction = swapped.getFaction();
-            assertThat(newFaction).isNotEqualTo("canto");
-            FactionModel newFactionModel = Mapper.getFaction(newFaction);
-            assertThat(newFactionModel).isNotNull();
-            assertThat(newFactionModel.getSource().isOfficial()).isTrue();
-            assertThat(game.getPlayers().values().stream()
-                            .filter(p -> newFaction.equals(p.getFaction()))
-                            .count())
-                    .isEqualTo(1);
+        assertThat(changed).isTrue();
+        assertThat(player.getPromissoryNotes()).containsKey("red_ps").containsKey("red_sftt");
+        assertThat(player.getPromissoryNotes()).doesNotContainKey("red_bsp_ps").doesNotContainKey("red_bsp_sftt");
+        assertThat(player.getPromissoryNotesOwned()).contains("red_ps", "red_sftt");
+        assertThat(player.getPromissoryNotesOwned()).doesNotContain("red_bsp_ps", "red_bsp_sftt");
 
-            // No Eronous component ids may remain on any player
-            for (Player p : game.getPlayers().values()) {
-                assertThat(p.getTechs()).doesNotContain("cantoy", "cantor");
-                assertThat(p.getExhaustedTechs()).doesNotContain("cantoy", "cantor");
-                assertThat(p.getFactionTechs()).doesNotContain("cantoy", "cantor");
-                assertThat(p.getPlanets()).doesNotContain("thyolcian");
-                assertThat(p.getUnitsOwned()).doesNotContain("canto_flagship", "canto_mech", "eidolon_fighter");
-                assertThat(p.getPromissoryNotesOwned()).doesNotContain("cantopn");
-                assertThat(p.getPromissoryNotes()).doesNotContainKey("cantopn");
-                assertThat(p.getLeaders().stream().map(Leader::getId))
-                        .doesNotContain("cantoagent", "cantocommander", "cantohero");
-                assertThat(p.getAbilities()).doesNotContain("enslave", "dominate", "seamless_integration");
-            }
-
-            // The Eronous home system was replaced in place by the new faction's home system
-            assertThat(game.getTileMap().values().stream().map(Tile::getTileID)).doesNotContain("as01");
-            Tile newHomeTile = game.getTileByPosition("210");
-            assertThat(newHomeTile).isNotNull();
-            assertThat(newHomeTile.getTileID()).isEqualTo(AliasHandler.resolveTile(newFactionModel.getHomeSystem()));
-            for (String homePlanet : newFactionModel.getHomePlanets()) {
-                assertThat(swapped.getPlanets()).contains(AliasHandler.resolvePlanet(homePlanet.toLowerCase()));
-            }
-
-            // Running again makes no further changes
-            assertThat(RunAgainstAllGames.removeEronousFactions(game)).isFalse();
-
-            // The updated game round-trips through save/load
-            GameManager.save(game, "test");
-            Game reloaded = harness.load();
-            Player reloadedPlayer = reloaded.getPlayer(swappedUserId);
-            assertThat(reloadedPlayer.getFaction()).isEqualTo(newFaction);
-        }
-    }
-
-    /**
-     * Rewrites the copied test map so the first player is playing the removed Eronous faction "canto"
-     * (with its leaders, techs, abilities, planets, and promissory note), a second player holds stray
-     * Eronous components, and the canto home system tile as01 is on the map.
-     */
-    private static void plantEronousFaction(String gameName) throws IOException {
-        Path path = Storage.getGamePath(gameName + Constants.TXT);
-        List<String> lines = Files.readAllLines(path);
-        int playerIndex = 0;
-        for (int i = 0; i < lines.size(); i++) {
-            String line = lines.get(i);
-            if ("-player-".equals(line)) {
-                playerIndex++;
-                continue;
-            }
-            if ("43 210".equals(line)) {
-                lines.set(i, "as01 210");
-                continue;
-            }
-            if (playerIndex == 1) {
-                if (line.startsWith("faction ")) lines.set(i, "faction canto");
-                else if (line.startsWith("faction_tech ")) lines.set(i, "faction_tech cantoy,cantor");
-                else if (line.startsWith("tech ")) lines.set(i, line + ",cantoy");
-                else if (line.startsWith("planets ")) lines.set(i, line + ",thyolcian");
-                else if (line.startsWith("promissory_notes_owned ")) lines.set(i, line + ",cantopn");
-                else if (line.startsWith("abilities ")) lines.set(i, "abilities enslave,dominate,seamless_integration");
-                else if (line.startsWith("leaders "))
-                    lines.set(
-                            i,
-                            "leaders cantoagent,agent,0,false,false,false;cantocommander,commander,0,false,false,false;cantohero,hero,0,true,false,false;");
-            } else if (playerIndex == 2) {
-                if (line.startsWith("promissory_notes ")) lines.set(i, line + "cantopn,55;");
-                else if (line.startsWith("units_owned ")) lines.set(i, line + ",eidolon_fighter");
-            }
-        }
-        Files.write(path, lines);
+        // Running again makes no further changes
+        assertThat(RunAgainstAllGames.removeBlackSpectrumGenericPNs(game)).isFalse();
     }
 }


### PR DESCRIPTION
getColorPromissoryNoteIDs only excluded Absol/Wekker Absol PNs by name, so any other colorable PN with homebrewReplacesID set (e.g. Black Spectrum's PS/SFTT variants) was dealt to every player in every game regardless of whether that source was in use. Add a generic rule: any colorable PN declaring homebrewReplacesID is opt-in only and excluded until something actually swaps it in, the same way Absol's PN already does explicitly. Future homebrew replacement PNs are covered automatically with no changes needed here.