### PR TITLE
Show which card was given for Syndicate

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/SyndicateAcd2ButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/SyndicateAcd2ButtonHandler.java
@@ -99,9 +99,11 @@ class SyndicateAcd2ButtonHandler {
         ButtonHelper.checkACLimit(game, target);
 
         String targetDisplay = FoWHelper.factionEmojiOrAnon(game, target, "another player");
+        String cardDisplay = Mapper.getActionCard(cardId).getNameRepresentation(game);
         MessageHelper.sendMessageToChannel(
                 player.getCorrectChannel(),
-                player.getRepresentationUnfogged() + " gave an action card to " + targetDisplay + " via _Syndicate_.");
+                player.getRepresentationUnfogged() + " gave " + cardDisplay + " to " + targetDisplay
+                        + " via _Syndicate_.");
 
         game.setStoredValue(SYNDICATE_CARDS_KEY, String.join(",", revealedCards));
         game.setStoredValue(SYNDICATE_PLAYERS_KEY, String.join(",", remainingPlayers));


### PR DESCRIPTION
The _Syndicate_ confirmation message previously said only "gave an action card to X", so the channel log never recorded which of the revealed cards each player actually received.

Now it names the card:

> **Player** gave 🎴_Card Name_ to 🏴 via _Syndicate_.

No information leak: `resolveSyndicate` already reveals the entire lot publicly with embeds before any assignment, so which card went to whom is public for this card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)