### PR TITLE
Veiled Heart: Paradigms & Unit Upgrades

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/edict/resolver/TfConveneResolver.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/edict/resolver/TfConveneResolver.java
@@ -55,7 +55,11 @@ public class TfConveneResolver implements EdictResolver {
                     + Mapper.getTech(cardID).getName();
             if (game.isVeiledHeartMode()) {
                 msg += " (It was turned face-down and may be put into play with a button in the `#cards-info` thread.)";
-                VeiledHeartService.addVeiledCard(tyrant, cardID);
+                VeiledHeartService.doSilentAction(
+                        VeiledHeartService.VeiledCardAction.DRAW,
+                        VeiledHeartService.VeiledCardType.ABILITY,
+                        tyrant,
+                        cardID);
             } else {
                 tyrant.addTech(cardID);
             }
@@ -112,7 +116,8 @@ public class TfConveneResolver implements EdictResolver {
                 + Mapper.getTech(cardID).getName();
         if (game.isVeiledHeartMode()) {
             msg += " (It was turned face-down and may be put into play with a button in the `#cards-info` thread.)";
-            VeiledHeartService.addVeiledCard(p2, cardID);
+            VeiledHeartService.doSilentAction(
+                    VeiledHeartService.VeiledCardAction.DRAW, VeiledHeartService.VeiledCardType.ABILITY, p2, cardID);
         } else {
             p2.addTech(cardID);
         }

--- a/src/main/java/ti4/discord/interactions/commands/tf/DoVeiledCardAction.java
+++ b/src/main/java/ti4/discord/interactions/commands/tf/DoVeiledCardAction.java
@@ -1,0 +1,44 @@
+package ti4.discord.interactions.commands.tf;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.GameStateSubcommand;
+import ti4.game.Player;
+import ti4.helpers.Constants;
+import ti4.service.VeiledHeartService;
+
+class DoVeiledCardAction extends GameStateSubcommand {
+
+    DoVeiledCardAction() {
+        super(
+                "veiled_card",
+                "Draw/Discard/Unveil a specified veiled card (Twilight's Fall: Veiled Heart mode)",
+                true,
+                true);
+        addOptions(
+                new OptionData(OptionType.STRING, "action", "Action Type (Draw/Discard/Unveil)", true)
+                        .addChoices(
+                                new Command.Choice("Draw", "draw"),
+                                new Command.Choice("Discard", "discard"),
+                                new Command.Choice("Unveil", "unveil")),
+                new OptionData(OptionType.STRING, "card", "Card to perform the action on", true),
+                new OptionData(OptionType.STRING, Constants.FACTION_COLOR, "Faction or Color performing the action")
+                        .setAutoComplete(true));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        Player player = getPlayer();
+        String actionStr = event.getOption("action", OptionMapping::getAsString);
+        String card = event.getOption("card", OptionMapping::getAsString);
+        VeiledHeartService.doAction(actionStr, player, card);
+    }
+
+    @Override
+    public boolean isSuspicious(SlashCommandInteractionEvent event) {
+        return true;
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/tf/TwilightFallCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/tf/TwilightFallCommand.java
@@ -22,7 +22,8 @@ public class TwilightFallCommand implements ParentCommand {
                     new AddToSplice(),
                     new DoEdictPhase(),
                     new SetupStartingFleet(),
-                    new DiscardVeiledCard())
+                    new DiscardVeiledCard(),
+                    new DoVeiledCardAction())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 
     @Override

--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.components.separator.Separator;
 import net.dv8tion.jda.api.components.separator.Separator.Spacing;
 import net.dv8tion.jda.api.components.textdisplay.TextDisplay;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.function.Consumers;
@@ -1446,7 +1447,7 @@ public final class ButtonHelperTwilightsFall {
             type = buttonID.split("_")[1];
         }
         List<Button> buttons = new ArrayList<>();
-        List<String> cards = getDeckForSplicing(game, type, 100);
+        List<String> cards = getDeckForSplicing(game, type, 100, false);
         for (String card : cards) {
             buttons.add(Buttons.green(
                     "drawSingularNewSpliceCard_" + type + "_" + card,
@@ -1457,8 +1458,15 @@ public final class ButtonHelperTwilightsFall {
                                             ? Mapper.getLeader(card).getName()
                                             : Mapper.getUnit(card).getName())));
         }
+        MessageChannel channel = player.getCorrectChannel();
+        if (game.isVeiledHeartMode()) {
+            String msg = String.format(
+                    "%s is searching the %s deck for a card to gain.", player.getRepresentationNoPing(), type);
+            MessageHelper.sendMessageToChannel(channel, msg);
+            channel = player.getCardsInfoThread();
+        }
         String msg = player.getRepresentation() + ", use these buttons to draw a card from the splice deck.";
-        MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), msg, buttons);
+        MessageHelper.sendMessageToChannelWithButtons(channel, msg, buttons);
         ButtonHelper.deleteMessage(event);
     }
 

--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -966,11 +966,7 @@ public final class ButtonHelperTwilightsFall {
                                 Mapper.getUnit(cardID).getRepresentationEmbed());
                     }
                 } else {
-                    VeiledHeartService.addVeiledCard(player, cardID);
-                    MessageHelper.sendMessageToChannel(
-                            player.getCorrectChannel(),
-                            player.getRepresentationNoPing()
-                                    + " has spliced in a secret card. They may put it into play with a button in their `#cards-info` thread.");
+                    VeiledHeartService.doAction(VeiledHeartService.VeiledCardAction.SPLICE, player, cardID);
                 }
                 if (!buttonID.contains("spoof_")) {
                     triggerYellowUnits(game, player);
@@ -1609,11 +1605,11 @@ public final class ButtonHelperTwilightsFall {
             MessageHelper.sendMessageToChannelWithEmbed(
                     player.getCorrectChannel(), msg, model.getRepresentationEmbed());
         } else {
-            VeiledHeartService.addVeiledCard(player, drawnCard);
-            MessageHelper.sendMessageToChannel(
-                    player.getCorrectChannel(),
-                    player.getRepresentationNoPing()
-                            + " has taken a secret card. They may put it into play with a button in their `#cards-info` thread.");
+            VeiledHeartService.doAction(
+                    VeiledHeartService.VeiledCardAction.DRAW,
+                    VeiledHeartService.VeiledCardType.ABILITY,
+                    player,
+                    drawnCard);
         }
     }
 

--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
@@ -444,6 +444,9 @@ public final class ButtonHelperTwilightsFallActionCards {
             }
             buttons.add(Buttons.gray("poisonHeroStep3_" + p2.getFaction() + "_" + ability, tech.getName()));
         }
+        if (game.isVeiledHeartMode()) {
+            buttons.addAll(VeiledHeartService.getVeiledStealButtonsForPoisonHero(player, p2));
+        }
         String msg = player.getRepresentation() + ", please choose the ability you wish to try to steal.";
         MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg, buttons);
         ButtonHelper.deleteMessage(event);
@@ -461,8 +464,9 @@ public final class ButtonHelperTwilightsFallActionCards {
         buttons.add(
                 Buttons.gray(p2.factionButtonChecker() + "poisonHeroStep4_" + player.getFaction(), "Give 2 Abilities"));
         String msg = p2.getRepresentation()
-                + ", you have been hit with _Poison of the Nefishh_, and now much choose to either give them the ability they named, or give them 2 of the abilities of you choice.";
-        MessageHelper.sendMessageToChannel(p2.getCorrectChannel(), msg, buttons);
+                + ", you have been hit with _Poison of the Nefishh_, and must now choose to either give them the ability they named, or give them 2 other abilities of your choice.";
+        MessageHelper.sendMessageToChannel(
+                game.isVeiledHeartMode() ? p2.getCardsInfoThread() : p2.getCorrectChannel(), msg, buttons);
         ButtonHelper.deleteMessage(event);
     }
 

--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
@@ -702,6 +702,9 @@ public final class ButtonHelperTwilightsFallActionCards {
             }
             buttons.add(Buttons.gray("lawsHeroStep3_" + p2.getFaction() + "_" + tech, techM.getName()));
         }
+        if (game.isVeiledHeartMode()) {
+            buttons.addAll(VeiledHeartService.getVeiledPurgeButtonsForLawsHero(player, p2));
+        }
         String msg = player.getRepresentation() + ", please choose the ability that you wish to purge.";
         MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg, buttons);
         ButtonHelper.deleteMessage(event);
@@ -710,14 +713,31 @@ public final class ButtonHelperTwilightsFallActionCards {
     @ButtonHandler("lawsHeroStep3")
     public static void lawsHeroStep3(Game game, Player player, ButtonInteractionEvent event, String buttonID) {
         Player p2 = game.getPlayerFromColorOrFaction(buttonID.split("_")[1]);
-        String agent = buttonID.split("_")[2];
-        game.setStoredValue("purgedAbilities", game.getStoredValue("purgedAbilities") + "_" + agent);
-        TechnologyModel lead = Mapper.getTech(agent);
-        p2.removeTech(agent);
-        String leaderRepresentation = lead.getNameRepresentation();
-        String msg = player.getRepresentation() + " has chosen to purge " + leaderRepresentation + " from "
+        String ability = buttonID.split("_")[2];
+        game.setStoredValue("purgedAbilities", game.getStoredValue("purgedAbilities") + "_" + ability);
+        TechnologyModel tech = Mapper.getTech(ability);
+
+        if (p2.hasTech(ability)) {
+            p2.removeTech(ability);
+        } else if (game.isVeiledHeartMode()) {
+            VeiledHeartService.doSilentAction(
+                    VeiledHeartService.VeiledCardAction.DISCARD,
+                    VeiledHeartService.VeiledCardType.ABILITY,
+                    p2,
+                    ability);
+        } else {
+            String msg = "Error: " + player.getFactionNameOrColor() + " attempted to purge " + ability + " from "
+                    + p2.getFactionNameOrColor() + ", but the ability was not found on that player!";
+            MessageHelper.sendMessageToChannel(p2.getCardsInfoThread(), msg);
+            MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);
+            ButtonHelper.deleteMessage(event);
+            return;
+        }
+
+        String techRepresentation = tech.getNameRepresentation();
+        String msg = player.getRepresentation() + " has chosen to purge " + techRepresentation + " from "
                 + p2.getFactionNameOrColor() + ".";
-        String msg2 = p2.getRepresentation() + ", you lost " + leaderRepresentation + " to _The Laws Unwritten_ by "
+        String msg2 = p2.getRepresentation() + ", you lost " + techRepresentation + " to _The Laws Unwritten_ by "
                 + player.getFactionNameOrColor() + "; it has been purged.";
         MessageHelper.sendMessageToChannel(p2.getCorrectChannel(), msg2);
         MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);

--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
@@ -849,23 +849,23 @@ public final class ButtonHelperTwilightsFallActionCards {
         for (String card : unitSpliceDeck) {
             embeds.add(Mapper.getUnit(card).getRepresentationEmbed());
             if (Mapper.getUnit(card).getBaseType().equalsIgnoreCase(unitT)) {
-                UnitModel unitModel = Mapper.getUnit(card);
-                String asyncId = unitModel.getAsyncId();
-                if (!"fs".equalsIgnoreCase(asyncId) && !"mf".equalsIgnoreCase(asyncId)) {
-                    List<UnitModel> unitsToRemove = player.getUnitsByAsyncID(asyncId).stream()
-                            .filter(unit -> unit.getFaction().isEmpty()
-                                    || unit.getUpgradesFromUnitId().isEmpty())
-                            .toList();
-                    for (UnitModel u : unitsToRemove) {
-                        player.removeOwnedUnitByID(u.getId());
-                    }
-                }
                 found = Mapper.getUnit(card).getNameRepresentation() + ". It has been automatically gained.";
                 if (game.isVeiledHeartMode()) {
                     found +=
                             " (It was gained face-down and may be put into play with a button in the `#cards-info` thread.)";
                     VeiledHeartService.addVeiledCard(player, card);
                 } else {
+                    UnitModel unitModel = Mapper.getUnit(card);
+                    String asyncId = unitModel.getAsyncId();
+                    if (!"fs".equalsIgnoreCase(asyncId) && !"mf".equalsIgnoreCase(asyncId)) {
+                        List<UnitModel> unitsToRemove = player.getUnitsByAsyncID(asyncId).stream()
+                                .filter(unit -> unit.getFaction().isEmpty()
+                                        || unit.getUpgradesFromUnitId().isEmpty())
+                                .toList();
+                        for (UnitModel u : unitsToRemove) {
+                            player.removeOwnedUnitByID(u.getId());
+                        }
+                    }
                     player.addOwnedUnitByID(card);
                 }
                 break;

--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFallActionCards.java
@@ -877,7 +877,11 @@ public final class ButtonHelperTwilightsFallActionCards {
                 if (game.isVeiledHeartMode()) {
                     found +=
                             " (It was gained face-down and may be put into play with a button in the `#cards-info` thread.)";
-                    VeiledHeartService.addVeiledCard(player, card);
+                    VeiledHeartService.doSilentAction(
+                            VeiledHeartService.VeiledCardAction.DRAW,
+                            VeiledHeartService.VeiledCardType.UNIT,
+                            player,
+                            card);
                 } else {
                     UnitModel unitModel = Mapper.getUnit(card);
                     String asyncId = unitModel.getAsyncId();

--- a/src/main/java/ti4/helpers/twilight_kart/TkHelperActionCards.java
+++ b/src/main/java/ti4/helpers/twilight_kart/TkHelperActionCards.java
@@ -133,29 +133,25 @@ public class TkHelperActionCards {
                 .map(Mapper::getLeader)
                 .map(LeaderModel::getTfRepresentationEmbed)
                 .toList();
-        if (!game.isVeiledHeartMode()) {
-            genomes.forEach(player::addLeader);
+        if (game.isVeiledHeartMode()) {
+            genomes.forEach(genome ->
+                    VeiledHeartService.doAction(
+                            VeiledHeartService.VeiledCardAction.DRAW,
+                            VeiledHeartService.VeiledCardType.GENOME,
+                            player,
+                            genome));
 
         } else {
-            genomes.forEach(genome -> VeiledHeartService.addVeiledCard(player, genome));
-        }
-
-        for (String cardID : genomes) {
-            if (!game.isVeiledHeartMode()) {
+            for (String cardID : genomes) {
                 player.addLeader(cardID);
                 MessageHelper.sendMessageToChannelWithEmbed(
                         player.getCorrectChannel(),
                         player.getRepresentation() + " has acquired the genome: "
                                 + Mapper.getLeader(cardID).getName(),
                         Mapper.getLeader(cardID).getRepresentationEmbed(true));
-            } else {
-                VeiledHeartService.addVeiledCard(player, cardID);
-
-                String msg = player.getRepresentationNoPing() + " has taken a secret card. They ";
-                msg += "may put it into play with a button in their `#cards-info` thread.";
-                MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);
             }
         }
+
         Button button = Buttons.red("discardSpliceCard_genome", "Discard 1 Genome", MiscEmojis.tf_genome);
         Button deleteButton = Buttons.DONE_DELETE_BUTTONS;
 

--- a/src/main/java/ti4/helpers/twilight_kart/TkHelperActionCards.java
+++ b/src/main/java/ti4/helpers/twilight_kart/TkHelperActionCards.java
@@ -134,12 +134,11 @@ public class TkHelperActionCards {
                 .map(LeaderModel::getTfRepresentationEmbed)
                 .toList();
         if (game.isVeiledHeartMode()) {
-            genomes.forEach(genome ->
-                    VeiledHeartService.doAction(
-                            VeiledHeartService.VeiledCardAction.DRAW,
-                            VeiledHeartService.VeiledCardType.GENOME,
-                            player,
-                            genome));
+            genomes.forEach(genome -> VeiledHeartService.doAction(
+                    VeiledHeartService.VeiledCardAction.DRAW,
+                    VeiledHeartService.VeiledCardType.GENOME,
+                    player,
+                    genome));
 
         } else {
             for (String cardID : genomes) {

--- a/src/main/java/ti4/service/VeiledHeartService.java
+++ b/src/main/java/ti4/service/VeiledHeartService.java
@@ -247,6 +247,14 @@ public class VeiledHeartService {
                 "lawsHeroStep3_" + targetPlayer.getFaction() + "_%s");
     }
 
+    public static List<Button> getVeiledStealButtonsForPoisonHero(Player activePlayer, Player targetPlayer) {
+        return getButtonsForChoosingForeignVeiledCard(
+                VeiledCardType.ABILITY,
+                activePlayer,
+                targetPlayer,
+                "poisonHeroStep3_" + targetPlayer.getFaction() + "_%s");
+    }
+
     public static List<Button> getVeiledGiveButtonsForCoerce(Player sender, Player recipient) {
         return getVeiledCards(VeiledCardType.ABILITY, sender)
                 .map(veiledAbility -> Buttons.red(
@@ -499,7 +507,7 @@ public class VeiledHeartService {
         addVeiledCard(recipient, ability);
 
         String msgPublic = String.format(
-                "%s has _Coerced_ %s into giving them %s.\n",
+                "%s made %s give them %s.\n",
                 recipient.getRepresentation(),
                 sender.getRepresentation(),
                 givingVeiled ? "a veiled ability" : ("the ability _'" + getRepresentation(type, ability) + "'_"));
@@ -511,10 +519,10 @@ public class VeiledHeartService {
                     "Because receiving abilities counts as gaining them, the ability has been turned face-down as if it had just been drawn. It may be put into play with a button in the `#cards-info` thread.";
         }
         String msgForSender = String.format(
-                "You were _Coerced_ by %s into giving them the _'%s'_ ability.",
-                recipient.getRepresentationNoPing(), getRepresentation(type, ability));
+                "You were made to give the _'%s'_ ability to %s.",
+                getRepresentation(type, ability), recipient.getRepresentationNoPing());
         String msgForRecipient = String.format(
-                "You _Coerced_ %s into giving you the _'%s'_ ability:",
+                "You made %s give you the _'%s'_ ability:",
                 sender.getRepresentationNoPing(), getRepresentation(type, ability));
 
         MessageHelper.sendMessageToChannel(sender.getCorrectChannel(), msgPublic);

--- a/src/main/java/ti4/service/VeiledHeartService.java
+++ b/src/main/java/ti4/service/VeiledHeartService.java
@@ -239,6 +239,14 @@ public class VeiledHeartService {
                 "veiled_discard_genome_%s_" + targetPlayer.getFaction());
     }
 
+    public static List<Button> getVeiledPurgeButtonsForLawsHero(Player activePlayer, Player targetPlayer) {
+        return getButtonsForChoosingForeignVeiledCard(
+                VeiledCardType.ABILITY,
+                activePlayer,
+                targetPlayer,
+                "lawsHeroStep3_" + targetPlayer.getFaction() + "_%s");
+    }
+
     public static List<Button> getVeiledGiveButtonsForCoerce(Player sender, Player recipient) {
         return getVeiledCards(VeiledCardType.ABILITY, sender)
                 .map(veiledAbility -> Buttons.red(
@@ -332,7 +340,7 @@ public class VeiledHeartService {
         ButtonHelper.deleteMessage(event);
     }
 
-    private static void doSilentAction(VeiledCardAction action, VeiledCardType type, Player player, String card) {
+    public static void doSilentAction(VeiledCardAction action, VeiledCardType type, Player player, String card) {
         switch (action) {
             case SPLICE, DRAW -> addVeiledCard(player, card);
             case DISCARD -> removeVeiledCard(player, card);

--- a/src/main/java/ti4/service/VeiledHeartService.java
+++ b/src/main/java/ti4/service/VeiledHeartService.java
@@ -348,9 +348,90 @@ public class VeiledHeartService {
         ButtonHelper.deleteMessage(event);
     }
 
+    private static Stream<String> getUnveiledDuplicateUnits(Player player, String asyncId) {
+        return player.getUnitsByAsyncID(asyncId).stream()
+                .map(UnitModel::getAlias)
+                .filter(unit -> unit.contains("tf-") || unit.contains("tk-"));
+    }
+
+    private static Stream<String> getVeiledDuplicateUnits(Player player, String asyncId) {
+        return getVeiledCards(VeiledCardType.UNIT, player)
+                .filter(unit -> asyncId.equalsIgnoreCase(Mapper.getUnit(unit).getAsyncId()));
+    }
+
+    @ButtonHandler("keepVeiledUnit_")
+    public static void keepVeiledUnit(Game game, Player player, String buttonID, ButtonInteractionEvent event) {
+        String unitToKeep = buttonID.split("_")[1];
+        String asyncId = Mapper.getUnit(unitToKeep).getAsyncId().toLowerCase();
+
+        getVeiledDuplicateUnits(player, asyncId)
+                .filter(unit -> !unitToKeep.equals(unit))
+                .forEach(unit -> doAction(VeiledCardAction.DISCARD, VeiledCardType.UNIT, player, unit));
+
+        List<String> unitsToRemove = getUnveiledDuplicateUnits(player, asyncId)
+                .filter(unit -> !unitToKeep.equals(unit))
+                .toList();
+        for (String unit : unitsToRemove) {
+            player.removeOwnedUnitByID(unit);
+            MessageHelper.sendMessageToChannelWithEmbed(
+                    player.getCorrectChannel(),
+                    player.getFactionNameOrColor() + " has discarded the unit upgrade: "
+                            + Mapper.getUnit(unit).getName(),
+                    Mapper.getUnit(unit).getRepresentationEmbed());
+        }
+        if (!unitsToRemove.isEmpty()) {
+            String replacementUnit = Mapper.getUnit(unitToKeep).getBaseType();
+            player.addOwnedUnitByID(replacementUnit);
+        }
+        ButtonHelper.deleteMessage(event);
+    }
+
+    private static void handleDuplicateUnits(Player player, String newUnit) {
+        String asyncId = Mapper.getUnit(newUnit).getAsyncId().toLowerCase();
+        if ("fs".equals(asyncId) || "mf".equals(asyncId)) {
+            // Duplicates are allowed for flagships & mechs
+            return;
+        }
+
+        List<Button> keepButtons = new ArrayList<>();
+        keepButtons.addAll(getUnveiledDuplicateUnits(player, asyncId)
+                .map(unit -> Buttons.blue(
+                        "keepVeiledUnit_" + unit,
+                        "Keep _" + Mapper.getUnit(unit).getName() + "_ (Unveiled)"))
+                .toList());
+        keepButtons.addAll(getVeiledDuplicateUnits(player, asyncId)
+                .map(unit -> Buttons.red(
+                        "keepVeiledUnit_" + unit,
+                        "Keep _" + Mapper.getUnit(unit).getName() + "_ (Veiled)"))
+                .toList());
+        if (keepButtons.isEmpty()) {
+            // No duplicates found
+            return;
+        }
+
+        String plural = keepButtons.size() > 1 ? "s" : "";
+        String msgPrivate = String.format(
+                "%s, you just gained the veiled unit upgrade _'%s'_, but you already have %s unit upgrade%s of that type. Click one of the buttons below to choose which of these unit upgrades to keep. The other one%s will be discarded.",
+                player.getRepresentation(), Mapper.getUnit(newUnit).getName(), keepButtons.size(), plural, plural);
+        String msgPublic = String.format(
+                "%s has gained a unit upgrade, but they already have %s unit upgrade%s of that type. They are currently choosing which unit upgrade to keep.",
+                player.getFactionNameOrColor(), keepButtons.size(), plural);
+
+        keepButtons.add(Buttons.green(
+                "keepVeiledUnit_" + newUnit, "Keep _" + Mapper.getUnit(newUnit).getName() + "_ (New, Veiled)"));
+
+        MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), msgPrivate, keepButtons);
+        MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msgPublic);
+    }
+
     public static void doSilentAction(VeiledCardAction action, VeiledCardType type, Player player, String card) {
         switch (action) {
-            case SPLICE, DRAW -> addVeiledCard(player, card);
+            case SPLICE, DRAW -> {
+                if (type == VeiledCardType.UNIT) {
+                    handleDuplicateUnits(player, card);
+                }
+                addVeiledCard(player, card);
+            }
             case DISCARD -> removeVeiledCard(player, card);
             case UNVEIL -> {
                 switch (type) {
@@ -427,8 +508,6 @@ public class VeiledHeartService {
     }
 
     public static void doAction(VeiledCardAction action, VeiledCardType type, Player player, String card) {
-        doSilentAction(action, type, player, card);
-
         String msg;
         switch (action) {
             case SPLICE ->
@@ -455,6 +534,8 @@ public class VeiledHeartService {
                         + type.toString().toLowerCase() + ", but was unable to.";
         }
         MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);
+
+        doSilentAction(action, type, player, card);
     }
 
     public static void doAction(

--- a/src/main/java/ti4/service/VeiledHeartService.java
+++ b/src/main/java/ti4/service/VeiledHeartService.java
@@ -418,7 +418,7 @@ public class VeiledHeartService {
         VeiledCardAction.fromString(actionStr).ifPresent(action -> doAction(action, player, card));
     }
 
-    private static void doAction(VeiledCardAction action, Player player, String card) {
+    public static void doAction(VeiledCardAction action, Player player, String card) {
         VeiledCardType.fromCard(card).ifPresent(type -> doAction(action, type, player, card));
     }
 
@@ -475,7 +475,7 @@ public class VeiledHeartService {
 
     public static void doManipulate(String typeStr, Player activePlayer, String card, Player targetPlayer) {
         VeiledCardType.fromString(typeStr).ifPresent(type -> {
-            addVeiledCard(targetPlayer, card);
+            doSilentAction(VeiledCardAction.SPLICE, type, targetPlayer, card);
 
             String msgPublic = String.format(
                     "%s has been forced to splice a veiled %s. They may put it into play with a button in their `#cards-info` thread.",

--- a/src/main/java/ti4/service/VeiledHeartService.java
+++ b/src/main/java/ti4/service/VeiledHeartService.java
@@ -99,7 +99,27 @@ public class VeiledHeartService {
         DRAW,
         SPLICE,
         SEND,
-        UNVEIL
+        UNVEIL;
+
+        static Optional<VeiledCardAction> fromString(String str) {
+            str = str.toLowerCase();
+            if (str.contains("discard")) {
+                return Optional.of(DISCARD);
+            }
+            if (str.contains("draw")) {
+                return Optional.of(DRAW);
+            }
+            if (str.contains("splice")) {
+                return Optional.of(SPLICE);
+            }
+            if (str.contains("send")) {
+                return Optional.of(SEND);
+            }
+            if (str.contains("unveil")) {
+                return Optional.of(UNVEIL);
+            }
+            return Optional.empty();
+        }
     }
 
     private static String toTitleCase(String s) {
@@ -376,6 +396,14 @@ public class VeiledHeartService {
                 removeVeiledCard(player, card);
             }
         }
+    }
+
+    public static void doAction(String actionStr, Player player, String card) {
+        VeiledCardAction.fromString(actionStr).ifPresent(action -> doAction(action, player, card));
+    }
+
+    private static void doAction(VeiledCardAction action, Player player, String card) {
+        VeiledCardType.fromCard(card).ifPresent(type -> doAction(action, type, player, card));
     }
 
     public static void doAction(VeiledCardAction action, String typeStr, Player player, String card) {


### PR DESCRIPTION
- Irradiate fix (no longer leaves the player with no units of a type)
- new `veiled_card` Command: flexible command to draw/discard/unveil a veiled card, useful for fixing the game state when things break
- Obsidian Paradigm fix (no longer reveals deck contents to all players)
- Deepwrought Paradigm fix (can target veiled cards)
- Naalu Paradigm fix (can target veiled cards)
- only ever keep 1 unit upgrade per type, including veiled unit upgrades