### PR TITLE
Fix Entropic Scar status scoring guard

### DIFF
--- a/src/main/java/ti4/helpers/StatusHelper.java
+++ b/src/main/java/ti4/helpers/StatusHelper.java
@@ -52,6 +52,7 @@ import ti4.service.info.ListPlayerInfoService;
 import ti4.service.info.SecretObjectiveInfoService;
 import ti4.service.objectives.ScorePublicObjectiveService;
 import ti4.service.planet.EronousPlanetService;
+import ti4.service.tech.EntropicScarService;
 import ti4.service.turn.StartTurnService;
 import ti4.settings.users.UserSettingsManager;
 import ti4.spring.service.gameevent.GameEventDraft;
@@ -331,16 +332,24 @@ public final class StatusHelper {
                 }
             }
 
+            boolean canScorePublicObjectives = Helper.canPlayerScorePOs(game, player);
+            boolean hasPendingScarChoice = scorables.isEmpty()
+                    && canScorePublicObjectives
+                    && EntropicScarService.hasPendingTechnologyChoice(game, player);
+
             if (!game.getStoredValue(keyV).isEmpty()
-                    && Helper.canPlayerScorePOs(game, player)
+                    && canScorePublicObjectives
                     && scorableInts.contains(Integer.parseInt(game.getStoredValue(keyV)))) {
                 poScoring(null, player, game.getStoredValue(keyV), game, player.getCorrectChannel());
             } else {
-                if (scorables.isEmpty()) {
+                if (hasPendingScarChoice) {
+                    messageText = player.getRepresentation()
+                            + ", you may become eligible to score a public objective after resolving Entropic Scar. Resolve that choice before choosing whether to score a public objective.";
+                } else if (scorables.isEmpty()) {
                     messageText = player.getRepresentation()
                             + ", the bot does not believe that you can score any public objectives.";
                 } else {
-                    if (Helper.canPlayerScorePOs(game, player)) {
+                    if (canScorePublicObjectives) {
                         messageText = player.getRepresentation()
                                 + ", as a reminder, the bot believes you are capable of scoring the following public objective"
                                 + (scorables.size() == 1 ? "" : "s") + ":\n";
@@ -353,7 +362,7 @@ public final class StatusHelper {
                 MessageHelper.sendMessageToChannel(player.getCardsInfoThread(), messageText);
             }
 
-            if (scorables.isEmpty() || !Helper.canPlayerScorePOs(game, player)) {
+            if (shouldAutoMarkNoPublicObjective(!scorables.isEmpty(), canScorePublicObjectives, hasPendingScarChoice)) {
                 String message = player.getRepresentation()
                         + " cannot score any public objectives according to the bot, and has been marked as not scoring a public objective.";
                 MessageHelper.sendMessageToChannel(player.getCorrectChannel(), message);
@@ -479,6 +488,11 @@ public final class StatusHelper {
             // Show the effects of the Agendas while scoring
             ButtonHelper.updateMap(game, event, "After Agendas, Round " + game.getRound() + ".");
         }
+    }
+
+    static boolean shouldAutoMarkNoPublicObjective(
+            boolean hasScorableObjectives, boolean canScorePublicObjectives, boolean hasPendingScarChoice) {
+        return !canScorePublicObjectives || (!hasScorableObjectives && !hasPendingScarChoice);
     }
 
     public static List<Player> getPlayersInScoringOrder(Game game) {
@@ -780,14 +794,7 @@ public final class StatusHelper {
         }
         for (Map.Entry<Player, Integer> entry : scars.entrySet()) {
             Player player = entry.getKey();
-            List<String> factionTechs = new ArrayList<>(player.getFactionTechs());
-            if (game.isTwilightsFallMode()) {
-                factionTechs.add("antimatter");
-                factionTechs.add("wavelength");
-            }
-            factionTechs.remove("vax");
-            factionTechs.remove("vay");
-            player.getTechs().forEach(factionTechs::remove);
+            List<String> factionTechs = EntropicScarService.getAvailableTechnologies(game, player);
             List<Button> buttons = new ArrayList<>(factionTechs.stream()
                     .map(tech -> {
                         TechnologyModel model = Mapper.getTech(tech);

--- a/src/main/java/ti4/service/tech/EntropicScarService.java
+++ b/src/main/java/ti4/service/tech/EntropicScarService.java
@@ -1,0 +1,40 @@
+package ti4.service.tech;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.helpers.Units.UnitType;
+
+@UtilityClass
+public class EntropicScarService {
+
+    public static List<String> getAvailableTechnologies(Game game, Player player) {
+        List<String> technologies = new ArrayList<>(player.getFactionTechs());
+        if (game.isTwilightsFallMode()) {
+            technologies.add("antimatter");
+            technologies.add("wavelength");
+        }
+        technologies.remove("vax");
+        technologies.remove("vay");
+        player.getTechs().forEach(technologies::remove);
+        return technologies;
+    }
+
+    public static boolean hasPendingTechnologyChoice(Game game, Player player) {
+        boolean canPay =
+                player.getStrategicCC() > 0 || player.hasRelicReady("emelpar") || player.hasRelicReady("absol_emelpar");
+        return canPay && !getAvailableTechnologies(game, player).isEmpty() && hasShipsInScar(game, player);
+    }
+
+    private static boolean hasShipsInScar(Game game, Player player) {
+        return game.getTileMap().values().stream().anyMatch(tile -> {
+            boolean isAurelionSystem = tile.getSpaceUnitHolder().getUnitKeys().stream()
+                    .anyMatch(unitKey -> unitKey.unitType() == UnitType.Aurelion);
+            return (tile.isScar() || isAurelionSystem)
+                    && Tile.tileHasPlayerShips(player).test(tile);
+        });
+    }
+}

--- a/src/test/java/ti4/helpers/StatusHelperTest.java
+++ b/src/test/java/ti4/helpers/StatusHelperTest.java
@@ -1,0 +1,32 @@
+package ti4.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StatusHelperTest {
+
+    @Test
+    void pendingScarChoicePreventsAutomaticNoScore() {
+        assertThat(StatusHelper.shouldAutoMarkNoPublicObjective(false, true, true))
+                .isFalse();
+    }
+
+    @Test
+    void noScorableObjectiveAndNoScarChoiceStillAutoMarksNoScore() {
+        assertThat(StatusHelper.shouldAutoMarkNoPublicObjective(false, true, false))
+                .isTrue();
+    }
+
+    @Test
+    void homeSystemRestrictionStillAutoMarksNoScore() {
+        assertThat(StatusHelper.shouldAutoMarkNoPublicObjective(true, false, true))
+                .isTrue();
+    }
+
+    @Test
+    void immediatelyScorableObjectiveDoesNotAutoMarkNoScore() {
+        assertThat(StatusHelper.shouldAutoMarkNoPublicObjective(true, true, false))
+                .isFalse();
+    }
+}

--- a/src/test/java/ti4/service/tech/EntropicScarServiceTest.java
+++ b/src/test/java/ti4/service/tech/EntropicScarServiceTest.java
@@ -1,0 +1,78 @@
+package ti4.service.tech;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Space;
+import ti4.game.Tile;
+
+class EntropicScarServiceTest {
+
+    private Game game;
+    private Player player;
+    private Tile scar;
+
+    @BeforeEach
+    void setUp() {
+        game = mock(Game.class);
+        player = mock(Player.class);
+        scar = mock(Tile.class);
+        Space space = mock(Space.class);
+
+        when(game.getTileMap()).thenReturn(Map.of("210", scar));
+        when(scar.isScar()).thenReturn(true);
+        when(scar.getSpaceUnitHolder()).thenReturn(space);
+        when(space.getUnitKeys()).thenReturn(Set.of());
+        when(scar.containsPlayersUnitsWithModelCondition(eq(player), any())).thenReturn(true);
+        when(player.getFactionTechs()).thenReturn(new ArrayList<>(List.of("ff2")));
+        when(player.getTechs()).thenReturn(new ArrayList<>());
+        when(player.getStrategicCC()).thenReturn(1);
+    }
+
+    @Test
+    void offersUnownedFactionTechnologyWhenPlayerCanPay() {
+        assertThat(EntropicScarService.getAvailableTechnologies(game, player)).contains("ff2");
+        assertThat(EntropicScarService.hasPendingTechnologyChoice(game, player)).isTrue();
+    }
+
+    @Test
+    void readyScepterCanPayInsteadOfStrategyToken() {
+        when(player.getStrategicCC()).thenReturn(0);
+        when(player.hasRelicReady("emelpar")).thenReturn(true);
+
+        assertThat(EntropicScarService.hasPendingTechnologyChoice(game, player)).isTrue();
+    }
+
+    @Test
+    void noPaymentSourceLeavesNoPendingChoice() {
+        when(player.getStrategicCC()).thenReturn(0);
+
+        assertThat(EntropicScarService.hasPendingTechnologyChoice(game, player)).isFalse();
+    }
+
+    @Test
+    void ownedFactionTechnologiesLeaveNoPendingChoice() {
+        when(player.getTechs()).thenReturn(new ArrayList<>(List.of("ff2")));
+
+        assertThat(EntropicScarService.getAvailableTechnologies(game, player)).isEmpty();
+        assertThat(EntropicScarService.hasPendingTechnologyChoice(game, player)).isFalse();
+    }
+
+    @Test
+    void noShipInScarLeavesNoPendingChoice() {
+        when(scar.containsPlayersUnitsWithModelCondition(eq(player), any())).thenReturn(false);
+
+        assertThat(EntropicScarService.hasPendingTechnologyChoice(game, player)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- keep a player in public-objective scoring when a payable Entropic Scar technology choice may make an objective scorable
- share the available Entropic Scar technology query between the scoring guard and the existing prompt
- preserve the current home-system restriction and automatic no-score behavior when no meaningful Scar choice exists

## Testing
- `mvn test` (full upstream checkout; passes)
- `mvn -Dtest=StatusHelperTest,EntropicScarServiceTest test` (9 tests pass)
- `mvn -Dtest=MapperTest test` (passes)