### PR TITLE
Add boom emoji to action-card hit totals

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/theodisi/MirrorShieldingLLButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/theodisi/MirrorShieldingLLButtonHandler.java
@@ -12,6 +12,7 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.Tile;
 import ti4.helpers.ButtonHelper;
+import ti4.helpers.CombatMessageHelper;
 import ti4.helpers.Constants;
 import ti4.helpers.FoWHelper;
 import ti4.message.MessageHelper;
@@ -53,9 +54,9 @@ public class MirrorShieldingLLButtonHandler {
 
         MessageHelper.sendMessageToChannel(
                 event.getMessageChannel(),
-                player.getRepresentationNoPing() + " used _Mirror Shielding_ to produce "
-                        + canceledHits + " hit" + (canceledHits == 1 ? "" : "s") + " against "
-                        + opponent.getRepresentationNoPing() + ".");
+                player.getRepresentationNoPing() + " used _Mirror Shielding_ against "
+                        + opponent.getRepresentationNoPing() + "."
+                        + CombatMessageHelper.displayHitResults(canceledHits).stripTrailing());
 
         if (Constants.SPACE.equals(context.unitHolderName())) {
             CombatRollService.sendSpaceAssignHitsButtons(event, game, opponent, tile, canceledHits);

--- a/src/main/java/ti4/helpers/ButtonHelperActionCards.java
+++ b/src/main/java/ti4/helpers/ButtonHelperActionCards.java
@@ -2465,9 +2465,8 @@ public final class ButtonHelperActionCards {
                     if (x == 1) nice &= (d1.getResult() == 9);
                 }
                 msg.append(nice ? " (nice)" : "")
-                        .append(".\n Total hits were ")
-                        .append(hits)
-                        .append(".");
+                        .append(".")
+                        .append(CombatMessageHelper.displayHitResults(hits).stripTrailing());
             }
             MessageHelper.sendMessageToChannel(p2.getCorrectChannel(), msg.toString());
             if (hits > 0 && p2.hasAbility("data_recovery")) {
@@ -2522,7 +2521,8 @@ public final class ButtonHelperActionCards {
                     hits++;
                 }
             }
-            msg = new StringBuilder(msg.substring(0, msg.length() - 2) + "\n Total hits were " + hits);
+            msg = new StringBuilder(msg.substring(0, msg.length() - 2)
+                    + CombatMessageHelper.displayHitResults(hits).stripTrailing());
             UnitKey key = Units.getUnitKey(UnitType.Fighter, p2.getColor());
             var unitParsed = new ParsedUnit(key, hits, Constants.SPACE);
             RemoveUnitService.removeUnit(event, tile, game, unitParsed);

--- a/src/main/java/ti4/helpers/DiceHelper.java
+++ b/src/main/java/ti4/helpers/DiceHelper.java
@@ -108,7 +108,7 @@ public final class DiceHelper {
                 sb.append('\n');
             }
         }
-        sb.append(String.format("Total: %d hits", countSuccesses(dice)));
+        sb.append(CombatMessageHelper.displayHitResults(countSuccesses(dice)).strip());
         return sb.toString();
     }
 }


### PR DESCRIPTION
## Summary
- Action cards that roll their own dice inline (Plague, Micrometeoroid Storm, Chain Reaction, Hostile World) and one that produces hits without rolling (Mirror Shielding) built ad-hoc result strings instead of reusing `CombatMessageHelper.displayHitResults`, so their hit totals were missing the boom emoji that every other hit-producing effect shows (Blitz, Raze, Courageous Charge, etc).
- Centralized `DiceHelper.formatDiceOutput`'s trailing "Total: N hits" line onto `displayHitResults`, which also fixes Chain Reaction and Hostile World (both ACD2) at the source, plus the Ponthous *Last Stand* ability which shares the same formatter.
- Updated Plague and Micrometeoroid Storm's hand-built totals in `ButtonHelperActionCards`, and reworded Mirror Shielding's inline hit count into a trailing `**Total hits N**` line.

## Test plan
- [x] `mvn -o compile` — clean build
- [x] `mvn -o spotless:check` — formatting clean
- [x] `mvn -o test` — 604 tests, 0 failures
- [x] Verified actual rendered output via `jshell` against compiled classes: `**Total hits N**` followed by N `:boom:` emoji, including the zero-hit case with no stray whitespace
- [ ] Manual in-game check of each card (Plague, Micrometeoroid Storm, Chain Reaction, Hostile World, Mirror Shielding, Ponthous Last Stand) recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
