### PR TITLE
Token Planet Image Render fix

### DIFF
--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -128,6 +128,14 @@ public final class Helper {
             new Point(172, 221),
             new Point(172, 79));
 
+    private static final List<Point> TWO_PLANET_OR_WORMHOLE_TOKEN_PLANET_POSITIONS = List.of(
+            new Point(Constants.TOKEN_PLANET_POSITION),
+            new Point(78, 178),
+            new Point(258, 221),
+            new Point(87, 221),
+            new Point(172, 79),
+            new Point(172, 221));
+
     public static int getCurrentHour() {
         long currentTime = System.currentTimeMillis();
         currentTime /= 1000;
@@ -587,12 +595,14 @@ public final class Helper {
             return defaultPosition;
         }
 
-        List<Point> positions = tile.getTileModel().getNumPlanets() == 3
+        int printedPlanetCount = tile.getTileModel().getNumPlanets();
+        boolean usesTwoPlanetOrWormholeSlots = printedPlanetCount != 3
+                && (printedPlanetCount == 2
+                        || printedPlanetCount > 0 && tile.getTileModel().hasWormhole());
+        List<Point> positions = printedPlanetCount == 3
                 ? TRIPLE_SYSTEM_TOKEN_PLANET_POSITIONS
-                : TOKEN_PLANET_POSITIONS;
-        Point position = tile.getTileModel().getNumPlanets() == 3 && index < 3
-                ? getTripleSystemTokenPlanetPosition(tile, index)
-                : null;
+                : usesTwoPlanetOrWormholeSlots ? TWO_PLANET_OR_WORMHOLE_TOKEN_PLANET_POSITIONS : TOKEN_PLANET_POSITIONS;
+        Point position = printedPlanetCount == 3 && index < 3 ? getTripleSystemTokenPlanetPosition(tile, index) : null;
         if (position == null) {
             if (index < positions.size()) {
                 position = positions.get(index);
@@ -604,17 +614,6 @@ public final class Helper {
             }
         }
 
-        if (tile.getTileModel().getNumPlanets() > 0 && tile.getTileModel().hasWormhole()
-                || tile.getTileModel().getNumPlanets() == 2) {
-            double theta = Math.toRadians(index == 0 ? -45 : 0);
-            int deltaX = position.x - Constants.SPACE_CENTER_POSITION.x;
-            int deltaY = position.y - Constants.SPACE_CENTER_POSITION.y;
-            int x = Constants.SPACE_CENTER_POSITION.x
-                    + (int) Math.round(deltaX * Math.cos(theta) - deltaY * Math.sin(theta));
-            int y = Constants.SPACE_CENTER_POSITION.y
-                    + (int) Math.round(deltaX * Math.sin(theta) + deltaY * Math.cos(theta));
-            return new Point(x, y);
-        }
         return new Point(position);
     }
 


### PR DESCRIPTION
Fixed the two planet and planet+wormhole system token planet rendering. I switched from special handling depending on planet holders in the system to a more stable set point system for those system types only. The first two token planets in a system should now be properly rendered in the correct empty spaces.