### PR TITLE
Limit TIGL Search for Players to searcher's rank or lower

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
@@ -33,6 +33,7 @@ import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.discord.interactions.routing.ModalHandler;
 import ti4.game.persistence.GameManager;
 import ti4.game.persistence.ManagedPlayer;
+import ti4.helpers.TIGLHelper;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.service.game.CreateGameLaunchPostService;
@@ -327,12 +328,13 @@ class MatchmakingButtonHandler {
                 filterPaceRestrictionsByIfPlayerHasCompletedRequiredGame(userId),
                 userSettings.getMatchmakingPaces(),
                 DEFAULT_PACE_OPTIONS);
+        List<String> rankOptions = TIGLHelper.filterStandardTiglRankOptionsAtOrBelow(
+                event.getUser(), MatchmakingOptions.TIGL_RANK_OPTIONS);
+        if (rankOptions.isEmpty()) {
+            rankOptions = List.of(MatchmakingOptions.UNRANKED_OPTION);
+        }
         CheckboxGroup ranks = buildCheckboxGroup(
-                TIGL_RANKS_ID,
-                MatchmakingOptions.TIGL_RANK_OPTIONS,
-                userSettings.getMatchmakingTiglRanks(),
-                DEFAULT_TIGL_RANK_OPTIONS,
-                true);
+                TIGL_RANKS_ID, rankOptions, userSettings.getMatchmakingTiglRanks(), DEFAULT_TIGL_RANK_OPTIONS, true);
         Modal.Builder modal = Modal.create(SEARCH_FOR_PLAYERS_TIGL_MODAL_ID, "Search for Players")
                 .addComponents(Label.of("Victory Point Goal", victoryPoints))
                 .addComponents(Label.of("Pace", paces))
@@ -512,6 +514,8 @@ class MatchmakingButtonHandler {
     }
 
     private static PlayerSearchCriteria buildTiglSearchCriteria(ModalInteractionEvent event) {
+        List<String> requestedRanks = getSelectedValues(event, TIGL_RANKS_ID);
+        List<String> allowedRanks = TIGLHelper.filterStandardTiglRankOptionsAtOrBelow(event.getUser(), requestedRanks);
         return new PlayerSearchCriteria(
                 List.of("6"),
                 getSelectedValues(event, VICTORY_POINTS_ID),
@@ -519,7 +523,7 @@ class MatchmakingButtonHandler {
                 getSelectedValues(event, PACE_RESTRICTIONS_ID),
                 searchRestrictions(event),
                 true,
-                getSelectedValues(event, TIGL_RANKS_ID));
+                allowedRanks);
     }
 
     private static List<String> searchRestrictions(ModalInteractionEvent event) {

--- a/src/main/java/ti4/helpers/TIGLHelper.java
+++ b/src/main/java/ti4/helpers/TIGLHelper.java
@@ -247,6 +247,20 @@ public final class TIGLHelper {
                 .toList();
     }
 
+    /**
+     * Filters standard-ladder rank display names to those at or below the user's current TIGL rank,
+     * so a searcher cannot pull in players ranked above them.
+     */
+    public static List<String> filterStandardTiglRankOptionsAtOrBelow(User user, List<String> options) {
+        int maxIndex = getUsersHighestTIGLRank(user, false).getIndex();
+        return options.stream()
+                .filter(opt -> {
+                    TIGLRank rank = TIGLRank.fromString(opt);
+                    return rank != null && rank.getIndex() >= 0 && rank.getIndex() <= maxIndex;
+                })
+                .toList();
+    }
+
     private static Map<Long, TIGLRank> getTIGLRoleIdToRankMap() {
         Map<Long, TIGLRank> roleIdToRank = new HashMap<>();
         for (TIGLRank rank : getAllTIGLRanks()) {

--- a/src/main/java/ti4/helpers/TIGLHelper.java
+++ b/src/main/java/ti4/helpers/TIGLHelper.java
@@ -247,10 +247,6 @@ public final class TIGLHelper {
                 .toList();
     }
 
-    /**
-     * Filters standard-ladder rank display names to those at or below the user's current TIGL rank,
-     * so a searcher cannot pull in players ranked above them.
-     */
     public static List<String> filterStandardTiglRankOptionsAtOrBelow(User user, List<String> options) {
         int maxIndex = getUsersHighestTIGLRank(user, false).getIndex();
         return options.stream()

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingNotifier.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingNotifier.java
@@ -28,10 +28,16 @@ class MatchmakingNotifier {
 
     static void notifyExpired(List<QueuedParty> expired) {
         if (expired.isEmpty()) return;
-        BotLogger.info("Expiring " + expired.size() + " matchmaking parties.");
         String expiryMessage = "The matchmaking service wasn't able to find you a game in the time frame you selected. "
                 + "Queue again when ready and consider being open to additional game types or longer wait times.";
         for (QueuedParty party : expired) {
+            String maxQueueTime = party.leaderSettings().getMatchmakingMaxQueueTime();
+            int maxHours = MatchmakingOptions.getHours(maxQueueTime);
+            for (MatchmakingQueueMember member : party.members()) {
+                BotLogger.info("Matchmaking queue: dropping user " + member.getUserId() + " (party "
+                        + party.party().getId() + ", tigl=" + party.party().isTigl()
+                        + ") after reaching max queue time of " + maxHours + "h.");
+            }
             if (party.members().size() != 1) continue;
             User user = JdaService.jda.getUserById(party.members().getFirst().getUserId());
             if (user == null) continue;

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingNotifier.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingNotifier.java
@@ -1,5 +1,6 @@
 package ti4.spring.service.statistics.matchmaking.queue;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.service.game.CreateGameLaunchPostService;
 import ti4.service.game.CreateGameService;
+import ti4.settings.users.UserSettings;
 
 @UtilityClass
 class MatchmakingNotifier {
@@ -31,18 +33,41 @@ class MatchmakingNotifier {
         String expiryMessage = "The matchmaking service wasn't able to find you a game in the time frame you selected. "
                 + "Queue again when ready and consider being open to additional game types or longer wait times.";
         for (QueuedParty party : expired) {
-            String maxQueueTime = party.leaderSettings().getMatchmakingMaxQueueTime();
-            int maxHours = MatchmakingOptions.getHours(maxQueueTime);
-            for (MatchmakingQueueMember member : party.members()) {
-                BotLogger.info("Matchmaking queue: dropping user " + member.getUserId() + " (party "
-                        + party.party().getId() + ", tigl=" + party.party().isTigl()
-                        + ") after reaching max queue time of " + maxHours + "h.");
-            }
+            BotLogger.info(describeExpiredParty(party));
             if (party.members().size() != 1) continue;
             User user = JdaService.jda.getUserById(party.members().getFirst().getUserId());
             if (user == null) continue;
             MessageHelper.sendMessageToUser(expiryMessage, user);
         }
+    }
+
+    private static String describeExpiredParty(QueuedParty party) {
+        UserSettings settings = party.leaderSettings();
+        int maxHours = MatchmakingOptions.getHours(settings.getMatchmakingMaxQueueTime());
+        List<String> memberIds =
+                party.members().stream().map(MatchmakingQueueMember::getUserId).toList();
+        List<String> extras = new ArrayList<>();
+        if (party.party().isTigl()) {
+            extras.add("tiglRanks=" + settings.getMatchmakingTiglRanks());
+        }
+        List<String> avoidList = settings.getMatchmakingAvoidList();
+        if (avoidList != null && !avoidList.isEmpty()) {
+            extras.add("avoidList=" + avoidList);
+        }
+        String extrasText = extras.isEmpty() ? "" : ", " + String.join(", ", extras);
+        return String.format(
+                "Matchmaking queue: dropping party %d (tigl=%s, members=%s) after reaching max queue time of %dh."
+                        + " Settings: expansions=%s, playerCounts=%s, victoryPoints=%s, paces=%s, restrictions=%s%s",
+                party.party().getId(),
+                party.party().isTigl(),
+                memberIds,
+                maxHours,
+                settings.getMatchmakingExpansions(),
+                settings.getMatchmakingPlayerCounts(),
+                settings.getMatchmakingVictoryPointGoals(),
+                settings.getMatchmakingPaces(),
+                settings.getMatchmakingRestrictions(),
+                extrasText);
     }
 
     static void postMatchedGames(List<MatchedGame> gamesToCreate) {


### PR DESCRIPTION
## Summary
- In the TIGL Search for Players modal, filter the Rank checkbox options to only those at or below the searcher's highest standard-ladder TIGL rank; re-filter on submit as a defensive backstop so a tampered submission still can't pull higher-ranked players. A Minister now sees Unranked and Minister; a Hero (or Emperor) sees all five.
- New public helper `TIGLHelper.filterStandardTiglRankOptionsAtOrBelow(User, List<String>)` centralizes the rank comparison and matches display names via existing `TIGLRank.fromString`.
- In `MatchmakingNotifier.notifyExpired`, emit one `BotLogger.info` per queued user whose party is being dropped due to hitting max queue time (user id, party id, tigl flag, configured hours). Removed the previous aggregate "Expiring N matchmaking parties." line.

## Test plan
- [ ] Manual: as a Minister in the making-tigl-games forum, click Search for Players and confirm only Unranked/Minister options are shown.
- [ ] Manual: as a Hero (or Emperor), confirm all five rank options are shown.
- [ ] Manual: as a Minister, verify submitting with tampered client rank values does not surface higher-ranked queued players.
- [ ] Ops: observe logs at the next queue expiry and confirm one info line per expiring queued user.
