### PR TITLE
Allow Extreme Duress to be played from hand

### DIFF
--- a/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
+++ b/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
@@ -60,7 +60,8 @@ public class TeHelperActionCards {
                 buttons.add(Buttons.green(ffcc + "transaction_BMD", "Start Black Market Transaction"));
             case "brilliance" -> buttons.add(Buttons.green(ffcc + "brilliance", resolve));
             case "crashlanding" -> buttons.add(Buttons.green(ffcc + "crashLandingStart", "Start Crash Landing"));
-            case "crisis", "extremeduress" -> nop(); // preset
+            case "crisis" -> nop(); // preset
+            case "extremeduress" -> buttons.add(Buttons.green(ffcc + "extremeDuressStart", resolve));
             case "exchangeprogram" ->
                 buttons.add(Buttons.green(ffcc + "exchangeProgramStart", "Start Exchange Program"));
             case "lieinwait" -> buttons.add(Buttons.green(ffcc + "lieInWait", resolve));
@@ -111,6 +112,61 @@ public class TeHelperActionCards {
         String message = "Choose the player who you are trying to have an exchange with.";
         MessageHelper.sendMessageToChannelWithButtons(player.getCorrectChannel(), message, buttons);
         ButtonHelper.deleteMessage(event);
+    }
+
+    @ButtonHandler("extremeDuressStart")
+    private static void extremeDuressStart(Game game, Player player, ButtonInteractionEvent event) {
+        List<Button> buttons = new ArrayList<>();
+        for (Player p2 : game.getRealPlayersExcludingThis(player)) {
+            if (!p2.hasUnplayedSCs()) {
+                continue;
+            }
+            buttons.add(FoWHelper.fogSafeTargetButton(
+                    player.factionButtonChecker() + "extremeDuressTarget_" + p2.getColor(), "gray", p2));
+        }
+        if (buttons.isEmpty()) {
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    player.getRepresentation()
+                            + ", no other player has a readied strategy card, so there is no legal target for _Extreme Duress_ right now.");
+            return;
+        }
+        buttons.add(Buttons.red("deleteButtons", "Decline"));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                player.getRepresentation() + ", choose the player who will experience _Extreme Duress_.",
+                buttons);
+        ButtonHelper.deleteMessage(event);
+    }
+
+    @ButtonHandler("extremeDuressTarget_")
+    private static void extremeDuressTarget(Game game, Player player, ButtonInteractionEvent event, String buttonID) {
+        String color = buttonID.split("_")[1];
+        Player target = game.getPlayerFromColorOrFaction(color);
+        if (target == null) {
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    "Could not find that player. Please resolve _Extreme Duress_ manually.");
+            return;
+        }
+        // If it was also pre-assigned, clear it so it does not fire a second time at the start of a turn.
+        game.removeStoredValue("ExtremeDuress");
+        sendExtremeDuressResolutionButtons(target, player);
+        MessageHelper.sendMessageToChannel(
+                player.getCorrectChannel(),
+                player.getRepresentation() + " played _Extreme Duress_ on " + target.getRepresentationNoPing() + ".");
+        ButtonHelper.deleteMessage(event);
+    }
+
+    /** Ask {@code target} to either concede to {@code duressPlayer}'s _Extreme Duress_ or take their strategic action. */
+    public static void sendExtremeDuressResolutionButtons(Player target, Player duressPlayer) {
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.red(
+                target.factionButtonChecker() + "concedeToED_" + duressPlayer.getFaction(),
+                "Lose Action Cards, Give Trade Goods, And Show Secrets"));
+        buttons.add(Buttons.green("deleteButtons", "Give In And Play Strategy Card (or Sabo Extreme Duress)"));
+        MessageHelper.sendMessageToChannel(
+                target.getCorrectChannel(), target.getRepresentation() + ", please resolve _Extreme Duress_.", buttons);
     }
 
     @ButtonHandler("concedeToED")

--- a/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
+++ b/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
@@ -149,7 +149,6 @@ public class TeHelperActionCards {
                     "Could not find that player. Please resolve _Extreme Duress_ manually.");
             return;
         }
-        // If it was also pre-assigned, clear it so it does not fire a second time at the start of a turn.
         game.removeStoredValue("ExtremeDuress");
         sendExtremeDuressResolutionButtons(target, player);
         MessageHelper.sendMessageToChannel(
@@ -158,7 +157,6 @@ public class TeHelperActionCards {
         ButtonHelper.deleteMessage(event);
     }
 
-    /** Ask {@code target} to either concede to {@code duressPlayer}'s _Extreme Duress_ or take their strategic action. */
     public static void sendExtremeDuressResolutionButtons(Player target, Player duressPlayer) {
         List<Button> buttons = new ArrayList<>();
         buttons.add(Buttons.red(

--- a/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
+++ b/src/main/java/ti4/helpers/thundersedge/TeHelperActionCards.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.discord.interactions.buttons.Buttons;
@@ -48,6 +49,8 @@ import ti4.service.unit.RemoveUnitService;
 @UtilityClass
 public class TeHelperActionCards {
 
+    public static final String EXTREME_DURESS_AUTO_RESOLVING = "ExtremeDuressAutoResolving";
+
     public static void nop() {}
 
     public static boolean resolveTeActionCard(ActionCardModel card, Player player, String introMsg) {
@@ -61,7 +64,11 @@ public class TeHelperActionCards {
             case "brilliance" -> buttons.add(Buttons.green(ffcc + "brilliance", resolve));
             case "crashlanding" -> buttons.add(Buttons.green(ffcc + "crashLandingStart", "Start Crash Landing"));
             case "crisis" -> nop(); // preset
-            case "extremeduress" -> buttons.add(Buttons.green(ffcc + "extremeDuressStart", resolve));
+            case "extremeduress" -> {
+                if (!isAutoResolvingExtremeDuress(player.getGame())) {
+                    buttons.add(Buttons.green(ffcc + "extremeDuressStart", resolve));
+                }
+            }
             case "exchangeprogram" ->
                 buttons.add(Buttons.green(ffcc + "exchangeProgramStart", "Start Exchange Program"));
             case "lieinwait" -> buttons.add(Buttons.green(ffcc + "lieInWait", resolve));
@@ -155,6 +162,21 @@ public class TeHelperActionCards {
                 player.getCorrectChannel(),
                 player.getRepresentation() + " played _Extreme Duress_ on " + target.getRepresentationNoPing() + ".");
         ButtonHelper.deleteMessage(event);
+    }
+
+    public static void autoResolveExtremeDuress(
+            GenericInteractionCreateEvent event, Game game, Player target, Player duressPlayer) {
+        game.setStoredValue(EXTREME_DURESS_AUTO_RESOLVING, "true");
+        try {
+            ActionCardHelper.playAC(event, game, duressPlayer, "extremeduress", game.getMainGameChannel());
+        } finally {
+            game.removeStoredValue(EXTREME_DURESS_AUTO_RESOLVING);
+        }
+        sendExtremeDuressResolutionButtons(target, duressPlayer);
+    }
+
+    private static boolean isAutoResolvingExtremeDuress(Game game) {
+        return !game.getStoredValue(EXTREME_DURESS_AUTO_RESOLVING).isEmpty();
     }
 
     public static void sendExtremeDuressResolutionButtons(Player target, Player duressPlayer) {

--- a/src/main/java/ti4/service/turn/StartTurnService.java
+++ b/src/main/java/ti4/service/turn/StartTurnService.java
@@ -43,6 +43,7 @@ import ti4.helpers.ComponentActionHelper;
 import ti4.helpers.FoWHelper;
 import ti4.helpers.Helper;
 import ti4.helpers.StringHelper;
+import ti4.helpers.thundersedge.TeHelperActionCards;
 import ti4.helpers.thundersedge.TeHelperTechs;
 import ti4.image.BannerGenerator;
 import ti4.image.Mapper;
@@ -282,16 +283,7 @@ public class StartTurnService {
                 if (p2.getPlayableActionCards().contains("extremeduress")) {
                     game.removeStoredValue("ExtremeDuress");
                     ActionCardHelper.playAC(event, game, p2, "extremeduress", game.getMainGameChannel());
-                    List<Button> buttons2 = new ArrayList<>();
-                    buttons2.add(Buttons.red(
-                            player.factionButtonChecker() + "concedeToED_" + p2.getFaction(),
-                            "Lose Action Cards, Give Trade Goods, And Show Secrets"));
-                    buttons2.add(
-                            Buttons.green("deleteButtons", "Give In And Play Strategy Card (or Sabo Extreme Duress)"));
-                    MessageHelper.sendMessageToChannel(
-                            player.getCorrectChannel(),
-                            player.getRepresentation() + ", please resolve _Extreme Duress_.",
-                            buttons2);
+                    TeHelperActionCards.sendExtremeDuressResolutionButtons(player, p2);
                 }
             }
         }

--- a/src/main/java/ti4/service/turn/StartTurnService.java
+++ b/src/main/java/ti4/service/turn/StartTurnService.java
@@ -282,8 +282,7 @@ public class StartTurnService {
             for (Player p2 : game.getRealPlayers()) {
                 if (p2.getPlayableActionCards().contains("extremeduress")) {
                     game.removeStoredValue("ExtremeDuress");
-                    ActionCardHelper.playAC(event, game, p2, "extremeduress", game.getMainGameChannel());
-                    TeHelperActionCards.sendExtremeDuressResolutionButtons(player, p2);
+                    TeHelperActionCards.autoResolveExtremeDuress(event, game, player, p2);
                 }
             }
         }


### PR DESCRIPTION
Extreme Duress only ever resolved through the pre-assignment flow. Playing it directly from hand hit the `case "crisis", "extremeduress" -> nop(); // preset` branch in `TeHelperActionCards.resolveTeActionCard`, so no buttons were generated, the `ExtremeDuress` stored value was never set, and the target was never prompted with anything.

## Changes

- Playing Extreme Duress from hand now offers a **Resolve Extreme Duress** button.
- That button lists every other player with a readied strategy card as a target (fog-safe buttons), plus Decline. If nobody qualifies it says so and leaves the button in place rather than stranding you after the card is already played.
- Choosing a target sends them the same prompt the pre-assigned path sends — *Lose Action Cards, Give Trade Goods, And Show Secrets* / *Give In And Play Strategy Card (or Sabo Extreme Duress)* — landing on the existing `concedeToED` handler.
- That prompt moved out of `StartTurnService` into a shared `sendExtremeDuressResolutionButtons`, so both paths post identical buttons.
- Choosing a target clears the `ExtremeDuress` stored value, so a stale pre-assignment can't fire the card a second time at someone's turn start.

`crisis` keeps its existing `nop()` preset-only behaviour.

## Note

Targets are filtered only on "has an unplayed strategy card", matching the filter `checkForAssigningExtremeDuress` already uses. Strictly, the card's window is the start of *another player's turn*, so only the active player is a legal target — but the pre-assign path doesn't enforce that either, and staying lenient keeps it usable for unusual turn orders and Mahact-style takeovers. Easy to tighten if you'd rather it hard-restrict to the active player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
