### PR TITLE
Don't auto-pass sabo for the player who is up to act

### DIFF
--- a/src/main/java/ti4/cron/SabotageAutoReactCron.java
+++ b/src/main/java/ti4/cron/SabotageAutoReactCron.java
@@ -74,17 +74,28 @@ public class SabotageAutoReactCron {
     }
 
     private static boolean playerShouldRandomlyReact(Player player, Game game) {
-        if (player.isAFK() || player.getAutoSaboPassMedian() == 0) {
-            return false;
-        }
-
-        boolean canSabotage = SabotageService.canSabotage(player, game);
-        if (canSabotage) {
+        if (!isEligibleForAutoPass(player, game)) {
             return false;
         }
 
         int rollMax = player.getAutoSaboPassMedian() * RUNS_PER_HOUR;
         int rollResult = ThreadLocalRandom.current().nextInt(1, rollMax + 1);
         return rollResult == rollMax;
+    }
+
+    static boolean isEligibleForAutoPass(Player player, Game game) {
+        if (player.isAFK() || player.getAutoSaboPassMedian() == 0) {
+            return false;
+        }
+
+        // The auto-pass only ever fires for players who cannot sabotage, so every one of them leaks
+        // information. That leak is worst for the player who is currently up to act: everyone can see
+        // they are at the keyboard, so a bot pass on their behalf is a clean tell that they hold no
+        // sabotage. Make them react manually instead - they can be auto-passed once their turn ends.
+        if (player.isActivePlayer()) {
+            return false;
+        }
+
+        return !SabotageService.canSabotage(player, game);
     }
 }

--- a/src/test/java/ti4/cron/SabotageAutoReactCronTest.java
+++ b/src/test/java/ti4/cron/SabotageAutoReactCronTest.java
@@ -1,0 +1,58 @@
+package ti4.cron;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.image.Mapper;
+import ti4.testUtils.BaseTi4Test;
+
+class SabotageAutoReactCronTest extends BaseTi4Test {
+
+    @Test
+    void testIsEligibleForAutoPass_EmptyHand() {
+        Game game = new Game();
+        Player player = createPlayer(game);
+
+        assertTrue(SabotageAutoReactCron.isEligibleForAutoPass(player, game));
+    }
+
+    @Test
+    void testIsEligibleForAutoPass_ActivePlayerMustReactManually() {
+        Game game = new Game();
+        Player player = createPlayer(game);
+        game.setActivePlayerID(player.getUserID());
+
+        assertTrue(player.isActivePlayer());
+        assertFalse(SabotageAutoReactCron.isEligibleForAutoPass(player, game));
+    }
+
+    @Test
+    void testIsEligibleForAutoPass_HoldingSabotage() {
+        Game game = new Game();
+        Player player = createPlayer(game);
+        player.setActionCard("sabo1");
+
+        assertFalse(SabotageAutoReactCron.isEligibleForAutoPass(player, game));
+    }
+
+    @Test
+    void testIsEligibleForAutoPass_AutoPassDisabled() {
+        Game game = new Game();
+        Player player = createPlayer(game);
+        player.setAutoSaboPassMedian(0);
+
+        assertFalse(SabotageAutoReactCron.isEligibleForAutoPass(player, game));
+    }
+
+    private static Player createPlayer(Game game) {
+        game.setActionCards(Mapper.getShuffledDeck("action_cards_pok"));
+        Player player = game.addPlayer("101", "testUser");
+        player.setFaction("winnu");
+        player.setColor("red");
+        player.setAutoSaboPassMedian(1);
+        return player;
+    }
+}


### PR DESCRIPTION
## What changed

The sabotage auto-pass cron only ever fires for players who *cannot* sabotage, so every automatic pass leaks information. That leak is worst for the active player: everyone can see they're at the keyboard, so a bot pass on their behalf is a clean tell that they hold no sabotage.

This skips the roll while a player is active — they react manually, and become eligible for the auto-pass again once their turn ends.

The deterministic guards were split out of `playerShouldRandomlyReact` so the rule can be tested without the RNG; `SabotageAutoReactCronTest` covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
