### PR TITLE
Update the winning path search command

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/special/SearchWinningPath.java
+++ b/src/main/java/ti4/discord/interactions/commands/special/SearchWinningPath.java
@@ -1,6 +1,11 @@
 package ti4.discord.interactions.commands.special;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -13,26 +18,88 @@ import ti4.game.Player;
 import ti4.game.persistence.ConsumeGameUtility;
 import ti4.helpers.Constants;
 import ti4.helpers.Helper;
-import ti4.helpers.PatternHelper;
 import ti4.message.MessageHelper;
+import ti4.service.statistics.game.WinningPathBreakdown;
 import ti4.service.statistics.game.WinningPathHelper;
 
 class SearchWinningPath extends Subcommand {
 
+    private record PathComponent(
+            String optionName, String label, String description, ToIntFunction<WinningPathBreakdown> count) {}
+
+    private record PathFlag(String optionName, String label, String pointSource) {}
+
+    private record Criterion(String description, Predicate<WinningPathBreakdown> matches) {}
+
+    private static final List<PathComponent> COMPONENTS = List.of(
+            new PathComponent(
+                    "stage_1s",
+                    "stage 1 objectives",
+                    "How many stage 1 objectives the winner scored",
+                    WinningPathBreakdown::stage1s),
+            new PathComponent(
+                    "stage_2s",
+                    "stage 2 objectives",
+                    "How many stage 2 objectives the winner scored",
+                    WinningPathBreakdown::stage2s),
+            new PathComponent(
+                    "secrets",
+                    "secret objectives",
+                    "How many secret objectives the winner scored",
+                    WinningPathBreakdown::secrets),
+            new PathComponent(
+                    "supports",
+                    "Support for the Throne",
+                    "How many Supports for the Throne the winner held",
+                    WinningPathBreakdown::supports),
+            new PathComponent(
+                    "custodians",
+                    "custodian/imperial",
+                    "How many points the winner took from the custodians token and Imperial",
+                    WinningPathBreakdown::custodians),
+            new PathComponent(
+                    "others",
+                    "other points",
+                    "How many points the winner took from every other source combined",
+                    WinningPathBreakdown::others));
+
+    private static final List<PathFlag> FLAGS = List.of(
+            new PathFlag("seed", "Seed of an Empire", WinningPathBreakdown.SEED),
+            new PathFlag("mutiny", "Mutiny", WinningPathBreakdown.MUTINY),
+            new PathFlag("shard", "Shard of the Throne", WinningPathBreakdown.SHARD),
+            new PathFlag("imperial_rider", "Imperial Rider", WinningPathBreakdown.IMPERIAL_RIDER),
+            new PathFlag("censure", "Political Censure", WinningPathBreakdown.CENSURE),
+            new PathFlag("crown", "Crown of Emphidia", WinningPathBreakdown.CROWN),
+            new PathFlag("latvinia", "Latvinia", WinningPathBreakdown.LATVINIA),
+            new PathFlag("styx", "Styx", WinningPathBreakdown.STYX));
+
     SearchWinningPath() {
-        super(Constants.SEARCH_WINNING_PATH, "List games with the provided winning path");
-        addOptions(new OptionData(OptionType.STRING, Constants.WINNING_PATH, "Winning path to search for")
-                .setRequired(true));
-        addOptions(GameStatisticsFilterer.gameStatsFilters());
+        super(Constants.SEARCH_WINNING_PATH, "List games whose winner took the provided path to victory");
+        for (PathComponent component : COMPONENTS) {
+            addOptions(
+                    new OptionData(OptionType.INTEGER, component.optionName(), component.description()).setMinValue(0));
+        }
+        for (PathFlag flag : FLAGS) {
+            addOptions(new OptionData(OptionType.BOOLEAN, flag.optionName(), "Did the winner score " + flag.label()));
+        }
+        addOptions(GameStatisticsFilterer.gameStatsFiltersExcept(
+                GameStatisticsFilterer.HAS_WINNER_FILTER,
+                GameStatisticsFilterer.MIN_PLAYER_COUNT_FILTER,
+                GameStatisticsFilterer.FRACTURE_IN_PLAY_FILTER));
     }
 
     @Override
     public void execute(SlashCommandInteractionEvent event) {
-        String searchedPath = event.getOption(Constants.WINNING_PATH, OptionMapping::getAsString);
+        List<Criterion> searchedPath = getSearchedPath(event);
+        if (searchedPath.isEmpty()) {
+            MessageHelper.sendMessageToEventChannel(
+                    event, "Set at least one part of the winning path, e.g. `stage_2s: 3`.");
+            return;
+        }
 
         var foundGames = new HashSet<String>();
         StringBuilder sb = new StringBuilder("__**Games with Winning Path:**__ ")
-                .append(searchedPath)
+                .append(describe(searchedPath))
                 .append('\n');
 
         ConsumeGameUtility.consumeAllGames(
@@ -52,11 +119,34 @@ class SearchWinningPath extends Subcommand {
         MessageHelper.sendMessageToThread(event.getChannel(), "Winning Path Games", sb.toString());
     }
 
-    private static boolean hasWinningPath(Game game, Player winner, String searchedPath) {
-        return PatternHelper.UNDERSCORE_PATTERN
-                .matcher(WinningPathHelper.buildWinningPath(game, winner))
-                .replaceAll("") // needed due to Support for the Throne being italicized
-                .contains(searchedPath);
+    private static List<Criterion> getSearchedPath(SlashCommandInteractionEvent event) {
+        List<Criterion> searchedPath = new ArrayList<>();
+        for (PathComponent component : COMPONENTS) {
+            Integer count = event.getOption(component.optionName(), null, OptionMapping::getAsInt);
+            if (count != null) {
+                searchedPath.add(new Criterion(
+                        count + " " + component.label(),
+                        path -> component.count().applyAsInt(path) == count));
+            }
+        }
+        for (PathFlag flag : FLAGS) {
+            Boolean scored = event.getOption(flag.optionName(), null, OptionMapping::getAsBoolean);
+            if (scored != null) {
+                searchedPath.add(new Criterion(
+                        (scored ? "with " : "without ") + flag.label(),
+                        path -> path.scored(flag.pointSource()) == scored));
+            }
+        }
+        return searchedPath;
+    }
+
+    private static String describe(List<Criterion> searchedPath) {
+        return searchedPath.stream().map(Criterion::description).collect(Collectors.joining(", "));
+    }
+
+    private static boolean hasWinningPath(Game game, Player winner, List<Criterion> searchedPath) {
+        WinningPathBreakdown path = WinningPathHelper.breakDownWinningPath(game, winner);
+        return searchedPath.stream().allMatch(criterion -> criterion.matches().test(path));
     }
 
     private static String formatGame(Game game) {

--- a/src/main/java/ti4/discord/interactions/commands/special/SearchWinningPath.java
+++ b/src/main/java/ti4/discord/interactions/commands/special/SearchWinningPath.java
@@ -31,6 +31,8 @@ class SearchWinningPath extends Subcommand {
 
     private record Criterion(String description, Predicate<WinningPathBreakdown> matches) {}
 
+    private static final int MAX_GAMES_LISTED = 100;
+
     private static final List<PathComponent> COMPONENTS = List.of(
             new PathComponent(
                     "stage_1s",
@@ -98,23 +100,32 @@ class SearchWinningPath extends Subcommand {
         }
 
         var foundGames = new HashSet<String>();
-        StringBuilder sb = new StringBuilder("__**Games with Winning Path:**__ ")
-                .append(describe(searchedPath))
-                .append('\n');
+        StringBuilder listedGames = new StringBuilder();
 
         ConsumeGameUtility.consumeAllGames(
                 GameStatisticsFilterer.getGamesFilterForWonGame(event).and(game -> game.getWinner()
                         .map(winner -> hasWinningPath(game, winner, searchedPath))
                         .orElse(false)),
                 game -> {
-                    foundGames.add(game.getName());
-                    sb.append(formatGame(game)).append('\n');
+                    if (foundGames.add(game.getName()) && foundGames.size() <= MAX_GAMES_LISTED) {
+                        listedGames.append(formatGame(game)).append('\n');
+                    }
                 },
                 ExecutionLockType.READ);
 
+        StringBuilder sb = new StringBuilder("__**Games with Winning Path:**__ ")
+                .append(describe(searchedPath))
+                .append('\n');
         if (foundGames.isEmpty()) {
             sb.append("No games match the selected path.");
+        } else if (foundGames.size() > MAX_GAMES_LISTED) {
+            sb.append("_Showing the first ")
+                    .append(MAX_GAMES_LISTED)
+                    .append(" of ")
+                    .append(foundGames.size())
+                    .append(" matching games._\n");
         }
+        sb.append(listedGames);
 
         MessageHelper.sendMessageToThread(event.getChannel(), "Winning Path Games", sb.toString());
     }

--- a/src/main/java/ti4/discord/interactions/commands/statistics/GameStatisticsFilterer.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/GameStatisticsFilterer.java
@@ -29,17 +29,17 @@ import ti4.spring.service.statistics.matchmaking.SkillTier;
 public class GameStatisticsFilterer {
 
     public static final String PLAYER_COUNT_FILTER = "player_count";
-    private static final String MIN_PLAYER_COUNT_FILTER = "min_player_count";
+    public static final String MIN_PLAYER_COUNT_FILTER = "min_player_count";
     static final String VICTORY_POINT_GOAL_FILTER = "victory_point_goal";
     public static final String GAME_TYPES_FILTER = "game_type";
     static final String FOG_FILTER = "is_fog";
     static final String HOMEBREW_FILTER = "has_homebrew";
-    private static final String HAS_WINNER_FILTER = "has_winner";
+    public static final String HAS_WINNER_FILTER = "has_winner";
     public static final String WINNING_FACTION_FILTER = "winning_faction";
     public static final String EXCLUDED_GAME_TYPES_FILTER = "exclude_game_types";
     private static final String HAS_GALACTIC_EVENT_FILTER = "has_galactic_event";
     private static final String HAS_SCENARIO_FILTER = "has_scenario";
-    private static final String FRACTURE_IN_PLAY_FILTER = "fracture_in_play";
+    public static final String FRACTURE_IN_PLAY_FILTER = "fracture_in_play";
     private static final String STARTED_AFTER_FILTER = "started_after";
     private static final String SKILL_TIER_FILTER = "skill_tier";
 
@@ -74,6 +74,13 @@ public class GameStatisticsFilterer {
                 OptionType.STRING, STARTED_AFTER_FILTER, "Filter games by if they started after a date (YYYY-MM-DD)"));
         filters.add(skillTierFilterOption());
         return filters;
+    }
+
+    public static List<OptionData> gameStatsFiltersExcept(String... omittedFilters) {
+        Set<String> omitted = Set.of(omittedFilters);
+        return gameStatsFilters().stream()
+                .filter(filter -> !omitted.contains(filter.getName()))
+                .toList();
     }
 
     private static OptionData skillTierFilterOption() {

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1125,7 +1125,6 @@ public final class Constants {
     public static final String ANON = "anon";
     public static final String ANNOUNCE = "announce";
     public static final String ENDED_GAMES = "ended_games";
-    public static final String WINNING_PATH = "winning_path";
     public static final String TEXT_SIZE = "text_size";
     public static final String FIX_CHANNEL_PERMISSIONS = "fix_channel_permissions";
     public static final String CATEGORY_CHANNEL_COUNT = "category_channel_count";

--- a/src/main/java/ti4/service/statistics/game/WinningPathBreakdown.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathBreakdown.java
@@ -1,0 +1,37 @@
+package ti4.service.statistics.game;
+
+import java.util.Map;
+
+public record WinningPathBreakdown(
+        int stage1s, int stage2s, int secrets, int supports, Map<String, Integer> otherPoints) {
+
+    public static final String SEED = "seed";
+    public static final String MUTINY = "mutiny";
+    public static final String SHARD = "shard";
+    public static final String CUSTODIAN_OR_IMPERIAL = "custodian/imperial";
+    public static final String IMPERIAL_RIDER = "imperial rider";
+    public static final String CENSURE = "censure";
+    public static final String CROWN = "crown";
+    public static final String LATVINIA = "latvinia";
+    public static final String STYX = "styx";
+    public static final String UNRECOGNIZED = "other (probably _Classified Document Leaks_)";
+
+    public int custodians() {
+        return pointsFrom(CUSTODIAN_OR_IMPERIAL);
+    }
+
+    public int others() {
+        return otherPoints.entrySet().stream()
+                .filter(entry -> !CUSTODIAN_OR_IMPERIAL.equals(entry.getKey()))
+                .mapToInt(Map.Entry::getValue)
+                .sum();
+    }
+
+    public int pointsFrom(String pointSource) {
+        return otherPoints.getOrDefault(pointSource, 0);
+    }
+
+    public boolean scored(String pointSource) {
+        return pointsFrom(pointSource) > 0;
+    }
+}

--- a/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathHelper.java
@@ -15,25 +15,28 @@ public class WinningPathHelper {
     private static final Pattern PATTERN = Pattern.compile("[^a-z]");
 
     public static String buildWinningPath(Game game, Player winner) {
-        int stage1Count = countPublicVictoryPoints(game, winner.getUserID(), 1);
-        int stage2Count = countPublicVictoryPoints(game, winner.getUserID(), 2);
-        int secretCount = winner.getSecretVictoryPoints();
-        int supportCount = winner.getSupportForTheThroneVictoryPoints();
-        String otherPoints = summarizeOtherVictoryPoints(game, winner.getUserID());
+        return describe(breakDownWinningPath(game, winner));
+    }
 
-        if (supportCount >= 2) {
-            return String.format(
-                    "%d stage 1 objectives, %d stage 2 objectives, %d secret objectives, %d _Supports for the Thrones_%s",
-                    stage1Count,
-                    stage2Count,
-                    secretCount,
-                    supportCount,
-                    otherPoints.isEmpty() ? "" : ", " + otherPoints);
-        }
+    public static WinningPathBreakdown breakDownWinningPath(Game game, Player winner) {
+        return new WinningPathBreakdown(
+                countPublicVictoryPoints(game, winner.getUserID(), 1),
+                countPublicVictoryPoints(game, winner.getUserID(), 2),
+                winner.getSecretVictoryPoints(),
+                winner.getSupportForTheThroneVictoryPoints(),
+                otherVictoryPoints(game, winner.getUserID()));
+    }
 
+    private static String describe(WinningPathBreakdown path) {
+        String otherPoints = summarizeOtherVictoryPoints(path.otherPoints());
         return String.format(
-                "%d stage 1 objectives, %d stage 2 objectives, %d secret objectives, %d _Support for the Throne_%s",
-                stage1Count, stage2Count, secretCount, supportCount, otherPoints.isEmpty() ? "" : ", " + otherPoints);
+                "%d stage 1 objectives, %d stage 2 objectives, %d secret objectives, %d %s%s",
+                path.stage1s(),
+                path.stage2s(),
+                path.secrets(),
+                path.supports(),
+                path.supports() >= 2 ? "_Supports for the Thrones_" : "_Support for the Throne_",
+                otherPoints.isEmpty() ? "" : ", " + otherPoints);
     }
 
     private static int countPublicVictoryPoints(Game game, String userId, int stage) {
@@ -45,8 +48,8 @@ public class WinningPathHelper {
                 .count();
     }
 
-    private static String summarizeOtherVictoryPoints(Game game, String userId) {
-        Map<String, Integer> otherVictoryPoints = game.getScoredPublicObjectives().entrySet().stream()
+    private static Map<String, Integer> otherVictoryPoints(Game game, String userId) {
+        return game.getScoredPublicObjectives().entrySet().stream()
                 .filter(entry -> entry.getValue().contains(userId))
                 .map(Map.Entry::getKey)
                 .filter(poID -> Mapper.getPublicObjective(poID) == null)
@@ -56,7 +59,9 @@ public class WinningPathHelper {
                         key -> Collections.frequency(
                                 game.getScoredPublicObjectives().get(key), userId),
                         Integer::sum));
+    }
 
+    private static String summarizeOtherVictoryPoints(Map<String, Integer> otherVictoryPoints) {
         return otherVictoryPoints.entrySet().stream()
                 .sorted(Map.Entry.<String, Integer>comparingByValue()
                         .reversed()
@@ -72,15 +77,15 @@ public class WinningPathHelper {
 
     private static String normalizeVictoryPointKey(String poID) {
         String normalized = PATTERN.matcher(poID.toLowerCase()).replaceAll("");
-        if (normalized.contains("seed")) return "seed";
-        if (normalized.contains("mutiny")) return "mutiny";
-        if (normalized.contains("shard")) return "shard";
-        if (normalized.contains("custodian")) return "custodian/imperial";
-        if (normalized.contains("imperial")) return "imperial rider";
-        if (normalized.contains("censure")) return "censure";
-        if (normalized.contains("crown") || normalized.contains("emph")) return "crown";
-        if (normalized.contains("latvinia")) return "latvinia";
-        if (normalized.contains("song")) return "styx";
-        return "other (probably _Classified Document Leaks_)";
+        if (normalized.contains("seed")) return WinningPathBreakdown.SEED;
+        if (normalized.contains("mutiny")) return WinningPathBreakdown.MUTINY;
+        if (normalized.contains("shard")) return WinningPathBreakdown.SHARD;
+        if (normalized.contains("custodian")) return WinningPathBreakdown.CUSTODIAN_OR_IMPERIAL;
+        if (normalized.contains("imperial")) return WinningPathBreakdown.IMPERIAL_RIDER;
+        if (normalized.contains("censure")) return WinningPathBreakdown.CENSURE;
+        if (normalized.contains("crown") || normalized.contains("emph")) return WinningPathBreakdown.CROWN;
+        if (normalized.contains("latvinia")) return WinningPathBreakdown.LATVINIA;
+        if (normalized.contains("song")) return WinningPathBreakdown.STYX;
+        return WinningPathBreakdown.UNRECOGNIZED;
     }
 }

--- a/src/test/java/ti4/discord/interactions/commands/special/SearchWinningPathOptionCountTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/special/SearchWinningPathOptionCountTest.java
@@ -1,0 +1,15 @@
+package ti4.discord.interactions.commands.special;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SearchWinningPathOptionCountTest {
+
+    private static final int DISCORD_OPTION_LIMIT = 25;
+
+    @Test
+    void usesEveryOptionSlotDiscordAllows() {
+        assertEquals(DISCORD_OPTION_LIMIT, new SearchWinningPath().getOptions().size());
+    }
+}


### PR DESCRIPTION
## Problem

`/special2 winning_path_games` took a single free-text `winning_path` option, matched as a substring of the winner's path. Finding "won on 2 stage 2s" meant typing out every earlier part of the sentence in the right order:

```
winning_path: 2 stage 1 objectives, 2 stage 2 objectives, 2 custodian/imperial
```

## Change

One option per point source. Unset options are wildcards, so a search only pins down the parts it cares about.

**Exact counts:** `stage_1s`, `stage_2s`, `secrets`, `supports`, `custodians`, `others`

**True/false — did the winner score it at all:** `seed`, `mutiny`, `shard`, `imperial_rider`, `censure`, `crown`, `latvinia`, `styx`

The example above becomes `stage_1s: 2 stage_2s: 2 custodians: 2`, and they compose freely — `stage_2s: 4 shard: true censure: false`. Running with nothing set now asks for a criterion instead of listing every won game.

## Notes

- `WinningPathHelper` builds a `WinningPathBreakdown` and formats that. The printed path text is byte-for-byte unchanged, so persisted paths and the end-game message are unaffected. The search matches counts directly, which also drops the underscore-stripping hack that existed only because Support for the Throne is italicized.
- The source names are now shared constants used by both `normalizeVictoryPointKey` and the options, so an option can't silently drift from the name shown in the path text.
- This puts the subcommand exactly on Discord's 25-option limit, which JDA enforces by throwing while building the subcommand — that would take the whole command down at startup. It gives up three game filters to fit: `has_winner` (inert here, the command already requires a winner), `min_player_count` (`player_count` covers it), and `fracture_in_play`. `gameStatsFiltersExcept(...)` is a new helper for that.
- `SearchWinningPathOptionCountTest` asserts the count is exactly 25, so the next option added fails a build rather than the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
