### PR TITLE
Restrict Search for Players button to matchmaking channels

### DIFF
--- a/src/main/java/ti4/service/game/CreateGameLaunchPostService.java
+++ b/src/main/java/ti4/service/game/CreateGameLaunchPostService.java
@@ -45,7 +45,11 @@ public class CreateGameLaunchPostService {
         buttons.add(Buttons.red("leaveGameList", "Leave Game"));
         buttons.add(Buttons.gray("editPlayers~MDL", "Add Players"));
         buttons.add(Buttons.gray("removePlayers~MDL", "Remove Players"));
-        buttons.add(Buttons.gray("searchForPlayers~MDL", "Search for Players"));
+        String parentName = channel.getParentChannel().getName();
+        if (MAKING_NEW_GAMES_CHANNEL.equalsIgnoreCase(parentName)
+                || MAKING_TIGL_GAMES_CHANNEL.equalsIgnoreCase(parentName)) {
+            buttons.add(Buttons.gray("searchForPlayers~MDL", "Search for Players"));
+        }
         buttons.add(Buttons.blue("launchGame", "Launch Game"));
         buttons.add(Buttons.gray("addSillyName~MDL", "Add Fun Game Name"));
 


### PR DESCRIPTION
## Summary
- Only render the `Search for Players` button on game-launch posts under `making-new-games` and `making-tigl-games` threads.

## Test plan
- [ ] Create a game post under `making-new-games` and confirm the button appears.
- [ ] Create a game post under `making-tigl-games` and confirm the button appears.
- [ ] Create a game post under `making-private-games` and `making-superfast-games` and confirm the button is absent.
