### PR TITLE
Action card stats: cancel attribution, deck-wide expected draws, dev debug

### DIFF
--- a/src/main/java/ti4/service/statistics/ActionCardStatsService.java
+++ b/src/main/java/ti4/service/statistics/ActionCardStatsService.java
@@ -14,6 +14,8 @@ import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.apache.commons.lang3.StringUtils;
+import ti4.discord.JdaService;
+import ti4.discord.interactions.commands.CommandHelper;
 import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
 import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
@@ -43,6 +45,7 @@ public class ActionCardStatsService {
         Map<String, Integer> cancelCounts = new HashMap<>();
         Map<String, Integer> actionCardsPlayedCounts = new HashMap<>();
         Map<String, PlayToWinCorrelationCount> playToWinCorrelationCounts = new HashMap<>();
+        Map<String, Integer> unattributedPlayCounts = new HashMap<>();
         Set<String> includedGameNames = new HashSet<>();
 
         // A discarded card that isn't in the selected deck means the game is mislabeled (e.g. it
@@ -55,14 +58,25 @@ public class ActionCardStatsService {
                         .and(game -> deckCardIds.containsAll(
                                 game.getDiscardActionCards().keySet())),
                 game -> accumulateActionCardStats(
-                        game, cancelCounts, actionCardsPlayedCounts, playToWinCorrelationCounts, includedGameNames),
+                        game,
+                        cancelCounts,
+                        actionCardsPlayedCounts,
+                        playToWinCorrelationCounts,
+                        unattributedPlayCounts,
+                        includedGameNames),
                 ExecutionLockType.READ);
 
         MessageHelper.sendMessageToThread(
                 event.getChannel(),
                 "Action Card Play Statistics",
                 buildMessage(
-                        acDeck, cancelCounts, actionCardsPlayedCounts, playToWinCorrelationCounts, includedGameNames));
+                        acDeck,
+                        cancelCounts,
+                        actionCardsPlayedCounts,
+                        playToWinCorrelationCounts,
+                        unattributedPlayCounts,
+                        includedGameNames,
+                        CommandHelper.hasRole(event, JdaService.developerRoles)));
     }
 
     private static void accumulateActionCardStats(
@@ -70,6 +84,7 @@ public class ActionCardStatsService {
             Map<String, Integer> cancelCounts,
             Map<String, Integer> actionCardsPlayedCounts,
             Map<String, PlayToWinCorrelationCount> playToWinCorrelationCounts,
+            Map<String, Integer> unattributedPlayCounts,
             Set<String> includedGameNames) {
         includedGameNames.add(game.getName());
 
@@ -87,7 +102,7 @@ public class ActionCardStatsService {
         if (winner == null) {
             return;
         }
-        accumulateActionCardPlayToWinCorrelation(game, winner, playToWinCorrelationCounts);
+        accumulateActionCardPlayToWinCorrelation(game, winner, playToWinCorrelationCounts, unattributedPlayCounts);
     }
 
     private static void incrementActionCardPlayCount(
@@ -137,7 +152,9 @@ public class ActionCardStatsService {
             Map<String, Integer> cancelCounts,
             Map<String, Integer> actionCardsPlayedCounts,
             Map<String, PlayToWinCorrelationCount> playToWinCorrelationCounts,
-            Set<String> includedGameNames) {
+            Map<String, Integer> unattributedPlayCounts,
+            Set<String> includedGameNames,
+            boolean includeDeveloperDebug) {
         Map<String, Integer> copiesPerName = getCopiesPerName(acDeck);
         Map<String, Integer> playedExpectedDraws = computeExpectedDraws(actionCardsPlayedCounts, copiesPerName);
         Map<String, Integer> playsIncludingCanceled = playToWinCorrelationCounts.entrySet().stream()
@@ -164,7 +181,33 @@ public class ActionCardStatsService {
             appendTrackingStartNote(message);
             appendOverruleStats(message, OverruleStatsService.get().getCountPerStrategyCard(includedGameNames));
         }
+        if (includeDeveloperDebug) {
+            appendUnattributedPlayDebug(message, unattributedPlayCounts);
+        }
         return message.toString();
+    }
+
+    // Plays we could not tie to a player, almost all of them cancels the legacy-save migration
+    // reconstructed. Canceled ones still count toward plays and Impact Score Ω; uncancelled ones
+    // are dropped, since they would otherwise feed a win rate with no winner to compare against.
+    private static void appendUnattributedPlayDebug(
+            StringBuilder message, Map<String, Integer> unattributedPlayCounts) {
+        message.append("\n**Unattributed plays (developer debug)**\n");
+        message.append("_Play-to-win correlation plays with no recorded player, per card._\n");
+        if (unattributedPlayCounts.isEmpty()) {
+            message.append("Every tracked play has a player.\n");
+            return;
+        }
+
+        unattributedPlayCounts.entrySet().stream()
+                .sorted(Comparator.comparingInt((Map.Entry<String, Integer> entry) -> entry.getValue())
+                        .reversed()
+                        .thenComparing(Map.Entry::getKey))
+                .forEach(entry -> message.append("- ")
+                        .append(entry.getKey())
+                        .append(": ")
+                        .append(entry.getValue())
+                        .append('\n'));
     }
 
     private static void appendTrackingStartNote(StringBuilder message) {
@@ -268,10 +311,16 @@ public class ActionCardStatsService {
     }
 
     static void accumulateActionCardPlayToWinCorrelation(
-            Game game, Player winner, Map<String, PlayToWinCorrelationCount> playToWinCorrelationCounts) {
+            Game game,
+            Player winner,
+            Map<String, PlayToWinCorrelationCount> playToWinCorrelationCounts,
+            Map<String, Integer> unattributedPlayCounts) {
         String winningPlayerId = StringUtils.defaultIfBlank(winner.getStatsTrackedUserID(), winner.getUserID());
         for (ActionCardPlay actionCardPlay : game.getGameStats().getActionCardPlays()) {
             boolean canceled = actionCardPlay.isCanceled();
+            if (StringUtils.isBlank(actionCardPlay.getPlayerId())) {
+                unattributedPlayCounts.merge(actionCardPlay.getActionCard(), 1, Integer::sum);
+            }
             // A canceled play never reaches win attribution below, so it still counts even when we
             // don't know who played it - the legacy-save migration reconstructs cancels as plays
             // with no player, and dropping those hid most of the cancels this section reports.

--- a/src/main/java/ti4/service/statistics/ActionCardStatsService.java
+++ b/src/main/java/ti4/service/statistics/ActionCardStatsService.java
@@ -267,18 +267,22 @@ public class ActionCardStatsService {
                         .append('\n'));
     }
 
-    private static void accumulateActionCardPlayToWinCorrelation(
+    static void accumulateActionCardPlayToWinCorrelation(
             Game game, Player winner, Map<String, PlayToWinCorrelationCount> playToWinCorrelationCounts) {
         String winningPlayerId = StringUtils.defaultIfBlank(winner.getStatsTrackedUserID(), winner.getUserID());
         for (ActionCardPlay actionCardPlay : game.getGameStats().getActionCardPlays()) {
-            if (StringUtils.isBlank(actionCardPlay.getPlayerId())) {
+            boolean canceled = actionCardPlay.isCanceled();
+            // A canceled play never reaches win attribution below, so it still counts even when we
+            // don't know who played it - the legacy-save migration reconstructs cancels as plays
+            // with no player, and dropping those hid most of the cancels this section reports.
+            if (!canceled && StringUtils.isBlank(actionCardPlay.getPlayerId())) {
                 continue;
             }
 
             PlayToWinCorrelationCount count = playToWinCorrelationCounts.computeIfAbsent(
                     actionCardPlay.getActionCard(), _ -> new PlayToWinCorrelationCount());
             count.incrementPlaysIncludingCanceled();
-            if (actionCardPlay.isCanceled()) {
+            if (canceled) {
                 continue;
             }
             count.incrementTotal();
@@ -288,7 +292,7 @@ public class ActionCardStatsService {
         }
     }
 
-    private static void appendPlayToWinCorrelationStats(
+    static void appendPlayToWinCorrelationStats(
             StringBuilder message,
             Map<String, PlayToWinCorrelationCount> playToWinCorrelationCounts,
             Map<String, Integer> expectedDrawsPerCard) {

--- a/src/main/java/ti4/service/statistics/ActionCardStatsService.java
+++ b/src/main/java/ti4/service/statistics/ActionCardStatsService.java
@@ -122,29 +122,43 @@ public class ActionCardStatsService {
         return copiesPerName;
     }
 
-    // Cards with the same number of copies in the deck have about the same draw rate, so the most
-    // played card of a copy class approximates one play per draw; its play count stands in for how
-    // many times each card of that class was drawn. The deck composition only classifies cards.
+    // The most played card approximates one play per draw, so it stands in for how often it was
+    // drawn. Every card of the same copy count shares that estimate; cards with a different copy
+    // count are drawn proportionally more or less often, so the estimate scales with the copies.
     static Map<String, Integer> computeExpectedDraws(
             Map<String, Integer> playCounts, Map<String, Integer> copiesPerName) {
-        Map<Integer, Integer> maxPlaysPerCopyCount = computeMaxPlaysPerCopyCount(playCounts, copiesPerName);
+        Map<Integer, Integer> expectedDrawsPerCopyCount = computeExpectedDrawsPerCopyCount(playCounts, copiesPerName);
 
         Map<String, Integer> expectedDraws = new HashMap<>();
         copiesPerName.forEach((name, copies) -> {
-            int classMax = maxPlaysPerCopyCount.getOrDefault(copies, 0);
-            if (classMax > 0) {
-                expectedDraws.put(name, classMax);
+            int draws = expectedDrawsPerCopyCount.getOrDefault(copies, 0);
+            if (draws > 0) {
+                expectedDraws.put(name, draws);
             }
         });
         return expectedDraws;
     }
 
-    private static Map<Integer, Integer> computeMaxPlaysPerCopyCount(
+    private static Map<Integer, Integer> computeExpectedDrawsPerCopyCount(
             Map<String, Integer> playCounts, Map<String, Integer> copiesPerName) {
-        Map<Integer, Integer> maxPlaysPerCopyCount = new HashMap<>();
-        copiesPerName.forEach(
-                (name, copies) -> maxPlaysPerCopyCount.merge(copies, playCounts.getOrDefault(name, 0), Integer::max));
-        return maxPlaysPerCopyCount;
+        double drawsPerCopy = computeDrawsPerCopy(playCounts, copiesPerName);
+        return copiesPerName.values().stream().distinct().collect(Collectors.toMap(copies -> copies, copies ->
+                (int) Math.round(drawsPerCopy * copies)));
+    }
+
+    // Plays per copy in the deck puts every card on equal footing, so a 4-of leading the deck sets
+    // the same per-copy estimate a 1-of would. Scaling that back up by a card's own copy count is
+    // what turns one leader's play count into an expected draw count for the whole deck.
+    private static double computeDrawsPerCopy(Map<String, Integer> playCounts, Map<String, Integer> copiesPerName) {
+        double drawsPerCopy = 0;
+        for (Map.Entry<String, Integer> entry : copiesPerName.entrySet()) {
+            int copies = entry.getValue();
+            if (copies > 0) {
+                double playsPerCopy = playCounts.getOrDefault(entry.getKey(), 0) / (double) copies;
+                drawsPerCopy = Math.max(drawsPerCopy, playsPerCopy);
+            }
+        }
+        return drawsPerCopy;
     }
 
     private static String buildMessage(
@@ -168,11 +182,11 @@ public class ActionCardStatsService {
                 .append(acDeck.getName())
                 .append("'._\n");
         message.append("\n**Action card plays, expected draws, and Sabotage/Cancels**\n");
-        appendExpectedDrawsNote(message, computeMaxPlaysPerCopyCount(actionCardsPlayedCounts, copiesPerName));
+        appendExpectedDrawsNote(message, computeExpectedDrawsPerCopyCount(actionCardsPlayedCounts, copiesPerName));
         appendActionCardPlayAndCancelStats(message, actionCardsPlayedCounts, cancelCounts, playedExpectedDraws);
         message.append("\n**Action card play-to-win correlation**\n");
         appendTrackingStartNote(message);
-        appendExpectedDrawsNote(message, computeMaxPlaysPerCopyCount(playsIncludingCanceled, copiesPerName));
+        appendExpectedDrawsNote(message, computeExpectedDrawsPerCopyCount(playsIncludingCanceled, copiesPerName));
         message.append(
                 "_The Impact Score compares wins to expected draws. Impact Score Ω raises that score by 1/5th of a win for each cancel of the card._\n");
         appendPlayToWinCorrelationStats(message, playToWinCorrelationCounts, winCorrelationExpectedDraws);

--- a/src/test/java/ti4/service/statistics/ActionCardStatsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/ActionCardStatsServiceTest.java
@@ -15,7 +15,9 @@ import ti4.testUtils.BaseTi4Test;
 class ActionCardStatsServiceTest extends BaseTi4Test {
 
     @Test
-    void shouldUseTheClassMaxPlaysAsExpectedDraws() {
+    void shouldScaleTheLeadingFourOfDownForOneOfs() {
+        // Sabotage leads on plays per copy (25 vs Direct Hit's 15 and Rise of a Messiah's 20), so a
+        // single copy is estimated at 25 draws: 100 for the 4-ofs, a quarter of that for the 1-of.
         Map<String, Integer> expectedDraws = ActionCardStatsService.computeExpectedDraws(
                 Map.of("Sabotage", 100, "Direct Hit", 60, "Rise of a Messiah", 20),
                 Map.of("Sabotage", 4, "Direct Hit", 4, "Rise of a Messiah", 1));
@@ -23,11 +25,21 @@ class ActionCardStatsServiceTest extends BaseTi4Test {
         assertThat(expectedDraws)
                 .containsEntry("Sabotage", 100)
                 .containsEntry("Direct Hit", 100)
-                .containsEntry("Rise of a Messiah", 20);
+                .containsEntry("Rise of a Messiah", 25);
     }
 
     @Test
-    void shouldGiveEveryClassMemberTheFullClassMax() {
+    void shouldScaleTheLeadingOneOfUpForFourOfs() {
+        // Rise of a Messiah is played 30 times off one copy, beating Sabotage's 25 per copy, so it
+        // sets the per-copy estimate and the 4-ofs get four times as many expected draws.
+        Map<String, Integer> expectedDraws = ActionCardStatsService.computeExpectedDraws(
+                Map.of("Sabotage", 100, "Rise of a Messiah", 30), Map.of("Sabotage", 4, "Rise of a Messiah", 1));
+
+        assertThat(expectedDraws).containsEntry("Sabotage", 120).containsEntry("Rise of a Messiah", 30);
+    }
+
+    @Test
+    void shouldGiveEveryCardOfTheSameCopyCountTheSameExpectedDraws() {
         Map<String, Integer> expectedDraws = ActionCardStatsService.computeExpectedDraws(
                 Map.of("Sabotage", 20, "Overrule", 30), Map.of("Sabotage", 4, "Overrule", 4));
 
@@ -43,20 +55,28 @@ class ActionCardStatsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldSkipClassesWithNoPlays() {
+    void shouldDeriveOneOfDrawsFromTheFourOfsWhenNoOneOfWasPlayed() {
         Map<String, Integer> expectedDraws = ActionCardStatsService.computeExpectedDraws(
                 Map.of("Sabotage", 10), Map.of("Sabotage", 4, "Rise of a Messiah", 1));
 
-        // The 1-of class has zero plays, so no expected draws can be derived for it.
-        assertThat(expectedDraws).containsOnlyKeys("Sabotage");
+        // 2.5 draws per copy, rounded for the single copy the 1-of has.
+        assertThat(expectedDraws).containsEntry("Sabotage", 10).containsEntry("Rise of a Messiah", 3);
     }
 
     @Test
-    void shouldIncludeUnplayedCardsWhoseClassHasPlays() {
+    void shouldSkipEveryCardWhenNothingWasPlayed() {
+        Map<String, Integer> expectedDraws =
+                ActionCardStatsService.computeExpectedDraws(Map.of(), Map.of("Sabotage", 4, "Rise of a Messiah", 1));
+
+        assertThat(expectedDraws).isEmpty();
+    }
+
+    @Test
+    void shouldIncludeUnplayedCardsWhoseCopyCountHasPlays() {
         Map<String, Integer> expectedDraws = ActionCardStatsService.computeExpectedDraws(
                 Map.of("Sabotage", 10), Map.of("Sabotage", 4, "Direct Hit", 4));
 
-        // Direct Hit was never played, but its class max still approximates its draws.
+        // Direct Hit was never played, but the per-copy estimate still approximates its draws.
         assertThat(expectedDraws).containsEntry("Direct Hit", 10);
     }
 

--- a/src/test/java/ti4/service/statistics/ActionCardStatsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/ActionCardStatsServiceTest.java
@@ -2,10 +2,16 @@ package ti4.service.statistics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.GameStats;
+import ti4.game.Player;
+import ti4.service.statistics.ActionCardStatsService.PlayToWinCorrelationCount;
+import ti4.testUtils.BaseTi4Test;
 
-class ActionCardStatsServiceTest {
+class ActionCardStatsServiceTest extends BaseTi4Test {
 
     @Test
     void shouldUseTheClassMaxPlaysAsExpectedDraws() {
@@ -51,5 +57,77 @@ class ActionCardStatsServiceTest {
 
         // Direct Hit was never played, but its class max still approximates its draws.
         assertThat(expectedDraws).containsEntry("Direct Hit", 10);
+    }
+
+    @Test
+    void shouldCountCancelsThatTheMigrationCouldNotAttributeToAPlayer() {
+        Game game = new Game();
+        Player winner = new Player("winner", "", game);
+        // The legacy-save migration reconstructs a cancel it cannot attribute as a canceled play
+        // with no player - the shape that used to be dropped before it was counted.
+        game.getGameStats().recordAcPlay(GameStats.OVERRULE, null);
+        game.getGameStats().markLatestPlayCanceled(GameStats.OVERRULE);
+        game.getGameStats().recordAcPlay(GameStats.OVERRULE, winner);
+
+        Map<String, PlayToWinCorrelationCount> counts = new HashMap<>();
+        ActionCardStatsService.accumulateActionCardPlayToWinCorrelation(game, winner, counts);
+
+        PlayToWinCorrelationCount overrule = counts.get(GameStats.OVERRULE);
+        assertThat(overrule.getPlaysIncludingCanceled()).isEqualTo(2);
+        assertThat(overrule.getCanceled()).isEqualTo(1);
+        // The unattributed cancel must not leak into anything win-attributed.
+        assertThat(overrule.getTotal()).isEqualTo(1);
+        assertThat(overrule.getWins()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldStillIgnoreUncancelledPlaysWithNoPlayer() {
+        Game game = new Game();
+        Player winner = new Player("winner", "", game);
+        game.getGameStats().recordAcPlay(GameStats.OVERRULE, null);
+
+        Map<String, PlayToWinCorrelationCount> counts = new HashMap<>();
+        ActionCardStatsService.accumulateActionCardPlayToWinCorrelation(game, winner, counts);
+
+        // An uncancelled play still feeds the win rate, so one with no player stays out entirely.
+        assertThat(counts).isEmpty();
+    }
+
+    @Test
+    void shouldLiftOnlyThePlayCountsAndOmegaWhenARecoveredCancelIsCounted() {
+        // The same card either side of the fix: identical wins and uncancelled plays, but the
+        // second run also counts one migration-recovered cancel. Expected draws are pinned here to
+        // isolate the change; in the real report they are derived from the play counts, so they
+        // move too.
+        String withoutRecoveredCancel = renderOverrule(playToWinCount(1, 1, 1));
+        String withRecoveredCancel = renderOverrule(playToWinCount(2, 1, 1));
+
+        assertThat(withoutRecoveredCancel)
+                .isEqualTo("- Overrule: 1 wins, 1 plays (100.0% win rate), 1 uncancelled plays (100.0% win rate),"
+                        + " 10.0 Impact Score (wins vs ~draws), 10.0 Impact Score Ω (+0.2 win per cancel)\n");
+        assertThat(withRecoveredCancel)
+                .isEqualTo("- Overrule: 1 wins, 2 plays (50.0% win rate), 1 uncancelled plays (100.0% win rate),"
+                        + " 10.0 Impact Score (wins vs ~draws), 12.0 Impact Score Ω (+0.2 win per cancel)\n");
+    }
+
+    private static String renderOverrule(PlayToWinCorrelationCount count) {
+        StringBuilder message = new StringBuilder();
+        ActionCardStatsService.appendPlayToWinCorrelationStats(
+                message, Map.of(GameStats.OVERRULE, count), Map.of(GameStats.OVERRULE, 10));
+        return message.toString();
+    }
+
+    private static PlayToWinCorrelationCount playToWinCount(int playsIncludingCanceled, int uncancelled, int wins) {
+        PlayToWinCorrelationCount count = new PlayToWinCorrelationCount();
+        for (int i = 0; i < playsIncludingCanceled; i++) {
+            count.incrementPlaysIncludingCanceled();
+        }
+        for (int i = 0; i < uncancelled; i++) {
+            count.incrementTotal();
+        }
+        for (int i = 0; i < wins; i++) {
+            count.incrementWins();
+        }
+        return count;
     }
 }

--- a/src/test/java/ti4/service/statistics/ActionCardStatsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/ActionCardStatsServiceTest.java
@@ -1,6 +1,7 @@
 package ti4.service.statistics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -70,7 +71,7 @@ class ActionCardStatsServiceTest extends BaseTi4Test {
         game.getGameStats().recordAcPlay(GameStats.OVERRULE, winner);
 
         Map<String, PlayToWinCorrelationCount> counts = new HashMap<>();
-        ActionCardStatsService.accumulateActionCardPlayToWinCorrelation(game, winner, counts);
+        ActionCardStatsService.accumulateActionCardPlayToWinCorrelation(game, winner, counts, new HashMap<>());
 
         PlayToWinCorrelationCount overrule = counts.get(GameStats.OVERRULE);
         assertThat(overrule.getPlaysIncludingCanceled()).isEqualTo(2);
@@ -87,7 +88,7 @@ class ActionCardStatsServiceTest extends BaseTi4Test {
         game.getGameStats().recordAcPlay(GameStats.OVERRULE, null);
 
         Map<String, PlayToWinCorrelationCount> counts = new HashMap<>();
-        ActionCardStatsService.accumulateActionCardPlayToWinCorrelation(game, winner, counts);
+        ActionCardStatsService.accumulateActionCardPlayToWinCorrelation(game, winner, counts, new HashMap<>());
 
         // An uncancelled play still feeds the win rate, so one with no player stays out entirely.
         assertThat(counts).isEmpty();
@@ -108,6 +109,25 @@ class ActionCardStatsServiceTest extends BaseTi4Test {
         assertThat(withRecoveredCancel)
                 .isEqualTo("- Overrule: 1 wins, 2 plays (50.0% win rate), 1 uncancelled plays (100.0% win rate),"
                         + " 10.0 Impact Score (wins vs ~draws), 12.0 Impact Score Ω (+0.2 win per cancel)\n");
+    }
+
+    @Test
+    void shouldTallyUnattributedPlaysPerCardForTheDeveloperDebug() {
+        Game game = new Game();
+        Player winner = new Player("winner", "", game);
+        game.getGameStats().recordAcPlay(GameStats.OVERRULE, null);
+        game.getGameStats().markLatestPlayCanceled(GameStats.OVERRULE);
+        game.getGameStats().recordAcPlay(GameStats.OVERRULE, null);
+        game.getGameStats().markLatestPlayCanceled(GameStats.OVERRULE);
+        game.getGameStats().recordAcPlay(GameStats.OVERRULE, winner);
+        game.getGameStats().recordAcPlay("Flank Speed", winner);
+
+        Map<String, Integer> unattributedPlayCounts = new HashMap<>();
+        ActionCardStatsService.accumulateActionCardPlayToWinCorrelation(
+                game, winner, new HashMap<>(), unattributedPlayCounts);
+
+        // Only the two plays with no recorded player are tallied, and cards with none stay out.
+        assertThat(unattributedPlayCounts).containsExactly(entry(GameStats.OVERRULE, 2));
     }
 
     private static String renderOverrule(PlayToWinCorrelationCount count) {


### PR DESCRIPTION
Follow-up to #5573. Three changes to `/statistics action_cards`: a cancel-attribution fix, a deck-wide expected-draws estimate, and a developer-only debug section.

# 1. Cancels the migration could not attribute to a player

## The symptom

The two sections of `/statistics action_cards` disagreed badly about Overrule:

```
Overrule: 1665 plays (77.66% of ~draws), 491 cancels (29.49% of plays)
Overrule: 206 wins, 638 plays (32.3% win rate), 603 uncancelled plays (34.2% win rate), ...
```

A 29% cancel rate up top, but only 35 cancels (638 − 603) in the play-to-win section.

## The cause

`accumulateActionCardPlayToWinCorrelation` skipped every play with a blank `playerId` *before* counting anything:

```java
if (StringUtils.isBlank(actionCardPlay.getPlayerId())) {
    continue;
}
```

The legacy-save migration in `GameStats.migrateTargetsToCanceledFlags` reconstructs a cancel it cannot attribute as a canceled play with a **null player**:

```java
ActionCardPlay placeholder = new ActionCardPlay(target, null);
placeholder.setCanceled(true);
```

So every migration-recovered cancel was dropped — not counted as a play, not counted as a cancel, and therefore invisible to Impact Score Ω.

Overrule took the worst of it. In the legacy format an Overrule play was only recorded once its strategy card was chosen, which happens *after* the sabotage window — so a canceled Overrule left no play behind at all and the migration always had to stand one in. Nearly every pre-migration Overrule cancel was being dropped; the 35 that survived are the ones recorded live since the new tracking landed.

## The fix

A canceled play never reaches win attribution — the loop `continue`s before `total`/`wins` — so requiring a player id on it bought nothing. The check now guards only uncancelled plays, which still feed the win rate and so still need to be attributable.

## What moves

| | before | after |
|---|---|---|
| wins | unchanged | unchanged |
| uncancelled plays + win rate | unchanged | unchanged |
| Impact Score | unchanged | unchanged |
| total plays + win rate | too low / too high | corrected |
| cancels, Impact Score Ω | too low | corrected |

`shouldLiftOnlyThePlayCountsAndOmegaWhenARecoveredCancelIsCounted` pins exactly that: same card, same wins and uncancelled plays, one recovered cancel — Ω moves 10.0 → 12.0 while the plain Impact Score and the uncancelled figures hold still.

One caveat worth knowing: that test pins expected draws to isolate the change. In the real report expected draws are *derived* from the play counts, so they shift too, and every card's scores move a little — not just the ones with recovered cancels.

The two sections still won't report identical cancel rates. Section one divides `gameStats` cancels by discard-pile plays and includes games with no winner; this section is `gameStats`-only and winners-only. This closes a 5x gap, not the last few points.

# 2. Expected draws estimated per copy across the whole deck

Expected draws approximate how often a card was drawn by assuming the most-played card is played nearly every time it is drawn. That estimate was computed **per copy class**: the 4-ofs got the highest 4-of play count, the 1-ofs got the highest 1-of play count, and the two never informed each other. A copy class with no plays at all got no estimate, and its cards were dropped from the Impact Score entirely.

Now every card's plays are normalized by its copies in the deck, the highest wins, and each card's expected draws are that per-copy figure scaled back up by its own copy count:

```java
double playsPerCopy = playCounts.getOrDefault(entry.getKey(), 0) / (double) copies;
drawsPerCopy = Math.max(drawsPerCopy, playsPerCopy);
```

Whichever card leads sets the estimate for the whole deck, whether it is a 1-of or a 4-of. A 4-of leader at 1665 plays gives 1665 to the 4-ofs and 416 to the 1-ofs; a 1-of leader at 500 gives 500 to the 1-ofs and 2000 to the 4-ofs. `computeMaxPlaysPerCopyCount` is replaced by `computeExpectedDrawsPerCopyCount`, which both the per-card map and the "_Expected draws: N 4-ofs, M 1-ofs._" note read from, so the note now reports the derived numbers rather than raw class maxima.

One behavior change: a card whose copy class has no plays now inherits the deck-wide estimate instead of being dropped, so a never-played 1-of shows a `0.0` Impact Score rather than no score. That is the intended consequence of letting the classes inform each other, but it does put a few more cards in the list.

`shouldScaleTheLeadingFourOfDownForOneOfs` and `shouldScaleTheLeadingOneOfUpForFourOfs` pin the scaling in both directions.

# 3. Unattributed play counts for developers

A trailing section, gated on `CommandHelper.hasRole(event, JdaService.developerRoles)`, tallies play-to-win plays with no recorded player, per card:

```
**Unattributed plays (developer debug)**
_Play-to-win correlation plays with no recorded player, per card._
- Overrule: 456
- Direct Hit: 12
```

The tally is scoped to the play-to-win dataset (games with a winner) so the number lines up with the section it explains, and it is built in the same walk that accumulates the correlation counts rather than as a second scan. It counts *all* unattributed plays, not just cancels — in practice they should be nearly all migration cancels, since live plays always record a player, so a card showing unattributed *uncancelled* plays is a genuine signal that something else is recording plays without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
