### PR TITLE
Fix: Update unit data for corsair to reflect upgrade status

### DIFF
--- a/src/main/resources/data/units/te_units.json
+++ b/src/main/resources/data/units/te_units.json
@@ -346,6 +346,7 @@
         "baseType": "cruiser",
         "asyncId": "ca",
         "name": "Corsair",
+        "upgradesFromUnitId": "cruiser2",
         "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/units/te/faction/mentak_cruiser3.jpg?raw=true",
         "source": "thunders_edge",
         "faction": "mentak",


### PR DESCRIPTION
Add `upgradesFromUnitId` to be consumed by web ui for displaying enhanced unit status