### PR TITLE
Wire Syndicate action card resolve button

### DIFF
--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -1179,6 +1179,11 @@ public class ActionCardHelper {
                 MessageHelper.sendMessageToChannelWithButtons(channel2, introMsg, codedButtons);
             }
 
+            if ("syndicate".equals(automationID)) {
+                codedButtons.add(Buttons.green(player.factionButtonChecker() + "resolveSyndicate", buttonLabel));
+                MessageHelper.sendMessageToChannelWithButtons(channel2, introMsg, codedButtons);
+            }
+
             if ("lost_treatise".equals(automationID)) {
                 codedButtons.add(Buttons.green(player.factionButtonChecker() + "resolveLostTreatise", buttonLabel));
                 MessageHelper.sendMessageToChannelWithButtons(channel2, introMsg, codedButtons);


### PR DESCRIPTION
## Summary
- `SyndicateAcd2ButtonHandler` defines `@ButtonHandler("resolveSyndicate")`, but `ActionCardHelper` had no branch for `automationID = "syndicate"`, so playing the card never emitted its resolve button. This wires up the button next to the other acd2 cards (e.g. `ubiquity`).

## Why
- Every other automated action card is wired up via an `if ("<automationID>".equals(automationID))` block in `ActionCardHelper.playAsAction`. Syndicate slipped through — the handler shipped without a corresponding emission site, so `Play Syndicate` produced no follow-up button.

## Scope check
- I audited every `acd2` card. This is the only card where a handler exists but no play-time button is emitted. Riders (`classified_rider`, `defense_rider`) and `amendment` correctly emit from `AgendaHelper` / `StartPhaseService` per their windows. The rest of the missing IDs have no handler code at all (out of scope for this fix).

## Test plan
- [ ] Play Syndicate as an action; a **Resolve Syndicate** button appears.
- [ ] Pressing it reveals N cards (N = real player count) and produces per-player assign buttons.
- [ ] Assigning cards routes each to the target player and clears state when done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)