### PR TITLE
Offer a "Purge Overrule" option at the start of games

### DIFF
--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -3596,6 +3596,9 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
             }
             Collections.shuffle(getActionCards());
         }
+        if ("true".equals(getStoredValue("removeOverrule"))) {
+            getActionCards().removeIf("overrule"::equals);
+        }
         return true;
     }
 

--- a/src/main/java/ti4/helpers/PlayerTitleHelper.java
+++ b/src/main/java/ti4/helpers/PlayerTitleHelper.java
@@ -149,6 +149,29 @@ public class PlayerTitleHelper {
         }
     }
 
+    @ButtonHandler("purgeOverrule")
+    public static void purgeOverrule(ButtonInteractionEvent event, String buttonID, Game game) {
+        ButtonHelper.deleteMessage(event);
+        if (buttonID.contains("confirmed")) {
+            boolean removed = game.getActionCards().removeIf("overrule"::equals);
+            game.setStoredValue("removeOverrule", "true");
+
+            MessageHelper.sendMessageToChannel(
+                    event.getChannel(),
+                    removed
+                            ? "Purged _Overrule_ from the action card deck."
+                            : "_Overrule_ was not in the action card deck, but it will be kept out if the deck is changed.");
+        } else {
+            List<Button> buttons = new ArrayList<>();
+            buttons.add(Buttons.red("purgeOverruleconfirmed", "Purge Overrule"));
+            buttons.add(Buttons.gray("deleteButtons", "Oops Mistake"));
+            MessageHelper.sendMessageToChannelWithButtons(
+                    event.getChannel(),
+                    "Please confirm that you are pressing this button to purge _Overrule_ from the game.",
+                    buttons);
+        }
+    }
+
     @ButtonHandler("noSupportSwaps")
     public static void noSupportSwaps(ButtonInteractionEvent event, String buttonID, Game game) {
         game.setNoSwapMode(true);

--- a/src/main/java/ti4/service/game/StartPhaseService.java
+++ b/src/main/java/ti4/service/game/StartPhaseService.java
@@ -1188,6 +1188,21 @@ public class StartPhaseService {
                             + " as they each have some impact upon the game. Questions 4 and 5 are purely for informational purposes/setting expectations.");
             game.setStoredValue("postedSurvey", "yes");
         }
+
+        if (game.getRound() == 1
+                && !game.isFowMode()
+                && game.getActionCards().contains("overrule")
+                && game.getStoredValue("offeredOverrulePurge").isEmpty()) {
+            List<Button> buttons = new ArrayList<>();
+            buttons.add(Buttons.red("purgeOverrule", "Purge Overrule"));
+            buttons.add(Buttons.gray("deleteButtons", "Keep Overrule"));
+            MessageHelper.sendMessageToChannelWithButtons(
+                    game.getTableTalkChannel(),
+                    "This game's action card deck contains _Overrule_ (_perform the primary ability of a readied or unchosen strategy card_)."
+                            + " Some groups prefer to play without it. If the table agrees to remove it, you can use these buttons to purge it from the deck.",
+                    buttons);
+            game.setStoredValue("offeredOverrulePurge", "yes");
+        }
     }
 
     public static void startActionPhase(GenericInteractionCreateEvent event, Game game, boolean incrementTgs) {


### PR DESCRIPTION
Adds a "Purge Overrule" option at the start of games, mirroring the existing "Purge Supports" option.

### What it does

- **`StartPhaseService.postSurveyResults`** — when the game's action card deck actually contains `overrule`, table talk gets a one-time message offering **Purge Overrule** / **Keep Overrule** buttons. Guarded by an `offeredOverrulePurge` stored value so it only fires once, and skipped in FoW mode. This runs at game creation and again at the start of round 1's action phase, so it still catches games whose deck is set after creation — and in either case it lands well before any action cards are dealt.
- **`PlayerTitleHelper.purgeOverrule`** — same two-step shape as `purgeSupports`: the first press asks for confirmation, and `purgeOverruleconfirmed` strips every copy of `overrule` from the deck and sets `removeOverrule`.
- **`Game.validateAndSetActionCardDeck`** — re-strips `overrule` when `removeOverrule` is set, so changing the action card deck later doesn't quietly bring it back. This is the equivalent of how `removeSupports` is honored during player setup.

### Notes

- It sits outside the survey-results block rather than becoming a sixth survey question, because `hasAnsweredSurvey` is set at question 1 — a new question would never be shown to anyone who has already taken the survey. The deck check keeps the offer from appearing in games that can't draw the card anyway.
- Only the Thunder's Edge `overrule` card is targeted, matching the existing precedent in `SetDeck` where the Evenfall SC set removes it. The Black Spectrum `bsp_overrule` is a different, VP-gated card and is left alone.
- No `Homebrew` enum entry / `/game setup` flag was added; this is just the start-of-game offer. Easy follow-up if it's wanted in the FoW setup wizard's homebrew list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
