### PR TITLE
Lost legacies

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/theodisi/Revenant/RevenantBreakthroughHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/faction/homebrew/theodisi/Revenant/RevenantBreakthroughHandler.java
@@ -19,6 +19,7 @@ import ti4.image.Mapper;
 import ti4.message.MessageHelper;
 import ti4.model.LeaderModel;
 import ti4.model.Source.ComponentSource;
+import ti4.service.leader.RefreshLeaderService;
 
 @UtilityClass
 public class RevenantBreakthroughHandler {
@@ -155,9 +156,11 @@ public class RevenantBreakthroughHandler {
         }
 
         Leader purgedLeader = player.getLeader(agentId).orElse(null);
+        Leader exhaustedLeader = player.getLeader(exhaustedAgentId).orElse(null);
         List<String> attachedAgents = getAttachedAgents(game, player);
         if (!player.hasUnlockedBreakthrough(REVENANT_RISING)
                 || purgedLeader == null
+                || exhaustedLeader == null
                 || !attachedAgents.contains(agentId)) {
             ButtonHelper.deleteMessage(event);
             return;
@@ -173,6 +176,7 @@ public class RevenantBreakthroughHandler {
         String result = player.getRepresentation() + " chose to purge _" + purgedName
                 + "_ instead of exhausting _Revenant Rising_.";
         BreakthroughCommandHelper.readyBreakthrough(player, REVENANT_RISING);
+        RefreshLeaderService.refreshLeader(player, exhaustedLeader, game);
         MessageHelper.sendMessageToChannel(game.getActionsChannel(), result);
         ButtonHelper.deleteMessage(event);
     }

--- a/src/main/java/ti4/image/PlayerAreaGenerator.java
+++ b/src/main/java/ti4/image/PlayerAreaGenerator.java
@@ -788,7 +788,12 @@ public class PlayerAreaGenerator {
                     .flatMap(t -> t.getUnitHolders().values().stream())
                     .mapToInt(UnitHolder::getTotalGalvanizedCount)
                     .sum();
-            if (totGalvanized > maxGalvanizeTokens) {
+            boolean hasNonBastionGalvanizeSource = game.getRealPlayers().stream()
+                    .anyMatch(p -> p.hasTech("thardentiar")
+                            || p.hasTech("thponthousr")
+                            || p.ownsPromissoryNote("thpnponthous")
+                            || p.hasUnlockedBreakthrough("kryxosbt"));
+            if (!game.isFrankenGame() && !hasNonBastionGalvanizeSource && totGalvanized > maxGalvanizeTokens) {
                 String msg = player.getRepresentation()
                         + ", there are too many Galvanized units on the board. Please review and resolve manually.";
                 MessageHelper.sendMessageToChannel(player.getCorrectChannel(), msg);


### PR DESCRIPTION
Suppress too many galvanized units message when it is a franken game and/or any player owns a non-Bastion galvanization source.

Fix revenant BT not readying the exhausted agent on purge of a different attached agent.