### PR TITLE
Add a planet_win_rates statistics2 command

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -36,6 +36,13 @@ class RunAgainstAllGames extends Subcommand {
     private static final String LEGACY_KELERES_FACTION = "keleres";
 
     /**
+     * What a player nothing in their game can place becomes. The handful this catches are all
+     * unfinished or fog games that no statistic reads, so the flavour is a label rather than a
+     * finding - each one is listed in the report so the guess stays visible.
+     */
+    private static final String DEFAULT_KELERES_FACTION = "keleresm";
+
+    /**
      * The Keleres-only home systems. Nobody else sits on these, so one of them anywhere on a board
      * names the flavour even when the player it belonged to cannot be placed any other way.
      */
@@ -93,7 +100,7 @@ class RunAgainstAllGames extends Subcommand {
                         + (dryRun ? " (dry run, nothing will be saved)." : "."));
 
         List<String> retypedGames = new ArrayList<>();
-        List<String> undeterminedGames = new ArrayList<>();
+        List<String> defaultedPlayers = new ArrayList<>();
         int[] retypedPlayers = {0};
         int[] restoredPositions = {0};
 
@@ -121,8 +128,8 @@ class RunAgainstAllGames extends Subcommand {
                             faction = orphanedBaseFaction;
                         }
                         if (faction == null) {
-                            undeterminedGames.add(describeUndetermined(game, player));
-                            continue;
+                            faction = DEFAULT_KELERES_FACTION;
+                            defaultedPlayers.add(describeUndetermined(game, player));
                         }
                         String homePosition = homeSystemPositionFor(game, faction);
                         if (homePosition != null) {
@@ -148,7 +155,7 @@ class RunAgainstAllGames extends Subcommand {
                 },
                 dryRun ? ExecutionLockType.READ : ExecutionLockType.WRITE);
 
-        report(event, dryRun, retypedGames, undeterminedGames, retypedPlayers[0], restoredPositions[0]);
+        report(event, dryRun, retypedGames, defaultedPlayers, retypedPlayers[0], restoredPositions[0]);
     }
 
     /**
@@ -269,7 +276,7 @@ class RunAgainstAllGames extends Subcommand {
             SlashCommandInteractionEvent event,
             boolean dryRun,
             List<String> retypedGames,
-            List<String> undeterminedGames,
+            List<String> defaultedPlayers,
             int retypedPlayers,
             int restoredPositions) {
         StringBuilder message = new StringBuilder();
@@ -282,19 +289,23 @@ class RunAgainstAllGames extends Subcommand {
                 .append(" games, ")
                 .append(restoredPositions)
                 .append(" of them with a home system position to restore.\n");
-        if (undeterminedGames.isEmpty()) {
-            message.append("Every legacy Keleres player was placed.");
+        if (defaultedPlayers.isEmpty()) {
+            message.append("Every legacy Keleres player was placed from their own game.");
         } else {
-            message.append("**Could not be determined (")
-                    .append(undeterminedGames.size())
+            message.append("**Nothing in the game said which flavour, so ")
+                    .append(DEFAULT_KELERES_FACTION)
+                    .append(" was used (")
+                    .append(defaultedPlayers.size())
                     .append("):**\n- ")
-                    .append(String.join("\n- ", undeterminedGames));
+                    .append(String.join("\n- ", defaultedPlayers));
         }
         MessageHelper.sendMessageToChannel(event.getChannel(), message.toString());
 
         BotLogger.info((dryRun ? "[DRY RUN] Would retype " : "Retyped ") + retypedPlayers
                 + " legacy Keleres player(s) across " + retypedGames.size() + " games: "
                 + String.join(", ", retypedGames)
-                + (undeterminedGames.isEmpty() ? "" : " | Undetermined: " + String.join(", ", undeterminedGames)));
+                + (defaultedPlayers.isEmpty()
+                        ? ""
+                        : " | Defaulted to " + DEFAULT_KELERES_FACTION + ": " + String.join(", ", defaultedPlayers)));
     }
 }

--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -6,10 +6,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import org.apache.commons.lang3.StringUtils;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
@@ -31,16 +33,41 @@ class RunAgainstAllGames extends Subcommand {
      */
     private static final String LEGACY_KELERES_FACTION = "keleres";
 
-    private static final Map<String, String> KELERES_FACTION_BY_HOME_TILE =
+    /**
+     * The Keleres-only home systems. Nobody else sits on these, so one of them anywhere on a board
+     * names the flavour even when the player it belonged to cannot be placed any other way.
+     */
+    private static final Map<String, String> KELERES_FACTION_BY_KELERES_TILE =
             Map.of("92new", "keleresx", "93new", "keleresa", "94new", "keleresm");
 
-    private static final Map<String, String> KELERES_FACTION_BY_HOME_PLANET = Map.of(
-            "archonrenk", "keleresx",
-            "archontauk", "keleresx",
-            "valkk", "keleresa",
-            "ylirk", "keleresa",
-            "avark", "keleresa",
-            "mollprimusk", "keleresm");
+    /**
+     * The same three home systems as the base factions wear them. Keleres predates the re-skinned
+     * 92new/93new/94new tiles, so the older games this command exists for seat Keleres on 02, 14 and
+     * 58 instead - which are also Mentak's, Xxcha's and Argent's, so these only count when the tile
+     * is the legacy Keleres player's own.
+     */
+    private static final Map<String, String> KELERES_FACTION_BY_OWN_TILE = Map.ofEntries(
+            Map.entry("92new", "keleresx"),
+            Map.entry("93new", "keleresa"),
+            Map.entry("94new", "keleresm"),
+            Map.entry("14", "keleresx"),
+            Map.entry("58", "keleresa"),
+            Map.entry("02", "keleresm"),
+            Map.entry("2", "keleresm"));
+
+    private static final Map<String, String> KELERES_FACTION_BY_HOME_PLANET = Map.ofEntries(
+            Map.entry("archonrenk", "keleresx"),
+            Map.entry("archontauk", "keleresx"),
+            Map.entry("valkk", "keleresa"),
+            Map.entry("ylirk", "keleresa"),
+            Map.entry("avark", "keleresa"),
+            Map.entry("mollprimusk", "keleresm"),
+            Map.entry("archonren", "keleresx"),
+            Map.entry("archontau", "keleresx"),
+            Map.entry("valk", "keleresa"),
+            Map.entry("ylir", "keleresa"),
+            Map.entry("avar", "keleresa"),
+            Map.entry("mollprimus", "keleresm"));
 
     RunAgainstAllGames() {
         super("run_against_all_games", "Retypes legacy 'keleres' players as keleresm, keleresa or keleresx.");
@@ -69,15 +96,18 @@ class RunAgainstAllGames extends Subcommand {
                         return;
                     }
 
-                    String homeTileFaction = factionFromTheOnlyKeleresHomeOnTheBoard(game);
+                    String boardFaction = factionFromTheOnlyKeleresHomeOnTheBoard(game);
                     List<String> retyped = new ArrayList<>();
                     for (Player player : legacyPlayers) {
                         String faction = factionFromTheirHomePlanets(player);
                         if (faction == null) {
-                            faction = homeTileFaction;
+                            faction = factionFromTheirOwnHomeTile(game, player);
                         }
                         if (faction == null) {
-                            undeterminedGames.add(game.getName() + " (" + player.getUserName() + ")");
+                            faction = boardFaction;
+                        }
+                        if (faction == null) {
+                            undeterminedGames.add(describeUndetermined(game, player));
                             continue;
                         }
                         if (!dryRun) {
@@ -119,10 +149,39 @@ class RunAgainstAllGames extends Subcommand {
     static String factionFromTheOnlyKeleresHomeOnTheBoard(Game game) {
         Set<String> factions = game.getTileMap().values().stream()
                 .map(Tile::getTileID)
-                .map(KELERES_FACTION_BY_HOME_TILE::get)
+                .map(KELERES_FACTION_BY_KELERES_TILE::get)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
         return factions.size() == 1 ? factions.iterator().next() : null;
+    }
+
+    /**
+     * The tile the player is anchored to. Safe to read the base home systems from, unlike a sweep of
+     * the whole board, because this one is theirs.
+     */
+    static String factionFromTheirOwnHomeTile(Game game, Player player) {
+        return Stream.of(player.getHomeSystemPosition(), player.getPlayerStatsAnchorPosition())
+                .filter(position -> StringUtils.isNotBlank(position) && !"null".equalsIgnoreCase(position))
+                .map(game::getTileByPosition)
+                .filter(Objects::nonNull)
+                .map(tile -> KELERES_FACTION_BY_OWN_TILE.get(tile.getTileID()))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /** Enough of the player to work out from a dry run why nothing placed them. */
+    private static String describeUndetermined(Game game, Player player) {
+        String position = StringUtils.defaultIfBlank(player.getHomeSystemPosition(), null);
+        if (position == null) {
+            position = StringUtils.defaultIfBlank(player.getPlayerStatsAnchorPosition(), null);
+        }
+        Tile tile = position == null ? null : game.getTileByPosition(position);
+        List<String> planets = player.getPlanets().stream().limit(8).toList();
+        return game.getName() + " (" + player.getUserName() + ") pos=" + (position == null ? "-" : position)
+                + " tile=" + (tile == null ? "-" : tile.getTileID())
+                + " tiles=" + game.getTileMap().size()
+                + " planets=" + (planets.isEmpty() ? "-" : String.join(",", planets));
     }
 
     private static void report(

--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -2,6 +2,7 @@ package ti4.discord.interactions.commands.developer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -55,6 +56,14 @@ class RunAgainstAllGames extends Subcommand {
             Map.entry("02", "keleresm"),
             Map.entry("2", "keleresm"));
 
+    /**
+     * The base faction each of those home systems belongs to when it is not Keleres sitting on it.
+     * Keleres never shares a table with the faction whose home it wears, so one of these tiles on a
+     * board with its own faction absent can only be the Keleres player's.
+     */
+    private static final Map<String, String> BASE_FACTION_BY_HOME_TILE = Map.ofEntries(
+            Map.entry("14", "xxcha"), Map.entry("58", "argent"), Map.entry("02", "mentak"), Map.entry("2", "mentak"));
+
     private static final Map<String, String> KELERES_FACTION_BY_HOME_PLANET = Map.ofEntries(
             Map.entry("archonrenk", "keleresx"),
             Map.entry("archontauk", "keleresx"),
@@ -97,6 +106,7 @@ class RunAgainstAllGames extends Subcommand {
                     }
 
                     String boardFaction = factionFromTheOnlyKeleresHomeOnTheBoard(game);
+                    String orphanedBaseFaction = factionFromAnOrphanedBaseHome(game);
                     List<String> retyped = new ArrayList<>();
                     for (Player player : legacyPlayers) {
                         String faction = factionFromTheirHomePlanets(player);
@@ -105,6 +115,9 @@ class RunAgainstAllGames extends Subcommand {
                         }
                         if (faction == null) {
                             faction = boardFaction;
+                        }
+                        if (faction == null) {
+                            faction = orphanedBaseFaction;
                         }
                         if (faction == null) {
                             undeterminedGames.add(describeUndetermined(game, player));
@@ -168,6 +181,32 @@ class RunAgainstAllGames extends Subcommand {
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
+    }
+
+    /**
+     * The last resort, for a player who lost their home system and has no position left to name it:
+     * a base home system on the board whose own faction is not at the table has to be theirs.
+     */
+    static String factionFromAnOrphanedBaseHome(Game game) {
+        Set<String> factionsAtTheTable = game.getPlayers().values().stream()
+                .map(Player::getFaction)
+                .filter(StringUtils::isNotBlank)
+                .map(faction -> faction.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
+
+        Set<String> candidates = game.getTileMap().values().stream()
+                .map(Tile::getTileID)
+                .filter(BASE_FACTION_BY_HOME_TILE::containsKey)
+                .filter(tileId -> !isAtTheTable(factionsAtTheTable, BASE_FACTION_BY_HOME_TILE.get(tileId)))
+                .map(KELERES_FACTION_BY_OWN_TILE::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        return candidates.size() == 1 ? candidates.iterator().next() : null;
+    }
+
+    private static boolean isAtTheTable(Set<String> factionsAtTheTable, String baseFaction) {
+        return factionsAtTheTable.stream()
+                .anyMatch(faction -> faction.equals(baseFaction) || faction.endsWith("_" + baseFaction));
     }
 
     /** Enough of the player to work out from a dry run why nothing placed them. */

--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -18,6 +18,7 @@ import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.Tile;
+import ti4.game.UnitHolder;
 import ti4.game.persistence.ConsumeGameUtility;
 import ti4.game.persistence.GameManager;
 import ti4.logging.BotLogger;
@@ -57,12 +58,11 @@ class RunAgainstAllGames extends Subcommand {
             Map.entry("2", "keleresm"));
 
     /**
-     * The base faction each of those home systems belongs to when it is not Keleres sitting on it.
-     * Keleres never shares a table with the faction whose home it wears, so one of these tiles on a
-     * board with its own faction absent can only be the Keleres player's.
+     * The faction each flavour borrows its home system from. Keleres never shares a table with that
+     * faction, so a home system of theirs in a game without them can only be the Keleres player's.
      */
-    private static final Map<String, String> BASE_FACTION_BY_HOME_TILE = Map.ofEntries(
-            Map.entry("14", "xxcha"), Map.entry("58", "argent"), Map.entry("02", "mentak"), Map.entry("2", "mentak"));
+    private static final Map<String, String> BORROWED_FROM =
+            Map.of("keleresx", "xxcha", "keleresa", "argent", "keleresm", "mentak");
 
     private static final Map<String, String> KELERES_FACTION_BY_HOME_PLANET = Map.ofEntries(
             Map.entry("archonrenk", "keleresx"),
@@ -95,6 +95,7 @@ class RunAgainstAllGames extends Subcommand {
         List<String> retypedGames = new ArrayList<>();
         List<String> undeterminedGames = new ArrayList<>();
         int[] retypedPlayers = {0};
+        int[] restoredPositions = {0};
 
         ConsumeGameUtility.consumeAllGames(
                 game -> {
@@ -123,10 +124,17 @@ class RunAgainstAllGames extends Subcommand {
                             undeterminedGames.add(describeUndetermined(game, player));
                             continue;
                         }
+                        String homePosition = homeSystemPositionFor(game, faction);
+                        if (homePosition != null) {
+                            restoredPositions[0]++;
+                        }
                         if (!dryRun) {
                             player.setFaction(faction);
+                            if (homePosition != null) {
+                                player.setHomeSystemPosition(homePosition);
+                            }
                         }
-                        retyped.add(faction);
+                        retyped.add(faction + (homePosition == null ? "" : "@" + homePosition));
                     }
 
                     if (retyped.isEmpty()) {
@@ -140,7 +148,7 @@ class RunAgainstAllGames extends Subcommand {
                 },
                 dryRun ? ExecutionLockType.READ : ExecutionLockType.WRITE);
 
-        report(event, dryRun, retypedGames, undeterminedGames, retypedPlayers[0]);
+        report(event, dryRun, retypedGames, undeterminedGames, retypedPlayers[0], restoredPositions[0]);
     }
 
     /**
@@ -184,8 +192,10 @@ class RunAgainstAllGames extends Subcommand {
     }
 
     /**
-     * The last resort, for a player who lost their home system and has no position left to name it:
-     * a base home system on the board whose own faction is not at the table has to be theirs.
+     * The last resort, for a player who lost their home system and has no position left to name it.
+     * A borrowed home system in a game its own faction is not playing can only be the Keleres seat,
+     * whether it is still a tile on the board or only survives as planets in a conqueror's hands -
+     * the oldest games no longer carry the tile at all.
      */
     static String factionFromAnOrphanedBaseHome(Game game) {
         Set<String> factionsAtTheTable = game.getPlayers().values().stream()
@@ -194,12 +204,13 @@ class RunAgainstAllGames extends Subcommand {
                 .map(faction -> faction.toLowerCase(Locale.ROOT))
                 .collect(Collectors.toSet());
 
-        Set<String> candidates = game.getTileMap().values().stream()
-                .map(Tile::getTileID)
-                .filter(BASE_FACTION_BY_HOME_TILE::containsKey)
-                .filter(tileId -> !isAtTheTable(factionsAtTheTable, BASE_FACTION_BY_HOME_TILE.get(tileId)))
-                .map(KELERES_FACTION_BY_OWN_TILE::get)
+        Set<String> candidates = Stream.concat(
+                        game.getTileMap().values().stream().map(Tile::getTileID).map(KELERES_FACTION_BY_OWN_TILE::get),
+                        game.getPlayers().values().stream()
+                                .flatMap(player -> player.getPlanets().stream())
+                                .map(KELERES_FACTION_BY_HOME_PLANET::get))
                 .filter(Objects::nonNull)
+                .filter(keleresFaction -> !isAtTheTable(factionsAtTheTable, BORROWED_FROM.get(keleresFaction)))
                 .collect(Collectors.toSet());
         return candidates.size() == 1 ? candidates.iterator().next() : null;
     }
@@ -207,6 +218,23 @@ class RunAgainstAllGames extends Subcommand {
     private static boolean isAtTheTable(Set<String> factionsAtTheTable, String baseFaction) {
         return factionsAtTheTable.stream()
                 .anyMatch(faction -> faction.equals(baseFaction) || faction.endsWith("_" + baseFaction));
+    }
+
+    /**
+     * Where the flavour's home system is sitting, found by its planets rather than its tile id -
+     * these games carry it as 02, 14 or 58 as often as the re-skinned 93new or 94new. Null when the
+     * board no longer holds the tile at all, which is half of them.
+     */
+    static String homeSystemPositionFor(Game game, String keleresFaction) {
+        return game.getTileMap().values().stream()
+                .filter(tile -> tile.getPlanetUnitHolders().stream()
+                        .map(UnitHolder::getName)
+                        .map(KELERES_FACTION_BY_HOME_PLANET::get)
+                        .anyMatch(keleresFaction::equals))
+                .map(Tile::getPosition)
+                .filter(StringUtils::isNotBlank)
+                .findFirst()
+                .orElse(null);
     }
 
     /** Enough of the player to work out from a dry run why nothing placed them. */
@@ -217,10 +245,15 @@ class RunAgainstAllGames extends Subcommand {
         }
         Tile tile = position == null ? null : game.getTileByPosition(position);
         List<String> planets = player.getPlanets().stream().limit(8).toList();
+        String factions = game.getPlayers().values().stream()
+                .map(Player::getFaction)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.joining(","));
         return game.getName() + " (" + player.getUserName() + ") pos=" + (position == null ? "-" : position)
                 + " tile=" + (tile == null ? "-" : tile.getTileID())
                 + " tiles=" + game.getTileMap().size()
-                + " planets=" + (planets.isEmpty() ? "-" : String.join(",", planets));
+                + " planets=" + (planets.isEmpty() ? "-" : String.join(",", planets))
+                + " factions=" + factions;
     }
 
     private static void report(
@@ -228,7 +261,8 @@ class RunAgainstAllGames extends Subcommand {
             boolean dryRun,
             List<String> retypedGames,
             List<String> undeterminedGames,
-            int retypedPlayers) {
+            int retypedPlayers,
+            int restoredPositions) {
         StringBuilder message = new StringBuilder();
         message.append(dryRun ? "Would retype " : "Retyped ")
                 .append(retypedPlayers)
@@ -236,7 +270,9 @@ class RunAgainstAllGames extends Subcommand {
                 .append(retypedGames.size())
                 .append(" game(s), out of ")
                 .append(GameManager.getGameCount())
-                .append(" games.\n");
+                .append(" games, ")
+                .append(restoredPositions)
+                .append(" of them with a home system position to restore.\n");
         if (undeterminedGames.isEmpty()) {
             message.append("Every legacy Keleres player was placed.");
         } else {

--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -1,35 +1,49 @@
 package ti4.discord.interactions.commands.developer;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import org.apache.commons.lang3.StringUtils;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
-import ti4.game.helper.GameHelper;
+import ti4.game.Player;
+import ti4.game.Tile;
 import ti4.game.persistence.ConsumeGameUtility;
 import ti4.game.persistence.GameManager;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
-import ti4.spring.service.statistics.overrule.OverruleStatsService;
 
 class RunAgainstAllGames extends Subcommand {
 
     private static final String DRY_RUN_OPTION = "dry_run";
 
-    // Games older than this recorded no player on any play, so a player-less cancel there says
-    // nothing about whether it really happened and the cleanup below cannot judge it.
-    private static final LocalDate PLAYER_TRACKING_START_DATE = LocalDate.of(2026, 5, 23);
+    /**
+     * Older games stored every Council Keleres as a bare "keleres", which no faction file answers
+     * to - faction_alias maps it to keleres_dont_use_this. Every statistic that reads a faction
+     * model drops those players, so retype them as the flavour their home system says they were.
+     */
+    private static final String LEGACY_KELERES_FACTION = "keleres";
+
+    private static final Map<String, String> KELERES_FACTION_BY_HOME_TILE =
+            Map.of("92new", "keleresx", "93new", "keleresa", "94new", "keleresm");
+
+    private static final Map<String, String> KELERES_FACTION_BY_HOME_PLANET = Map.of(
+            "archonrenk", "keleresx",
+            "archontauk", "keleresx",
+            "valkk", "keleresa",
+            "ylirk", "keleresa",
+            "avark", "keleresa",
+            "mollprimusk", "keleresm");
 
     RunAgainstAllGames() {
-        super("run_against_all_games", "Runs this custom code against all games.");
+        super("run_against_all_games", "Retypes legacy 'keleres' players as keleresm, keleresa or keleresx.");
         addOptions(new OptionData(
                 OptionType.BOOLEAN, DRY_RUN_OPTION, "Report what would change without saving anything."));
     }
@@ -39,74 +53,105 @@ class RunAgainstAllGames extends Subcommand {
         boolean dryRun = event.getOption(DRY_RUN_OPTION, false, OptionMapping::getAsBoolean);
         MessageHelper.sendMessageToChannel(
                 event.getChannel(),
-                "Running custom command against all games" + (dryRun ? " (dry run, nothing will be saved)." : "."));
+                "Retyping legacy Keleres players across all games"
+                        + (dryRun ? " (dry run, nothing will be saved)." : "."));
 
-        List<String> changedGames = new ArrayList<>();
-        int[] removedPlays = {0};
-        int[] migratedTargets = {0};
+        List<String> retypedGames = new ArrayList<>();
+        List<String> undeterminedGames = new ArrayList<>();
+        int[] retypedPlayers = {0};
+
         ConsumeGameUtility.consumeAllGames(
                 game -> {
-                    int migrated = migrateLegacyTargets(game, dryRun);
-                    int removed = startedAfterPlayerTracking(game) ? removeFabricatedCancels(game, dryRun) : 0;
-                    if (migrated == 0 && removed == 0) {
+                    List<Player> legacyPlayers = game.getPlayers().values().stream()
+                            .filter(player -> LEGACY_KELERES_FACTION.equalsIgnoreCase(player.getFaction()))
+                            .toList();
+                    if (legacyPlayers.isEmpty()) {
                         return;
                     }
-                    migratedTargets[0] += migrated;
-                    removedPlays[0] += removed;
-                    changedGames.add(
-                            game.getName() + " (" + removed + (migrated == 0 ? "" : ", " + migrated + "T)") + ")");
+
+                    String homeTileFaction = factionFromTheOnlyKeleresHomeOnTheBoard(game);
+                    List<String> retyped = new ArrayList<>();
+                    for (Player player : legacyPlayers) {
+                        String faction = factionFromTheirHomePlanets(player);
+                        if (faction == null) {
+                            faction = homeTileFaction;
+                        }
+                        if (faction == null) {
+                            undeterminedGames.add(game.getName() + " (" + player.getUserName() + ")");
+                            continue;
+                        }
+                        if (!dryRun) {
+                            player.setFaction(faction);
+                        }
+                        retyped.add(faction);
+                    }
+
+                    if (retyped.isEmpty()) {
+                        return;
+                    }
+                    retypedPlayers[0] += retyped.size();
+                    retypedGames.add(game.getName() + " -> " + String.join(", ", retyped));
                     if (!dryRun) {
-                        GameManager.save(game, "Removed action card cancels that never happened.");
+                        GameManager.save(game, "Retyped legacy Keleres players from their home system.");
                     }
                 },
                 dryRun ? ExecutionLockType.READ : ExecutionLockType.WRITE);
 
-        MessageHelper.sendMessageToChannel(event.getChannel(), "Finished custom command against all games.");
-        BotLogger.info((dryRun ? "[DRY RUN] Would remove " : "Removed ") + removedPlays[0] + " fabricated cancel plays"
-                + " and convert " + migratedTargets[0] + " leftover legacy targets"
-                + " across " + changedGames.size() + " games out of " + GameManager.getGameCount() + " games: "
-                + String.join(", ", changedGames));
-    }
-
-    private static int removeFabricatedCancels(Game game, boolean dryRun) {
-        return dryRun
-                ? game.getGameStats().findFabricatedCancels().size()
-                : game.getGameStats().removeFabricatedCancels();
+        report(event, dryRun, retypedGames, undeterminedGames, retypedPlayers[0]);
     }
 
     /**
-     * Targets kept being written until 2026-08-08, after the migration that converts them last ran,
-     * so a handful of games still carry some. Sweep them up here so the whole legacy target path can
-     * be deleted once this has run.
+     * A player still sitting on a Keleres homeworld names their own flavour, which is the only
+     * signal that survives a game holding more than one legacy player.
      */
-    @SuppressWarnings("deprecation")
-    private static int migrateLegacyTargets(Game game, boolean dryRun) {
-        if (dryRun) {
-            // Counting instead of converting - a dry run must not touch the game.
-            return (int) game.getGameStats().getActionCardPlays().stream()
-                    .filter(play -> play.getTarget() != null)
-                    .count();
-        }
-        int pending = migrateLegacyTargets(game, true);
-        if (pending == 0) {
-            return 0;
-        }
-        Map<String, Integer> strategyCardChoices =
-                game.getGameStats().migrateTargetsToCanceledFlags().strategyCardChoices();
-        if (!strategyCardChoices.isEmpty()) {
-            OverruleStatsService.get().addMigratedCounts(game.getName(), strategyCardChoices);
-        }
-        return pending;
+    static String factionFromTheirHomePlanets(Player player) {
+        Set<String> factions = player.getPlanets().stream()
+                .map(KELERES_FACTION_BY_HOME_PLANET::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        return factions.size() == 1 ? factions.iterator().next() : null;
     }
 
-    static boolean startedAfterPlayerTracking(Game game) {
-        if (StringUtils.isBlank(game.getCreationDate())) {
-            return false;
+    /**
+     * Only one Council Keleres is ever at a table, so a single Keleres home system on the board
+     * says which flavour it was even after they lost the planets in it.
+     */
+    static String factionFromTheOnlyKeleresHomeOnTheBoard(Game game) {
+        Set<String> factions = game.getTileMap().values().stream()
+                .map(Tile::getTileID)
+                .map(KELERES_FACTION_BY_HOME_TILE::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        return factions.size() == 1 ? factions.iterator().next() : null;
+    }
+
+    private static void report(
+            SlashCommandInteractionEvent event,
+            boolean dryRun,
+            List<String> retypedGames,
+            List<String> undeterminedGames,
+            int retypedPlayers) {
+        StringBuilder message = new StringBuilder();
+        message.append(dryRun ? "Would retype " : "Retyped ")
+                .append(retypedPlayers)
+                .append(" legacy Keleres player(s) across ")
+                .append(retypedGames.size())
+                .append(" game(s), out of ")
+                .append(GameManager.getGameCount())
+                .append(" games.\n");
+        if (undeterminedGames.isEmpty()) {
+            message.append("Every legacy Keleres player was placed.");
+        } else {
+            message.append("**Could not be determined (")
+                    .append(undeterminedGames.size())
+                    .append("):**\n- ")
+                    .append(String.join("\n- ", undeterminedGames));
         }
-        try {
-            return GameHelper.getCreationDateAsLocalDate(game).isAfter(PLAYER_TRACKING_START_DATE);
-        } catch (DateTimeParseException e) {
-            return false;
-        }
+        MessageHelper.sendMessageToChannel(event.getChannel(), message.toString());
+
+        BotLogger.info((dryRun ? "[DRY RUN] Would retype " : "Retyped ") + retypedPlayers
+                + " legacy Keleres player(s) across " + retypedGames.size() + " games: "
+                + String.join(", ", retypedGames)
+                + (undeterminedGames.isEmpty() ? "" : " | Undetermined: " + String.join(", ", undeterminedGames)));
     }
 }

--- a/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/RunAgainstAllGames.java
@@ -198,11 +198,7 @@ class RunAgainstAllGames extends Subcommand {
      * the oldest games no longer carry the tile at all.
      */
     static String factionFromAnOrphanedBaseHome(Game game) {
-        Set<String> factionsAtTheTable = game.getPlayers().values().stream()
-                .map(Player::getFaction)
-                .filter(StringUtils::isNotBlank)
-                .map(faction -> faction.toLowerCase(Locale.ROOT))
-                .collect(Collectors.toSet());
+        Set<String> factionsAtTheTable = factionsAtTheTable(game);
 
         Set<String> candidates = Stream.concat(
                         game.getTileMap().values().stream().map(Tile::getTileID).map(KELERES_FACTION_BY_OWN_TILE::get),
@@ -213,6 +209,14 @@ class RunAgainstAllGames extends Subcommand {
                 .filter(keleresFaction -> !isAtTheTable(factionsAtTheTable, BORROWED_FROM.get(keleresFaction)))
                 .collect(Collectors.toSet());
         return candidates.size() == 1 ? candidates.iterator().next() : null;
+    }
+
+    private static Set<String> factionsAtTheTable(Game game) {
+        return game.getPlayers().values().stream()
+                .map(Player::getFaction)
+                .filter(StringUtils::isNotBlank)
+                .map(faction -> faction.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
     }
 
     private static boolean isAtTheTable(Set<String> factionsAtTheTable, String baseFaction) {
@@ -226,11 +230,16 @@ class RunAgainstAllGames extends Subcommand {
      * board no longer holds the tile at all, which is half of them.
      */
     static String homeSystemPositionFor(Game game, String keleresFaction) {
+        // With the borrowed faction at the table, a shared home system is theirs and not Keleres's -
+        // only the Keleres-only tiles can be claimed then.
+        boolean sharedHomesAreSpokenFor = isAtTheTable(factionsAtTheTable(game), BORROWED_FROM.get(keleresFaction));
         return game.getTileMap().values().stream()
                 .filter(tile -> tile.getPlanetUnitHolders().stream()
                         .map(UnitHolder::getName)
                         .map(KELERES_FACTION_BY_HOME_PLANET::get)
                         .anyMatch(keleresFaction::equals))
+                .filter(tile ->
+                        !sharedHomesAreSpokenFor || KELERES_FACTION_BY_KELERES_TILE.containsKey(tile.getTileID()))
                 .map(Tile::getPosition)
                 .filter(StringUtils::isNotBlank)
                 .findFirst()

--- a/src/main/java/ti4/discord/interactions/commands/statistics/ExpeditionWinRateStatisticsService.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/ExpeditionWinRateStatisticsService.java
@@ -39,7 +39,7 @@ class ExpeditionWinRateStatisticsService {
         int[] playersWithBreakthroughWithoutExpeditionVersusWithBreakthrough = {0, 0};
 
         ConsumeGameUtility.consumeAllGames(
-                ExpeditionWinRateStatisticsService::isEligibleGame,
+                GameStatisticsFilterer.getStandardCompetitiveGamesFilter().and(Game::isThundersEdge),
                 game -> consumeGame(
                         game,
                         factionExpeditionStats,
@@ -249,43 +249,6 @@ class ExpeditionWinRateStatisticsService {
                 }
             }
         }
-    }
-
-    private static boolean isEligibleGame(Game game) {
-        return game.getWinner().isPresent()
-                && game.getRealAndEliminatedPlayers().size() == 6
-                && game.getVp() == 10
-                && game.isThundersEdge()
-                && !game.hasHomebrew()
-                && !hasGalacticEvent(game)
-                && !hasScenario(game);
-    }
-
-    private static boolean hasScenario(Game game) {
-        return game.isLiberationC4Mode() || game.isOrdinianC1Mode() || game.isAllianceMode();
-    }
-
-    private static boolean hasGalacticEvent(Game game) {
-        return game.isAdventOfTheWarsunMode()
-                || game.isStellarAtomicsMode()
-                || game.isAgeOfFightersMode()
-                || game.isCivilizedSocietyMode()
-                || game.isDangerousWildsMode()
-                || game.isCallOfTheVoidMode()
-                || game.isHiddenAgendaMode()
-                || game.isWildWildGalaxyMode()
-                || game.isCulturalExchangeProgramMode()
-                || game.isCosmicPhenomenaeMode()
-                || game.isMercenariesForHireMode()
-                || game.isRapidMobilizationMode()
-                || game.isWeirdWormholesMode()
-                || game.isMonumentToTheAgesMode()
-                || game.isZealousOrthodoxyMode()
-                || game.isConventionsOfWarAbandonedMode()
-                || game.isAgeOfExplorationMode()
-                || game.isTotalWarMode()
-                || game.isAgeOfCommerceMode()
-                || game.isMinorFactionsMode();
     }
 
     private static boolean checkFactionsEqual(String faction1, String faction2) {

--- a/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
@@ -15,6 +15,11 @@ class PlanetWinRates extends Subcommand {
                 OptionType.BOOLEAN,
                 PlanetWinRateStatisticsService.POK_ONLY_OPTION,
                 "'true' for Prophecy of Kings games only, dropping Thunder's Edge (default: both)"));
+        addOptions(new OptionData(
+                        OptionType.STRING,
+                        PlanetWinRateStatisticsService.HOME_LOSS_FACTION_OPTION,
+                        "List every game this faction ended without a home planet, and who holds it")
+                .setAutoComplete(true));
     }
 
     @Override

--- a/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
@@ -1,0 +1,18 @@
+package ti4.discord.interactions.commands.statistics;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.helpers.Constants;
+import ti4.service.statistics.PlanetWinRateStatisticsService;
+
+class PlanetWinRates extends Subcommand {
+
+    PlanetWinRates() {
+        super(Constants.PLANET_WIN_RATES, "Win rates by the planets a player controls at the end of the game");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        PlanetWinRateStatisticsService.queueReply(event);
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
@@ -14,12 +14,7 @@ class PlanetWinRates extends Subcommand {
         addOptions(new OptionData(
                 OptionType.BOOLEAN,
                 PlanetWinRateStatisticsService.POK_ONLY_OPTION,
-                "'true' for Prophecy of Kings games only, dropping Thunder's Edge (default: both)"));
-        addOptions(new OptionData(
-                        OptionType.STRING,
-                        PlanetWinRateStatisticsService.HOME_LOSS_FACTION_OPTION,
-                        "List every game this faction ended without a home planet, and who holds it")
-                .setAutoComplete(true));
+                "'true' for Prophecy of Kings games without Thunder's Edge (default: games with both)"));
     }
 
     @Override

--- a/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/PlanetWinRates.java
@@ -1,6 +1,8 @@
 package ti4.discord.interactions.commands.statistics;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import ti4.discord.interactions.commands.Subcommand;
 import ti4.helpers.Constants;
 import ti4.service.statistics.PlanetWinRateStatisticsService;
@@ -9,6 +11,10 @@ class PlanetWinRates extends Subcommand {
 
     PlanetWinRates() {
         super(Constants.PLANET_WIN_RATES, "Win rates by the planets a player controls at the end of the game");
+        addOptions(new OptionData(
+                OptionType.BOOLEAN,
+                PlanetWinRateStatisticsService.POK_ONLY_OPTION,
+                "'true' for Prophecy of Kings games only, dropping Thunder's Edge (default: both)"));
     }
 
     @Override

--- a/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand2.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand2.java
@@ -17,6 +17,7 @@ public class StatisticsCommand2 implements ParentCommand {
                     new TwilightsFallSpliceWinRates(),
                     new ExpeditionWinRates(),
                     new SliceTileWinRates(),
+                    new PlanetWinRates(),
                     new StellarConverterStatistics(),
                     new FactionRecordOfTech(),
                     new FactionRecordOfSCPick(),

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -513,6 +513,7 @@ public final class Constants {
     public static final String EXPEDITION_WIN_RATES = "expedition_win_rates";
     public static final String TWILIGHTS_FALL_SPLICE_WIN_RATES = "tf_splice_win_rates";
     public static final String SLICE_TILE_WIN_RATES = "slice_tile_win_rates";
+    public static final String PLANET_WIN_RATES = "planet_win_rates";
     public static final String SEND_DEBT = "send_debt";
     public static final String DEBT_COUNT = "debt_count";
     public static final String REMOVE_DEBT = "remove_debt";

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -43,6 +43,9 @@ public class PlanetWinRateStatisticsService {
      */
     private static final String COEXISTING_FACTION = "deepwrought";
 
+    /** The factions that coexist by design, and so the only ones the coexistence section reports. */
+    private static final List<String> COEXISTING_FACTIONS = List.of(COEXISTING_FACTION, "titans");
+
     private static final int BAND_SIZE = 2;
     private static final int OPEN_ENDED_BAND_START = 11;
     private static final int COEXIST_OPEN_ENDED_BAND_START = 5;
@@ -400,14 +403,18 @@ public class PlanetWinRateStatisticsService {
 
     private static void appendCoexistedPlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Win rate by planets coexisted on\n"
-                + "_Planets a player had ground forces or structures on at the end of the game without controlling"
-                + " them._\n"
                 + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
 
-        blocks.add(renderCoexistGroup("**All factions**", stats.overall));
-        wellSampledFactions(stats)
+        List<Entry<String, PlanetHoldingStats>> reported = COEXISTING_FACTIONS.stream()
+                .filter(stats.byFaction::containsKey)
+                .map(faction -> Map.entry(faction, stats.byFaction.get(faction)))
                 .sorted(BY_AVERAGE_COEXISTED_PLANETS_DESC)
-                .forEach(entry -> blocks.add(renderCoexistGroup(factionLabel(entry.getKey()), entry.getValue())));
+                .toList();
+        if (reported.isEmpty()) {
+            blocks.add("- Neither faction appeared in the sample.\n");
+            return;
+        }
+        reported.forEach(entry -> blocks.add(renderCoexistGroup(factionLabel(entry.getKey()), entry.getValue())));
     }
 
     private static String renderCoexistGroup(String label, PlanetHoldingStats group) {

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import org.apache.commons.lang3.StringUtils;
 import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
 import ti4.executors.ExecutionLockType;
@@ -31,6 +32,8 @@ import ti4.model.PlanetModel;
 
 @UtilityClass
 public class PlanetWinRateStatisticsService {
+
+    public static final String POK_ONLY_OPTION = "pok_only";
 
     private static final int BAND_SIZE = 2;
     private static final int OPEN_ENDED_BAND_START = 12;
@@ -56,33 +59,41 @@ public class PlanetWinRateStatisticsService {
                     .thenComparing(Entry::getKey);
 
     public static void queueReply(SlashCommandInteractionEvent event) {
-        StatisticsPipeline.queue(event, () -> showPlanetWinRates(event));
+        boolean pokOnly = event.getOption(POK_ONLY_OPTION, false, OptionMapping::getAsBoolean);
+        StatisticsPipeline.queue(event, () -> showPlanetWinRates(event, pokOnly));
     }
 
-    private static void showPlanetWinRates(SlashCommandInteractionEvent event) {
-        PlanetWinRateStats stats = new PlanetWinRateStats();
+    private static void showPlanetWinRates(SlashCommandInteractionEvent event, boolean pokOnly) {
+        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly);
         ConsumeGameUtility.consumeAllGames(
                 GameStatisticsFilterer.getStandardCompetitiveGamesFilter()
-                        .and(PlanetWinRateStatisticsService::isEligibleGameType),
+                        .and(game -> isEligibleGameType(game, pokOnly)),
                 game -> accumulateGame(game, stats),
                 ExecutionLockType.READ);
 
         MessageHelper.sendMessageToThread(event.getChannel(), "Planet win rates", buildReport(stats));
     }
 
-    static List<String> buildReport(List<Game> games) {
-        PlanetWinRateStats stats = new PlanetWinRateStats();
+    static List<String> buildReport(List<Game> games, boolean pokOnly) {
+        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly);
         games.forEach(game -> accumulateGame(game, stats));
         return buildReport(stats);
     }
 
-    static boolean isEligibleGameType(Game game) {
-        return !game.isTwilightsFallMode();
+    static boolean isEligibleGameType(Game game, boolean pokOnly) {
+        if (game.isTwilightsFallMode()) {
+            return false;
+        }
+        return pokOnly ? game.isProphecyOfKings() && !game.isThundersEdge() : sampledGameType(game);
+    }
+
+    private static boolean sampledGameType(Game game) {
+        return game.isThundersEdge() || game.isProphecyOfKings();
     }
 
     private static void accumulateGame(Game game, PlanetWinRateStats stats) {
         Player winner = game.getWinner().orElse(null);
-        if (winner == null || !isEligibleGameType(game)) {
+        if (winner == null || !isEligibleGameType(game, stats.pokOnly)) {
             return;
         }
         stats.games++;
@@ -176,8 +187,12 @@ public class PlanetWinRateStatisticsService {
 
         StringBuilder header = new StringBuilder("## __**Planet Win Rates**__\n");
         header.append("_Planets each player controlled at the end of the game. Oceans are never counted._\n");
-        header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario,"
-                + " non-Twilight's-Fall games with winners._\n");
+        header.append(
+                        stats.pokOnly
+                                ? "_Prophecy of Kings games, no Thunder's Edge."
+                                : "_Thunder's Edge and Prophecy" + " of Kings games.")
+                .append(" 6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario,"
+                        + " non-Twilight's-Fall, with winners._\n");
         if (stats.overall.players == 0) {
             header.append('\n')
                     .append(
@@ -367,6 +382,12 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static class PlanetWinRateStats {
+        private PlanetWinRateStats(boolean pokOnly) {
+            this.pokOnly = pokOnly;
+        }
+
+        final boolean pokOnly;
+
         final PlanetHoldingStats overall = new PlanetHoldingStats();
 
         final Map<String, PlanetHoldingStats> byFaction = new HashMap<>();

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -61,7 +61,8 @@ public class PlanetWinRateStatisticsService {
     private static void showPlanetWinRates(SlashCommandInteractionEvent event) {
         PlanetWinRateStats stats = new PlanetWinRateStats();
         ConsumeGameUtility.consumeAllGames(
-                GameStatisticsFilterer.getStandardCompetitiveGamesFilter(),
+                GameStatisticsFilterer.getStandardCompetitiveGamesFilter()
+                        .and(PlanetWinRateStatisticsService::isEligibleGameType),
                 game -> accumulateGame(game, stats),
                 ExecutionLockType.READ);
 
@@ -74,9 +75,13 @@ public class PlanetWinRateStatisticsService {
         return buildReport(stats);
     }
 
+    static boolean isEligibleGameType(Game game) {
+        return !game.isTwilightsFallMode();
+    }
+
     private static void accumulateGame(Game game, PlanetWinRateStats stats) {
         Player winner = game.getWinner().orElse(null);
-        if (winner == null) {
+        if (winner == null || !isEligibleGameType(game)) {
             return;
         }
         stats.games++;
@@ -154,8 +159,8 @@ public class PlanetWinRateStatisticsService {
 
         StringBuilder header = new StringBuilder("## __**Planet Win Rates**__\n");
         header.append("_Planets each player controlled at the end of the game. Oceans are never counted._\n");
-        header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario games with"
-                + " winners._\n");
+        header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario,"
+                + " non-Twilight's-Fall games with winners._\n");
         if (stats.overall.players == 0) {
             header.append('\n')
                     .append(

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -36,7 +36,7 @@ public class PlanetWinRateStatisticsService {
     public static final String POK_ONLY_OPTION = "pok_only";
 
     private static final int BAND_SIZE = 2;
-    private static final int OPEN_ENDED_BAND_START = 12;
+    private static final int OPEN_ENDED_BAND_START = 11;
     private static final int MINIMUM_FACTION_PLAYERS = 25;
     private static final int SKIPPED_FACTIONS_LISTED = 10;
 
@@ -287,10 +287,20 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static int bandStartFor(int planets) {
-        return planets >= OPEN_ENDED_BAND_START ? OPEN_ENDED_BAND_START : planets / BAND_SIZE * BAND_SIZE;
+        if (planets == 0) {
+            return 0;
+        }
+        if (planets >= OPEN_ENDED_BAND_START) {
+            return OPEN_ENDED_BAND_START;
+        }
+        return (planets - 1) / BAND_SIZE * BAND_SIZE + 1;
     }
 
     private static void appendBandLabel(StringBuilder sb, int bandStart) {
+        if (bandStart == 0) {
+            sb.append("0 planets");
+            return;
+        }
         if (bandStart >= OPEN_ENDED_BAND_START) {
             sb.append(bandStart).append("+ planets");
             return;

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -574,11 +574,7 @@ public class PlanetWinRateStatisticsService {
         if (group.silverFlamed.getPlayers() == 0) {
             return;
         }
-        sb.append(". ")
-                .append(group.silverFlamed.getPlayers())
-                .append(" Silver Flames (")
-                .append(ActionCardStatsService.formatPercent(group.silverFlamed.getWinRate()))
-                .append(" win rate).");
+        sb.append(". ").append(group.silverFlamed.getPlayers()).append(" Silver Flames.");
     }
 
     private static void appendCoexistedThrough(StringBuilder sb, PlanetHoldingStats group) {

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -31,8 +31,8 @@ import ti4.model.PlanetModel;
 @UtilityClass
 public class PlanetWinRateStatisticsService {
 
-    private static final int BAND_SIZE = 3;
-    private static final int OPEN_ENDED_BAND_START = 18;
+    private static final int BAND_SIZE = 2;
+    private static final int OPEN_ENDED_BAND_START = 12;
     private static final int MINIMUM_FACTION_PLAYERS = 25;
     private static final int MINIMUM_PLANET_HOLDINGS = 25;
 
@@ -99,10 +99,13 @@ public class PlanetWinRateStatisticsService {
         for (PlayerHome seat : seats) {
             String faction = seat.player().getFaction();
             Set<String> homePlanets = seat.homePlanets();
-            Set<String> controlledPlanets = new HashSet<>(seat.player().getPlanets());
+            Set<String> controlledPlanets = seat.player().getPlanets().stream()
+                    .filter(planet -> !isOcean(planet))
+                    .collect(Collectors.toCollection(HashSet::new));
             boolean isWinner = faction.equals(winner.getFaction());
             int nonHomePlanets = (int) controlledPlanets.stream()
                     .filter(planet -> !homePlanets.contains(planet))
+                    .filter(planet -> !isTradeStation(planet))
                     .count();
             boolean lostAHomePlanet = !controlledPlanets.containsAll(homePlanets);
 
@@ -119,6 +122,16 @@ public class PlanetWinRateStatisticsService {
                             .computeIfAbsent(planet, _ -> new WinRateCount())
                             .record(isWinner));
         }
+    }
+
+    private static boolean isOcean(String planetId) {
+        PlanetModel planetModel = Mapper.getPlanet(planetId);
+        return planetModel != null && planetModel.isFake();
+    }
+
+    private static boolean isTradeStation(String planetId) {
+        PlanetModel planetModel = Mapper.getPlanet(planetId);
+        return planetModel != null && planetModel.isSpaceStation();
     }
 
     private static Set<String> getHomePlanets(Player player) {
@@ -138,7 +151,7 @@ public class PlanetWinRateStatisticsService {
         List<String> blocks = new ArrayList<>();
 
         StringBuilder header = new StringBuilder("## __**Planet Win Rates**__\n");
-        header.append("_Planets each player controlled at the end of the game._\n");
+        header.append("_Planets each player controlled at the end of the game. Oceans are never counted._\n");
         header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario games with"
                 + " winners._\n");
         if (stats.overall.players == 0) {
@@ -173,7 +186,8 @@ public class PlanetWinRateStatisticsService {
 
     private static void appendNonHomePlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Win rate by non-home planets controlled\n"
-                + "_Planets held at the end of the game outside the player's own home system._\n"
+                + "_Planets held at the end of the game outside the player's own home system."
+                + " Trade stations are not counted._\n"
                 + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
 
         blocks.add(renderBandedGroup("**All factions**", stats.overall));
@@ -225,41 +239,53 @@ public class PlanetWinRateStatisticsService {
         blocks.add("\n### Home planets lost\n"
                 + "_Players who did not control every planet of their own home system at the end of the game._\n");
 
-        blocks.add(renderHomePlanetsLostLine("**All factions**", stats.overall));
+        blocks.add(renderCombinedHomePlanetsLostLine(stats.overall));
         wellSampledFactions(stats)
                 .sorted(BY_HOME_LOSS_RATE_DESC)
-                .forEach(
-                        entry -> blocks.add(renderHomePlanetsLostLine(factionLabel(entry.getKey()), entry.getValue())));
+                .forEach(entry ->
+                        blocks.add(renderFactionHomePlanetsLostLine(factionLabel(entry.getKey()), entry.getValue())));
     }
 
-    private static String renderHomePlanetsLostLine(String label, PlanetHoldingStats group) {
-        StringBuilder sb = new StringBuilder("- ");
-        sb.append(label).append(": ");
-        WinRateCount lost = group.lostAHomePlanet;
-        WinRateCount held = group.heldEveryHomePlanet;
-        if (lost.getPlayers() == 0) {
-            return sb.append("never lost a home planet, across ")
-                    .append(group.players)
-                    .append(" players\n")
-                    .toString();
+    private static String renderCombinedHomePlanetsLostLine(PlanetHoldingStats group) {
+        StringBuilder sb = appendHomePlanetsLostCount(new StringBuilder("- **All factions**: "), group);
+        if (group.lostAHomePlanet.getPlayers() == 0) {
+            return sb.append(" of players lost a home planet\n").toString();
         }
-        sb.append(lost.getPlayers())
+        return sb.append(" of players lost a home planet. ")
+                .append(ActionCardStatsService.formatPercent(group.lostAHomePlanet.getWinRate()))
+                .append(" win rate when they did, ")
+                .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
+                .append(" when they did not\n")
+                .toString();
+    }
+
+    private static String renderFactionHomePlanetsLostLine(String label, PlanetHoldingStats group) {
+        StringBuilder sb =
+                appendHomePlanetsLostCount(new StringBuilder("- ").append(label).append(": "), group);
+        if (group.lostAHomePlanet.getPlayers() == 0) {
+            return sb.append(" homes lost\n").toString();
+        }
+        return sb.append(" homes lost. ")
+                .append(ActionCardStatsService.formatPercent(group.lostAHomePlanet.getWinRate()))
+                .append(" win rate, ")
+                .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
+                .append(" otherwise\n")
+                .toString();
+    }
+
+    private static StringBuilder appendHomePlanetsLostCount(StringBuilder sb, PlanetHoldingStats group) {
+        return sb.append(group.lostAHomePlanet.getPlayers())
                 .append('/')
                 .append(group.players)
                 .append(" (")
                 .append(ActionCardStatsService.formatPercent(group.homeLossRate()))
-                .append(") lost one - ")
-                .append(ActionCardStatsService.formatPercent(lost.getWinRate()))
-                .append(" win rate when they did, ")
-                .append(ActionCardStatsService.formatPercent(held.getWinRate()))
-                .append(" when they did not\n");
-        return sb.toString();
+                .append(')');
     }
 
     private static void appendPerPlanetSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Win rate by planet controlled\n"
                 + "_A player's win rate when they held the planet at the end of the game. Home planets are left"
-                + " out, since they sit with whoever started on them nearly every game._\n"
+                + " out._\n"
                 + "_Only planets held at least " + MINIMUM_PLANET_HOLDINGS + " times are shown._\n");
 
         List<Entry<String, WinRateCount>> ranked = stats.byPlanet.entrySet().stream()

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -21,6 +21,7 @@ import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
 import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.game.UnitHolder;
 import ti4.game.persistence.ConsumeGameUtility;
 import ti4.helpers.AliasHandler;
 import ti4.image.Mapper;
@@ -92,7 +93,7 @@ public class PlanetWinRateStatisticsService {
             if (StringUtils.isBlank(player.getFaction())) {
                 continue;
             }
-            Set<String> homePlanets = getHomePlanets(player);
+            Set<String> homePlanets = getHomePlanets(game, player);
             if (homePlanets.isEmpty()) {
                 stats.playersWithoutAKnownHome++;
                 stats.skippedPlayersByFaction.merge(player.getFaction(), 1, Integer::sum);
@@ -141,15 +142,31 @@ public class PlanetWinRateStatisticsService {
         return planetModel != null && planetModel.isSpaceStation();
     }
 
-    private static Set<String> getHomePlanets(Player player) {
+    private static Set<String> getHomePlanets(Game game, Player player) {
         FactionModel factionModel = player.getFactionModel();
-        if (factionModel == null) {
-            return Set.of();
+        if (factionModel != null) {
+            Set<String> homePlanets = factionModel.getHomePlanets().stream()
+                    .filter(StringUtils::isNotBlank)
+                    .map(planet -> AliasHandler.resolvePlanet(planet.toLowerCase(Locale.ROOT)))
+                    .collect(Collectors.toSet());
+            if (!homePlanets.isEmpty()) {
+                return homePlanets;
+            }
         }
-        return factionModel.getHomePlanets().stream()
-                .filter(StringUtils::isNotBlank)
-                .map(planet -> AliasHandler.resolvePlanet(planet.toLowerCase(Locale.ROOT)))
-                .collect(Collectors.toSet());
+        return getHomePlanetsFromTheBoard(game, player);
+    }
+
+    private static Set<String> getHomePlanetsFromTheBoard(Game game, Player player) {
+        return Stream.of(player.getHomeSystemPosition(), player.getPlayerStatsAnchorPosition())
+                .filter(position -> StringUtils.isNotBlank(position) && !"null".equalsIgnoreCase(position))
+                .map(game::getTileByPosition)
+                .filter(tile -> tile != null && tile.isHomeSystem())
+                .map(tile -> tile.getPlanetUnitHolders().stream()
+                        .map(UnitHolder::getName)
+                        .collect(Collectors.toSet()))
+                .filter(homePlanets -> !homePlanets.isEmpty())
+                .findFirst()
+                .orElse(Set.of());
     }
 
     private record PlayerHome(Player player, Set<String> homePlanets) {}
@@ -194,8 +211,8 @@ public class PlanetWinRateStatisticsService {
         StringBuilder sb = new StringBuilder("\n### Skipped players\n");
         sb.append("_")
                 .append(stats.playersWithoutAKnownHome)
-                .append(" player(s) had no home planets on file for their faction, so they are in none of the numbers"
-                        + " above or below. Each row names a game to look at._\n");
+                .append(" player(s) had no home planets on file for their faction and no home system on the board, so"
+                        + " they are in none of the numbers above or below. Each row names a game to look at._\n");
 
         List<Entry<String, Integer>> byFaction = stats.skippedPlayersByFaction.entrySet().stream()
                 .sorted(Entry.<String, Integer>comparingByValue().reversed().thenComparing(Entry::getKey))

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -34,7 +34,7 @@ public class PlanetWinRateStatisticsService {
     private static final int BAND_SIZE = 2;
     private static final int OPEN_ENDED_BAND_START = 12;
     private static final int MINIMUM_FACTION_PLAYERS = 25;
-    private static final int MINIMUM_PLANET_HOLDINGS = 25;
+    private static final int SKIPPED_FACTIONS_LISTED = 10;
 
     private static final Comparator<Entry<String, WinRateCount>> BY_WIN_RATE_DESC = Comparator.comparingDouble(
                     (Entry<String, WinRateCount> entry) -> entry.getValue().getWinRate())
@@ -90,6 +90,8 @@ public class PlanetWinRateStatisticsService {
             Set<String> homePlanets = getHomePlanets(player);
             if (homePlanets.isEmpty()) {
                 stats.playersWithoutAKnownHome++;
+                stats.skippedPlayersByFaction.merge(player.getFaction(), 1, Integer::sum);
+                stats.skippedGameNames.putIfAbsent(player.getFaction(), game.getName());
                 continue;
             }
             seats.add(new PlayerHome(player, homePlanets));
@@ -170,18 +172,42 @@ public class PlanetWinRateStatisticsService {
                 .append(" | Players analyzed: ")
                 .append(stats.overall.players)
                 .append('\n');
-        if (stats.playersWithoutAKnownHome > 0) {
-            header.append("_Skipped ")
-                    .append(stats.playersWithoutAKnownHome)
-                    .append(" player(s) whose home planets could not be identified._\n");
-        }
         blocks.add(header.toString());
+        appendSkippedPlayersSection(blocks, stats);
 
         appendNonHomePlanetsSection(blocks, stats);
         appendHomePlanetsLostSection(blocks, stats);
         appendPerPlanetSection(blocks, stats);
 
         return blocks;
+    }
+
+    private static void appendSkippedPlayersSection(List<String> blocks, PlanetWinRateStats stats) {
+        if (stats.playersWithoutAKnownHome == 0) {
+            return;
+        }
+        StringBuilder sb = new StringBuilder("\n### Skipped players\n");
+        sb.append("_")
+                .append(stats.playersWithoutAKnownHome)
+                .append(" player(s) had no home planets on file for their faction, so they are in none of the numbers"
+                        + " above or below. Each row names a game to look at._\n");
+
+        List<Entry<String, Integer>> byFaction = stats.skippedPlayersByFaction.entrySet().stream()
+                .sorted(Entry.<String, Integer>comparingByValue().reversed().thenComparing(Entry::getKey))
+                .toList();
+        byFaction.stream().limit(SKIPPED_FACTIONS_LISTED).forEach(entry -> sb.append("- `")
+                .append(entry.getKey())
+                .append("` - ")
+                .append(entry.getValue())
+                .append(" player(s), e.g. game `")
+                .append(stats.skippedGameNames.get(entry.getKey()))
+                .append("`\n"));
+        if (byFaction.size() > SKIPPED_FACTIONS_LISTED) {
+            sb.append("- and ")
+                    .append(byFaction.size() - SKIPPED_FACTIONS_LISTED)
+                    .append(" more faction(s)\n");
+        }
+        blocks.add(sb.toString());
     }
 
     private static void appendNonHomePlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
@@ -285,15 +311,12 @@ public class PlanetWinRateStatisticsService {
     private static void appendPerPlanetSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Win rate by planet controlled\n"
                 + "_A player's win rate when they held the planet at the end of the game. Home planets are left"
-                + " out._\n"
-                + "_Only planets held at least " + MINIMUM_PLANET_HOLDINGS + " times are shown._\n");
+                + " out._\n");
 
-        List<Entry<String, WinRateCount>> ranked = stats.byPlanet.entrySet().stream()
-                .filter(entry -> entry.getValue().getPlayers() >= MINIMUM_PLANET_HOLDINGS)
-                .sorted(BY_WIN_RATE_DESC)
-                .toList();
+        List<Entry<String, WinRateCount>> ranked =
+                stats.byPlanet.entrySet().stream().sorted(BY_WIN_RATE_DESC).toList();
         if (ranked.isEmpty()) {
-            blocks.add("- No planet was held that often.\n");
+            blocks.add("- No planets were held.\n");
             return;
         }
         ranked.forEach(entry -> blocks.add(renderPlanetLine(entry)));
@@ -327,6 +350,10 @@ public class PlanetWinRateStatisticsService {
         final Map<String, PlanetHoldingStats> byFaction = new HashMap<>();
 
         final Map<String, WinRateCount> byPlanet = new HashMap<>();
+
+        final Map<String, Integer> skippedPlayersByFaction = new HashMap<>();
+
+        final Map<String, String> skippedGameNames = new HashMap<>();
 
         int games;
         int playersWithoutAKnownHome;

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -1,0 +1,365 @@
+package ti4.service.statistics;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.apache.commons.lang3.StringUtils;
+import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
+import ti4.executors.ExecutionLockType;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.persistence.ConsumeGameUtility;
+import ti4.helpers.AliasHandler;
+import ti4.image.Mapper;
+import ti4.message.MessageHelper;
+import ti4.model.FactionModel;
+import ti4.model.PlanetModel;
+
+@UtilityClass
+public class PlanetWinRateStatisticsService {
+
+    private static final int BAND_SIZE = 3;
+    private static final int OPEN_ENDED_BAND_START = 18;
+    private static final int MINIMUM_FACTION_PLAYERS = 25;
+    private static final int MINIMUM_PLANET_HOLDINGS = 25;
+
+    private static final Comparator<Entry<String, WinRateCount>> BY_WIN_RATE_DESC = Comparator.comparingDouble(
+                    (Entry<String, WinRateCount> entry) -> entry.getValue().getWinRate())
+            .thenComparingInt(entry -> entry.getValue().getPlayers())
+            .reversed()
+            .thenComparing(entry -> planetName(entry.getKey()));
+
+    private static final Comparator<Entry<String, PlanetHoldingStats>> BY_HOME_LOSS_RATE_DESC =
+            Comparator.comparingDouble((Entry<String, PlanetHoldingStats> entry) ->
+                            entry.getValue().homeLossRate())
+                    .reversed()
+                    .thenComparing(Entry::getKey);
+
+    private static final Comparator<Entry<String, PlanetHoldingStats>> BY_AVERAGE_NON_HOME_PLANETS_DESC =
+            Comparator.comparingDouble((Entry<String, PlanetHoldingStats> entry) ->
+                            entry.getValue().averageNonHomePlanets())
+                    .reversed()
+                    .thenComparing(Entry::getKey);
+
+    public static void queueReply(SlashCommandInteractionEvent event) {
+        StatisticsPipeline.queue(event, () -> showPlanetWinRates(event));
+    }
+
+    private static void showPlanetWinRates(SlashCommandInteractionEvent event) {
+        PlanetWinRateStats stats = new PlanetWinRateStats();
+        ConsumeGameUtility.consumeAllGames(
+                GameStatisticsFilterer.getStandardCompetitiveGamesFilter(),
+                game -> accumulateGame(game, stats),
+                ExecutionLockType.READ);
+
+        MessageHelper.sendMessageToThread(event.getChannel(), "Planet win rates", buildReport(stats));
+    }
+
+    static List<String> buildReport(List<Game> games) {
+        PlanetWinRateStats stats = new PlanetWinRateStats();
+        games.forEach(game -> accumulateGame(game, stats));
+        return buildReport(stats);
+    }
+
+    private static void accumulateGame(Game game, PlanetWinRateStats stats) {
+        Player winner = game.getWinner().orElse(null);
+        if (winner == null) {
+            return;
+        }
+        stats.games++;
+
+        List<PlayerHome> seats = new ArrayList<>();
+        Set<String> everyHomePlanetOnTheBoard = new HashSet<>();
+        for (Player player : game.getRealAndEliminatedPlayers()) {
+            if (StringUtils.isBlank(player.getFaction())) {
+                continue;
+            }
+            Set<String> homePlanets = getHomePlanets(player);
+            if (homePlanets.isEmpty()) {
+                stats.playersWithoutAKnownHome++;
+                continue;
+            }
+            seats.add(new PlayerHome(player, homePlanets));
+            everyHomePlanetOnTheBoard.addAll(homePlanets);
+        }
+
+        for (PlayerHome seat : seats) {
+            String faction = seat.player().getFaction();
+            Set<String> homePlanets = seat.homePlanets();
+            Set<String> controlledPlanets = new HashSet<>(seat.player().getPlanets());
+            boolean isWinner = faction.equals(winner.getFaction());
+            int nonHomePlanets = (int) controlledPlanets.stream()
+                    .filter(planet -> !homePlanets.contains(planet))
+                    .count();
+            boolean lostAHomePlanet = !controlledPlanets.containsAll(homePlanets);
+
+            stats.overall.record(isWinner, nonHomePlanets, lostAHomePlanet);
+            for (String factionKey : FactionStatisticsHelper.getStatisticsFactionKeys(faction)) {
+                stats.byFaction
+                        .computeIfAbsent(factionKey, _ -> new PlanetHoldingStats())
+                        .record(isWinner, nonHomePlanets, lostAHomePlanet);
+            }
+
+            controlledPlanets.stream()
+                    .filter(planet -> !everyHomePlanetOnTheBoard.contains(planet))
+                    .forEach(planet -> stats.byPlanet
+                            .computeIfAbsent(planet, _ -> new WinRateCount())
+                            .record(isWinner));
+        }
+    }
+
+    private static Set<String> getHomePlanets(Player player) {
+        FactionModel factionModel = player.getFactionModel();
+        if (factionModel == null) {
+            return Set.of();
+        }
+        return factionModel.getHomePlanets().stream()
+                .filter(StringUtils::isNotBlank)
+                .map(planet -> AliasHandler.resolvePlanet(planet.toLowerCase(Locale.ROOT)))
+                .collect(Collectors.toSet());
+    }
+
+    private record PlayerHome(Player player, Set<String> homePlanets) {}
+
+    private static List<String> buildReport(PlanetWinRateStats stats) {
+        List<String> blocks = new ArrayList<>();
+
+        StringBuilder header = new StringBuilder("## __**Planet Win Rates**__\n");
+        header.append("_Planets each player controlled at the end of the game._\n");
+        header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario games with"
+                + " winners._\n");
+        if (stats.overall.players == 0) {
+            header.append('\n')
+                    .append(
+                            stats.games == 0
+                                    ? "No games matched."
+                                    : "None of the " + stats.games
+                                            + " matching games had a player whose home planets could be identified.")
+                    .append('\n');
+            blocks.add(header.toString());
+            return blocks;
+        }
+        header.append("Games analyzed: ")
+                .append(stats.games)
+                .append(" | Players analyzed: ")
+                .append(stats.overall.players)
+                .append('\n');
+        if (stats.playersWithoutAKnownHome > 0) {
+            header.append("_Skipped ")
+                    .append(stats.playersWithoutAKnownHome)
+                    .append(" player(s) whose home planets could not be identified._\n");
+        }
+        blocks.add(header.toString());
+
+        appendNonHomePlanetsSection(blocks, stats);
+        appendHomePlanetsLostSection(blocks, stats);
+        appendPerPlanetSection(blocks, stats);
+
+        return blocks;
+    }
+
+    private static void appendNonHomePlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
+        blocks.add("\n### Win rate by non-home planets controlled\n"
+                + "_Planets held at the end of the game outside the player's own home system._\n"
+                + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
+
+        blocks.add(renderBandedGroup("**All factions**", stats.overall));
+        wellSampledFactions(stats)
+                .sorted(BY_AVERAGE_NON_HOME_PLANETS_DESC)
+                .forEach(entry -> blocks.add(renderBandedGroup(factionLabel(entry.getKey()), entry.getValue())));
+    }
+
+    private static String renderBandedGroup(String label, PlanetHoldingStats group) {
+        StringBuilder sb = new StringBuilder("- ");
+        sb.append(label)
+                .append(": ")
+                .append(String.format("%.2f", group.averageNonHomePlanets()))
+                .append(" non-home planets on average, ")
+                .append(ActionCardStatsService.formatPercent(group.winRate()))
+                .append(" win rate from ");
+        ActionCardStatsService.appendCount(sb, group.players, "player");
+        sb.append('\n');
+
+        group.playersByBand.forEach((bandStart, count) -> {
+            sb.append("  - ");
+            appendBandLabel(sb, bandStart);
+            sb.append(": ")
+                    .append(ActionCardStatsService.formatPercent(count.getWinRate()))
+                    .append(" (")
+                    .append(count.getWins())
+                    .append('/')
+                    .append(count.getPlayers())
+                    .append("; ")
+                    .append(ActionCardStatsService.formatPercent(count.getPlayers() / (double) group.players))
+                    .append(")\n");
+        });
+        return sb.toString();
+    }
+
+    private static int bandStartFor(int planets) {
+        return planets >= OPEN_ENDED_BAND_START ? OPEN_ENDED_BAND_START : planets / BAND_SIZE * BAND_SIZE;
+    }
+
+    private static void appendBandLabel(StringBuilder sb, int bandStart) {
+        if (bandStart >= OPEN_ENDED_BAND_START) {
+            sb.append(bandStart).append("+ planets");
+            return;
+        }
+        sb.append(bandStart).append('-').append(bandStart + BAND_SIZE - 1).append(" planets");
+    }
+
+    private static void appendHomePlanetsLostSection(List<String> blocks, PlanetWinRateStats stats) {
+        blocks.add("\n### Home planets lost\n"
+                + "_Players who did not control every planet of their own home system at the end of the game._\n");
+
+        blocks.add(renderHomePlanetsLostLine("**All factions**", stats.overall));
+        wellSampledFactions(stats)
+                .sorted(BY_HOME_LOSS_RATE_DESC)
+                .forEach(
+                        entry -> blocks.add(renderHomePlanetsLostLine(factionLabel(entry.getKey()), entry.getValue())));
+    }
+
+    private static String renderHomePlanetsLostLine(String label, PlanetHoldingStats group) {
+        StringBuilder sb = new StringBuilder("- ");
+        sb.append(label).append(": ");
+        WinRateCount lost = group.lostAHomePlanet;
+        WinRateCount held = group.heldEveryHomePlanet;
+        if (lost.getPlayers() == 0) {
+            return sb.append("never lost a home planet, across ")
+                    .append(group.players)
+                    .append(" players\n")
+                    .toString();
+        }
+        sb.append(lost.getPlayers())
+                .append('/')
+                .append(group.players)
+                .append(" (")
+                .append(ActionCardStatsService.formatPercent(group.homeLossRate()))
+                .append(") lost one - ")
+                .append(ActionCardStatsService.formatPercent(lost.getWinRate()))
+                .append(" win rate when they did, ")
+                .append(ActionCardStatsService.formatPercent(held.getWinRate()))
+                .append(" when they did not\n");
+        return sb.toString();
+    }
+
+    private static void appendPerPlanetSection(List<String> blocks, PlanetWinRateStats stats) {
+        blocks.add("\n### Win rate by planet controlled\n"
+                + "_A player's win rate when they held the planet at the end of the game. Home planets are left"
+                + " out, since they sit with whoever started on them nearly every game._\n"
+                + "_Only planets held at least " + MINIMUM_PLANET_HOLDINGS + " times are shown._\n");
+
+        List<Entry<String, WinRateCount>> ranked = stats.byPlanet.entrySet().stream()
+                .filter(entry -> entry.getValue().getPlayers() >= MINIMUM_PLANET_HOLDINGS)
+                .sorted(BY_WIN_RATE_DESC)
+                .toList();
+        if (ranked.isEmpty()) {
+            blocks.add("- No planet was held that often.\n");
+            return;
+        }
+        ranked.forEach(entry -> blocks.add(renderPlanetLine(entry)));
+    }
+
+    private static String renderPlanetLine(Entry<String, WinRateCount> entry) {
+        WinRateCount count = entry.getValue();
+        return "* `" + StringUtils.leftPad(Long.toString(count.percent()), 3) + "%` (" + count.getWins() + '/'
+                + count.getPlayers() + ") " + planetName(entry.getKey()) + '\n';
+    }
+
+    private static Stream<Entry<String, PlanetHoldingStats>> wellSampledFactions(PlanetWinRateStats stats) {
+        return stats.byFaction.entrySet().stream().filter(entry -> entry.getValue().players >= MINIMUM_FACTION_PLAYERS);
+    }
+
+    private static String planetName(String planetId) {
+        PlanetModel planetModel = Mapper.getPlanet(planetId);
+        String name = planetModel == null ? null : planetModel.getNameNullSafe();
+        return StringUtils.isBlank(name) ? planetId : name;
+    }
+
+    private static String factionLabel(String faction) {
+        FactionModel factionModel = Mapper.getFaction(faction);
+        String factionName = factionModel != null ? factionModel.getFactionNameWithSourceEmoji() : faction;
+        return FactionStatisticsHelper.getFactionEmoji(faction) + " **" + factionName + "**";
+    }
+
+    private static class PlanetWinRateStats {
+        final PlanetHoldingStats overall = new PlanetHoldingStats();
+
+        final Map<String, PlanetHoldingStats> byFaction = new HashMap<>();
+
+        final Map<String, WinRateCount> byPlanet = new HashMap<>();
+
+        int games;
+        int playersWithoutAKnownHome;
+    }
+
+    private static class PlanetHoldingStats {
+        final NavigableMap<Integer, WinRateCount> playersByBand = new TreeMap<>();
+
+        final WinRateCount lostAHomePlanet = new WinRateCount();
+
+        final WinRateCount heldEveryHomePlanet = new WinRateCount();
+
+        int players;
+        int wins;
+        int nonHomePlanetsAtTheirRealCounts;
+
+        void record(boolean isWinner, int nonHomePlanets, boolean lostHome) {
+            players++;
+            if (isWinner) {
+                wins++;
+            }
+            nonHomePlanetsAtTheirRealCounts += nonHomePlanets;
+            playersByBand
+                    .computeIfAbsent(bandStartFor(nonHomePlanets), _ -> new WinRateCount())
+                    .record(isWinner);
+            (lostHome ? lostAHomePlanet : heldEveryHomePlanet).record(isWinner);
+        }
+
+        double winRate() {
+            return players == 0 ? 0 : (double) wins / players;
+        }
+
+        double averageNonHomePlanets() {
+            return players == 0 ? 0 : (double) nonHomePlanetsAtTheirRealCounts / players;
+        }
+
+        double homeLossRate() {
+            return players == 0 ? 0 : (double) lostAHomePlanet.getPlayers() / players;
+        }
+    }
+
+    @Getter
+    private static class WinRateCount {
+        private int players;
+        private int wins;
+
+        void record(boolean isWinner) {
+            players++;
+            if (isWinner) {
+                wins++;
+            }
+        }
+
+        double getWinRate() {
+            return players == 0 ? 0 : (double) wins / players;
+        }
+
+        long percent() {
+            return players == 0 ? 0 : Math.round(wins * 100.0 / players);
+        }
+    }
+}

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -36,6 +36,9 @@ import ti4.model.PlanetModel;
 public class PlanetWinRateStatisticsService {
 
     public static final String POK_ONLY_OPTION = "pok_only";
+    public static final String HOME_LOSS_FACTION_OPTION = "home_loss_faction";
+
+    private static final int HOME_LOSS_GAMES_LISTED = 40;
 
     /**
      * Coexistence carries any faction through a home planet loss, but only the Deepwrought
@@ -78,11 +81,13 @@ public class PlanetWinRateStatisticsService {
 
     public static void queueReply(SlashCommandInteractionEvent event) {
         boolean pokOnly = event.getOption(POK_ONLY_OPTION, false, OptionMapping::getAsBoolean);
-        StatisticsPipeline.queue(event, () -> showPlanetWinRates(event, pokOnly));
+        String homeLossFaction = event.getOption(HOME_LOSS_FACTION_OPTION, null, OptionMapping::getAsString);
+        StatisticsPipeline.queue(event, () -> showPlanetWinRates(event, pokOnly, homeLossFaction));
     }
 
-    private static void showPlanetWinRates(SlashCommandInteractionEvent event, boolean pokOnly) {
-        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly);
+    private static void showPlanetWinRates(
+            SlashCommandInteractionEvent event, boolean pokOnly, String homeLossFaction) {
+        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly, homeLossFaction);
         ConsumeGameUtility.consumeAllGames(
                 GameStatisticsFilterer.getStandardCompetitiveGamesFilter()
                         .and(game -> isEligibleGameType(game, pokOnly)),
@@ -93,7 +98,11 @@ public class PlanetWinRateStatisticsService {
     }
 
     static List<String> buildReport(List<Game> games, boolean pokOnly) {
-        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly);
+        return buildReport(games, pokOnly, null);
+    }
+
+    static List<String> buildReport(List<Game> games, boolean pokOnly, String homeLossFaction) {
+        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly, homeLossFaction);
         games.forEach(game -> accumulateGame(game, stats));
         return buildReport(stats);
     }
@@ -151,6 +160,10 @@ public class PlanetWinRateStatisticsService {
             boolean coexistedThroughALoss =
                     !lostAHomePlanet && homePlanets.stream().anyMatch(coexistedOn::contains);
 
+            if (lostAHomePlanet && faction.equalsIgnoreCase(stats.homeLossFaction)) {
+                stats.homeLossGames.add(describeHomeLoss(game, seat, controlledPlanets, coexistedOn));
+            }
+
             SeatOutcome outcome = new SeatOutcome(
                     isWinner, nonHomePlanets, coexistedOn.size(), lostAHomePlanet, coexistedThroughALoss);
             stats.overall.record(outcome);
@@ -186,6 +199,35 @@ public class PlanetWinRateStatisticsService {
             }
         }
         return coexistedOn;
+    }
+
+    /**
+     * One line per home planet loss for the faction being debugged: which planets went, who has them
+     * now, and whether the home system is still on the board at all.
+     */
+    private static String describeHomeLoss(
+            Game game, PlayerHome seat, Set<String> controlledPlanets, Set<String> coexistedOn) {
+        StringBuilder sb = new StringBuilder("- `").append(game.getName()).append("`");
+        for (String homePlanet : seat.homePlanets().stream().sorted().toList()) {
+            if (controlledPlanets.contains(homePlanet) || coexistedOn.contains(homePlanet)) {
+                continue;
+            }
+            UnitHolder unitHolder = game.getUnitHolderFromPlanet(homePlanet);
+            String holder = game.getRealAndEliminatedPlayers().stream()
+                    .filter(player -> player.getPlanets().contains(homePlanet))
+                    .map(Player::getFaction)
+                    .findFirst()
+                    .orElse(unitHolder == null ? "not on the board" : "nobody");
+            sb.append(' ')
+                    .append(planetName(homePlanet))
+                    .append(" (")
+                    .append(holder)
+                    .append(')');
+        }
+        if (game.getStoredValue("silverFlamed").contains(seat.player().getFaction())) {
+            sb.append(" [silverFlamed]");
+        }
+        return sb.append('\n').toString();
     }
 
     private static boolean isOcean(String planetId) {
@@ -298,8 +340,25 @@ public class PlanetWinRateStatisticsService {
         }
         appendHomePlanetsLostSection(blocks, stats);
         appendPerPlanetSection(blocks, stats);
+        appendHomeLossDebugSection(blocks, stats);
 
         return blocks;
+    }
+
+    private static void appendHomeLossDebugSection(List<String> blocks, PlanetWinRateStats stats) {
+        if (StringUtils.isBlank(stats.homeLossFaction)) {
+            return;
+        }
+        blocks.add("\n### Home planet losses for `" + stats.homeLossFaction + "`\n"
+                + "_Each line names the game, the home planets they ended without, and who holds each one._\n");
+        if (stats.homeLossGames.isEmpty()) {
+            blocks.add("- They never lost a home planet.\n");
+            return;
+        }
+        stats.homeLossGames.stream().limit(HOME_LOSS_GAMES_LISTED).forEach(blocks::add);
+        if (stats.homeLossGames.size() > HOME_LOSS_GAMES_LISTED) {
+            blocks.add("- and " + (stats.homeLossGames.size() - HOME_LOSS_GAMES_LISTED) + " more\n");
+        }
     }
 
     private static void appendSkippedPlayersSection(List<String> blocks, PlanetWinRateStats stats) {
@@ -552,11 +611,16 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static class PlanetWinRateStats {
-        private PlanetWinRateStats(boolean pokOnly) {
+        private PlanetWinRateStats(boolean pokOnly, String homeLossFaction) {
             this.pokOnly = pokOnly;
+            this.homeLossFaction = homeLossFaction;
         }
 
         final boolean pokOnly;
+
+        final String homeLossFaction;
+
+        final List<String> homeLossGames = new ArrayList<>();
 
         final PlanetHoldingStats overall = new PlanetHoldingStats();
 

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -328,7 +328,7 @@ public class PlanetWinRateStatisticsService {
     private static void appendNonHomePlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Win rate by non-home planets controlled\n"
                 + "_Planets held at the end of the game outside the player's own home system."
-                + " Trade stations are not counted, and neither is coexisting on a planet without controlling it._\n"
+                + " Trade stations and coexisting do not count._\n"
                 + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
 
         blocks.add(renderBandedGroup("**All factions**", stats.overall));
@@ -459,7 +459,8 @@ public class PlanetWinRateStatisticsService {
                     .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
                     .append(" when they did not");
         }
-        appendCoexistedThrough(sb, group);
+        // No coexistence line here: it belongs to the one faction that can do it, not to a total
+        // that every other faction is counted into.
         return sb.append('\n').toString();
     }
 

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -105,9 +105,33 @@ public class PlanetWinRateStatisticsService {
         return pokOnly ? !game.isThundersEdge() : game.isThundersEdge();
     }
 
+    /**
+     * Some games sit on a Thunder's Edge board without carrying the flag, so a run that means to be
+     * free of Thunder's Edge has to look at what is actually on the table rather than trust the mode.
+     */
+    static boolean hasOnlyProphecyOfKingsPlanets(Game game) {
+        return everyPlanetInPlay(game)
+                .map(Mapper::getPlanet)
+                .allMatch(planet -> planet != null
+                        && planet.getSource() != null
+                        && planet.getSource().isPok());
+    }
+
+    private static Stream<String> everyPlanetInPlay(Game game) {
+        return Stream.concat(
+                game.getTileMap().values().stream()
+                        .flatMap(tile -> tile.getPlanetUnitHolders().stream())
+                        .map(UnitHolder::getName),
+                game.getRealAndEliminatedPlayers().stream().flatMap(player -> player.getPlanets().stream()));
+    }
+
     private static void accumulateGame(Game game, PlanetWinRateStats stats) {
         Player winner = game.getWinner().orElse(null);
         if (winner == null || !isEligibleGameType(game, stats.pokOnly)) {
+            return;
+        }
+        if (stats.pokOnly && !hasOnlyProphecyOfKingsPlanets(game)) {
+            stats.gamesWithLaterPlanets++;
             return;
         }
         stats.games++;
@@ -281,7 +305,7 @@ public class PlanetWinRateStatisticsService {
         header.append("_Planets each player controlled at the end of the game. Oceans are never counted._\n");
         header.append(
                         stats.pokOnly
-                                ? "_Prophecy of Kings games without Thunder's Edge."
+                                ? "_Prophecy of Kings games with no Thunder's Edge planets on the table."
                                 : "_Games with both Prophecy of Kings and Thunder's Edge.")
                 .append(" 6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario,"
                         + " non-Twilight's-Fall, with winners._\n");
@@ -293,6 +317,7 @@ public class PlanetWinRateStatisticsService {
                                     : "None of the " + stats.games
                                             + " matching games had a player whose home planets could be identified.")
                     .append('\n');
+            appendGamesDroppedForLaterPlanets(header, stats);
             blocks.add(header.toString());
             return blocks;
         }
@@ -301,6 +326,7 @@ public class PlanetWinRateStatisticsService {
                 .append(" | Players analyzed: ")
                 .append(stats.overall.players)
                 .append('\n');
+        appendGamesDroppedForLaterPlanets(header, stats);
         blocks.add(header.toString());
         appendSkippedPlayersSection(blocks, stats);
 
@@ -312,6 +338,15 @@ public class PlanetWinRateStatisticsService {
         appendPerPlanetSection(blocks, stats);
 
         return blocks;
+    }
+
+    private static void appendGamesDroppedForLaterPlanets(StringBuilder header, PlanetWinRateStats stats) {
+        if (stats.gamesWithLaterPlanets == 0) {
+            return;
+        }
+        header.append("Dropped ")
+                .append(stats.gamesWithLaterPlanets)
+                .append(" game(s) that were not flagged as Thunder's Edge but had planets from it in play.\n");
     }
 
     private static void appendSkippedPlayersSection(List<String> blocks, PlanetWinRateStats stats) {
@@ -590,6 +625,7 @@ public class PlanetWinRateStatisticsService {
         final Map<String, String> skippedGameNames = new HashMap<>();
 
         int games;
+        int gamesWithLaterPlanets;
         int playersWithoutAKnownHome;
     }
 

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -449,7 +449,7 @@ public class PlanetWinRateStatisticsService {
     private static void appendHomePlanetsLostSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Home planets lost\n"
                 + "_Players who ended the game without every planet of their own home system. Coexisting on one"
-                + " counts as holding it, so keeping a home system means holding or coexisting on all of it._\n");
+                + " counts as holding it._\n");
 
         blocks.add(renderCombinedHomePlanetsLostLine(stats.overall));
         wellSampledFactions(stats)

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
 import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
+import ti4.game.Planet;
 import ti4.game.Player;
 import ti4.game.UnitHolder;
 import ti4.game.persistence.ConsumeGameUtility;
@@ -126,13 +127,16 @@ public class PlanetWinRateStatisticsService {
                     .filter(planet -> !homePlanets.contains(planet))
                     .filter(planet -> !isTradeStation(planet))
                     .count();
-            boolean lostAHomePlanet = !controlledPlanets.containsAll(homePlanets);
+            Set<String> coexistedOn = coexistedHomePlanets(game, seat.player(), homePlanets, controlledPlanets);
+            boolean lostAHomePlanet = homePlanets.stream()
+                    .anyMatch(planet -> !controlledPlanets.contains(planet) && !coexistedOn.contains(planet));
+            boolean coexistedThroughALoss = !lostAHomePlanet && !coexistedOn.isEmpty();
 
-            stats.overall.record(isWinner, nonHomePlanets, lostAHomePlanet);
+            stats.overall.record(isWinner, nonHomePlanets, lostAHomePlanet, coexistedThroughALoss);
             for (String factionKey : FactionStatisticsHelper.getStatisticsFactionKeys(faction)) {
                 stats.byFaction
                         .computeIfAbsent(factionKey, _ -> new PlanetHoldingStats())
-                        .record(isWinner, nonHomePlanets, lostAHomePlanet);
+                        .record(isWinner, nonHomePlanets, lostAHomePlanet, coexistedThroughALoss);
             }
 
             controlledPlanets.stream()
@@ -141,6 +145,26 @@ public class PlanetWinRateStatisticsService {
                             .computeIfAbsent(planet, _ -> new WinRateCount())
                             .record(isWinner));
         }
+    }
+
+    /**
+     * Home planets the player no longer controls but still has ground forces or structures on. The
+     * same reading of coexistence {@link Player#getPlanetsForScoring} takes, scoped to the planets
+     * this section is asking about.
+     */
+    private static Set<String> coexistedHomePlanets(
+            Game game, Player player, Set<String> homePlanets, Set<String> controlledPlanets) {
+        Set<String> coexistedOn = new HashSet<>();
+        for (String homePlanet : homePlanets) {
+            if (controlledPlanets.contains(homePlanet)) {
+                continue;
+            }
+            if (game.getUnitHolderFromPlanet(homePlanet) instanceof Planet planet
+                    && (planet.hasGroundForces(player) || planet.hasStructures(player))) {
+                coexistedOn.add(homePlanet);
+            }
+        }
+        return coexistedOn;
     }
 
     private static boolean isOcean(String planetId) {
@@ -338,7 +362,8 @@ public class PlanetWinRateStatisticsService {
 
     private static void appendHomePlanetsLostSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Home planets lost\n"
-                + "_Players who did not control every planet of their own home system at the end of the game._\n");
+                + "_Players who did not control every planet of their own home system at the end of the game."
+                + " Coexisting on one counts as holding it._\n");
 
         blocks.add(renderCombinedHomePlanetsLostLine(stats.overall));
         wellSampledFactions(stats)
@@ -349,29 +374,44 @@ public class PlanetWinRateStatisticsService {
 
     private static String renderCombinedHomePlanetsLostLine(PlanetHoldingStats group) {
         StringBuilder sb = appendHomePlanetsLostCount(new StringBuilder("- **All factions**: "), group);
-        if (group.lostAHomePlanet.getPlayers() == 0) {
-            return sb.append(" of players lost a home planet\n").toString();
+        sb.append(" of players lost a home planet");
+        if (group.lostAHomePlanet.getPlayers() > 0) {
+            sb.append(". ")
+                    .append(ActionCardStatsService.formatPercent(group.lostAHomePlanet.getWinRate()))
+                    .append(" win rate when they did, ")
+                    .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
+                    .append(" when they did not");
         }
-        return sb.append(" of players lost a home planet. ")
-                .append(ActionCardStatsService.formatPercent(group.lostAHomePlanet.getWinRate()))
-                .append(" win rate when they did, ")
-                .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
-                .append(" when they did not\n")
-                .toString();
+        appendCoexistedThrough(sb, group);
+        return sb.append('\n').toString();
     }
 
     private static String renderFactionHomePlanetsLostLine(String label, PlanetHoldingStats group) {
         StringBuilder sb =
                 appendHomePlanetsLostCount(new StringBuilder("- ").append(label).append(": "), group);
-        if (group.lostAHomePlanet.getPlayers() == 0) {
-            return sb.append(" homes lost\n").toString();
+        sb.append(" homes lost");
+        if (group.lostAHomePlanet.getPlayers() > 0) {
+            sb.append(". ")
+                    .append(ActionCardStatsService.formatPercent(group.lostAHomePlanet.getWinRate()))
+                    .append(" win rate, ")
+                    .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
+                    .append(" otherwise");
         }
-        return sb.append(" homes lost. ")
-                .append(ActionCardStatsService.formatPercent(group.lostAHomePlanet.getWinRate()))
-                .append(" win rate, ")
-                .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
-                .append(" otherwise\n")
-                .toString();
+        appendCoexistedThrough(sb, group);
+        return sb.append('\n').toString();
+    }
+
+    private static void appendCoexistedThrough(StringBuilder sb, PlanetHoldingStats group) {
+        if (group.coexistedThroughLosses == 0) {
+            return;
+        }
+        sb.append(". Coexisted through ")
+                .append(group.coexistedThroughLosses)
+                .append('/')
+                .append(group.homeControlLosses())
+                .append(" (")
+                .append(ActionCardStatsService.formatPercent(group.coexistedThroughRate()))
+                .append(") of home system losses.");
     }
 
     private static StringBuilder appendHomePlanetsLostCount(StringBuilder sb, PlanetHoldingStats group) {
@@ -450,17 +490,31 @@ public class PlanetWinRateStatisticsService {
         int players;
         int wins;
         int nonHomePlanetsAtTheirRealCounts;
+        int coexistedThroughLosses;
 
-        void record(boolean isWinner, int nonHomePlanets, boolean lostHome) {
+        void record(boolean isWinner, int nonHomePlanets, boolean lostHome, boolean coexistedThroughALoss) {
             players++;
             if (isWinner) {
                 wins++;
             }
             nonHomePlanetsAtTheirRealCounts += nonHomePlanets;
+            if (coexistedThroughALoss) {
+                coexistedThroughLosses++;
+            }
             playersByBand
                     .computeIfAbsent(bandStartFor(nonHomePlanets), _ -> new WinRateCount())
                     .record(isWinner);
             (lostHome ? lostAHomePlanet : heldEveryHomePlanet).record(isWinner);
+        }
+
+        /** Losses of control, before coexistence hands some of them back. */
+        int homeControlLosses() {
+            return lostAHomePlanet.getPlayers() + coexistedThroughLosses;
+        }
+
+        double coexistedThroughRate() {
+            int losses = homeControlLosses();
+            return losses == 0 ? 0 : (double) coexistedThroughLosses / losses;
         }
 
         double winRate() {

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -23,6 +23,7 @@ import ti4.executors.ExecutionLockType;
 import ti4.game.Game;
 import ti4.game.Planet;
 import ti4.game.Player;
+import ti4.game.Tile;
 import ti4.game.UnitHolder;
 import ti4.game.persistence.ConsumeGameUtility;
 import ti4.helpers.AliasHandler;
@@ -36,8 +37,15 @@ public class PlanetWinRateStatisticsService {
 
     public static final String POK_ONLY_OPTION = "pok_only";
 
+    /**
+     * The Deepwrought Scholarate is the one faction that holds ground alongside whoever controls a
+     * planet, so it is the only one whose coexistence can carry it through losing a home planet.
+     */
+    private static final String COEXISTING_FACTION = "deepwrought";
+
     private static final int BAND_SIZE = 2;
     private static final int OPEN_ENDED_BAND_START = 11;
+    private static final int COEXIST_OPEN_ENDED_BAND_START = 5;
     private static final int MINIMUM_FACTION_PLAYERS = 25;
     private static final int SKIPPED_FACTIONS_LISTED = 10;
 
@@ -56,6 +64,12 @@ public class PlanetWinRateStatisticsService {
     private static final Comparator<Entry<String, PlanetHoldingStats>> BY_AVERAGE_NON_HOME_PLANETS_DESC =
             Comparator.comparingDouble((Entry<String, PlanetHoldingStats> entry) ->
                             entry.getValue().averageNonHomePlanets())
+                    .reversed()
+                    .thenComparing(Entry::getKey);
+
+    private static final Comparator<Entry<String, PlanetHoldingStats>> BY_AVERAGE_COEXISTED_PLANETS_DESC =
+            Comparator.comparingDouble((Entry<String, PlanetHoldingStats> entry) ->
+                            entry.getValue().averageCoexistedPlanets())
                     .reversed()
                     .thenComparing(Entry::getKey);
 
@@ -127,16 +141,20 @@ public class PlanetWinRateStatisticsService {
                     .filter(planet -> !homePlanets.contains(planet))
                     .filter(planet -> !isTradeStation(planet))
                     .count();
-            Set<String> coexistedOn = coexistedHomePlanets(game, seat.player(), homePlanets, controlledPlanets);
+            Set<String> coexistedOn = coexistedPlanets(game, seat.player(), controlledPlanets);
+            Set<String> coexistedHomePlanets = COEXISTING_FACTION.equalsIgnoreCase(faction) ? coexistedOn : Set.of();
             boolean lostAHomePlanet = homePlanets.stream()
-                    .anyMatch(planet -> !controlledPlanets.contains(planet) && !coexistedOn.contains(planet));
-            boolean coexistedThroughALoss = !lostAHomePlanet && !coexistedOn.isEmpty();
+                    .anyMatch(planet -> !controlledPlanets.contains(planet) && !coexistedHomePlanets.contains(planet));
+            boolean coexistedThroughALoss =
+                    !lostAHomePlanet && homePlanets.stream().anyMatch(coexistedHomePlanets::contains);
 
-            stats.overall.record(isWinner, nonHomePlanets, lostAHomePlanet, coexistedThroughALoss);
+            SeatOutcome outcome = new SeatOutcome(
+                    isWinner, nonHomePlanets, coexistedOn.size(), lostAHomePlanet, coexistedThroughALoss);
+            stats.overall.record(outcome);
             for (String factionKey : FactionStatisticsHelper.getStatisticsFactionKeys(faction)) {
                 stats.byFaction
                         .computeIfAbsent(factionKey, _ -> new PlanetHoldingStats())
-                        .record(isWinner, nonHomePlanets, lostAHomePlanet, coexistedThroughALoss);
+                        .record(outcome);
             }
 
             controlledPlanets.stream()
@@ -148,20 +166,20 @@ public class PlanetWinRateStatisticsService {
     }
 
     /**
-     * Home planets the player no longer controls but still has ground forces or structures on. The
-     * same reading of coexistence {@link Player#getPlanetsForScoring} takes, scoped to the planets
-     * this section is asking about.
+     * Planets the player does not control but still has ground forces or structures on - the same
+     * reading of coexistence {@link Player#getPlanetsForScoring} takes.
      */
-    private static Set<String> coexistedHomePlanets(
-            Game game, Player player, Set<String> homePlanets, Set<String> controlledPlanets) {
+    private static Set<String> coexistedPlanets(Game game, Player player, Set<String> controlledPlanets) {
         Set<String> coexistedOn = new HashSet<>();
-        for (String homePlanet : homePlanets) {
-            if (controlledPlanets.contains(homePlanet)) {
-                continue;
-            }
-            if (game.getUnitHolderFromPlanet(homePlanet) instanceof Planet planet
-                    && (planet.hasGroundForces(player) || planet.hasStructures(player))) {
-                coexistedOn.add(homePlanet);
+        for (Tile tile : game.getTileMap().values()) {
+            for (Planet planet : tile.getPlanetUnitHolders()) {
+                String planetId = planet.getName();
+                if (controlledPlanets.contains(planetId) || isOcean(planetId)) {
+                    continue;
+                }
+                if (planet.hasGroundForces(player) || planet.hasStructures(player)) {
+                    coexistedOn.add(planetId);
+                }
             }
         }
         return coexistedOn;
@@ -234,6 +252,13 @@ public class PlanetWinRateStatisticsService {
 
     private record PlayerHome(Player player, Set<String> homePlanets) {}
 
+    private record SeatOutcome(
+            boolean isWinner,
+            int nonHomePlanets,
+            int coexistedPlanets,
+            boolean lostHome,
+            boolean coexistedThroughALoss) {}
+
     private static List<String> buildReport(PlanetWinRateStats stats) {
         List<String> blocks = new ArrayList<>();
 
@@ -265,6 +290,7 @@ public class PlanetWinRateStatisticsService {
         appendSkippedPlayersSection(blocks, stats);
 
         appendNonHomePlanetsSection(blocks, stats);
+        appendCoexistedPlanetsSection(blocks, stats);
         appendHomePlanetsLostSection(blocks, stats);
         appendPerPlanetSection(blocks, stats);
 
@@ -302,7 +328,7 @@ public class PlanetWinRateStatisticsService {
     private static void appendNonHomePlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Win rate by non-home planets controlled\n"
                 + "_Planets held at the end of the game outside the player's own home system."
-                + " Trade stations are not counted._\n"
+                + " Trade stations are not counted, and neither is coexisting on a planet without controlling it._\n"
                 + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
 
         blocks.add(renderBandedGroup("**All factions**", stats.overall));
@@ -360,10 +386,61 @@ public class PlanetWinRateStatisticsService {
         sb.append(bandStart).append('-').append(bandStart + BAND_SIZE - 1).append(" planets");
     }
 
+    private static int coexistBandStartFor(int planets) {
+        return Math.min(planets, COEXIST_OPEN_ENDED_BAND_START);
+    }
+
+    private static void appendCoexistBandLabel(StringBuilder sb, int bandStart) {
+        sb.append(bandStart)
+                .append(
+                        bandStart >= COEXIST_OPEN_ENDED_BAND_START
+                                ? "+ planets"
+                                : bandStart == 1 ? " planet" : " planets");
+    }
+
+    private static void appendCoexistedPlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
+        blocks.add("\n### Win rate by planets coexisted on\n"
+                + "_Planets a player had ground forces or structures on at the end of the game without controlling"
+                + " them._\n"
+                + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
+
+        blocks.add(renderCoexistGroup("**All factions**", stats.overall));
+        wellSampledFactions(stats)
+                .sorted(BY_AVERAGE_COEXISTED_PLANETS_DESC)
+                .forEach(entry -> blocks.add(renderCoexistGroup(factionLabel(entry.getKey()), entry.getValue())));
+    }
+
+    private static String renderCoexistGroup(String label, PlanetHoldingStats group) {
+        StringBuilder sb = new StringBuilder("- ");
+        sb.append(label)
+                .append(": ")
+                .append(String.format("%.2f", group.averageCoexistedPlanets()))
+                .append(" planets coexisted on on average, ")
+                .append(ActionCardStatsService.formatPercent(group.winRate()))
+                .append(" win rate from ");
+        ActionCardStatsService.appendCount(sb, group.players, "player");
+        sb.append('\n');
+
+        group.playersByCoexistBand.forEach((bandStart, count) -> {
+            sb.append("  - ");
+            appendCoexistBandLabel(sb, bandStart);
+            sb.append(": ")
+                    .append(ActionCardStatsService.formatPercent(count.getWinRate()))
+                    .append(" (")
+                    .append(count.getWins())
+                    .append('/')
+                    .append(count.getPlayers())
+                    .append("; ")
+                    .append(ActionCardStatsService.formatPercent(count.getPlayers() / (double) group.players))
+                    .append(")\n");
+        });
+        return sb.toString();
+    }
+
     private static void appendHomePlanetsLostSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Home planets lost\n"
                 + "_Players who did not control every planet of their own home system at the end of the game."
-                + " Coexisting on one counts as holding it._\n");
+                + " For the Deepwrought Scholarate, coexisting on one counts as holding it._\n");
 
         blocks.add(renderCombinedHomePlanetsLostLine(stats.overall));
         wellSampledFactions(stats)
@@ -487,24 +564,35 @@ public class PlanetWinRateStatisticsService {
 
         final WinRateCount heldEveryHomePlanet = new WinRateCount();
 
+        final NavigableMap<Integer, WinRateCount> playersByCoexistBand = new TreeMap<>();
+
         int players;
         int wins;
         int nonHomePlanetsAtTheirRealCounts;
+        int coexistedPlanetsAtTheirRealCounts;
         int coexistedThroughLosses;
 
-        void record(boolean isWinner, int nonHomePlanets, boolean lostHome, boolean coexistedThroughALoss) {
+        void record(SeatOutcome outcome) {
             players++;
-            if (isWinner) {
+            if (outcome.isWinner()) {
                 wins++;
             }
-            nonHomePlanetsAtTheirRealCounts += nonHomePlanets;
-            if (coexistedThroughALoss) {
+            nonHomePlanetsAtTheirRealCounts += outcome.nonHomePlanets();
+            coexistedPlanetsAtTheirRealCounts += outcome.coexistedPlanets();
+            if (outcome.coexistedThroughALoss()) {
                 coexistedThroughLosses++;
             }
             playersByBand
-                    .computeIfAbsent(bandStartFor(nonHomePlanets), _ -> new WinRateCount())
-                    .record(isWinner);
-            (lostHome ? lostAHomePlanet : heldEveryHomePlanet).record(isWinner);
+                    .computeIfAbsent(bandStartFor(outcome.nonHomePlanets()), _ -> new WinRateCount())
+                    .record(outcome.isWinner());
+            playersByCoexistBand
+                    .computeIfAbsent(coexistBandStartFor(outcome.coexistedPlanets()), _ -> new WinRateCount())
+                    .record(outcome.isWinner());
+            (outcome.lostHome() ? lostAHomePlanet : heldEveryHomePlanet).record(outcome.isWinner());
+        }
+
+        double averageCoexistedPlanets() {
+            return players == 0 ? 0 : (double) coexistedPlanetsAtTheirRealCounts / players;
         }
 
         /** Losses of control, before coexistence hands some of them back. */

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -38,8 +38,8 @@ public class PlanetWinRateStatisticsService {
     public static final String POK_ONLY_OPTION = "pok_only";
 
     /**
-     * The Deepwrought Scholarate is the one faction that holds ground alongside whoever controls a
-     * planet, so it is the only one whose coexistence can carry it through losing a home planet.
+     * Coexistence carries any faction through a home planet loss, but only the Deepwrought
+     * Scholarate does it often enough for the count to be worth a line of its own.
      */
     private static final String COEXISTING_FACTION = "deepwrought";
 
@@ -145,11 +145,11 @@ public class PlanetWinRateStatisticsService {
                     .filter(planet -> !isTradeStation(planet))
                     .count();
             Set<String> coexistedOn = coexistedPlanets(game, seat.player(), controlledPlanets);
-            Set<String> coexistedHomePlanets = COEXISTING_FACTION.equalsIgnoreCase(faction) ? coexistedOn : Set.of();
+            // A home system is kept only by holding or coexisting on every planet in it.
             boolean lostAHomePlanet = homePlanets.stream()
-                    .anyMatch(planet -> !controlledPlanets.contains(planet) && !coexistedHomePlanets.contains(planet));
+                    .anyMatch(planet -> !controlledPlanets.contains(planet) && !coexistedOn.contains(planet));
             boolean coexistedThroughALoss =
-                    !lostAHomePlanet && homePlanets.stream().anyMatch(coexistedHomePlanets::contains);
+                    !lostAHomePlanet && homePlanets.stream().anyMatch(coexistedOn::contains);
 
             SeatOutcome outcome = new SeatOutcome(
                     isWinner, nonHomePlanets, coexistedOn.size(), lostAHomePlanet, coexistedThroughALoss);
@@ -293,7 +293,9 @@ public class PlanetWinRateStatisticsService {
         appendSkippedPlayersSection(blocks, stats);
 
         appendNonHomePlanetsSection(blocks, stats);
-        appendCoexistedPlanetsSection(blocks, stats);
+        if (!stats.pokOnly) {
+            appendCoexistedPlanetsSection(blocks, stats);
+        }
         appendHomePlanetsLostSection(blocks, stats);
         appendPerPlanetSection(blocks, stats);
 
@@ -446,14 +448,16 @@ public class PlanetWinRateStatisticsService {
 
     private static void appendHomePlanetsLostSection(List<String> blocks, PlanetWinRateStats stats) {
         blocks.add("\n### Home planets lost\n"
-                + "_Players who did not control every planet of their own home system at the end of the game."
-                + " For the Deepwrought Scholarate, coexisting on one counts as holding it._\n");
+                + "_Players who ended the game without every planet of their own home system. Coexisting on one"
+                + " counts as holding it, so keeping a home system means holding or coexisting on all of it._\n");
 
         blocks.add(renderCombinedHomePlanetsLostLine(stats.overall));
         wellSampledFactions(stats)
                 .sorted(BY_HOME_LOSS_RATE_DESC)
-                .forEach(entry ->
-                        blocks.add(renderFactionHomePlanetsLostLine(factionLabel(entry.getKey()), entry.getValue())));
+                .forEach(entry -> blocks.add(renderFactionHomePlanetsLostLine(
+                        factionLabel(entry.getKey()),
+                        entry.getValue(),
+                        COEXISTING_FACTION.equalsIgnoreCase(entry.getKey()))));
     }
 
     private static String renderCombinedHomePlanetsLostLine(PlanetHoldingStats group) {
@@ -471,7 +475,8 @@ public class PlanetWinRateStatisticsService {
         return sb.append('\n').toString();
     }
 
-    private static String renderFactionHomePlanetsLostLine(String label, PlanetHoldingStats group) {
+    private static String renderFactionHomePlanetsLostLine(
+            String label, PlanetHoldingStats group, boolean showCoexistence) {
         StringBuilder sb =
                 appendHomePlanetsLostCount(new StringBuilder("- ").append(label).append(": "), group);
         sb.append(" homes lost");
@@ -482,7 +487,9 @@ public class PlanetWinRateStatisticsService {
                     .append(ActionCardStatsService.formatPercent(group.heldEveryHomePlanet.getWinRate()))
                     .append(" otherwise");
         }
-        appendCoexistedThrough(sb, group);
+        if (showCoexistence) {
+            appendCoexistedThrough(sb, group);
+        }
         return sb.append('\n').toString();
     }
 

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -136,7 +136,7 @@ public class PlanetWinRateStatisticsService {
             }
 
             controlledPlanets.stream()
-                    .filter(planet -> !everyHomePlanetOnTheBoard.contains(planet))
+                    .filter(planet -> !everyHomePlanetOnTheBoard.contains(planet) && !isFactionHomeworld(planet))
                     .forEach(planet -> stats.byPlanet
                             .computeIfAbsent(planet, _ -> new WinRateCount())
                             .record(isWinner));
@@ -151,6 +151,11 @@ public class PlanetWinRateStatisticsService {
     private static boolean isTradeStation(String planetId) {
         PlanetModel planetModel = Mapper.getPlanet(planetId);
         return planetModel != null && planetModel.isSpaceStation();
+    }
+
+    private static boolean isFactionHomeworld(String planetId) {
+        PlanetModel planetModel = Mapper.getPlanet(planetId);
+        return planetModel != null && StringUtils.isNotBlank(planetModel.getFactionHomeworld());
     }
 
     private static Set<String> getHomePlanets(Game game, Player player) {
@@ -168,7 +173,7 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static Set<String> getHomePlanetsFromTheBoard(Game game, Player player) {
-        return Stream.of(player.getHomeSystemPosition(), player.getPlayerStatsAnchorPosition())
+        Set<String> atTheirPosition = Stream.of(player.getHomeSystemPosition(), player.getPlayerStatsAnchorPosition())
                 .filter(position -> StringUtils.isNotBlank(position) && !"null".equalsIgnoreCase(position))
                 .map(game::getTileByPosition)
                 .filter(tile -> tile != null && tile.isHomeSystem())
@@ -178,6 +183,29 @@ public class PlanetWinRateStatisticsService {
                 .filter(homePlanets -> !homePlanets.isEmpty())
                 .findFirst()
                 .orElse(Set.of());
+        return atTheirPosition.isEmpty() ? homeworldsBelongingTo(game, player.getFaction()) : atTheirPosition;
+    }
+
+    private static Set<String> homeworldsBelongingTo(Game game, String faction) {
+        return game.getTileMap().values().stream()
+                .flatMap(tile -> tile.getPlanetUnitHolders().stream())
+                .map(UnitHolder::getName)
+                .filter(planetId -> isHomeworldOf(planetId, faction))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Older games stored Keleres as a bare "keleres", which no faction file answers to, while its
+     * homeworlds are marked for keleresa, keleresm and keleresx. Only one of those is ever on a
+     * board, so the alias the planet names starting with the one the player carries picks it out.
+     */
+    private static boolean isHomeworldOf(String planetId, String faction) {
+        PlanetModel planetModel = Mapper.getPlanet(planetId);
+        if (planetModel == null || StringUtils.isBlank(planetModel.getFactionHomeworld())) {
+            return false;
+        }
+        String homeworldFaction = planetModel.getFactionHomeworld().toLowerCase(Locale.ROOT);
+        return homeworldFaction.startsWith(faction.toLowerCase(Locale.ROOT));
     }
 
     private record PlayerHome(Player player, Set<String> homePlanets) {}

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -165,7 +165,12 @@ public class PlanetWinRateStatisticsService {
             }
 
             SeatOutcome outcome = new SeatOutcome(
-                    isWinner, nonHomePlanets, coexistedOn.size(), lostAHomePlanet, coexistedThroughALoss);
+                    isWinner,
+                    nonHomePlanets,
+                    coexistedOn.size(),
+                    lostAHomePlanet,
+                    coexistedThroughALoss,
+                    wasSilverFlamed(game, faction));
             stats.overall.record(outcome);
             for (String factionKey : FactionStatisticsHelper.getStatisticsFactionKeys(faction)) {
                 stats.byFaction
@@ -224,10 +229,20 @@ public class PlanetWinRateStatisticsService {
                     .append(holder)
                     .append(')');
         }
-        if (game.getStoredValue("silverFlamed").contains(seat.player().getFaction())) {
+        if (wasSilverFlamed(game, seat.player().getFaction())) {
             sb.append(" [silverFlamed]");
         }
         return sb.append('\n').toString();
+    }
+
+    /**
+     * The Silver Flame purges a home system outright - SilverFlameService strips its planets from
+     * everyone, removes the tile and drops a silver flame tile in its place, so nobody took it. It
+     * stores the one faction it happened to under a single key, so this is an equality test rather
+     * than a lookup in a list.
+     */
+    private static boolean wasSilverFlamed(Game game, String faction) {
+        return game.getStoredValue("silverFlamed").equalsIgnoreCase(faction);
     }
 
     private static boolean isOcean(String planetId) {
@@ -302,7 +317,8 @@ public class PlanetWinRateStatisticsService {
             int nonHomePlanets,
             int coexistedPlanets,
             boolean lostHome,
-            boolean coexistedThroughALoss) {}
+            boolean coexistedThroughALoss,
+            boolean silverFlamed) {}
 
     private static List<String> buildReport(PlanetWinRateStats stats) {
         List<String> blocks = new ArrayList<>();
@@ -531,6 +547,7 @@ public class PlanetWinRateStatisticsService {
         }
         // No coexistence line here: it belongs to the one faction that can do it, not to a total
         // that every other faction is counted into.
+        appendSilverFlames(sb, group);
         return sb.append('\n').toString();
     }
 
@@ -549,7 +566,19 @@ public class PlanetWinRateStatisticsService {
         if (showCoexistence) {
             appendCoexistedThrough(sb, group);
         }
+        appendSilverFlames(sb, group);
         return sb.append('\n').toString();
+    }
+
+    private static void appendSilverFlames(StringBuilder sb, PlanetHoldingStats group) {
+        if (group.silverFlamed.getPlayers() == 0) {
+            return;
+        }
+        sb.append(". ")
+                .append(group.silverFlamed.getPlayers())
+                .append(" Silver Flames (")
+                .append(ActionCardStatsService.formatPercent(group.silverFlamed.getWinRate()))
+                .append(" win rate).");
     }
 
     private static void appendCoexistedThrough(StringBuilder sb, PlanetHoldingStats group) {
@@ -643,6 +672,8 @@ public class PlanetWinRateStatisticsService {
 
         final WinRateCount heldEveryHomePlanet = new WinRateCount();
 
+        final WinRateCount silverFlamed = new WinRateCount();
+
         final NavigableMap<Integer, WinRateCount> playersByCoexistBand = new TreeMap<>();
 
         int players;
@@ -668,6 +699,9 @@ public class PlanetWinRateStatisticsService {
                     .computeIfAbsent(coexistBandStartFor(outcome.coexistedPlanets()), _ -> new WinRateCount())
                     .record(outcome.isWinner());
             (outcome.lostHome() ? lostAHomePlanet : heldEveryHomePlanet).record(outcome.isWinner());
+            if (outcome.silverFlamed()) {
+                silverFlamed.record(outcome.isWinner());
+            }
         }
 
         double averageCoexistedPlanets() {

--- a/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/PlanetWinRateStatisticsService.java
@@ -36,9 +36,6 @@ import ti4.model.PlanetModel;
 public class PlanetWinRateStatisticsService {
 
     public static final String POK_ONLY_OPTION = "pok_only";
-    public static final String HOME_LOSS_FACTION_OPTION = "home_loss_faction";
-
-    private static final int HOME_LOSS_GAMES_LISTED = 40;
 
     /**
      * Coexistence carries any faction through a home planet loss, but only the Deepwrought
@@ -81,13 +78,11 @@ public class PlanetWinRateStatisticsService {
 
     public static void queueReply(SlashCommandInteractionEvent event) {
         boolean pokOnly = event.getOption(POK_ONLY_OPTION, false, OptionMapping::getAsBoolean);
-        String homeLossFaction = event.getOption(HOME_LOSS_FACTION_OPTION, null, OptionMapping::getAsString);
-        StatisticsPipeline.queue(event, () -> showPlanetWinRates(event, pokOnly, homeLossFaction));
+        StatisticsPipeline.queue(event, () -> showPlanetWinRates(event, pokOnly));
     }
 
-    private static void showPlanetWinRates(
-            SlashCommandInteractionEvent event, boolean pokOnly, String homeLossFaction) {
-        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly, homeLossFaction);
+    private static void showPlanetWinRates(SlashCommandInteractionEvent event, boolean pokOnly) {
+        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly);
         ConsumeGameUtility.consumeAllGames(
                 GameStatisticsFilterer.getStandardCompetitiveGamesFilter()
                         .and(game -> isEligibleGameType(game, pokOnly)),
@@ -98,24 +93,16 @@ public class PlanetWinRateStatisticsService {
     }
 
     static List<String> buildReport(List<Game> games, boolean pokOnly) {
-        return buildReport(games, pokOnly, null);
-    }
-
-    static List<String> buildReport(List<Game> games, boolean pokOnly, String homeLossFaction) {
-        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly, homeLossFaction);
+        PlanetWinRateStats stats = new PlanetWinRateStats(pokOnly);
         games.forEach(game -> accumulateGame(game, stats));
         return buildReport(stats);
     }
 
     static boolean isEligibleGameType(Game game, boolean pokOnly) {
-        if (game.isTwilightsFallMode()) {
+        if (game.isTwilightsFallMode() || !game.isProphecyOfKings()) {
             return false;
         }
-        return pokOnly ? game.isProphecyOfKings() && !game.isThundersEdge() : sampledGameType(game);
-    }
-
-    private static boolean sampledGameType(Game game) {
-        return game.isThundersEdge() || game.isProphecyOfKings();
+        return pokOnly ? !game.isThundersEdge() : game.isThundersEdge();
     }
 
     private static void accumulateGame(Game game, PlanetWinRateStats stats) {
@@ -160,10 +147,6 @@ public class PlanetWinRateStatisticsService {
             boolean coexistedThroughALoss =
                     !lostAHomePlanet && homePlanets.stream().anyMatch(coexistedOn::contains);
 
-            if (lostAHomePlanet && faction.equalsIgnoreCase(stats.homeLossFaction)) {
-                stats.homeLossGames.add(describeHomeLoss(game, seat, controlledPlanets, coexistedOn));
-            }
-
             SeatOutcome outcome = new SeatOutcome(
                     isWinner,
                     nonHomePlanets,
@@ -204,35 +187,6 @@ public class PlanetWinRateStatisticsService {
             }
         }
         return coexistedOn;
-    }
-
-    /**
-     * One line per home planet loss for the faction being debugged: which planets went, who has them
-     * now, and whether the home system is still on the board at all.
-     */
-    private static String describeHomeLoss(
-            Game game, PlayerHome seat, Set<String> controlledPlanets, Set<String> coexistedOn) {
-        StringBuilder sb = new StringBuilder("- `").append(game.getName()).append("`");
-        for (String homePlanet : seat.homePlanets().stream().sorted().toList()) {
-            if (controlledPlanets.contains(homePlanet) || coexistedOn.contains(homePlanet)) {
-                continue;
-            }
-            UnitHolder unitHolder = game.getUnitHolderFromPlanet(homePlanet);
-            String holder = game.getRealAndEliminatedPlayers().stream()
-                    .filter(player -> player.getPlanets().contains(homePlanet))
-                    .map(Player::getFaction)
-                    .findFirst()
-                    .orElse(unitHolder == null ? "not on the board" : "nobody");
-            sb.append(' ')
-                    .append(planetName(homePlanet))
-                    .append(" (")
-                    .append(holder)
-                    .append(')');
-        }
-        if (wasSilverFlamed(game, seat.player().getFaction())) {
-            sb.append(" [silverFlamed]");
-        }
-        return sb.append('\n').toString();
     }
 
     /**
@@ -327,8 +281,8 @@ public class PlanetWinRateStatisticsService {
         header.append("_Planets each player controlled at the end of the game. Oceans are never counted._\n");
         header.append(
                         stats.pokOnly
-                                ? "_Prophecy of Kings games, no Thunder's Edge."
-                                : "_Thunder's Edge and Prophecy" + " of Kings games.")
+                                ? "_Prophecy of Kings games without Thunder's Edge."
+                                : "_Games with both Prophecy of Kings and Thunder's Edge.")
                 .append(" 6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario,"
                         + " non-Twilight's-Fall, with winners._\n");
         if (stats.overall.players == 0) {
@@ -356,32 +310,15 @@ public class PlanetWinRateStatisticsService {
         }
         appendHomePlanetsLostSection(blocks, stats);
         appendPerPlanetSection(blocks, stats);
-        appendHomeLossDebugSection(blocks, stats);
 
         return blocks;
-    }
-
-    private static void appendHomeLossDebugSection(List<String> blocks, PlanetWinRateStats stats) {
-        if (StringUtils.isBlank(stats.homeLossFaction)) {
-            return;
-        }
-        blocks.add("\n### Home planet losses for `" + stats.homeLossFaction + "`\n"
-                + "_Each line names the game, the home planets they ended without, and who holds each one._\n");
-        if (stats.homeLossGames.isEmpty()) {
-            blocks.add("- They never lost a home planet.\n");
-            return;
-        }
-        stats.homeLossGames.stream().limit(HOME_LOSS_GAMES_LISTED).forEach(blocks::add);
-        if (stats.homeLossGames.size() > HOME_LOSS_GAMES_LISTED) {
-            blocks.add("- and " + (stats.homeLossGames.size() - HOME_LOSS_GAMES_LISTED) + " more\n");
-        }
     }
 
     private static void appendSkippedPlayersSection(List<String> blocks, PlanetWinRateStats stats) {
         if (stats.playersWithoutAKnownHome == 0) {
             return;
         }
-        StringBuilder sb = new StringBuilder("\n### Skipped players\n");
+        StringBuilder sb = new StringBuilder("### Skipped players\n");
         sb.append("_")
                 .append(stats.playersWithoutAKnownHome)
                 .append(" player(s) had no home planets on file for their faction and no home system on the board, so"
@@ -406,7 +343,7 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static void appendNonHomePlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
-        blocks.add("\n### Win rate by non-home planets controlled\n"
+        blocks.add("### Win rate by non-home planets controlled\n"
                 + "_Planets held at the end of the game outside the player's own home system."
                 + " Trade stations and coexisting do not count._\n"
                 + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
@@ -479,7 +416,7 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static void appendCoexistedPlanetsSection(List<String> blocks, PlanetWinRateStats stats) {
-        blocks.add("\n### Win rate by planets coexisted on\n"
+        blocks.add("### Win rate by planets coexisted on\n"
                 + "_Each row reads: win rate (wins/players; share of that group's players who got that far)._\n");
 
         List<Entry<String, PlanetHoldingStats>> reported = COEXISTING_FACTIONS.stream()
@@ -522,7 +459,7 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static void appendHomePlanetsLostSection(List<String> blocks, PlanetWinRateStats stats) {
-        blocks.add("\n### Home planets lost\n"
+        blocks.add("### Home planets lost\n"
                 + "_Players who ended the game without every planet of their own home system. Coexisting on one"
                 + " counts as holding it._\n");
 
@@ -600,7 +537,7 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static void appendPerPlanetSection(List<String> blocks, PlanetWinRateStats stats) {
-        blocks.add("\n### Win rate by planet controlled\n"
+        blocks.add("### Win rate by planet controlled\n"
                 + "_A player's win rate when they held the planet at the end of the game. Home planets are left"
                 + " out._\n");
 
@@ -636,16 +573,11 @@ public class PlanetWinRateStatisticsService {
     }
 
     private static class PlanetWinRateStats {
-        private PlanetWinRateStats(boolean pokOnly, String homeLossFaction) {
+        private PlanetWinRateStats(boolean pokOnly) {
             this.pokOnly = pokOnly;
-            this.homeLossFaction = homeLossFaction;
         }
 
         final boolean pokOnly;
-
-        final String homeLossFaction;
-
-        final List<String> homeLossGames = new ArrayList<>();
 
         final PlanetHoldingStats overall = new PlanetHoldingStats();
 

--- a/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
@@ -121,6 +121,51 @@ class RunAgainstAllGamesTest extends BaseTi4Test {
         return player;
     }
 
+    @Test
+    void shouldNameTheFlavourFromABaseHomeSystemWhoseOwnFactionIsNotPlaying() {
+        // The Xxcha home is on the board and no Xxcha is at the table, so it is the Keleres seat.
+        Game game = gameWithTiles("14", "19", "20");
+        seat(game, "keleres");
+        seat(game, "sol");
+
+        assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isEqualTo("keleresx");
+    }
+
+    @Test
+    void shouldNotClaimABaseHomeSystemItsOwnFactionIsPlaying() {
+        Game game = gameWithTiles("14", "19");
+        seat(game, "keleres");
+        seat(game, "xxcha");
+
+        assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isNull();
+    }
+
+    @Test
+    void shouldNotClaimABaseHomeSystemItsOwnVariantFactionIsPlaying() {
+        Game game = gameWithTiles("02", "19");
+        seat(game, "keleres");
+        seat(game, "pi_mentak");
+
+        assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isNull();
+    }
+
+    @Test
+    void shouldNotGuessBetweenTwoOrphanedBaseHomeSystems() {
+        Game game = gameWithTiles("14", "58");
+        seat(game, "keleres");
+        seat(game, "sol");
+
+        assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isNull();
+    }
+
+    private static void seat(Game game, String faction) {
+        Player player = game.addPlayer(faction + "-user", faction);
+        player.setFaction(faction);
+        player.setColor(COLORS.get(game.getPlayers().size() - 1));
+    }
+
+    private static final List<String> COLORS = List.of("red", "blue", "green", "yellow", "purple", "orange");
+
     private static Player anchoredAt(Game game, String position) {
         Player player = game.addPlayer("user-" + position, "user");
         player.setFaction("keleres");

--- a/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
@@ -207,6 +207,26 @@ class RunAgainstAllGamesTest extends BaseTi4Test {
                 .isEqualTo("101");
     }
 
+    /**
+     * Xxcha's own home has the same planets as the Keleres-Xxcha home, so with Xxcha at the table
+     * that tile is theirs and must not be handed to Keleres.
+     */
+    @Test
+    void shouldNotClaimASharedHomeSystemItsOwnFactionIsPlaying() {
+        Game game = gameWithTiles("14");
+        seat(game, "keleres");
+        seat(game, "xxcha");
+
+        assertThat(RunAgainstAllGames.homeSystemPositionFor(game, "keleresx")).isNull();
+
+        Game keleresOnlyTile = gameWithTiles("92new");
+        seat(keleresOnlyTile, "keleres");
+        seat(keleresOnlyTile, "xxcha");
+
+        assertThat(RunAgainstAllGames.homeSystemPositionFor(keleresOnlyTile, "keleresx"))
+                .isEqualTo("101");
+    }
+
     @Test
     void shouldFindNoHomeSystemPositionWhenTheTileIsGoneFromTheBoard() {
         assertThat(RunAgainstAllGames.homeSystemPositionFor(gameWithTiles("19", "20"), "keleresx"))

--- a/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
@@ -2,39 +2,78 @@ package ti4.discord.interactions.commands.developer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.Tile;
 import ti4.testUtils.BaseTi4Test;
 
 class RunAgainstAllGamesTest extends BaseTi4Test {
 
     @Test
-    void shouldOnlyCleanUpGamesThatRecordAPlayerOnEveryPlay() {
-        assertThat(RunAgainstAllGames.startedAfterPlayerTracking(gameCreatedOn("2026.05.24")))
-                .isTrue();
+    void shouldNameTheFlavourAPlayerStillSittingOnTheirHomeworldWas() {
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("mollprimusk", "wellon")))
+                .isEqualTo("keleresm");
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("archonrenk", "archontauk")))
+                .isEqualTo("keleresx");
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("valkk", "ylirk", "avark")))
+                .isEqualTo("keleresa");
     }
 
     @Test
-    void shouldSkipGamesFromBeforePlayerTrackingBegan() {
-        // Every play in these games is player-less, so a player-less cancel is not evidence of
-        // anything and the cleanup has no way to tell a fabricated one from a real one.
-        assertThat(RunAgainstAllGames.startedAfterPlayerTracking(gameCreatedOn("2026.05.23")))
-                .isFalse();
-        assertThat(RunAgainstAllGames.startedAfterPlayerTracking(gameCreatedOn("2026.01.01")))
-                .isFalse();
+    void shouldNotGuessFromPlanetsThatNameNoFlavourOrMoreThanOne() {
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("wellon", "vefutii")))
+                .isNull();
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding()))
+                .isNull();
+        // Conquering another Keleres home would make the planets disagree - the board decides then.
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("valkk", "mollprimusk")))
+                .isNull();
     }
 
     @Test
-    void shouldSkipGamesItCannotDate() {
-        assertThat(RunAgainstAllGames.startedAfterPlayerTracking(gameCreatedOn("not a date")))
-                .isFalse();
-        assertThat(RunAgainstAllGames.startedAfterPlayerTracking(gameCreatedOn("")))
-                .isFalse();
+    void shouldNameTheFlavourFromTheHomeSystemLeftOnTheBoard() {
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("93new", "19", "20")))
+                .isEqualTo("keleresa");
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("92new")))
+                .isEqualTo("keleresx");
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("94new")))
+                .isEqualTo("keleresm");
     }
 
-    private static Game gameCreatedOn(String creationDate) {
+    @Test
+    void shouldNotGuessFromABoardWithNoKeleresHomeOrMoreThanOne() {
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("19", "20")))
+                .isNull();
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles()))
+                .isNull();
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("92new", "94new")))
+                .isNull();
+    }
+
+    /** The plain Xxcha, Argent and Mentak homes are different systems, and must not be read as Keleres. */
+    @Test
+    void shouldNotReadThePlainHomeSystemsAsKeleres() {
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("92", "93", "94")))
+                .isNull();
+    }
+
+    private static Player playerHolding(String... planets) {
         Game game = new Game();
-        game.setCreationDate(creationDate);
+        Player player = game.addPlayer("user", "user");
+        player.setFaction("keleres");
+        player.setColor("red");
+        player.getPlanets().addAll(List.of(planets));
+        return player;
+    }
+
+    private static Game gameWithTiles(String... tileIds) {
+        Game game = new Game();
+        int position = 101;
+        for (String tileId : tileIds) {
+            game.setTile(new Tile(tileId, Integer.toString(position++)));
+        }
         return game;
     }
 }

--- a/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
@@ -158,10 +158,68 @@ class RunAgainstAllGamesTest extends BaseTi4Test {
         assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isNull();
     }
 
-    private static void seat(Game game, String faction) {
+    /**
+     * pbd189c: the Keleres home tile is not on the map at all any more, and Saar is holding Archon
+     * Ren and Archon Tau. With no Xxcha at the table those planets can only have come from Keleres.
+     */
+    @Test
+    void shouldNameTheFlavourFromHomePlanetsAConquerorIsHolding() {
+        Game game = gameWithTiles("19", "20");
+        seat(game, "keleres");
+        seat(game, "saar", "archonren", "archontau", "lodor");
+        seat(game, "cabal");
+
+        assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isEqualTo("keleresx");
+    }
+
+    /**
+     * pbd108: Argent is at the table and holding both its own home and Moll Primus, so only the
+     * borrowed home whose faction is absent is left to name the Keleres seat.
+     */
+    @Test
+    void shouldIgnoreHomePlanetsThatBelongToAFactionActuallyPlaying() {
+        Game game = gameWithTiles("19");
+        seat(game, "keleres");
+        seat(game, "argent", "valk", "avar", "ylir", "mollprimus");
+
+        assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isEqualTo("keleresm");
+    }
+
+    /** pbd353: two borrowed homes are orphaned at once, so there is nothing to pick between them. */
+    @Test
+    void shouldNotGuessBetweenTwoOrphanedHomesHeldByConquerors() {
+        Game game = gameWithTiles("19");
+        seat(game, "keleres");
+        seat(game, "sardakk", "archonren");
+        seat(game, "winnu", "mollprimus");
+
+        assertThat(RunAgainstAllGames.factionFromAnOrphanedBaseHome(game)).isNull();
+    }
+
+    @Test
+    void shouldFindTheHomeSystemPositionByItsPlanetsWhateverTheTileIdIs() {
+        // These games carry the Keleres home as 02, 14 or 58 as often as the re-skinned tiles.
+        assertThat(RunAgainstAllGames.homeSystemPositionFor(gameWithTiles("19", "14"), "keleresx"))
+                .isEqualTo("102");
+        assertThat(RunAgainstAllGames.homeSystemPositionFor(gameWithTiles("58"), "keleresa"))
+                .isEqualTo("101");
+        assertThat(RunAgainstAllGames.homeSystemPositionFor(gameWithTiles("94new"), "keleresm"))
+                .isEqualTo("101");
+    }
+
+    @Test
+    void shouldFindNoHomeSystemPositionWhenTheTileIsGoneFromTheBoard() {
+        assertThat(RunAgainstAllGames.homeSystemPositionFor(gameWithTiles("19", "20"), "keleresx"))
+                .isNull();
+        assertThat(RunAgainstAllGames.homeSystemPositionFor(gameWithTiles("14"), "keleresm"))
+                .isNull();
+    }
+
+    private static void seat(Game game, String faction, String... planets) {
         Player player = game.addPlayer(faction + "-user", faction);
         player.setFaction(faction);
         player.setColor(COLORS.get(game.getPlayers().size() - 1));
+        player.getPlanets().addAll(List.of(planets));
     }
 
     private static final List<String> COLORS = List.of("red", "blue", "green", "yellow", "purple", "orange");

--- a/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
+++ b/src/test/java/ti4/discord/interactions/commands/developer/RunAgainstAllGamesTest.java
@@ -21,6 +21,59 @@ class RunAgainstAllGamesTest extends BaseTi4Test {
                 .isEqualTo("keleresa");
     }
 
+    /**
+     * Keleres predates the re-skinned Keleres planets, so the games this command exists for hold the
+     * base faction's planet ids. The player's faction is already known to be Keleres, so these name
+     * a flavour just as well as the k-suffixed ones.
+     */
+    @Test
+    void shouldNameTheFlavourFromTheBaseFactionsPlanetIds() {
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("mollprimus", "wellon")))
+                .isEqualTo("keleresm");
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("archonren", "archontau")))
+                .isEqualTo("keleresx");
+        assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("valk", "avar", "ylir")))
+                .isEqualTo("keleresa");
+    }
+
+    @Test
+    void shouldNameTheFlavourFromTheTileThePlayerIsAnchoredTo() {
+        Game mentakHome = gameWithTiles("02");
+        assertThat(RunAgainstAllGames.factionFromTheirOwnHomeTile(mentakHome, anchoredAt(mentakHome, "101")))
+                .isEqualTo("keleresm");
+
+        Game xxchaHome = gameWithTiles("14");
+        assertThat(RunAgainstAllGames.factionFromTheirOwnHomeTile(xxchaHome, anchoredAt(xxchaHome, "101")))
+                .isEqualTo("keleresx");
+
+        Game argentHome = gameWithTiles("58");
+        assertThat(RunAgainstAllGames.factionFromTheirOwnHomeTile(argentHome, anchoredAt(argentHome, "101")))
+                .isEqualTo("keleresa");
+    }
+
+    /**
+     * A board-wide sweep must not read the base home systems, since 02, 14 and 58 belong to Mentak,
+     * Xxcha and Argent whenever those factions are the ones playing them.
+     */
+    @Test
+    void shouldNotSweepTheBoardForBaseFactionHomeSystems() {
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("02", "19")))
+                .isNull();
+        assertThat(RunAgainstAllGames.factionFromTheOnlyKeleresHomeOnTheBoard(gameWithTiles("14", "58")))
+                .isNull();
+    }
+
+    @Test
+    void shouldNotGuessFromAnAnchorPointingAtNothingKeleres() {
+        Game game = gameWithTiles("19");
+        assertThat(RunAgainstAllGames.factionFromTheirOwnHomeTile(game, anchoredAt(game, "101")))
+                .isNull();
+        assertThat(RunAgainstAllGames.factionFromTheirOwnHomeTile(game, anchoredAt(game, "999")))
+                .isNull();
+        assertThat(RunAgainstAllGames.factionFromTheirOwnHomeTile(game, anchoredAt(game, null)))
+                .isNull();
+    }
+
     @Test
     void shouldNotGuessFromPlanetsThatNameNoFlavourOrMoreThanOne() {
         assertThat(RunAgainstAllGames.factionFromTheirHomePlanets(playerHolding("wellon", "vefutii")))
@@ -65,6 +118,14 @@ class RunAgainstAllGamesTest extends BaseTi4Test {
         player.setFaction("keleres");
         player.setColor("red");
         player.getPlanets().addAll(List.of(planets));
+        return player;
+    }
+
+    private static Player anchoredAt(Game game, String position) {
+        Player player = game.addPlayer("user-" + position, "user");
+        player.setFaction("keleres");
+        player.setColor("red");
+        player.setPlayerStatsAnchorPosition(position);
         return player;
     }
 

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -141,20 +141,33 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         assertThat(report).contains("homes lost. Coexisted through 25/25 (100%) of home system losses.\n");
     }
 
-    /** Every other faction has to actually control its home planets to keep them. */
+    /** Coexistence keeps any faction's home, not just the Deepwrought - only the note is theirs. */
     @Test
-    void shouldNotLetAnyOtherFactionCoexistThroughAHomePlanetLoss() {
+    void shouldCountAnyFactionsCoexistenceAsHoldingItsHome() {
         Game game = newGame("1");
-        game.setTile(new Tile("01", "101"));
-        Player letnev = addPlayer(game, "letnev", false, "arcprime", "wrenterra");
-        addPlayer(game, "sol", true, "jord");
-        // Letnev is standing on Jord, which does nothing for Sol or for Letnev's own home.
-        putInfantryOn(game, "jord", letnev);
+        game.setTile(new Tile("10", "101"));
+        Player letnev = addPlayer(game, "letnev", false);
+        addPlayer(game, "sol", true, "jord", "arcprime", "wrenterra");
+        // Sol took both Letnev home planets, and Letnev is standing on both.
+        putInfantryOn(game, "arcprime", letnev);
+        putInfantryOn(game, "wrenterra", letnev);
 
         String report = render(List.of(game));
 
         assertThat(report).contains("- **All factions**: 0/2 (0%) of players lost a home planet\n");
         assertThat(report).doesNotContain("Coexisted through");
+    }
+
+    /** Half a home system is still a lost home system. */
+    @Test
+    void shouldCountALossWhenOnlySomeOfTheHomeSystemIsHeldOrCoexistedOn() {
+        Game game = newGame("1");
+        game.setTile(new Tile("10", "101"));
+        Player letnev = addPlayer(game, "letnev", false);
+        addPlayer(game, "sol", true, "jord", "arcprime", "wrenterra");
+        putInfantryOn(game, "arcprime", letnev);
+
+        assertThat(render(List.of(game))).contains("- **All factions**: 1/2 (50%) of players lost a home planet.");
     }
 
     @Test
@@ -238,6 +251,17 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         putInfantryOn(game, "wellon", titans);
 
         assertThat(render(List.of(game))).contains("  - 1 planet: 100% (1/1; 100%)\n");
+    }
+
+    @Test
+    void shouldDropTheCoexistenceSectionEntirelyForPokOnly() {
+        Game game = prophecyOfKingsGame("1");
+        game.setTile(new Tile("19", "101"));
+        Player titans = addPlayer(game, "titans", false, "elysium");
+        putInfantryOn(game, "wellon", titans);
+
+        assertThat(render(List.of(game), true)).doesNotContain("### Win rate by planets coexisted on");
+        assertThat(render(List.of(game), false)).contains("### Win rate by planets coexisted on");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -27,11 +27,12 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
         assertThat(report)
                 .contains("- **All factions**: 1.00 non-home planets on average, 50% win rate from 2 players");
-        assertThat(report).contains("  - 0-2 planets: 50% (1/2; 100%)\n");
+        assertThat(report).contains("  - 0-1 planets: 0% (0/1; 50%)\n");
+        assertThat(report).contains("  - 2-3 planets: 100% (1/1; 50%)\n");
     }
 
     @Test
-    void shouldPoolCountsIntoBandsThreeWideAndCapTheLastOne() {
+    void shouldPoolCountsIntoBandsTwoWideAndCapTheLastOne() {
         Game game = newGame("1");
         addPlayer(game, "sol", true, "jord");
         takePlanets(game.getPlayerFromColorOrFaction("sol"), 4);
@@ -40,9 +41,35 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
 
         String report = render(List.of(game));
 
-        assertThat(report).contains("  - 3-5 planets: 100% (1/1; 50%)\n");
-        assertThat(report).contains("  - 18+ planets: 0% (0/1; 50%)\n");
+        assertThat(report).contains("  - 4-5 planets: 100% (1/1; 50%)\n");
+        assertThat(report).contains("  - 12+ planets: 0% (0/1; 50%)\n");
         assertThat(report).contains("12.00 non-home planets on average");
+    }
+
+    @Test
+    void shouldNeverCountOceans() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon", "ocean3", "ocean4", "ocean5");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("- **All factions**: 0.50 non-home planets on average");
+        assertThat(report)
+                .doesNotContain("Deep Abyss")
+                .doesNotContain("Brine Pool")
+                .doesNotContain("Ice Shelf");
+    }
+
+    @Test
+    void shouldLeaveTradeStationsOutOfTheNonHomePlanetCountButStillRankThem() {
+        String report = render(repeatGame(MINIMUM_SAMPLE, game -> {
+            addPlayer(game, "sol", true, "jord", "wellon", "thewatchtower");
+            addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+        }));
+
+        assertThat(report).contains("- **All factions**: 0.50 non-home planets on average");
+        assertThat(report).contains("* `100%` (25/25) The Watchtower\n");
     }
 
     @Test
@@ -55,8 +82,19 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
 
         assertThat(report).contains("### Home planets lost\n");
         assertThat(report)
-                .contains("- **All factions**: 1/2 (50%) lost one - 0% win rate when they did, 100% when they did"
-                        + " not\n");
+                .contains("- **All factions**: 1/2 (50%) of players lost a home planet. 0% win rate when they did,"
+                        + " 100% when they did not\n");
+    }
+
+    @Test
+    void shouldRenderFactionHomePlanetsLostInItsOwnShorterForm() {
+        String report = render(repeatGame(MINIMUM_SAMPLE, game -> {
+            addPlayer(game, "sol", true, "jord");
+            addPlayer(game, "letnev", false, "arcprime");
+        }));
+
+        assertThat(report).contains("- **All factions**: 25/50 (50%) of players lost a home planet.");
+        assertThat(report).contains("(100%) homes lost. 0% win rate, 0% otherwise\n");
     }
 
     @Test
@@ -65,7 +103,7 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         addPlayer(game, "sol", true, "jord", "wellon");
         addPlayer(game, "letnev", false, "arcprime", "wrenterra");
 
-        assertThat(render(List.of(game))).contains("- **All factions**: never lost a home planet, across 2 players\n");
+        assertThat(render(List.of(game))).contains("- **All factions**: 0/2 (0%) of players lost a home planet\n");
     }
 
     @Test
@@ -91,7 +129,7 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         assertThat(report).doesNotContain("Arc Prime");
         assertThat(report).contains("* `100%` (25/25) Wellon\n");
         assertThat(report).contains("- **All factions**: 1.00 non-home planets on average");
-        assertThat(report).contains("- **All factions**: 25/50 (50%) lost one");
+        assertThat(report).contains("- **All factions**: 25/50 (50%) of players lost a home planet.");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -8,6 +8,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import ti4.game.Game;
 import ti4.game.Player;
+import ti4.game.Tile;
 import ti4.testUtils.BaseTi4Test;
 
 class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
@@ -170,6 +171,37 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
 
         assertThat(PlanetWinRateStatisticsService.isEligibleGameType(normal)).isTrue();
         assertThat(render(List.of(twilightsFall, normal))).contains("Games analyzed: 1 | Players analyzed: 2\n");
+    }
+
+    @Test
+    void shouldReadHomePlanetsOffTheBoardWhenTheFactionFileHasNone() {
+        // Older games stored Keleres as a bare "keleres", which has no faction model behind it.
+        Game game = newGame("1");
+        game.setTile(new Tile("92new", "101"));
+        Player keleres = addPlayer(game, "keleres", true, "archonrenk", "archontauk", "wellon");
+        keleres.setPlayerStatsAnchorPosition("101");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        String report = render(List.of(game));
+
+        assertThat(report).doesNotContain("### Skipped players");
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+        // Archon Ren and Archon Tau are home, so Wellon is the one planet taken outside it.
+        assertThat(report).contains("- **All factions**: 0.50 non-home planets on average");
+        assertThat(report).contains("* `100%` (1/1) Wellon\n");
+        assertThat(report).doesNotContain("Archon Ren").doesNotContain("Archon Tau");
+    }
+
+    @Test
+    void shouldStillSkipAPlayerWithNoFactionFileAndNoHomeSystemOnTheBoard() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "keleres", false, "archonrenk");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("### Skipped players\n");
+        assertThat(report).contains("- `keleres` - 1 player(s), e.g. game `planet-stats-1`\n");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -124,9 +124,21 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
 
         String report = render(List.of(game));
 
-        assertThat(report)
-                .contains("- **All factions**: 0/2 (0%) of players lost a home planet."
-                        + " Coexisted through 1/1 (100%) of home system losses.\n");
+        assertThat(report).contains("- **All factions**: 0/2 (0%) of players lost a home planet\n");
+    }
+
+    /** The combined row is every faction summed, so a rescue only one of them can earn stays off it. */
+    @Test
+    void shouldKeepTheCoexistedThroughLineOffTheCombinedRow() {
+        String report = render(repeatGame(MINIMUM_SAMPLE, game -> {
+            game.setTile(new Tile("95", "101"));
+            Player deepwrought = addPlayer(game, "deepwrought", false);
+            addPlayer(game, "sol", true, "jord", "ikatena");
+            putInfantryOn(game, "ikatena", deepwrought);
+        }));
+
+        assertThat(report).contains("- **All factions**: 0/50 (0%) of players lost a home planet\n");
+        assertThat(report).contains("homes lost. Coexisted through 25/25 (100%) of home system losses.\n");
     }
 
     /** Every other faction has to actually control its home planets to keep them. */

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -273,7 +273,7 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
             addPlayer(game, "sol", true, "jord", "wellon");
         }));
 
-        assertThat(report).contains(" 25 Silver Flames (0% win rate).\n");
+        assertThat(report).contains(" 25 Silver Flames.\n");
         assertThat(report).contains("- **All factions**: 25/50 (50%) of players lost a home planet.");
     }
 

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -407,8 +407,56 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
                 .isTrue();
 
         String report = render(List.of(bothExpansions, prophecyOfKings), true);
-        assertThat(report).contains("_Prophecy of Kings games without Thunder's Edge.");
+        assertThat(report).contains("_Prophecy of Kings games with no Thunder's Edge planets on the table.");
         assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+    }
+
+    @Test
+    void shouldDropPokOnlyGamesHoldingAPlanetFromALaterExpansion() {
+        Game game = prophecyOfKingsGame("1");
+        addPlayer(game, "hacan", false, "tempesta");
+
+        assertThat(PlanetWinRateStatisticsService.hasOnlyProphecyOfKingsPlanets(game))
+                .isFalse();
+        assertThat(render(List.of(game), true)).contains("No games matched.\n");
+    }
+
+    @Test
+    void shouldDropPokOnlyGamesWithALaterExpansionTileStillOnTheBoard() {
+        Game game = prophecyOfKingsGame("1");
+        game.setTile(new Tile("18", "000"));
+        assertThat(PlanetWinRateStatisticsService.hasOnlyProphecyOfKingsPlanets(game))
+                .isTrue();
+
+        game.setTile(new Tile("112", "000"));
+
+        assertThat(PlanetWinRateStatisticsService.hasOnlyProphecyOfKingsPlanets(game))
+                .isFalse();
+    }
+
+    @Test
+    void shouldReportHowManyPokOnlyGamesCarriedALaterExpansionsPlanets() {
+        Game clean = prophecyOfKingsGame("1");
+        Game withThundersEdge = prophecyOfKingsGame("2");
+        addPlayer(withThundersEdge, "hacan", false, "tempesta");
+
+        String report = render(List.of(clean, withThundersEdge), true);
+
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+        assertThat(report)
+                .contains("Dropped 1 game(s) that were not flagged as Thunder's Edge but had planets from it in"
+                        + " play.\n");
+    }
+
+    @Test
+    void shouldLeaveLaterExpansionPlanetsAloneOutsidePokOnly() {
+        Game game = pokAndThundersEdgeGame("1");
+        addPlayer(game, "hacan", false, "tempesta");
+
+        String report = render(List.of(game), false);
+
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 3\n");
+        assertThat(report).doesNotContain("Dropped");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -161,7 +161,9 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         addPlayer(twilightsFall, "sol", true, "jord", "wellon");
         addPlayer(twilightsFall, "letnev", false, "arcprime", "wrenterra");
 
-        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(twilightsFall))
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(twilightsFall, false))
+                .isFalse();
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(twilightsFall, true))
                 .isFalse();
         assertThat(render(List.of(twilightsFall))).contains("No games matched.\n");
 
@@ -169,8 +171,65 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         addPlayer(normal, "sol", true, "jord", "wellon");
         addPlayer(normal, "letnev", false, "arcprime", "wrenterra");
 
-        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(normal)).isTrue();
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(normal, false))
+                .isTrue();
         assertThat(render(List.of(twilightsFall, normal))).contains("Games analyzed: 1 | Players analyzed: 2\n");
+    }
+
+    @Test
+    void shouldTakeBothThundersEdgeAndProphecyOfKingsByDefault() {
+        Game thundersEdge = pokAndThundersEdgeGame("1");
+        Game prophecyOfKings = prophecyOfKingsGame("2");
+
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(thundersEdge, false))
+                .isTrue();
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(prophecyOfKings, false))
+                .isTrue();
+
+        String report = render(List.of(thundersEdge, prophecyOfKings));
+        assertThat(report).contains("_Thunder's Edge and Prophecy of Kings games.");
+        assertThat(report).contains("Games analyzed: 2 | Players analyzed: 4\n");
+    }
+
+    @Test
+    void shouldDropThundersEdgeGamesWhenPokOnly() {
+        Game thundersEdge = pokAndThundersEdgeGame("1");
+        Game prophecyOfKings = prophecyOfKingsGame("2");
+
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(thundersEdge, true))
+                .isFalse();
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(prophecyOfKings, true))
+                .isTrue();
+
+        String report = render(List.of(thundersEdge, prophecyOfKings), true);
+        assertThat(report).contains("_Prophecy of Kings games, no Thunder's Edge.");
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+    }
+
+    @Test
+    void shouldDropGamesThatAreNeitherThundersEdgeNorProphecyOfKings() {
+        Game baseGame = pokAndThundersEdgeGame("1");
+        baseGame.setThundersEdge(false);
+        baseGame.setProphecyOfKings(false);
+
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(baseGame, false))
+                .isFalse();
+        assertThat(render(List.of(baseGame))).contains("No games matched.\n");
+    }
+
+    private static Game pokAndThundersEdgeGame(String suffix) {
+        Game game = newGame(suffix);
+        game.setThundersEdge(true);
+        game.setProphecyOfKings(true);
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+        return game;
+    }
+
+    private static Game prophecyOfKingsGame(String suffix) {
+        Game game = pokAndThundersEdgeGame(suffix);
+        game.setThundersEdge(false);
+        return game;
     }
 
     @Test
@@ -267,7 +326,11 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     private static String render(List<Game> games) {
-        return String.join("", PlanetWinRateStatisticsService.buildReport(games));
+        return render(games, false);
+    }
+
+    private static String render(List<Game> games, boolean pokOnly) {
+        return String.join("", PlanetWinRateStatisticsService.buildReport(games, pokOnly));
     }
 
     private static Game newGame(String suffix) {

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -255,13 +255,18 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
 
     @Test
     void shouldDropTheCoexistenceSectionEntirelyForPokOnly() {
-        Game game = prophecyOfKingsGame("1");
+        Game pokOnlyGame = withCoexistingTitans(prophecyOfKingsGame("1"));
+        Game bothExpansions = withCoexistingTitans(pokAndThundersEdgeGame("2"));
+
+        assertThat(render(List.of(pokOnlyGame), true)).doesNotContain("### Win rate by planets coexisted on");
+        assertThat(render(List.of(bothExpansions), false)).contains("### Win rate by planets coexisted on");
+    }
+
+    private static Game withCoexistingTitans(Game game) {
         game.setTile(new Tile("19", "101"));
         Player titans = addPlayer(game, "titans", false, "elysium");
         putInfantryOn(game, "wellon", titans);
-
-        assertThat(render(List.of(game), true)).doesNotContain("### Win rate by planets coexisted on");
-        assertThat(render(List.of(game), false)).contains("### Win rate by planets coexisted on");
+        return game;
     }
 
     @Test
@@ -284,39 +289,6 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         addPlayer(game, "sol", true, "jord", "wrenterra");
 
         assertThat(render(List.of(game))).doesNotContain("Silver Flames");
-    }
-
-    @Test
-    void shouldListTheGamesAFactionLostItsHomePlanetsIn() {
-        Game game = newGame("1");
-        game.setTile(new Tile("10", "101"));
-        addPlayer(game, "letnev", false, "arcprime");
-        addPlayer(game, "sol", true, "jord", "wrenterra");
-
-        String report = String.join("", PlanetWinRateStatisticsService.buildReport(List.of(game), false, "letnev"));
-
-        assertThat(report).contains("### Home planet losses for `letnev`\n");
-        assertThat(report).contains("- `planet-stats-1` Wren Terra (sol)\n");
-    }
-
-    @Test
-    void shouldSayAFactionNeverLostAHomePlanetWhenItDidNot() {
-        Game game = newGame("1");
-        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
-        addPlayer(game, "sol", true, "jord");
-
-        String report = String.join("", PlanetWinRateStatisticsService.buildReport(List.of(game), false, "letnev"));
-
-        assertThat(report).contains("- They never lost a home planet.\n");
-    }
-
-    @Test
-    void shouldLeaveTheHomeLossDebugSectionOutWhenNoFactionIsAskedFor() {
-        Game game = newGame("1");
-        addPlayer(game, "letnev", false, "arcprime");
-        addPlayer(game, "sol", true, "jord", "wrenterra");
-
-        assertThat(render(List.of(game))).doesNotContain("### Home planet losses for");
     }
 
     @Test
@@ -410,42 +382,43 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldTakeBothThundersEdgeAndProphecyOfKingsByDefault() {
-        Game thundersEdge = pokAndThundersEdgeGame("1");
+    void shouldTakeOnlyGamesCarryingBothExpansionsByDefault() {
+        Game bothExpansions = pokAndThundersEdgeGame("1");
         Game prophecyOfKings = prophecyOfKingsGame("2");
 
-        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(thundersEdge, false))
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(bothExpansions, false))
                 .isTrue();
         assertThat(PlanetWinRateStatisticsService.isEligibleGameType(prophecyOfKings, false))
-                .isTrue();
-
-        String report = render(List.of(thundersEdge, prophecyOfKings));
-        assertThat(report).contains("_Thunder's Edge and Prophecy of Kings games.");
-        assertThat(report).contains("Games analyzed: 2 | Players analyzed: 4\n");
-    }
-
-    @Test
-    void shouldDropThundersEdgeGamesWhenPokOnly() {
-        Game thundersEdge = pokAndThundersEdgeGame("1");
-        Game prophecyOfKings = prophecyOfKingsGame("2");
-
-        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(thundersEdge, true))
                 .isFalse();
-        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(prophecyOfKings, true))
-                .isTrue();
 
-        String report = render(List.of(thundersEdge, prophecyOfKings), true);
-        assertThat(report).contains("_Prophecy of Kings games, no Thunder's Edge.");
+        String report = render(List.of(bothExpansions, prophecyOfKings));
+        assertThat(report).contains("_Games with both Prophecy of Kings and Thunder's Edge.");
         assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
     }
 
     @Test
-    void shouldDropGamesThatAreNeitherThundersEdgeNorProphecyOfKings() {
+    void shouldTakeOnlyGamesWithoutThundersEdgeWhenPokOnly() {
+        Game bothExpansions = pokAndThundersEdgeGame("1");
+        Game prophecyOfKings = prophecyOfKingsGame("2");
+
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(bothExpansions, true))
+                .isFalse();
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(prophecyOfKings, true))
+                .isTrue();
+
+        String report = render(List.of(bothExpansions, prophecyOfKings), true);
+        assertThat(report).contains("_Prophecy of Kings games without Thunder's Edge.");
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+    }
+
+    @Test
+    void shouldDropGamesWithoutProphecyOfKingsEitherWay() {
         Game baseGame = pokAndThundersEdgeGame("1");
-        baseGame.setThundersEdge(false);
         baseGame.setProphecyOfKings(false);
 
         assertThat(PlanetWinRateStatisticsService.isEligibleGameType(baseGame, false))
+                .isFalse();
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(baseGame, true))
                 .isFalse();
         assertThat(render(List.of(baseGame))).contains("No games matched.\n");
     }

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -265,6 +265,39 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
+    void shouldListTheGamesAFactionLostItsHomePlanetsIn() {
+        Game game = newGame("1");
+        game.setTile(new Tile("10", "101"));
+        addPlayer(game, "letnev", false, "arcprime");
+        addPlayer(game, "sol", true, "jord", "wrenterra");
+
+        String report = String.join("", PlanetWinRateStatisticsService.buildReport(List.of(game), false, "letnev"));
+
+        assertThat(report).contains("### Home planet losses for `letnev`\n");
+        assertThat(report).contains("- `planet-stats-1` Wren Terra (sol)\n");
+    }
+
+    @Test
+    void shouldSayAFactionNeverLostAHomePlanetWhenItDidNot() {
+        Game game = newGame("1");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+        addPlayer(game, "sol", true, "jord");
+
+        String report = String.join("", PlanetWinRateStatisticsService.buildReport(List.of(game), false, "letnev"));
+
+        assertThat(report).contains("- They never lost a home planet.\n");
+    }
+
+    @Test
+    void shouldLeaveTheHomeLossDebugSectionOutWhenNoFactionIsAskedFor() {
+        Game game = newGame("1");
+        addPlayer(game, "letnev", false, "arcprime");
+        addPlayer(game, "sol", true, "jord", "wrenterra");
+
+        assertThat(render(List.of(game))).doesNotContain("### Home planet losses for");
+    }
+
+    @Test
     void shouldSayNeitherFactionAppearedWhenTheSampleHasNoCoexistingFaction() {
         Game game = newGame("1");
         addPlayer(game, "sol", true, "jord", "wellon");

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -114,35 +114,99 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldCountCoexistingOnAHomePlanetAsHoldingIt() {
+    void shouldCountDeepwroughtCoexistingOnItsHomePlanetAsHoldingIt() {
         Game game = newGame("1");
-        game.setTile(new Tile("01", "101"));
-        Player sol = addPlayer(game, "sol", true, "wellon");
-        Player letnev = addPlayer(game, "letnev", false, "arcprime", "wrenterra", "jord");
-        // Sol lost Jord to Letnev but still has infantry standing on it.
-        putInfantryOn(game, "jord", sol);
+        game.setTile(new Tile("95", "101"));
+        Player deepwrought = addPlayer(game, "deepwrought", false);
+        addPlayer(game, "sol", true, "jord", "ikatena");
+        // Sol took Ikatena, but the Deepwrought are still standing on it.
+        putInfantryOn(game, "ikatena", deepwrought);
 
         String report = render(List.of(game));
 
         assertThat(report)
                 .contains("- **All factions**: 0/2 (0%) of players lost a home planet."
                         + " Coexisted through 1/1 (100%) of home system losses.\n");
-        assertThat(letnev.getPlanets()).contains("jord");
+    }
+
+    /** Every other faction has to actually control its home planets to keep them. */
+    @Test
+    void shouldNotLetAnyOtherFactionCoexistThroughAHomePlanetLoss() {
+        Game game = newGame("1");
+        game.setTile(new Tile("01", "101"));
+        Player letnev = addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+        addPlayer(game, "sol", true, "jord");
+        // Letnev is standing on Jord, which does nothing for Sol or for Letnev's own home.
+        putInfantryOn(game, "jord", letnev);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("- **All factions**: 0/2 (0%) of players lost a home planet\n");
+        assertThat(report).doesNotContain("Coexisted through");
     }
 
     @Test
-    void shouldStillCountALossWhenCoexistingOnOnlyOneOfTwoHomePlanets() {
+    void shouldStillCountALossWhenDeepwroughtIsNotStandingOnItsHome() {
         Game game = newGame("1");
-        game.setTile(new Tile("10", "101"));
-        Player letnev = addPlayer(game, "letnev", false);
-        Player sol = addPlayer(game, "sol", true, "jord", "arcprime", "wrenterra");
-        // Letnev holds neither home planet and is only standing on one of them.
-        putInfantryOn(game, "arcprime", letnev);
+        game.setTile(new Tile("95", "101"));
+        addPlayer(game, "deepwrought", false);
+        addPlayer(game, "sol", true, "jord", "ikatena");
 
         String report = render(List.of(game));
 
         assertThat(report).contains("- **All factions**: 1/2 (50%) of players lost a home planet.");
         assertThat(report).doesNotContain("Coexisted through");
+    }
+
+    @Test
+    void shouldBandTheCoexistedPlanetCountAndAverageIt() {
+        Game game = newGame("1");
+        game.setTile(new Tile("19", "101"));
+        game.setTile(new Tile("20", "102"));
+        Player sol = addPlayer(game, "sol", true, "jord");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon", "vefutii", "abyz");
+        // Sol controls neither Wellon nor Vefut II but is standing on both.
+        putInfantryOn(game, "wellon", sol);
+        putInfantryOn(game, "vefutii", sol);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("### Win rate by planets coexisted on\n");
+        assertThat(report)
+                .contains("- **All factions**: 1.00 planets coexisted on on average, 50% win rate from 2 players");
+        assertThat(report).contains("  - 0 planets: 0% (0/1; 50%)\n");
+        assertThat(report).contains("  - 2 planets: 100% (1/1; 50%)\n");
+    }
+
+    @Test
+    void shouldCollectEveryCoexistenceAtOrAboveFiveIntoOneBand() {
+        Game game = newGame("1");
+        // Wellon on 19, Vefut II on 20, Abyz on 38, Arinam and Meer both on 37.
+        game.setTile(new Tile("19", "101"));
+        game.setTile(new Tile("20", "102"));
+        game.setTile(new Tile("38", "103"));
+        game.setTile(new Tile("37", "104"));
+        Player sol = addPlayer(game, "sol", true, "jord");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon", "vefutii", "abyz", "arinam", "meer");
+        for (String planet : List.of("wellon", "vefutii", "abyz", "arinam", "meer")) {
+            putInfantryOn(game, planet, sol);
+        }
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("  - 5+ planets: 100% (1/1; 50%)\n");
+        assertThat(report).contains("2.50 planets coexisted on on average");
+    }
+
+    @Test
+    void shouldSayOnePlanetInTheSingularForTheCoexistBands() {
+        Game game = newGame("1");
+        game.setTile(new Tile("19", "101"));
+        Player sol = addPlayer(game, "sol", true, "jord");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon");
+        putInfantryOn(game, "wellon", sol);
+
+        assertThat(render(List.of(game))).contains("  - 1 planet: 100% (1/1; 50%)\n");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -107,7 +107,7 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldRankPlanetsByWinRateOnceTheyClearTheSampleThreshold() {
+    void shouldRankPlanetsByWinRateHighestFirst() {
         String report = render(repeatGame(MINIMUM_SAMPLE, game -> {
             addPlayer(game, "sol", true, "jord", "wellon");
             addPlayer(game, "letnev", false, "arcprime", "wrenterra", "vefutii");
@@ -133,15 +133,49 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldSuppressPlanetsBelowTheSampleThreshold() {
-        String report = render(repeatGame(MINIMUM_SAMPLE - 1, game -> {
-            addPlayer(game, "sol", true, "jord", "wellon");
-            addPlayer(game, "letnev", false, "arcprime", "wrenterra");
-        }));
+    void shouldRankAPlanetHeldOnlyOnce() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        assertThat(render(List.of(game))).contains("* `100%` (1/1) Wellon\n");
+    }
+
+    @Test
+    void shouldSayNoPlanetsWereHeldWhenEveryoneOnlyHasTheirHome() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        String report = render(List.of(game));
 
         assertThat(report).contains("### Win rate by planet controlled\n");
-        assertThat(report).contains("- No planet was held that often.\n");
-        assertThat(report).doesNotContain("Wellon");
+        assertThat(report).contains("- No planets were held.\n");
+    }
+
+    @Test
+    void shouldBreakDownSkippedPlayersByFactionWithAGameToLookAt() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "bluetf", false);
+        addPlayer(game, "redtf", false);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 1\n");
+        assertThat(report).contains("### Skipped players\n");
+        assertThat(report).contains("2 player(s) had no home planets on file for their faction");
+        assertThat(report).contains("- `bluetf` - 1 player(s), e.g. game `planet-stats-1`\n");
+        assertThat(report).contains("- `redtf` - 1 player(s), e.g. game `planet-stats-1`\n");
+    }
+
+    @Test
+    void shouldLeaveOutTheSkippedSectionWhenEveryHomeWasIdentified() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        assertThat(render(List.of(game))).doesNotContain("### Skipped players");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -175,19 +175,38 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         Game game = newGame("1");
         game.setTile(new Tile("19", "101"));
         game.setTile(new Tile("20", "102"));
-        Player sol = addPlayer(game, "sol", true, "jord");
-        addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon", "vefutii", "abyz");
-        // Sol controls neither Wellon nor Vefut II but is standing on both.
-        putInfantryOn(game, "wellon", sol);
-        putInfantryOn(game, "vefutii", sol);
+        Player titans = addPlayer(game, "titans", true, "elysium");
+        addPlayer(game, "deepwrought", false, "ikatena");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon", "vefutii");
+        // The Titans control neither Wellon nor Vefut II but are standing on both.
+        putInfantryOn(game, "wellon", titans);
+        putInfantryOn(game, "vefutii", titans);
 
         String report = render(List.of(game));
 
         assertThat(report).contains("### Win rate by planets coexisted on\n");
-        assertThat(report)
-                .contains("- **All factions**: 1.00 planets coexisted on on average, 50% win rate from 2 players");
-        assertThat(report).contains("  - 0 planets: 0% (0/1; 50%)\n");
-        assertThat(report).contains("  - 2 planets: 100% (1/1; 50%)\n");
+        assertThat(report).contains("2.00 planets coexisted on on average, 100% win rate from 1 player");
+        assertThat(report).contains("  - 2 planets: 100% (1/1; 100%)\n");
+        assertThat(report).contains("0.00 planets coexisted on on average, 0% win rate from 1 player");
+    }
+
+    @Test
+    void shouldReportOnlyTheFactionsThatCoexistByDesign() {
+        Game game = newGame("1");
+        game.setTile(new Tile("19", "101"));
+        Player letnev = addPlayer(game, "letnev", true, "arcprime", "wrenterra");
+        addPlayer(game, "titans", false, "elysium");
+        addPlayer(game, "sol", false, "jord", "wellon");
+        // Letnev is coexisting, but only the Deepwrought and the Titans earn a row here.
+        putInfantryOn(game, "wellon", letnev);
+
+        List<String> coexistRows = render(List.of(game))
+                .lines()
+                .filter(line -> line.contains("planets coexisted on on average"))
+                .toList();
+
+        assertThat(coexistRows).hasSize(1);
+        assertThat(coexistRows.getFirst()).contains("Titans").doesNotContain("**All factions**");
     }
 
     @Test
@@ -198,27 +217,39 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         game.setTile(new Tile("20", "102"));
         game.setTile(new Tile("38", "103"));
         game.setTile(new Tile("37", "104"));
-        Player sol = addPlayer(game, "sol", true, "jord");
+        Player titans = addPlayer(game, "titans", true, "elysium");
         addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon", "vefutii", "abyz", "arinam", "meer");
         for (String planet : List.of("wellon", "vefutii", "abyz", "arinam", "meer")) {
-            putInfantryOn(game, planet, sol);
+            putInfantryOn(game, planet, titans);
         }
 
         String report = render(List.of(game));
 
-        assertThat(report).contains("  - 5+ planets: 100% (1/1; 50%)\n");
-        assertThat(report).contains("2.50 planets coexisted on on average");
+        assertThat(report).contains("  - 5+ planets: 100% (1/1; 100%)\n");
+        assertThat(report).contains("5.00 planets coexisted on on average");
     }
 
     @Test
     void shouldSayOnePlanetInTheSingularForTheCoexistBands() {
         Game game = newGame("1");
         game.setTile(new Tile("19", "101"));
-        Player sol = addPlayer(game, "sol", true, "jord");
+        Player titans = addPlayer(game, "titans", true, "elysium");
         addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon");
-        putInfantryOn(game, "wellon", sol);
+        putInfantryOn(game, "wellon", titans);
 
-        assertThat(render(List.of(game))).contains("  - 1 planet: 100% (1/1; 50%)\n");
+        assertThat(render(List.of(game))).contains("  - 1 planet: 100% (1/1; 100%)\n");
+    }
+
+    @Test
+    void shouldSayNeitherFactionAppearedWhenTheSampleHasNoCoexistingFaction() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("### Win rate by planets coexisted on\n");
+        assertThat(report).contains("- Neither faction appeared in the sample.\n");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -154,6 +154,25 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
+    void shouldLeaveOutTwilightsFallGames() {
+        Game twilightsFall = newGame("1");
+        twilightsFall.setTwilightsFallMode(true);
+        addPlayer(twilightsFall, "sol", true, "jord", "wellon");
+        addPlayer(twilightsFall, "letnev", false, "arcprime", "wrenterra");
+
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(twilightsFall))
+                .isFalse();
+        assertThat(render(List.of(twilightsFall))).contains("No games matched.\n");
+
+        Game normal = newGame("2");
+        addPlayer(normal, "sol", true, "jord", "wellon");
+        addPlayer(normal, "letnev", false, "arcprime", "wrenterra");
+
+        assertThat(PlanetWinRateStatisticsService.isEligibleGameType(normal)).isTrue();
+        assertThat(render(List.of(twilightsFall, normal))).contains("Games analyzed: 1 | Players analyzed: 2\n");
+    }
+
+    @Test
     void shouldBreakDownSkippedPlayersByFactionWithAGameToLookAt() {
         Game game = newGame("1");
         addPlayer(game, "sol", true, "jord", "wellon");

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.game.Tile;
+import ti4.helpers.Units;
+import ti4.helpers.Units.UnitType;
 import ti4.testUtils.BaseTi4Test;
 
 class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
@@ -109,6 +111,38 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
 
         assertThat(report).contains("- **All factions**: 25/50 (50%) of players lost a home planet.");
         assertThat(report).contains("(100%) homes lost. 0% win rate, 0% otherwise\n");
+    }
+
+    @Test
+    void shouldCountCoexistingOnAHomePlanetAsHoldingIt() {
+        Game game = newGame("1");
+        game.setTile(new Tile("01", "101"));
+        Player sol = addPlayer(game, "sol", true, "wellon");
+        Player letnev = addPlayer(game, "letnev", false, "arcprime", "wrenterra", "jord");
+        // Sol lost Jord to Letnev but still has infantry standing on it.
+        putInfantryOn(game, "jord", sol);
+
+        String report = render(List.of(game));
+
+        assertThat(report)
+                .contains("- **All factions**: 0/2 (0%) of players lost a home planet."
+                        + " Coexisted through 1/1 (100%) of home system losses.\n");
+        assertThat(letnev.getPlanets()).contains("jord");
+    }
+
+    @Test
+    void shouldStillCountALossWhenCoexistingOnOnlyOneOfTwoHomePlanets() {
+        Game game = newGame("1");
+        game.setTile(new Tile("10", "101"));
+        Player letnev = addPlayer(game, "letnev", false);
+        Player sol = addPlayer(game, "sol", true, "jord", "arcprime", "wrenterra");
+        // Letnev holds neither home planet and is only standing on one of them.
+        putInfantryOn(game, "arcprime", letnev);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("- **All factions**: 1/2 (50%) of players lost a home planet.");
+        assertThat(report).doesNotContain("Coexisted through");
     }
 
     @Test
@@ -400,6 +434,12 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         }
         player.getPlanets().addAll(List.of(planets));
         return player;
+    }
+
+    private static void putInfantryOn(Game game, String planet, Player player) {
+        // Coexistence is read through the player's own unit models, so they have to own infantry.
+        player.addOwnedUnitByID("infantry");
+        game.getUnitHolderFromPlanet(planet).addUnit(Units.getUnitKey(UnitType.Infantry, player.getColorID()), 1);
     }
 
     private static void takePlanets(Player player, int count) {

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -28,12 +28,25 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
         assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
         assertThat(report)
                 .contains("- **All factions**: 1.00 non-home planets on average, 50% win rate from 2 players");
-        assertThat(report).contains("  - 0-1 planets: 0% (0/1; 50%)\n");
-        assertThat(report).contains("  - 2-3 planets: 100% (1/1; 50%)\n");
+        assertThat(report).contains("  - 0 planets: 0% (0/1; 50%)\n");
+        assertThat(report).contains("  - 1-2 planets: 100% (1/1; 50%)\n");
     }
 
     @Test
-    void shouldPoolCountsIntoBandsTwoWideAndCapTheLastOne() {
+    void shouldGiveZeroPlanetsABandOfItsOwnAheadOfOneAndTwo() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra", "wellon");
+        addPlayer(game, "jolnar", false, "jol", "nar", "vefutii", "quann");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("  - 0 planets: 100% (1/1; 33.33%)\n");
+        assertThat(report).contains("  - 1-2 planets: 0% (0/2; 66.67%)\n");
+    }
+
+    @Test
+    void shouldPoolCountsIntoOddStartingBandsTwoWideAndCapTheLastOne() {
         Game game = newGame("1");
         addPlayer(game, "sol", true, "jord");
         takePlanets(game.getPlayerFromColorOrFaction("sol"), 4);
@@ -42,8 +55,8 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
 
         String report = render(List.of(game));
 
-        assertThat(report).contains("  - 4-5 planets: 100% (1/1; 50%)\n");
-        assertThat(report).contains("  - 12+ planets: 0% (0/1; 50%)\n");
+        assertThat(report).contains("  - 3-4 planets: 100% (1/1; 50%)\n");
+        assertThat(report).contains("  - 11+ planets: 0% (0/1; 50%)\n");
         assertThat(report).contains("12.00 non-home planets on average");
     }
 

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -265,15 +265,51 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldStillSkipAPlayerWithNoFactionFileAndNoHomeSystemOnTheBoard() {
+    void shouldFindALegacyKeleresHomeWithoutAPositionToGoOn() {
+        // pbd298-era games store a bare "keleres" and no home system position, so the only thing
+        // naming their home is the Keleres tile sitting on the board.
+        Game game = newGame("1");
+        game.setTile(new Tile("93new", "101"));
+        addPlayer(game, "keleres", true, "valkk", "ylirk", "avark", "wellon");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        String report = render(List.of(game));
+
+        assertThat(report).doesNotContain("### Skipped players");
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+        assertThat(report).contains("- **All factions**: 0.50 non-home planets on average");
+        assertThat(report).contains("* `100%` (1/1) Wellon\n");
+    }
+
+    @Test
+    void shouldStillSkipAPlayerWhoseFactionHasNoHomeworldAnywhereOnTheBoard() {
         Game game = newGame("1");
         addPlayer(game, "sol", true, "jord", "wellon");
-        addPlayer(game, "keleres", false, "archonrenk");
+        addPlayer(game, "keleres", false, "wellon");
 
         String report = render(List.of(game));
 
         assertThat(report).contains("### Skipped players\n");
         assertThat(report).contains("- `keleres` - 1 player(s), e.g. game `planet-stats-1`\n");
+    }
+
+    @Test
+    void shouldKeepEveryFactionHomeworldOutOfThePerPlanetRanking() {
+        // Nobody at this table is Letnev or Arborec, so their homeworlds are not covered by any
+        // seated player's home planets - the planet data is what has to keep them out.
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "arcprime", "wrenterra", "nestphar", "wellon");
+        addPlayer(game, "jolnar", false, "jol", "nar");
+
+        String report = render(List.of(game));
+
+        assertThat(report)
+                .doesNotContain("Arc Prime")
+                .doesNotContain("Wren Terra")
+                .doesNotContain("Nestphar");
+        assertThat(report).contains("* `100%` (1/1) Wellon\n");
+        // They are still ground taken outside Sol's own home system.
+        assertThat(report).contains("- **All factions**: 2.00 non-home planets on average");
     }
 
     @Test

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -265,6 +265,28 @@ class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
+    void shouldCountSilverFlamesOnEveryHomePlanetsLostLine() {
+        // pbd15718's shape: Crimson is silver flamed, so Ahk Creuxx is off the board entirely.
+        String report = render(repeatGame(MINIMUM_SAMPLE, game -> {
+            game.setStoredValue("silverFlamed", "crimson");
+            addPlayer(game, "crimson", false);
+            addPlayer(game, "sol", true, "jord", "wellon");
+        }));
+
+        assertThat(report).contains(" 25 Silver Flames (0% win rate).\n");
+        assertThat(report).contains("- **All factions**: 25/50 (50%) of players lost a home planet.");
+    }
+
+    @Test
+    void shouldLeaveTheSilverFlameSentenceOffWhenThereAreNone() {
+        Game game = newGame("1");
+        addPlayer(game, "letnev", false, "arcprime");
+        addPlayer(game, "sol", true, "jord", "wrenterra");
+
+        assertThat(render(List.of(game))).doesNotContain("Silver Flames");
+    }
+
+    @Test
     void shouldListTheGamesAFactionLostItsHomePlanetsIn() {
         Game game = newGame("1");
         game.setTile(new Tile("10", "101"));

--- a/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/PlanetWinRateStatisticsServiceTest.java
@@ -1,0 +1,173 @@
+package ti4.service.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.testUtils.BaseTi4Test;
+
+class PlanetWinRateStatisticsServiceTest extends BaseTi4Test {
+
+    private static final int MINIMUM_SAMPLE = 25;
+
+    private static final List<String> COLORS = List.of("red", "blue", "green", "yellow", "purple", "orange");
+
+    @Test
+    void shouldCountOnlyThePlanetsOutsideAPlayersOwnHomeSystem() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon", "vefutii");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+        assertThat(report)
+                .contains("- **All factions**: 1.00 non-home planets on average, 50% win rate from 2 players");
+        assertThat(report).contains("  - 0-2 planets: 50% (1/2; 100%)\n");
+    }
+
+    @Test
+    void shouldPoolCountsIntoBandsThreeWideAndCapTheLastOne() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord");
+        takePlanets(game.getPlayerFromColorOrFaction("sol"), 4);
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+        takePlanets(game.getPlayerFromColorOrFaction("letnev"), 20);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("  - 3-5 planets: 100% (1/1; 50%)\n");
+        assertThat(report).contains("  - 18+ planets: 0% (0/1; 50%)\n");
+        assertThat(report).contains("12.00 non-home planets on average");
+    }
+
+    @Test
+    void shouldSplitTheWinRateOnWhetherAHomePlanetWasLost() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "letnev", false, "arcprime");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("### Home planets lost\n");
+        assertThat(report)
+                .contains("- **All factions**: 1/2 (50%) lost one - 0% win rate when they did, 100% when they did"
+                        + " not\n");
+    }
+
+    @Test
+    void shouldSayNobodyLostAHomePlanetRatherThanDividingByZero() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true, "jord", "wellon");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        assertThat(render(List.of(game))).contains("- **All factions**: never lost a home planet, across 2 players\n");
+    }
+
+    @Test
+    void shouldRankPlanetsByWinRateOnceTheyClearTheSampleThreshold() {
+        String report = render(repeatGame(MINIMUM_SAMPLE, game -> {
+            addPlayer(game, "sol", true, "jord", "wellon");
+            addPlayer(game, "letnev", false, "arcprime", "wrenterra", "vefutii");
+        }));
+
+        assertThat(report).contains("* `100%` (25/25) Wellon\n");
+        assertThat(report).contains("* `  0%` (0/25) Vefut II\n");
+        assertThat(report).doesNotContain("Jord").doesNotContain("Arc Prime").doesNotContain("Wren Terra");
+        assertThat(report.indexOf("Wellon")).isLessThan(report.indexOf("Vefut II"));
+    }
+
+    @Test
+    void shouldKeepAConqueredHomePlanetOutOfThePerPlanetRankingButCountItAsNonHome() {
+        String report = render(repeatGame(MINIMUM_SAMPLE, game -> {
+            addPlayer(game, "sol", true, "jord", "arcprime", "wellon");
+            addPlayer(game, "letnev", false, "wrenterra");
+        }));
+
+        assertThat(report).doesNotContain("Arc Prime");
+        assertThat(report).contains("* `100%` (25/25) Wellon\n");
+        assertThat(report).contains("- **All factions**: 1.00 non-home planets on average");
+        assertThat(report).contains("- **All factions**: 25/50 (50%) lost one");
+    }
+
+    @Test
+    void shouldSuppressPlanetsBelowTheSampleThreshold() {
+        String report = render(repeatGame(MINIMUM_SAMPLE - 1, game -> {
+            addPlayer(game, "sol", true, "jord", "wellon");
+            addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+        }));
+
+        assertThat(report).contains("### Win rate by planet controlled\n");
+        assertThat(report).contains("- No planet was held that often.\n");
+        assertThat(report).doesNotContain("Wellon");
+    }
+
+    @Test
+    void shouldGiveAFactionItsOwnSectionOnlyOnceItHasEnoughPlayers() {
+        Consumer<Game> table = game -> {
+            addPlayer(game, "sol", true, "jord", "wellon");
+            addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+        };
+
+        assertThat(render(repeatGame(MINIMUM_SAMPLE - 1, table))).doesNotContain("The Federation of Sol");
+
+        String atThreshold = render(repeatGame(MINIMUM_SAMPLE, table));
+        assertThat(atThreshold).contains("The Federation of Sol");
+        assertThat(atThreshold).contains("1.00 non-home planets on average, 100% win rate from 25 players");
+        assertThat(atThreshold).contains("0.00 non-home planets on average, 0% win rate from 25 players");
+    }
+
+    @Test
+    void shouldSayNothingMatchedWhenNoGameHadAWinner() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", false, "jord");
+        addPlayer(game, "letnev", false, "arcprime", "wrenterra");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("No games matched.\n");
+        assertThat(report).doesNotContain("### Home planets lost");
+    }
+
+    private static List<Game> repeatGame(int count, Consumer<Game> seatPlayers) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(i -> {
+                    Game game = newGame(Integer.toString(i));
+                    seatPlayers.accept(game);
+                    return game;
+                })
+                .toList();
+    }
+
+    private static String render(List<Game> games) {
+        return String.join("", PlanetWinRateStatisticsService.buildReport(games));
+    }
+
+    private static Game newGame(String suffix) {
+        Game game = new Game();
+        game.setName("planet-stats-" + suffix);
+        game.setVp(1);
+        game.setRound(3);
+        game.setHasEnded(true);
+        return game;
+    }
+
+    private static Player addPlayer(Game game, String faction, boolean isWinner, String... planets) {
+        Player player = game.addPlayer(faction + "-user-" + game.getName(), faction);
+        player.setFaction(faction);
+        player.setColor(COLORS.get(game.getPlayers().size() - 1));
+        if (isWinner) {
+            player.setSecretScored("so-" + faction + "-" + game.getName());
+        }
+        player.getPlanets().addAll(List.of(planets));
+        return player;
+    }
+
+    private static void takePlanets(Player player, int count) {
+        IntStream.range(0, count).mapToObj(i -> "filler-" + i).forEach(player.getPlanets()::add);
+    }
+}


### PR DESCRIPTION
Adds `/statistics2 planet_win_rates`: what a player's board holdings at the end of the game say about whether they won.

Sample is the standard competitive one already used by the slice-tile and action-card reports — 6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario games with winners.

### Sections

**Win rate by non-home planets controlled** — planets held at the end of the game outside the player's own home system, banded three wide (`0-2`, `3-5`, … `18+`), each row carrying the share of that group's players who got that far, in the shape of the existing "Win rate by cards played". The lead bullet is the combined answer; every well-sampled faction gets its own bullet below it. Combined and per-faction bullets both lead with that group's average non-home planet count.

**Home planets lost** — how often each faction ends the game without every planet of its own home system, with the win rate when they lost one against the win rate when they did not. Combined answer first, then per faction, sorted by how often they lose one.

**Win rate by planet controlled** — a ranked row per planet. Home planets are excluded whoever ends up holding them, since they sit with the faction that started there nearly every game; a conquered homeworld still counts toward the conqueror's non-home planet total in the first section.

### Notes

- Home planets come from the faction file. Homebrew is outside the sample, so there is no franken fallback; a faction that isn't on file is skipped and counted in a header note.
- Faction sections need 25 players and planet rows need 25 holdings — below that the bands are one or two players reading as 0% and 100%. Both are constants at the top of the service.
- Output is emitted as blocks so a faction's bullet and its nested bands always land in the same Discord message.
- 9 tests in `PlanetWinRateStatisticsServiceTest`, via a package-private `buildReport(List<Game>)` mirroring `SliceTileWinRateStatisticsService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
