### PR TITLE
ACD2 tweaks: Tomb Raiders bullets, Strategic Focus pass ping, stats cleanup

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/TombRaidersAcd2ButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/TombRaidersAcd2ButtonHandler.java
@@ -13,6 +13,7 @@ import ti4.image.Mapper;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.model.ExploreModel;
+import ti4.service.emoji.ExploreEmojis;
 import ti4.service.leader.CommanderUnlockCheckService;
 
 @UtilityClass
@@ -28,7 +29,13 @@ class TombRaidersAcd2ButtonHandler {
             String cardId = game.drawExplore(type);
             ExploreModel card = Mapper.getExplore(cardId);
             String cardType = card.getResolution();
-            sb.append("\nRevealed _")
+            sb.append("\n- ");
+            if (Constants.FRAGMENT.equalsIgnoreCase(cardType)) {
+                sb.append(ExploreEmojis.getFragEmoji(type)).append(" ");
+            } else {
+                sb.append("❌ ");
+            }
+            sb.append("Revealed _")
                     .append(card.getName())
                     .append("_ from the top of the ")
                     .append(type)

--- a/src/main/java/ti4/discord/interactions/commands/statistics/ActionCardStats.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/ActionCardStats.java
@@ -1,8 +1,6 @@
 package ti4.discord.interactions.commands.statistics;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.OptionType;
-import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.helpers.Constants;
 import ti4.service.statistics.ActionCardStatsService;
@@ -11,11 +9,6 @@ class ActionCardStats extends Subcommand {
 
     ActionCardStats() {
         super(Constants.ACTION_CARD_STATS, "Action card play statistics");
-        addOptions(new OptionData(
-                        OptionType.STRING,
-                        Constants.AC_DECK,
-                        "Action card deck games must use (default: Prophecy of Kings deck)")
-                .setAutoComplete(true));
     }
 
     @Override

--- a/src/main/java/ti4/helpers/ButtonHelperActionCards.java
+++ b/src/main/java/ti4/helpers/ButtonHelperActionCards.java
@@ -2067,6 +2067,27 @@ public final class ButtonHelperActionCards {
         }
     }
 
+    public static void checkForPlayingStrategicFocus(Game game, Player player) {
+        if (IsPlayerElectedService.isPlayerElected(game, player, "censure")
+                || IsPlayerElectedService.isPlayerElected(game, player, "absol_censure")) {
+            return;
+        }
+        if (!player.getPlayableActionCards().contains("strategic_focus")) {
+            return;
+        }
+        Integer handIndex = player.getActionCards().get("strategic_focus");
+        String msg = player.getRepresentation()
+                + ", you have _Strategic Focus_ in your hand and just passed — this is the window to play it."
+                + " Use the button below to play it now, or ignore this message if you don't want to.";
+        List<Button> buttons = new ArrayList<>();
+        if (handIndex != null) {
+            buttons.add(Buttons.green(
+                    Constants.AC_PLAY_FROM_HAND + handIndex, "Play Strategic Focus", CardEmojis.getACEmoji(game)));
+        }
+        buttons.add(Buttons.red("deleteButtons", "Decline"));
+        MessageHelper.sendMessageToChannelWithButtons(player.getCardsInfoThread(), msg, buttons);
+    }
+
     public static void checkForPlayingBountyContracts(Game game, Player player) {
         if (IsPlayerElectedService.isPlayerElected(game, player, "censure")
                 || IsPlayerElectedService.isPlayerElected(game, player, "absol_censure")) {

--- a/src/main/java/ti4/service/statistics/ActionCardStatsService.java
+++ b/src/main/java/ti4/service/statistics/ActionCardStatsService.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import org.apache.commons.lang3.StringUtils;
 import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
 import ti4.executors.ExecutionLockType;
@@ -22,7 +21,6 @@ import ti4.game.GameStats;
 import ti4.game.GameStats.ActionCardPlay;
 import ti4.game.Player;
 import ti4.game.persistence.ConsumeGameUtility;
-import ti4.helpers.Constants;
 import ti4.image.Mapper;
 import ti4.message.MessageHelper;
 import ti4.model.ActionCardModel;
@@ -39,13 +37,7 @@ public class ActionCardStatsService {
     }
 
     private static void showActionCardStats(SlashCommandInteractionEvent event) {
-        String acDeckId = event.getOption(Constants.AC_DECK, DEFAULT_AC_DECK_ID, OptionMapping::getAsString);
-        DeckModel acDeck = Mapper.getDeck(acDeckId);
-        if (acDeck == null || acDeck.getType() != DeckModel.DeckType.ACTION_CARD) {
-            MessageHelper.sendMessageToChannel(
-                    event.getChannel(), "'" + acDeckId + "' is not an action card deck, please retry.");
-            return;
-        }
+        DeckModel acDeck = Mapper.getDeck(DEFAULT_AC_DECK_ID);
 
         Map<String, Integer> cancelCounts = new HashMap<>();
         Map<String, Integer> actionCardsPlayedCounts = new HashMap<>();
@@ -58,7 +50,7 @@ public class ActionCardStatsService {
 
         ConsumeGameUtility.consumeAllGames(
                 GameStatisticsFilterer.getStandardCompetitiveGamesFilter()
-                        .and(game -> acDeckId.equals(game.getAcDeckID()))
+                        .and(game -> DEFAULT_AC_DECK_ID.equals(game.getAcDeckID()))
                         .and(game -> deckCardIds.containsAll(
                                 game.getDiscardActionCards().keySet())),
                 game -> accumulateActionCardStats(
@@ -91,7 +83,7 @@ public class ActionCardStatsService {
         }
 
         Player winner = game.getWinner().orElse(null);
-        if (actionCardPlays.isEmpty() || winner == null) {
+        if (winner == null) {
             return;
         }
         accumulateActionCardPlayToWinCorrelation(game, winner, playToWinCorrelationCounts);

--- a/src/main/java/ti4/service/turn/PassService.java
+++ b/src/main/java/ti4/service/turn/PassService.java
@@ -41,6 +41,7 @@ public class PassService {
             ButtonHelperCommanders.olradinCommanderStep1(player, game);
         }
         ButtonHelperActionCards.checkForPlayingBountyContracts(game, player);
+        ButtonHelperActionCards.checkForPlayingStrategicFocus(game, player);
         game.setStoredValue(
                 "currentActionSummary" + player.getFaction(),
                 game.getStoredValue("currentActionSummary" + player.getFaction()) + " Passed.");


### PR DESCRIPTION
## Summary
Two ACD2 tweaks and a small ActionCardStats cleanup, cherry-picked onto a fresh branch off master so they land without the in-flight overrule work.

- **Tomb Raiders** — each of the four reveal lines is now a `-` bullet prefixed with the matching fragment emoji on a hit or ❌ on a discard.
- **Strategic Focus** — when a player passes while still holding the card, they get a ping in their cards-info thread with a direct **Play Strategic Focus** button, since the "After you pass" window is easy to miss in async.
- **ActionCardStats** — drop the deck option and always run against the default AC deck; simplify the winner guard.

## Test plan
- [ ] Play _Tomb Raiders_ and confirm each of the four lines renders as a bullet with the matching fragment emoji or ❌
- [ ] Pass while holding _Strategic Focus_ and confirm the cards-info thread gets the reminder with a working Play button
- [ ] Pass without _Strategic Focus_ in hand and confirm no extra ping is sent
- [ ] `/statistics action_card_stats` runs without the deck option and returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
