### PR TITLE
FrankenDraz faciton priority settings

### DIFF
--- a/src/main/java/ti4/draft/FrankenDrazDraft.java
+++ b/src/main/java/ti4/draft/FrankenDrazDraft.java
@@ -29,6 +29,7 @@ import ti4.draft.items.SpeakerOrderDraftItem;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.PatternHelper;
+import ti4.image.Mapper;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
 import ti4.message.componentsV2.MessageV2Builder;
@@ -37,9 +38,14 @@ import ti4.model.FactionModel;
 import ti4.model.Source.ComponentSource;
 import ti4.service.franken.FrankenDraftBagService;
 import ti4.service.milty.MiltyDraftManager;
+import ti4.service.milty.MiltyService;
 
 public class FrankenDrazDraft extends FrankenDraft {
     public static final String UNLIMITED_KEPT_COMPONENTS_KEY = "frankenDrazUnlimitedKeptComponents";
+    public static final String PRIORITY_FACTIONS_KEY = "frankenDrazPriorityFactions";
+    public static final String DISCORDANT_STARS_FACTION_LIMITS_KEY = "frankenDrazDiscordantStarsFactionLimits";
+    public static final String BLUE_REVERIE_FACTION_LIMITS_KEY = "frankenDrazBlueReverieFactionLimits";
+    public static final String LOST_LEGACIES_FACTION_LIMITS_KEY = "frankenDrazLostLegaciesFactionLimits";
     private static final int DEFAULT_FACTION_LIMIT = 6;
     private static final List<DraftCategory> POST_DRAFT_COMPONENT_CATEGORIES = List.of(
             DraftCategory.ABILITY,
@@ -117,7 +123,32 @@ public class FrankenDrazDraft extends FrankenDraft {
     public List<DraftBag> generateBags(Game game) {
         Map<DraftCategory, List<DraftItem>> allDraftableItems = new HashMap<>();
         List<FactionModel> allDraftableFactions = getDraftableFactionsForGame(game);
-        allDraftableItems.put(DraftCategory.FACTION, FactionDraftItem.buildAllDraftableItems(allDraftableFactions));
+        List<DraftItem> factionItems = FactionDraftItem.buildAllDraftableItems(allDraftableFactions);
+        int factionPoolSize = game.getRealPlayers().size() * getFactionDraftLimit();
+        Map<ComponentSource, int[]> sourceLimits = new HashMap<>();
+        for (Map.Entry<ComponentSource, String> entry : Map.of(
+                        ComponentSource.ds, DISCORDANT_STARS_FACTION_LIMITS_KEY,
+                        ComponentSource.blue_reverie, BLUE_REVERIE_FACTION_LIMITS_KEY,
+                        ComponentSource.theodisi, LOST_LEGACIES_FACTION_LIMITS_KEY)
+                .entrySet()) {
+            String[] limits = game.getStoredValue(entry.getValue()).split("\\|", 2);
+            if (limits.length == 2) {
+                sourceLimits.put(entry.getKey(), new int[] {Integer.parseInt(limits[0]), Integer.parseInt(limits[1])});
+            }
+        }
+        List<String> factionAliases =
+                factionItems.stream().map(DraftItem::getItemId).toList();
+        List<String> priorityFactions =
+                List.of(PatternHelper.FIN_SEPERATOR_PATTERN.split(game.getStoredValue(PRIORITY_FACTIONS_KEY)));
+        List<FactionModel> selectedFactions = MiltyService.createFactionDraft(
+                        factionPoolSize, new ArrayList<>(factionAliases), priorityFactions, sourceLimits)
+                .stream()
+                .map(Mapper::getFaction)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        List<DraftItem> selectedFactionItems = FactionDraftItem.buildAllItems(selectedFactions);
+        Collections.shuffle(selectedFactionItems);
+        allDraftableItems.put(DraftCategory.FACTION, selectedFactionItems);
         allDraftableItems.put(DraftCategory.DRAFTORDER, SpeakerOrderDraftItem.buildAllDraftableItems(game));
 
         MiltyDraftManager draftManager = game.getMiltyDraftManager();

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FrankenDrazFactionPrioritySettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FrankenDrazFactionPrioritySettings.java
@@ -1,0 +1,144 @@
+package ti4.helpers.settingsFramework.menus;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.helpers.settingsFramework.settings.IntegerRangeSetting;
+import ti4.helpers.settingsFramework.settings.ListSetting;
+import ti4.helpers.settingsFramework.settings.SettingInterface;
+import ti4.image.Mapper;
+import ti4.model.FactionModel;
+import ti4.model.Source.ComponentSource;
+import tools.jackson.databind.JsonNode;
+
+@Getter
+@JsonIgnoreProperties("messageId")
+class FrankenDrazFactionPrioritySettings extends SettingsMenu {
+    private static final String MENU_ID = "drazFactionPriorities";
+
+    private final ListSetting<FactionModel> prioritizedFactions;
+    private final IntegerRangeSetting discordantStarsFactionLimits;
+    private final IntegerRangeSetting blueReverieFactionLimits;
+    private final IntegerRangeSetting lostLegaciesFactionLimits;
+
+    FrankenDrazFactionPrioritySettings(JsonNode json, SettingsMenu parent) {
+        super(
+                MENU_ID,
+                "FrankenDraz Faction Priorities",
+                "Prioritize factions and set source minimums and maximums for the FrankenDraz faction pool.",
+                parent);
+
+        Set<String> empty = new HashSet<>();
+        prioritizedFactions = new ListSetting<>(
+                "PriorityFactions",
+                "Prioritized Factions",
+                "Prioritize Faction",
+                "Unprioritize Faction",
+                Map.<String, FactionModel>of().entrySet(),
+                empty,
+                empty);
+        prioritizedFactions.setGetEmoji(FactionModel::getFactionEmoji);
+        prioritizedFactions.setShow(FactionModel::getFactionName);
+        prioritizedFactions.setExtraInfo("These factions will be included in the draft first.");
+
+        discordantStarsFactionLimits = sourceRange("DiscordantStars", "Discordant Stars Factions", ComponentSource.ds);
+        blueReverieFactionLimits = sourceRange("BlueReverie", "Blue Reverie Factions", ComponentSource.blue_reverie);
+        lostLegaciesFactionLimits = sourceRange("LostLegacies", "Lost Legacies Factions", ComponentSource.theodisi);
+
+        updateTransientSettings();
+        if (json != null && json.has("factionPrioritySettings")) json = json.get("factionPrioritySettings");
+        if (FrankenSettings.isMenuJson(json, MENU_ID)) {
+            prioritizedFactions.initialize(json.get("prioritizedFactions"));
+            if (json.has("discordantStarsFactionLimits")) {
+                discordantStarsFactionLimits.initialize(json.get("discordantStarsFactionLimits"));
+            }
+            if (json.has("blueReverieFactionLimits")) {
+                blueReverieFactionLimits.initialize(json.get("blueReverieFactionLimits"));
+            }
+            if (json.has("lostLegaciesFactionLimits")) {
+                lostLegaciesFactionLimits.initialize(json.get("lostLegaciesFactionLimits"));
+            }
+        }
+    }
+
+    @Override
+    protected List<SettingInterface> settings() {
+        if (!(parent instanceof FrankenSettings settings) || !settings.isFrankendrazMode()) {
+            return List.of();
+        }
+        List<SettingInterface> output = new ArrayList<>(List.of(prioritizedFactions));
+        if (settings.isEffectiveDiscordantStarsEnabled()) output.add(discordantStarsFactionLimits);
+        if (settings.isEffectiveBlueReverieEnabled()) output.add(blueReverieFactionLimits);
+        if (settings.isLostLegaciesEnabled()) output.add(lostLegaciesFactionLimits);
+        return output;
+    }
+
+    @Override
+    protected List<Button> specialButtons() {
+        if (!(parent instanceof FrankenSettings settings) || !settings.isFrankendrazMode()) {
+            return List.of();
+        }
+        String prefix = menuAction + "_" + navId() + "_";
+        List<Button> buttons = new ArrayList<>();
+        if (settings.isEffectiveDiscordantStarsEnabled()) {
+            buttons.add(Buttons.blue(prefix + "prioritizeDiscordantStars", "Prioritize Discordant Stars"));
+        }
+        if (settings.isEffectiveBlueReverieEnabled()) {
+            buttons.add(Buttons.blue(prefix + "prioritizeBlueReverie", "Prioritize Blue Reverie"));
+        }
+        if (settings.isLostLegaciesEnabled()) {
+            buttons.add(Buttons.blue(prefix + "prioritizeLostLegacies", "Prioritize Lost Legacies"));
+        }
+        return buttons;
+    }
+
+    @Override
+    protected String handleSpecialButtonAction(GenericInteractionCreateEvent event, String action) {
+        ComponentSource source =
+                switch (action) {
+                    case "prioritizeDiscordantStars" -> ComponentSource.ds;
+                    case "prioritizeBlueReverie" -> ComponentSource.blue_reverie;
+                    case "prioritizeLostLegacies" -> ComponentSource.theodisi;
+                    default -> null;
+                };
+        if (source == null) return null;
+        List<String> priorities = new ArrayList<>(prioritizedFactions.getKeys());
+        prioritizedFactions.getAllValues().values().stream()
+                .filter(faction -> faction.getSource() == source)
+                .map(FactionModel::getAlias)
+                .filter(faction -> !priorities.contains(faction))
+                .forEach(priorities::add);
+        prioritizedFactions.setKeys(priorities);
+        return "success";
+    }
+
+    @Override
+    public String menuSummaryString(String lastSettingTouched) {
+        String summary = super.menuSummaryString(lastSettingTouched);
+        if (parent instanceof FrankenSettings settings) {
+            settings.persistSettings();
+        }
+        return summary;
+    }
+
+    @Override
+    protected void updateTransientSettings() {
+        if (parent instanceof FrankenSettings settings) {
+            prioritizedFactions.setAllValues(settings.getLegalFactionOptions());
+        }
+    }
+
+    private static IntegerRangeSetting sourceRange(String id, String name, ComponentSource source) {
+        int factionCount = (int) Mapper.getFactionsValues().stream()
+                .filter(faction -> faction.getSource() == source)
+                .count();
+        return new IntegerRangeSetting(id, name, 0, 0, factionCount, factionCount, 0, factionCount, 1);
+    }
+}

--- a/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/FrankenSettings.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.commands.franken.ban.BanService;
 import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.draft.FrankenDrazDraft;
 import ti4.game.Game;
 import ti4.helpers.Constants;
 import ti4.helpers.settingsFramework.settings.BooleanSetting;
@@ -59,6 +60,7 @@ public class FrankenSettings extends SettingsMenu {
     private final ListSetting<FactionModel> bannedFactions;
     private final ListSetting<FrankenBanList> banLists;
     private final FrankenHomebrewSettings homebrewSettings;
+    private final FrankenDrazFactionPrioritySettings factionPrioritySettings;
 
     private final FrankenDeckSettings deckSettings;
 
@@ -118,6 +120,7 @@ public class FrankenSettings extends SettingsMenu {
         }
 
         homebrewSettings = new FrankenHomebrewSettings(game, json, this);
+        factionPrioritySettings = new FrankenDrazFactionPrioritySettings(json, this);
         deckSettings = new FrankenDeckSettings(game, json, this);
         draftLimitSettings = new FrankenDraftLimitSettings(game, json, this);
 
@@ -142,7 +145,11 @@ public class FrankenSettings extends SettingsMenu {
 
     @Override
     protected List<SettingsMenu> categories() {
-        return List.of(homebrewSettings, deckSettings, draftLimitSettings);
+        List<SettingsMenu> categories = new ArrayList<>(List.of(homebrewSettings, deckSettings, draftLimitSettings));
+        if (isFrankendrazMode()) {
+            categories.add(factionPrioritySettings);
+        }
+        return categories;
     }
 
     @Override
@@ -189,6 +196,7 @@ public class FrankenSettings extends SettingsMenu {
         deckSettings.resetSettings();
         draftLimitSettings.resetSettings();
         if (isFrankendrazMode()) {
+            factionPrioritySettings.resetSettings();
             banAllDsFactions.setVal(true);
             banAllBrFactions.setVal(true);
             homebrewSettings.getDiscoStars().setVal(true);
@@ -205,6 +213,7 @@ public class FrankenSettings extends SettingsMenu {
         applyHomebrewSettings();
         deckSettings.applyDecks(game, event);
         applyBanSettings();
+        applyPriorityFactionSettings();
         return FrankenDraftStartService.startFrankenDraft(event, game, force.isVal(), selectedDraftMode());
     }
 
@@ -221,6 +230,45 @@ public class FrankenSettings extends SettingsMenu {
         }
     }
 
+    private void applyPriorityFactionSettings() {
+        game.removeStoredValue(FrankenDrazDraft.PRIORITY_FACTIONS_KEY);
+        game.removeStoredValue(FrankenDrazDraft.DISCORDANT_STARS_FACTION_LIMITS_KEY);
+        game.removeStoredValue(FrankenDrazDraft.BLUE_REVERIE_FACTION_LIMITS_KEY);
+        game.removeStoredValue(FrankenDrazDraft.LOST_LEGACIES_FACTION_LIMITS_KEY);
+        if (isFrankendrazMode()
+                && !factionPrioritySettings.getPrioritizedFactions().getKeys().isEmpty()) {
+            game.setStoredValue(
+                    FrankenDrazDraft.PRIORITY_FACTIONS_KEY,
+                    String.join(
+                            Constants.FIN_SEPARATOR,
+                            factionPrioritySettings.getPrioritizedFactions().getKeys()));
+        }
+        if (isFrankendrazMode() && isEffectiveDiscordantStarsEnabled()) {
+            game.setStoredValue(
+                    FrankenDrazDraft.DISCORDANT_STARS_FACTION_LIMITS_KEY,
+                    factionPrioritySettings.getDiscordantStarsFactionLimits().getValLow() + "|"
+                            + factionPrioritySettings
+                                    .getDiscordantStarsFactionLimits()
+                                    .getValHigh());
+        }
+        if (isFrankendrazMode() && isEffectiveBlueReverieEnabled()) {
+            game.setStoredValue(
+                    FrankenDrazDraft.BLUE_REVERIE_FACTION_LIMITS_KEY,
+                    factionPrioritySettings.getBlueReverieFactionLimits().getValLow() + "|"
+                            + factionPrioritySettings
+                                    .getBlueReverieFactionLimits()
+                                    .getValHigh());
+        }
+        if (isFrankendrazMode() && isLostLegaciesEnabled()) {
+            game.setStoredValue(
+                    FrankenDrazDraft.LOST_LEGACIES_FACTION_LIMITS_KEY,
+                    factionPrioritySettings.getLostLegaciesFactionLimits().getValLow() + "|"
+                            + factionPrioritySettings
+                                    .getLostLegaciesFactionLimits()
+                                    .getValHigh());
+        }
+    }
+
     private void applySourceFactionBans(BanService banService, ComponentSource source, boolean enabled) {
         if (!enabled) return;
         Mapper.getFactionsValues().stream()
@@ -231,11 +279,7 @@ public class FrankenSettings extends SettingsMenu {
 
     @Override
     protected void updateTransientSettings() {
-        bannedFactions.setAllValues(legalFactionOptions(
-                game.isThundersEdge(),
-                isEffectiveDiscordantStarsEnabled(),
-                isEffectiveBlueReverieEnabled(),
-                isLostLegaciesEnabled()));
+        bannedFactions.setAllValues(getLegalFactionOptions());
     }
 
     void applyHomebrewSettings() {
@@ -408,6 +452,14 @@ public class FrankenSettings extends SettingsMenu {
         return Mapper.getFactionsValues().stream()
                 .filter(faction -> isLegalFrankenFaction(faction, teEnabled, dsEnabled, brEnabled, lostLegaciesEnabled))
                 .collect(Collectors.toMap(FactionModel::getAlias, faction -> faction));
+    }
+
+    Map<String, FactionModel> getLegalFactionOptions() {
+        return legalFactionOptions(
+                game.isThundersEdge(),
+                isEffectiveDiscordantStarsEnabled(),
+                isEffectiveBlueReverieEnabled(),
+                isLostLegaciesEnabled());
     }
 
     private static boolean isLegalFrankenFaction(

--- a/src/main/java/ti4/service/milty/MiltyService.java
+++ b/src/main/java/ti4/service/milty/MiltyService.java
@@ -250,7 +250,7 @@ public class MiltyService {
      * - Per-source constraints cap/guarantee the remaining slots per expansion.
      * - If constraints is null/empty, falls back to the original unconstrained shuffle.
      */
-    static List<String> createFactionDraft(
+    public static List<String> createFactionDraft(
             int factionCount,
             List<String> factions,
             List<String> firstFactions,


### PR DESCRIPTION
Added a settings menu for FrankenDraz only that allows prioritization of the factions that appear, as well as source minimums and maximums