### PR TITLE
Restore shared JDA mocks per-test in BaseTi4Test

### DIFF
--- a/src/test/java/ti4/testUtils/BaseTi4Test.java
+++ b/src/test/java/ti4/testUtils/BaseTi4Test.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.managers.Presence;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import ti4.discord.JdaService;
 import ti4.discord.interactions.selections.SelectionManager;
 import ti4.game.persistence.GameManager;
@@ -39,6 +40,13 @@ public class BaseTi4Test {
         if (!setupCountDownLatch.await(GLOBAL_BEFORE_ALL_WAIT_THRESHOLD_SECONDS, TimeUnit.SECONDS)) {
             throw new AssertionError("Setup timed out");
         }
+    }
+
+    @BeforeEach
+    void restoreSharedJdaMocks() {
+        JdaService.testingMode = true;
+        JdaService.jda = mockJda;
+        JdaService.guildPrimary = mockGuild;
     }
 
     private static void globalBeforeAll() {


### PR DESCRIPTION
## Summary
- `PlayerTest.afterEach` sets `JdaService.jda = null`, and `BaseTi4Test` only initializes the shared mocks once in `@BeforeAll` (guarded by an `AtomicBoolean`), so the nulled state leaks into any later `BaseTi4Test` subclass — `MatchDescriber.logFormedMatch → JdaService.getUsername` then NPEs, failing `MatchmakerServiceTest` and `MatchmakingGrouperTest` depending on test order.
- Reassert `JdaService.jda`, `guildPrimary`, and `testingMode` in a `@BeforeEach` on `BaseTi4Test` so subclasses always see the shared mocks regardless of ordering.

## Test plan
- [x] `mvn test -Dtest='MatchmakerServiceTest,MatchmakingGrouperTest'` passes
- [x] `mvn test -Dtest='PlayerTest,FoWHelperTest,LoreServiceTest,MapJsonIOServiceTest,MatchmakerServiceTest,MatchmakingGrouperTest'` — 220/220 pass