### PR TITLE
Cancel-aware action card win rates and Impact Score Ω

### DIFF
--- a/src/main/java/ti4/service/statistics/ActionCardStatsService.java
+++ b/src/main/java/ti4/service/statistics/ActionCardStatsService.java
@@ -31,7 +31,7 @@ import ti4.spring.service.statistics.overrule.OverruleStatsService;
 public class ActionCardStatsService {
     private static final LocalDate PLAYER_TRACKING_START_DATE = LocalDate.of(2026, 5, 23);
     private static final String DEFAULT_AC_DECK_ID = "action_cards_te";
-    private static final double CANCEL_WIN_EQUIVALENT = 0.1;
+    private static final double CANCEL_WIN_EQUIVALENT = 0.2;
 
     public static void queueReply(SlashCommandInteractionEvent event) {
         StatisticsPipeline.queue(event, () -> showActionCardStats(event));
@@ -157,7 +157,7 @@ public class ActionCardStatsService {
         appendTrackingStartNote(message);
         appendExpectedDrawsNote(message, computeMaxPlaysPerCopyCount(playsIncludingCanceled, copiesPerName));
         message.append(
-                "_The Impact Score compares wins to expected draws. Impact Score Ω raises that score by 1/10th of a win for each cancel of the card._\n");
+                "_The Impact Score compares wins to expected draws. Impact Score Ω raises that score by 1/5th of a win for each cancel of the card._\n");
         appendPlayToWinCorrelationStats(message, playToWinCorrelationCounts, winCorrelationExpectedDraws);
         if (copiesPerName.containsKey(GameStats.OVERRULE)) {
             message.append("\n**Overrule targets**\n");
@@ -344,7 +344,7 @@ public class ActionCardStatsService {
                         .append(firstEntry ? " Impact Score (wins vs ~draws)" : " Impact Score")
                         .append(", ")
                         .append(String.format("%.1f", getOmegaImpactScore(count, expectedDraws)))
-                        .append(firstEntry ? " Impact Score Ω (+0.1 win per cancel)" : " Impact Score Ω");
+                        .append(firstEntry ? " Impact Score Ω (+0.2 win per cancel)" : " Impact Score Ω");
             }
             message.append('\n');
         }

--- a/src/main/java/ti4/service/statistics/ActionCardStatsService.java
+++ b/src/main/java/ti4/service/statistics/ActionCardStatsService.java
@@ -31,6 +31,7 @@ import ti4.spring.service.statistics.overrule.OverruleStatsService;
 public class ActionCardStatsService {
     private static final LocalDate PLAYER_TRACKING_START_DATE = LocalDate.of(2026, 5, 23);
     private static final String DEFAULT_AC_DECK_ID = "action_cards_te";
+    private static final double CANCEL_WIN_EQUIVALENT = 0.1;
 
     public static void queueReply(SlashCommandInteractionEvent event) {
         StatisticsPipeline.queue(event, () -> showActionCardStats(event));
@@ -155,7 +156,8 @@ public class ActionCardStatsService {
         message.append("\n**Action card play-to-win correlation**\n");
         appendTrackingStartNote(message);
         appendExpectedDrawsNote(message, computeMaxPlaysPerCopyCount(playsIncludingCanceled, copiesPerName));
-        message.append("_The Impact Score compares wins to expected draws._\n");
+        message.append(
+                "_The Impact Score compares wins to expected draws. Impact Score Ω raises that score by 1/10th of a win for each cancel of the card._\n");
         appendPlayToWinCorrelationStats(message, playToWinCorrelationCounts, winCorrelationExpectedDraws);
         if (copiesPerName.containsKey(GameStats.OVERRULE)) {
             message.append("\n**Overrule targets**\n");
@@ -326,15 +328,23 @@ public class ActionCardStatsService {
                     .append(": ")
                     .append(count.getWins())
                     .append(" wins, ")
-                    .append(count.getTotal())
+                    .append(count.getPlaysIncludingCanceled())
                     .append(" plays (")
+                    .append(String.format("%.1f%%", count.getWinRateIncludingCanceled() * 100))
+                    .append(firstEntry ? " win rate), " : "), ")
+                    .append(count.getTotal())
+                    .append(" uncancelled plays (")
                     .append(String.format("%.1f%%", count.getWinRate() * 100))
                     .append(firstEntry ? " win rate)" : ")");
-            Double impactScore = getImpactScore(count.getWins(), expectedDrawsPerCard.get(entry.getKey()));
+            Integer expectedDraws = expectedDrawsPerCard.get(entry.getKey());
+            Double impactScore = getImpactScore(count.getWins(), expectedDraws);
             if (impactScore != null) {
                 message.append(", ")
                         .append(String.format("%.1f", impactScore))
-                        .append(firstEntry ? " Impact Score (wins vs ~draws)" : " Impact Score");
+                        .append(firstEntry ? " Impact Score (wins vs ~draws)" : " Impact Score")
+                        .append(", ")
+                        .append(String.format("%.1f", getOmegaImpactScore(count, expectedDraws)))
+                        .append(firstEntry ? " Impact Score Ω (+0.1 win per cancel)" : " Impact Score Ω");
             }
             message.append('\n');
         }
@@ -342,6 +352,10 @@ public class ActionCardStatsService {
 
     private static Double getImpactScore(int wins, Integer expectedDraws) {
         return expectedDraws == null || expectedDraws <= 0 ? null : wins / (double) expectedDraws * 100;
+    }
+
+    private static double getOmegaImpactScore(PlayToWinCorrelationCount count, int expectedDraws) {
+        return (count.getWins() + CANCEL_WIN_EQUIVALENT * count.getCanceled()) / (double) expectedDraws * 100;
     }
 
     @Getter
@@ -362,8 +376,16 @@ public class ActionCardStatsService {
             wins++;
         }
 
+        int getCanceled() {
+            return playsIncludingCanceled - total;
+        }
+
         double getWinRate() {
             return total == 0 ? 0 : (double) wins / total;
+        }
+
+        double getWinRateIncludingCanceled() {
+            return playsIncludingCanceled == 0 ? 0 : (double) wins / playsIncludingCanceled;
         }
     }
 }

--- a/src/main/resources/data/action_cards/theodisi.json
+++ b/src/main/resources/data/action_cards/theodisi.json
@@ -266,7 +266,7 @@
         "name": "Exploration Rider",
         "phase": "Agenda",
         "window": "After an agenda is revealed",
-        "text": "You cannot vote on this agenda. Predict aloud the outcome of this agenda. If your prediction is correct, explore 1 planet you conrol of each trait.",
+        "text": "You cannot vote on this agenda. Predict aloud the outcome of this agenda. If your prediction is correct, explore 1 planet you control of each trait.",
         "flavorText": "*\"I'm willing to work with you, but I'll need mineral rights to the area before I can convince our diplomats of anything.\"*",
         "source": "theodisi"
     },


### PR DESCRIPTION
## What changed

The action card **play-to-win correlation** section previously reported only uncancelled plays, which hid how often a card gets sabotaged. Each line now reports both:

- total plays (cancels included), with its win rate
- uncancelled plays, with its win rate

It also adds **Impact Score Ω**, which credits each cancel as 1/10th of a win in the Impact Score numerator:

```
Ω = (wins + 0.1 × cancels) / expectedDraws × 100
```

The idea is that a card which keeps drawing sabotage is doing something worth stopping, and the plain Impact Score gives it no credit for that.

Cancels are counted within that section's own dataset (`playsIncludingCanceled - total`), not the wider cancel tally reported in the first section — those cover different game sets. The section note now explains the Ω adjustment.

Also includes a one-word typo fix in Exploration Rider's card text (`conrol` → `control`), unrelated but it was sitting in the tree.

## Reviewer notes

- Sorting in that section still keys off the plain Impact Score, not Ω. Easy to flip if Ω should drive the ranking.
- The Ω weight is a single constant, `CANCEL_WIN_EQUIVALENT = 0.1`.
- Output lines are noticeably longer now (two win rates + two scores) — worth a look at how it wraps in Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
