### PR TITLE
Fix Black Spectrum plot card duplication for Firmament/Obsidian players

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -2,25 +2,19 @@ package ti4.discord.interactions.commands.developer;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
-import ti4.game.Leader;
 import ti4.game.Player;
 import ti4.game.persistence.ConsumeGameUtility;
 import ti4.game.persistence.GameManager;
 import ti4.image.Mapper;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
-import ti4.model.AbilityModel;
-import ti4.model.LeaderModel;
+import ti4.model.GenericCardModel;
 import ti4.model.Source.ComponentSource;
-import ti4.model.TechnologyModel;
-import ti4.model.UnitModel;
 
 class RunAgainstAllGames extends Subcommand {
 
@@ -35,11 +29,10 @@ class RunAgainstAllGames extends Subcommand {
         Set<String> changedGames = new HashSet<>();
         ConsumeGameUtility.consumeAllGames(
                 game -> {
-                    boolean changed = removeBlackSpectrumGenericPNs(game);
-                    changed |= revertOtherBlackSpectrumComponents(game);
+                    boolean changed = revertBlackSpectrumPlots(game);
                     if (changed) {
                         changedGames.add(game.getName());
-                        GameManager.save(game, "Reverted stray Black Spectrum components to what they replaced.");
+                        GameManager.save(game, "Removed stray Black Spectrum plot card duplicates.");
                     }
                 },
                 ExecutionLockType.WRITE);
@@ -49,99 +42,22 @@ class RunAgainstAllGames extends Subcommand {
                 + " games: " + String.join(", ", changedGames));
     }
 
-    // Black Spectrum's colorable Political Secret/Support for the Throne replacements were dealt
-    // to every player in every game, since nothing gated them behind an actual "is Black Spectrum
-    // enabled" check. Strip any stray copies out of every player's hand and owned-PN pool, wherever
-    // they ended up (including after being traded away from whoever originally received them).
-    static boolean removeBlackSpectrumGenericPNs(Game game) {
+    // Player.setupFactionSpecificOptions() hands every Firmament/Obsidian player every plot card
+    // ever loaded (Mapper.getPlots()), with no source filtering. Black Spectrum added 5 plot cards
+    // reusing the same names as the base 5 (Enervate/Siphon/Seethe/Assail/Extract), so every such
+    // player ended up with 10 cards: a normal one and a buffed Black Spectrum one for each name.
+    // Strip the stray Black Spectrum copies from every player's plot card pool.
+    static boolean revertBlackSpectrumPlots(Game game) {
         boolean changed = false;
         for (Player player : game.getPlayers().values()) {
-            for (String pnID : new ArrayList<>(player.getPromissoryNotes().keySet())) {
-                if (pnID.endsWith("_bsp_ps") || pnID.endsWith("_bsp_sftt")) {
-                    player.removePromissoryNote(pnID);
+            for (String plotId : new ArrayList<>(player.getPlotCardsRaw().keySet())) {
+                GenericCardModel model = Mapper.getPlot(plotId);
+                if (model != null
+                        && model.getSource() == ComponentSource.black_spectrum
+                        && model.getHomebrewReplacesID().isPresent()) {
+                    player.getPlotCardsRaw().remove(plotId);
                     changed = true;
                 }
-            }
-            for (String pnID : new ArrayList<>(player.getPromissoryNotesOwned())) {
-                if (pnID.endsWith("_bsp_ps") || pnID.endsWith("_bsp_sftt")) {
-                    player.removeOwnedPromissoryNoteByID(pnID);
-                    changed = true;
-                }
-            }
-        }
-        return changed;
-    }
-
-    // Some of Black Spectrum's other replacement units/leaders/techs/abilities (each declaring
-    // homebrewReplacesID) can also end up owned by a player with no way for that to have been an
-    // intentional choice, since nothing gates Black Spectrum content behind an "is it enabled" check
-    // yet. For every player, swap any such stray black_spectrum component back for the original
-    // component it claims to replace.
-    static boolean revertOtherBlackSpectrumComponents(Game game) {
-        boolean changed = false;
-        for (Player player : game.getPlayers().values()) {
-            changed |= revertUnitsOwned(player);
-            changed |= revertLeaders(player);
-            changed |= revertTechList(player.getTechs());
-            changed |= revertTechList(player.getFactionTechs());
-            changed |= revertTechList(player.getExhaustedTechs());
-            changed |= revertTechList(player.getPurgedTechs());
-            changed |= revertAbilities(player.getAbilities());
-            changed |= revertAbilities(player.getExhaustedAbilities());
-        }
-        return changed;
-    }
-
-    private static boolean isStrayBlackSpectrum(ComponentSource source, Optional<String> replacesID) {
-        return source == ComponentSource.black_spectrum && replacesID.isPresent();
-    }
-
-    private static boolean revertUnitsOwned(Player player) {
-        boolean changed = false;
-        for (String unitId : new ArrayList<>(player.getUnitsOwned())) {
-            UnitModel model = Mapper.getUnit(unitId);
-            if (model != null && isStrayBlackSpectrum(model.getSource(), model.getHomebrewReplacesID())) {
-                player.removeOwnedUnitByID(unitId);
-                player.addOwnedUnitByID(model.getHomebrewReplacesID().get());
-                changed = true;
-            }
-        }
-        return changed;
-    }
-
-    private static boolean revertLeaders(Player player) {
-        boolean changed = false;
-        for (Leader leader : new ArrayList<>(player.getLeaders())) {
-            LeaderModel model = Mapper.getLeader(leader.getId());
-            if (model != null && isStrayBlackSpectrum(model.getSource(), model.getHomebrewReplacesID())) {
-                player.removeLeader(leader.getId());
-                player.addLeader(model.getHomebrewReplacesID().get());
-                changed = true;
-            }
-        }
-        return changed;
-    }
-
-    private static boolean revertTechList(List<String> techIds) {
-        boolean changed = false;
-        for (int i = 0; i < techIds.size(); i++) {
-            TechnologyModel model = Mapper.getTech(techIds.get(i));
-            if (model != null && isStrayBlackSpectrum(model.getSource(), model.getHomebrewReplacesID())) {
-                techIds.set(i, model.getHomebrewReplacesID().get());
-                changed = true;
-            }
-        }
-        return changed;
-    }
-
-    private static boolean revertAbilities(Set<String> abilityIds) {
-        boolean changed = false;
-        for (String abilityId : new ArrayList<>(abilityIds)) {
-            AbilityModel model = Mapper.getAbility(abilityId);
-            if (model != null && isStrayBlackSpectrum(model.getSource(), model.getHomebrewReplacesID())) {
-                abilityIds.remove(abilityId);
-                abilityIds.add(model.getHomebrewReplacesID().get());
-                changed = true;
             }
         }
         return changed;

--- a/src/main/java/ti4/game/Player.java
+++ b/src/main/java/ti4/game/Player.java
@@ -1816,7 +1816,10 @@ public class Player extends PlayerProperties implements StoredValueHelper {
         }
         if (hasAbility("puppetsoftheblade") && !game.isFrankenGame()) {
             List<GenericCardModel> allPlots = new ArrayList<>(Mapper.getPlots().values())
-                    .stream().filter(p -> !p.getAlias().startsWith("mutated")).toList();
+                    .stream()
+                            .filter(p -> !p.getAlias().startsWith("mutated"))
+                            .filter(p -> p.getHomebrewReplacesID().isEmpty())
+                            .toList();
             allPlots.forEach(plot -> setPlotCard(plot.getAlias()));
         }
     }

--- a/src/main/java/ti4/model/GenericCardModel.java
+++ b/src/main/java/ti4/model/GenericCardModel.java
@@ -1,5 +1,6 @@
 package ti4.model;
 
+import java.util.Optional;
 import lombok.Data;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -19,9 +20,14 @@ public class GenericCardModel implements ModelInterface, EmbeddableModel {
     private String notes;
     CardType cardType;
     ComponentSource source;
+    private String homebrewReplacesID;
 
     public boolean isValid() {
         return alias != null && name != null && text != null && cardType != null && source != null;
+    }
+
+    public Optional<String> getHomebrewReplacesID() {
+        return Optional.ofNullable(homebrewReplacesID);
     }
 
     public String autoCompleteString() {

--- a/src/main/resources/data/genericcards/black_spectrum_firmament_plots.json
+++ b/src/main/resources/data/genericcards/black_spectrum_firmament_plots.json
@@ -4,6 +4,7 @@
         "name": "Seethe",
         "text": "When this card is revealed, capture each unit on a non-home planet controlled by the puppeted player.\n\nOnce per combat in which you are the defender, after 1 of the puppeted player's non-structure units is destroyed, you may capture that unit.\n\nAt the start of the status phase, you may return 1 or more captured units of the puppeted player. Then, for each returned unit, place 1 unit of that type from your reinforcements in a system that contains your units and no other players' units.",
         "cardType": "plot",
+        "homebrewReplacesID": "seethe",
         "source": "black_spectrum"
     },
     {
@@ -11,6 +12,7 @@
         "name": "Assail",
         "text": "When this card is revealed, choose 1 non-fighter ship type that the puppeted player has on the game board. The puppeted player destroys half of their ships of that type, rounded up.\n\nApply +1 to the results of each of your combat and unit ability rolls against the puppeted player.\n\nAt the start of your turn, you may treat your flagship as if it had the text ability of 1 of the puppeted players' flagship until the end of that turn.",
         "cardType": "plot",
+        "homebrewReplacesID": "assail",
         "source": "black_spectrum"
     },
     {
@@ -18,6 +20,7 @@
         "name": "Enervate",
         "text": "After this card is revealed, perform a strategic action using the puppeted player's readied strategy card; exhaust that strategy card. Then, each other player may resolve its secondary ability.\n\nWhen the puppeted player performs a strategic action, you can perform the secondary ability of their strategy card without spending a command token. For Leadership, you can perform the primary ability instead.",
         "cardType": "plot",
+        "homebrewReplacesID": "enervate",
         "source": "black_spectrum"
     },
     {
@@ -25,6 +28,7 @@
         "name": "Siphon",
         "text": "When this card is revealed, take 1 of the puppeted player's relics.\n\nWhen the puppeted player gains commodities, you gain an equal number of trade goods.",
         "cardType": "plot",
+        "homebrewReplacesID": "siphon",
         "source": "black_spectrum"
     },
     {
@@ -32,6 +36,7 @@
         "name": "Extract",
         "text": "When this card is revealed, choose 1 non-unit upgrade, non-faction technology owned by the puppeted player; that player returns that technology to their technology deck. Then, gain that technology, if able.\n\nWhen the puppeted player gains a non-faction technology, you may spend 4 resources to gain that technology.",
         "cardType": "plot",
+        "homebrewReplacesID": "extract",
         "source": "black_spectrum"
     }
 ]

--- a/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
@@ -2,66 +2,34 @@ package ti4.discord.interactions.commands.developer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import ti4.game.Game;
-import ti4.game.Leader;
 import ti4.game.Player;
 import ti4.testUtils.BaseTi4Test;
 
 class RunAgainstAllGamesTest extends BaseTi4Test {
 
     @Test
-    void removeBlackSpectrumGenericPNsStripsOnlyTheBlackSpectrumDuplicates() {
+    void revertBlackSpectrumPlotsStripsOnlyTheBlackSpectrumDuplicates() {
         Game game = new Game();
         Player player = new Player("user-id", "user/name", game);
         player.setColor("red");
         game.setPlayers(new LinkedHashMap<>(Map.of("user-id", player)));
 
-        player.setPromissoryNote("red_ps");
-        player.setPromissoryNote("red_bsp_ps");
-        player.setPromissoryNote("red_sftt");
-        player.setPromissoryNote("red_bsp_sftt");
-        player.setPromissoryNotesOwned(new HashSet<>(List.of("red_ps", "red_bsp_ps", "red_sftt", "red_bsp_sftt")));
+        player.setPlotCard("seethe");
+        player.setPlotCard("bsp_seethe");
+        player.setPlotCard("assail");
+        player.setPlotCard("bsp_assail");
 
-        boolean changed = RunAgainstAllGames.removeBlackSpectrumGenericPNs(game);
-
-        assertThat(changed).isTrue();
-        assertThat(player.getPromissoryNotes()).containsKey("red_ps").containsKey("red_sftt");
-        assertThat(player.getPromissoryNotes()).doesNotContainKey("red_bsp_ps").doesNotContainKey("red_bsp_sftt");
-        assertThat(player.getPromissoryNotesOwned()).contains("red_ps", "red_sftt");
-        assertThat(player.getPromissoryNotesOwned()).doesNotContain("red_bsp_ps", "red_bsp_sftt");
-
-        // Running again makes no further changes
-        assertThat(RunAgainstAllGames.removeBlackSpectrumGenericPNs(game)).isFalse();
-    }
-
-    @Test
-    void revertOtherBlackSpectrumComponentsSwapsUnitsLeadersAndTechsBackToWhatTheyReplaced() {
-        Game game = new Game();
-        Player player = new Player("user-id", "user/name", game);
-        player.setColor("red");
-        game.setPlayers(new LinkedHashMap<>(Map.of("user-id", player)));
-
-        player.setUnitsOwned(new HashSet<>(List.of("bsp_bastion_spacedock2", "cruiser")));
-        player.addLeader("bsp_yinhero");
-        player.getTechs().add("bsp_st");
-        player.getTechs().add("cl2");
-
-        boolean changed = RunAgainstAllGames.revertOtherBlackSpectrumComponents(game);
+        boolean changed = RunAgainstAllGames.revertBlackSpectrumPlots(game);
 
         assertThat(changed).isTrue();
-        assertThat(player.getUnitsOwned()).contains("bastion_spacedock2", "cruiser");
-        assertThat(player.getUnitsOwned()).doesNotContain("bsp_bastion_spacedock2");
-        assertThat(player.getLeaders().stream().map(Leader::getId)).contains("yinhero");
-        assertThat(player.getLeaders().stream().map(Leader::getId)).doesNotContain("bsp_yinhero");
-        assertThat(player.getTechs()).contains("st", "cl2");
-        assertThat(player.getTechs()).doesNotContain("bsp_st");
+        assertThat(player.getPlotCardsRaw()).containsKey("seethe").containsKey("assail");
+        assertThat(player.getPlotCardsRaw()).doesNotContainKey("bsp_seethe").doesNotContainKey("bsp_assail");
 
         // Running again makes no further changes
-        assertThat(RunAgainstAllGames.revertOtherBlackSpectrumComponents(game)).isFalse();
+        assertThat(RunAgainstAllGames.revertBlackSpectrumPlots(game)).isFalse();
     }
 }


### PR DESCRIPTION
Player.setupFactionSpecificOptions() handed every such player all plot cards with no source filtering, and Black Spectrum's 5 plots reused the base 5's exact names with no declared relationship, so everyone got 10. Added homebrewReplacesID to GenericCardModel, tagged the Black Spectrum plots with it, and excluded them from the deal-out logic; also fixed the filename typo and updated /run_against_all_games for already-affected games.