### PR TITLE
LL Old Glory Automation

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/theodisi/Ponthous/PonthousUnitHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/theodisi/Ponthous/PonthousUnitHandler.java
@@ -1,0 +1,123 @@
+package ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Ponthous;
+
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import org.apache.commons.lang3.math.NumberUtils;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.game.UnitHolder;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.Units;
+import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitType;
+import ti4.message.MessageHelper;
+import ti4.model.UnitModel;
+import ti4.service.emoji.FactionEmojis;
+import ti4.service.unit.UnitModelValueInjectionService;
+import ti4.service.unit.UnitModelValueInjectionService.BooleanValueInjection;
+import ti4.service.unit.UnitModelValueInjectionService.UnitValueInjection;
+
+@UtilityClass
+public class PonthousUnitHandler {
+
+    private static final String PONTHOUS_FLAGSHIP = "ponthous_flagship";
+    private static final String OLD_GLORY_SUSTAIN = "ponthousOldGlorySustain_";
+    private static final String USE_OLD_GLORY_SUSTAIN = "useOldGlorySustain_";
+
+    public static Button getOldGlorySustainButton(Player player, Tile tile) {
+        if (!canOfferOldGlorySustain(player, tile)) return null;
+        return Buttons.gray(
+                player.factionButtonChecker() + USE_OLD_GLORY_SUSTAIN + tile.getPosition(),
+                "Use Old Glory Ability",
+                FactionEmojis.ponthous);
+    }
+
+    @ButtonHandler(USE_OLD_GLORY_SUSTAIN)
+    public static void useOldGlorySustain(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        Tile tile = game.getTileByPosition(buttonID.substring(USE_OLD_GLORY_SUSTAIN.length()));
+        if (tile == null || !canResolveOldGlorySustain(player, tile)) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "Old Glory cannot use this ability right now.");
+            return;
+        }
+
+        UnitHolder space = tile.getSpaceUnitHolder();
+        UnitKey flagship = Units.getUnitKey(UnitType.Flagship, player.getColorID());
+        UnitKey fighter = Units.getUnitKey(UnitType.Fighter, player.getColorID());
+        int fightersToGrantSustain = Math.min(2, space.getUnitCount(fighter) - space.getDamagedUnitCount(fighter));
+        if (fightersToGrantSustain < 1) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "There are no undamaged fighters to gain sustain damage.");
+            return;
+        }
+
+        space.addDamagedUnit(flagship, 1);
+        game.setStoredValue(getOldGlorySustainKey(player, tile), Integer.toString(fightersToGrantSustain));
+        ButtonHelper.deleteButtonAndDeleteMessageIfEmpty(event);
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(),
+                player.getRepresentationNoPing()
+                        + " damaged _Old Glory_. "
+                        + fightersToGrantSustain
+                        + " fighter"
+                        + (fightersToGrantSustain == 1 ? " gains" : "s gain")
+                        + " SUSTAIN DAMAGE until this combat ends.");
+    }
+
+    public static UnitModel injectTemporaryFighterSustain(Game game, Player player, Tile tile, UnitModel unit) {
+        if (unit.getUnitType() != UnitType.Fighter || getRemainingFighterSustains(game, player, tile) < 1) {
+            return unit;
+        }
+        return UnitModelValueInjectionService.injectTemporaryValues(
+                unit, UnitValueInjection.of(BooleanValueInjection.create().sustainDamage(true)));
+    }
+
+    public static int getTemporaryFighterSustainRemaining(Game game, Player player, Tile tile) {
+        return getRemainingFighterSustains(game, player, tile);
+    }
+
+    public static void consumeTemporaryFighterSustain(Game game, Player player, Tile tile, int amount) {
+        int remaining = getRemainingFighterSustains(game, player, tile) - amount;
+        String key = getOldGlorySustainKey(player, tile);
+        if (remaining > 0) {
+            game.setStoredValue(key, Integer.toString(remaining));
+        } else {
+            game.removeStoredValue(key);
+        }
+    }
+
+    public static void clearOldGlorySustain(Game game) {
+        game.getStoredValueMap().keySet().stream()
+                .filter(key -> key.startsWith(OLD_GLORY_SUSTAIN))
+                .toList()
+                .forEach(game::removeStoredValue);
+    }
+
+    private static boolean canOfferOldGlorySustain(Player player, Tile tile) {
+        if (!player.ownsUnit(PONTHOUS_FLAGSHIP)) return false;
+        UnitHolder space = tile.getSpaceUnitHolder();
+        UnitKey flagship = Units.getUnitKey(UnitType.Flagship, player.getColorID());
+        UnitKey fighter = Units.getUnitKey(UnitType.Fighter, player.getColorID());
+        return space.getUnitCount(flagship) > 0 && space.getUnitCount(fighter) > 0;
+    }
+
+    private static boolean canResolveOldGlorySustain(Player player, Tile tile) {
+        if (!canOfferOldGlorySustain(player, tile)) return false;
+        UnitHolder space = tile.getSpaceUnitHolder();
+        UnitKey flagship = Units.getUnitKey(UnitType.Flagship, player.getColorID());
+        UnitKey fighter = Units.getUnitKey(UnitType.Fighter, player.getColorID());
+        return space.getUnitCount(flagship) > space.getDamagedUnitCount(flagship)
+                && space.getUnitCount(fighter) > space.getDamagedUnitCount(fighter);
+    }
+
+    private static int getRemainingFighterSustains(Game game, Player player, Tile tile) {
+        return NumberUtils.toInt(game.getStoredValue(getOldGlorySustainKey(player, tile)));
+    }
+
+    private static String getOldGlorySustainKey(Player player, Tile tile) {
+        return OLD_GLORY_SUSTAIN + player.getFaction() + "_" + tile.getPosition();
+    }
+}

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/unit/AssignHitsButtonHandlers.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/unit/AssignHitsButtonHandlers.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.StringUtils;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Iron.IronLeadersHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.ashen.AshenUnitHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Ponthous.PonthousUnitHandler;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
 import ti4.game.Player;
@@ -198,6 +199,9 @@ class AssignHitsButtonHandlers {
                     UnitHolder holder =
                             planetName != null ? tile.getUnitHolderFromPlanet(planetName) : tile.getSpaceUnitHolder();
                     if (holder != null) holder.addDamagedUnit(Units.getUnitKey(type, player.getColorID()), amt);
+                    if (holder == tile.getSpaceUnitHolder() && type == UnitType.Fighter) {
+                        PonthousUnitHandler.consumeTemporaryFighterSustain(game, player, tile, amt);
+                    }
                     CommanderUnlockCheckService.checkPlayer(player, "ponthous");
 
                     String plural = (amt == 1 || "infantry".equalsIgnoreCase(type.humanReadableName())) ? "" : "s";

--- a/src/main/java/ti4/helpers/ButtonHelper.java
+++ b/src/main/java/ti4/helpers/ButtonHelper.java
@@ -60,6 +60,7 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.netrunne
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.ta.TaBreakthroughHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Aeterna.AeternaBreakthroughHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Arcanum.*;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Ponthous.PonthousUnitHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Revenant.RevenantLeadersHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Xytheris.*;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.arvaxi.ArvaxiBreakthroughHandler;
@@ -6746,6 +6747,9 @@ public class ButtonHelper {
                 if (!player.unitBelongsToPlayer(unitKey)) continue;
                 UnitModel unitModel = player.getUnitFromUnitKey(unitKey);
                 if (unitModel == null) continue;
+                if (combat) {
+                    unitModel = PonthousUnitHandler.injectTemporaryFighterSustain(game, player, tile, unitModel);
+                }
                 if (unitModel.getUnitType() == UnitType.Infantry
                         && spaceCombatish
                         && (player.hasUnit("purpletf_mech") || player.hasUnit("naaz_voltron"))) {
@@ -6771,6 +6775,11 @@ public class ButtonHelper {
                 for (UnitState state : UnitState.values()) {
                     if (state.isDamaged() || !canDamage) continue;
                     int max = Math.min(oneButtonPerUnit ? 1 : 2, unitHolder.getUnitCountForState(unitKey, state));
+                    if (unitKey.unitType() == UnitType.Fighter) {
+                        int temporarySustains =
+                                PonthousUnitHandler.getTemporaryFighterSustainRemaining(game, player, tile);
+                        if (temporarySustains > 0) max = Math.min(max, temporarySustains);
+                    }
                     for (int x = 1; x <= max; x++) {
                         buttons.add(buildAssignHitButton(player, tile, unitHolder, state, unitKey, x, true));
                     }

--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -23,6 +23,7 @@ import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Iron.IronAbilitiesHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.Iron.IronLeadersHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.beans.ashen.AshenUnitHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Ponthous.PonthousUnitHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.kalora.KaloraAbilityHandler;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
@@ -579,7 +580,9 @@ public final class ButtonHelperModifyUnits {
             msg = new StringBuilder("The hit" + (hits == 1 ? "" : "s") + " would be assigned in the following way:\n");
         }
         Map<UnitKey, Integer> units = new HashMap<>(unitHolder.getUnits());
-        int numSustains = getNumberOfSustainableUnits(player, game, unitHolder, true, spaceCannonOffence);
+        int oldGloryFighterSustains = PonthousUnitHandler.getTemporaryFighterSustainRemaining(game, player, tile);
+        int numSustains = getNumberOfSustainableUnits(player, game, unitHolder, true, spaceCannonOffence)
+                + oldGloryFighterSustains;
         boolean noMechPowers = ButtonHelper.isLawInPlay(game, "articles_war");
         boolean opponentCanDirectHit = true;
         if (!spaceCannonOffence) {
@@ -665,8 +668,10 @@ public final class ButtonHelperModifyUnits {
                 if (!player.unitBelongsToPlayer(unitKey)) continue;
 
                 UnitModel unitModel = player.getUnitFromUnitKey(unitKey);
+                boolean oldGloryFighter = unitKey.unitType() == UnitType.Fighter && oldGloryFighterSustains > 0;
                 if (unitModel == null
                         || (!unitModel.getSustainDamage()
+                                && !oldGloryFighter
                                 && (metailUsed || unitModel.getUnitType() == UnitType.Fighter))
                         || ((!unitModel.getIsShip()
                                         && !(ButtonHelper.doesPlayerHaveFSHere("nekro_flagship", player, tile)
@@ -688,7 +693,9 @@ public final class ButtonHelperModifyUnits {
                         ? unitHolder.getUnitDamage().getOrDefault(unitKey, 0)
                         : 0;
                 int totalUnits = unitEntry.getValue() - damagedUnits;
-                if (!unitModel.getSustainDamage() && !metailUsed && totalUnits > 0) {
+                if (oldGloryFighter) {
+                    totalUnits = Math.min(totalUnits, oldGloryFighterSustains);
+                } else if (!unitModel.getSustainDamage() && !metailUsed && totalUnits > 0) {
                     totalUnits = 1;
                     metailUsed = true;
                 }
@@ -713,6 +720,10 @@ public final class ButtonHelperModifyUnits {
                                 .append(unitModel.getUnitEmoji())
                                 .append('\n');
                         tile.addUnitDamage("space", unitKey, min);
+                        if (oldGloryFighter) {
+                            PonthousUnitHandler.consumeTemporaryFighterSustain(game, player, tile, min);
+                            oldGloryFighterSustains -= min;
+                        }
                         for (int x = 0; x < min; x++) {
                             ButtonHelperCommanders.resolveLetnevCommanderCheck(player, game, event);
                         }

--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -20,6 +20,7 @@ import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Arcan
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Ardentia.*;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Kairn.*;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Myrr.MyrrUnitsHandler;
+import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Ponthous.PonthousUnitHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Thrones.ThronesTechHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.theodisi.Xytheris.XytherisLeadersHandler;
 import ti4.discord.interactions.buttons.handlers.faction.homebrew.whispers.lunarium.LunariumAbilityHandler;
@@ -478,6 +479,7 @@ public final class ButtonHelperTacticalAction {
         game.removeStoredValue("ghostagent_active");
         XytherisLeadersHandler.clearMyrixAgentEffects(game);
         XytherisLeadersHandler.clearHeroUnitAbilityRoll(game);
+        PonthousUnitHandler.clearOldGlorySustain(game);
         ArcanumBreakthroughHandler.clearPowerWordWish(game);
         ArcanumTechHandler.clearSigilOfTransmutation(game);
         KairnTechHandler.clearSurveyorsLensFragmentWindows(game);

--- a/src/main/java/ti4/service/combat/StartCombatService.java
+++ b/src/main/java/ti4/service/combat/StartCombatService.java
@@ -319,6 +319,7 @@ public class StartCombatService {
         if (!game.isFowMode()) {
             channel = game.getMainGameChannel();
         }
+        PonthousUnitHandler.clearOldGlorySustain(game);
         game.setStoredValue("factionsInCombat", player1.getFaction() + "_" + player2.getFaction());
 
         sendStartOfCombatSecretMessages(game, player1, player2, tile, spaceOrGround, unitHolderName);
@@ -1427,6 +1428,11 @@ public class StartCombatService {
                     "Mercenaries",
                     FactionEmojis.florzen));
         }
+
+        Button oldGloryP1 = PonthousUnitHandler.getOldGlorySustainButton(p1, tile);
+        if (oldGloryP1 != null) buttons.add(oldGloryP1);
+        Button oldGloryP2 = PonthousUnitHandler.getOldGlorySustainButton(p2, tile);
+        if (oldGloryP2 != null) buttons.add(oldGloryP2);
 
         return buttons;
     }

--- a/src/main/java/ti4/service/unit/UnitModelValueInjectionService.java
+++ b/src/main/java/ti4/service/unit/UnitModelValueInjectionService.java
@@ -63,6 +63,15 @@ public class UnitModelValueInjectionService {
         return injectedUnit;
     }
 
+    /**
+     * Applies a combat- or action-local value injection to a copied unit model.
+     *
+     * <p>The caller is responsible for storing and clearing the condition that makes this temporary injection apply.
+     */
+    public UnitModel injectTemporaryValues(UnitModel unit, UnitValueInjection values) {
+        return injectValues(unit, values);
+    }
+
     public UnitModel injectValues(UnitModel unit, IntegerValueInjection values) {
         Objects.requireNonNull(unit);
         Objects.requireNonNull(values);

--- a/src/main/resources/data/units/theodisi_units.json
+++ b/src/main/resources/data/units/theodisi_units.json
@@ -641,7 +641,8 @@
     "sustainDamage": true,
     "canBeDirectHit": true,
     "isShip": true,
-    "ability": "At the start of combat in this unit's system, you may damage this unit to give up to 2 fighters in this system SUSTAIN DAMAGE until the end of that combat."
+    "ability": "At the start of combat in this unit's system, you may damage this unit to give up to 2 fighters in this system SUSTAIN DAMAGE until the end of that combat.",
+    "notes": "There is no way to show which fighters are sustained, you will have to keep track. However, the manual assign and auto-assign don't offer fighter sustains past when 2 fighters are sustained."
   },
   {
     "id": "ponthous_mech",


### PR DESCRIPTION
Also added a way for UnitModelValueInjectionService to grant temporary values to a unit (all of a type, need special handling for individual units in a stack). State must be cleared by the caller though or it will persist.