### PR TITLE
Show SPACE CANNON die counts in system activation range warning

### DIFF
--- a/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTacticalAction.java
@@ -817,19 +817,33 @@ public final class ButtonHelperTacticalAction {
 
         List<Player> playersWithPds2 = ButtonHelper.getPlayersWithPds2Cover(player, game, pos);
         if (!game.isFowMode() && !playersWithPds2.isEmpty() && !game.isL1Hero()) {
+            Tile pdsTile = game.getTileByPosition(pos);
+            Map<String, PdsCoverage> pdsCoverage =
+                    pdsTile == null ? null : PdsCoverageHelper.calculatePdsCoverage(game, pdsTile);
             List<String> mentions = new ArrayList<>();
+            int totalDice = 0;
             for (Player playerWithPds : playersWithPds2) {
                 if (playerWithPds == player) {
                     continue;
                 }
-                mentions.add(playerWithPds.getRepresentationNoPing());
+                PdsCoverage coverage = pdsCoverage == null ? null : pdsCoverage.get(playerWithPds.getFaction());
+                if (coverage == null) {
+                    mentions.add(playerWithPds.getRepresentationNoPing());
+                    continue;
+                }
+                totalDice += coverage.getCount();
+                mentions.add(playerWithPds.getRepresentationNoPing() + " (" + coverage.getCount()
+                        + (coverage.getCount() == 1 ? " die)" : " dice)"));
             }
             if (!mentions.isEmpty()) {
                 message.append('\n')
                         .append(player.getRepresentationUnfogged())
                         .append(" the activated system is in range of SPACE CANNON units owned by ")
-                        .append(String.join(", ", mentions))
-                        .append(".");
+                        .append(String.join(", ", mentions));
+                if (mentions.size() > 1 && totalDice > 0) {
+                    message.append(", for a total of ").append(totalDice).append(totalDice == 1 ? " die" : " dice");
+                }
+                message.append(".");
             }
         }
 


### PR DESCRIPTION
## Summary
- The activation warning ("the activated system is in range of SPACE CANNON units owned by ...") only listed which players had range, not how many dice they'd roll.
- Reuse `PdsCoverageHelper.calculatePdsCoverage` (the same source the map image and website PDS overlay use) to append a per-player die count, e.g. `Psychedelic (5 dice)`, and a combined total when 2+ players have coverage.
- Players whose coverage comes from a source `calculatePdsCoverage` doesn't model (Sigil of Transmutation, Twilight Defense, Hive Echo, Netrunners Commander) are still listed, just without a count, and are excluded from the total so it's never wrong.

## Test plan
- [x] `mvn -q -o compile -DskipTests` passes
- [ ] Manually activate a system in range of two players' SPACE CANNON in a live game and confirm the message shows per-player dice and a total

🤖 Generated with [Claude Code](https://claude.com/claude-code)