### PR TITLE
Fix: Al'Raith/Fracture announcement leaks player identity in FoW

### DIFF
--- a/src/main/java/ti4/helpers/thundersedge/BreakthroughCommandHelper.java
+++ b/src/main/java/ti4/helpers/thundersedge/BreakthroughCommandHelper.java
@@ -249,7 +249,7 @@ public final class BreakthroughCommandHelper {
                                 + " Ingress tokens will be placed in their position on the map, if there were no choices to be made.";
                         FractureService.spawnFracture(null, game);
                         FractureService.spawnIngressTokens(null, game, player, bt.getID());
-                        MessageHelper.sendMessageToChannel(game.getMainGameChannel(), msg);
+                        MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);
                     }
                     AlRaithService.serveBeginCabalBreakthroughButtons(null, game, player);
                 }


### PR DESCRIPTION
When a player gains cabalbt and The Fracture hasn't yet entered play, the bot auto-spawns The Fracture and announces it unconditionally to game.getMainGameChannel(). 
In a Fog of War game, that channel is the shared anonymous announcements channel, so the message revealed which player/color gained the bt, breaking FoW anonymity.

FIX: Routes the message through player.getCorrectChannel() instead, matching the identical message's routing in FractureService.resolveFractureRoll (the dice-roll trigger for the same event already does this correctly).