### PR TITLE
Stop Thunder's Edge being placeable on hyperlanes

### DIFF
--- a/src/main/java/ti4/game/Tile.java
+++ b/src/main/java/ti4/game/Tile.java
@@ -131,7 +131,7 @@ public class Tile {
 
     public static Predicate<Tile> tileMayHaveThundersEdge() {
         return tile -> {
-            if (tile.getTilePath().toLowerCase().contains("hyperlane")) return false;
+            if (tile.getTileModel().isHyperlane()) return false;
             if (!tile.getPlanetUnitHolders().isEmpty()) return false;
             if (tile.isSupernova()) return false;
             if (tile.getPosition().contains("frac")) return false;

--- a/src/main/java/ti4/helpers/thundersedge/TeHelperGeneral.java
+++ b/src/main/java/ti4/helpers/thundersedge/TeHelperGeneral.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
@@ -177,11 +178,18 @@ public class TeHelperGeneral {
         }
 
         if (newMessage != null) {
-            // edit the message with the new partX buttons
-            event.getMessage()
-                    .editMessage(newMessage)
-                    .setComponents(ButtonHelper.turnButtonListIntoActionRowList(newButtons))
-                    .queue(Consumers.nop(), BotLogger::catchRestError);
+            List<List<ActionRow>> partitions = MessageHelper.getPartitionedButtonLists(newButtons);
+            if (partitions.size() > 1) {
+                // too many buttons to fit one message's component limit, so send them split up instead
+                ButtonHelper.deleteMessage(event);
+                MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), newMessage, newButtons);
+            } else {
+                // edit the message with the new partX buttons
+                event.getMessage()
+                        .editMessage(newMessage)
+                        .setComponents(ButtonHelper.turnButtonListIntoActionRowList(newButtons))
+                        .queue(Consumers.nop(), BotLogger::catchRestError);
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`Tile.tileMayHaveThundersEdge()` screened hyperlanes by image filename:

```java
if (tile.getTilePath().toLowerCase().contains("hyperlane")) return false;
```

That catches the numbered hyperlanes (`83a`–`91b`, e.g. `83a300_Hyperlane.png`), but misses
the `hl_*` family, whose paths look like `hl_horizon_0.png`. Of 172 hyperlane tile models,
**64 slipped through**.

Those tiles declare `"planets": []`, carry no wormhole and aren't supernovas, so they cleared
every remaining clause and were offered as Thunder's Edge placement targets.

Offering all of them also pushed the button list past Discord's 5 action row limit, throwing
out of `resolvePlaceThundersEdge`:

```
java.lang.IllegalStateException: Cannot build message with over 5 top-level components, provided 10
	at ti4.helpers.thundersedge.TeHelperGeneral.resolvePlaceThundersEdge(TeHelperGeneral.java:184)
```

## Changes

**`Tile.java`** — screen on the `TileModel.isHyperlane` flag instead of the filename. This is
the check used everywhere else in the codebase (~35 call sites), including
`TeHelperActionCards.java:471` in this same package.

**`TeHelperGeneral.java`** — guard the send path as well, so a long list can't crash
regardless of what feeds it. When the buttons no longer fit one message, delete and send them
split via `MessageHelper.sendMessageToChannelWithButtons` rather than editing in place. It
targets `player.getCorrectChannel()`, so the tile list stays private in fog games — matching
what the part3 branch of this method already does.

Scars are deliberately left eligible.

## Testing

- `mvn compile` and `mvn spotless:check` both pass.
- Parsed every file in `src/main/resources/systems`: 172 hyperlane tile models, 64 previously
  slipping past the filename test, 0 after the change.
