### PR TITLE
Replace color hue with a colorCategories set

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/help/SampleColors.java
+++ b/src/main/java/ti4/discord/interactions/commands/help/SampleColors.java
@@ -30,10 +30,17 @@ import ti4.service.image.FileUploadService;
 
 class SampleColors extends Subcommand {
 
+    private static final String MULTI = "MULTI";
+
     SampleColors() {
         super(Constants.SAMPLE_COLORS, "Show a sample image of dreadnoughts in various player colors.");
         addOptions(new OptionData(OptionType.STRING, Constants.HUE, "General hue of colors to show (default: all)")
                 .setAutoComplete(true));
+    }
+
+    private static boolean isInCategory(ColorModel color, String category) {
+        if (MULTI.equals(category)) return color.isMulti();
+        return !color.isMulti() && color.getColorCategories().contains(category);
     }
 
     @Override
@@ -55,9 +62,8 @@ class SampleColors extends Subcommand {
         if (input == null
                 || Constants.ALL.equals(input.getAsString())
                 || input.getAsString().isEmpty()) {
-            hues = Arrays.asList(
-                    "RED", "GRAY", "ORANGE", "YELLOW", "GREEN", "BLUE", "PURPLE", "PINK", "MULTI1", "MULTI2", "MULTI3");
-            fewer = 3;
+            hues = Arrays.asList("RED", "GRAY", "ORANGE", "YELLOW", "GREEN", "BLUE", "PURPLE", "PINK", MULTI);
+            fewer = 1;
         } else {
             SPACING = 12;
             DREADWIDTH = 77 + 2 * SPACING;
@@ -66,11 +72,9 @@ class SampleColors extends Subcommand {
             LINEHEIGHT = 20;
             bigFont = Storage.getFont16();
             smallFont = Storage.getFont12();
-            if ("MULTI".equals(input.getAsString())) {
-                hues = Arrays.asList("MULTI1", "MULTI2", "MULTI3");
-                fewer = 3;
-            } else {
-                hues.add(input.getAsString());
+            hues.add(input.getAsString());
+            if (MULTI.equals(input.getAsString())) {
+                fewer = 1;
             }
             stroke = new BasicStroke(3.0f);
         }
@@ -79,7 +83,7 @@ class SampleColors extends Subcommand {
         for (String h : hues) {
             int count = 0;
             for (ColorModel c : Mapper.getColors()) {
-                if (c.getHue().equals(h)) {
+                if (isInCategory(c, h)) {
                     count++;
                 }
             }
@@ -106,9 +110,9 @@ class SampleColors extends Subcommand {
 
         for (String h : hues) {
             x = left;
-            boolean multi = h.contains("MULTI");
+            boolean multi = MULTI.equals(h);
             for (ColorModel c : Mapper.getColors()) {
-                if (!c.getHue().equals(h)) {
+                if (!isInCategory(c, h)) {
                     continue;
                 }
                 String alias = c.getAlias();

--- a/src/main/java/ti4/discord/interactions/commands/help/SampleColors.java
+++ b/src/main/java/ti4/discord/interactions/commands/help/SampleColors.java
@@ -62,7 +62,8 @@ class SampleColors extends Subcommand {
         if (input == null
                 || Constants.ALL.equals(input.getAsString())
                 || input.getAsString().isEmpty()) {
-            hues = Arrays.asList("RED", "GRAY", "ORANGE", "YELLOW", "GREEN", "BLUE", "PURPLE", "PINK", MULTI);
+            hues = Arrays.asList(
+                    "RED", "ORANGE", "BROWN", "YELLOW", "GREEN", "BLUE", "PURPLE", "PINK", "WHITE", "BLACK", MULTI);
             fewer = 1;
         } else {
             SPACING = 12;

--- a/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
+++ b/src/main/java/ti4/discord/interactions/listeners/AutoCompleteProvider.java
@@ -183,16 +183,15 @@ class AutoCompleteProvider {
                 Map<String, String> values = new HashMap<>() {
                     {
                         put("RED", "Reds");
-                        put("GRAY", "Grays");
-                        // put("GRAY", "Greys");// TODO duplicate keys
-                        // put("GRAY", "Blacks");
                         put("ORANGE", "Oranges");
-                        // put("ORANGE", "Browns");
+                        put("BROWN", "Browns");
                         put("YELLOW", "Yellows");
                         put("GREEN", "Greens");
                         put("BLUE", "Blues");
                         put("PURPLE", "Purples");
                         put("PINK", "Pinks");
+                        put("WHITE", "Whites");
+                        put("BLACK", "Blacks");
                         put("MULTI", "Multi-Colours");
                         put(Constants.ALL, "ALL COLOURS");
                     }

--- a/src/main/java/ti4/model/ColorModel.java
+++ b/src/main/java/ti4/model/ColorModel.java
@@ -3,6 +3,7 @@ package ti4.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.awt.Color;
 import java.util.List;
+import java.util.Set;
 import lombok.Data;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import org.apache.commons.lang3.StringUtils;
@@ -17,7 +18,8 @@ public class ColorModel implements ModelInterface {
     private String displayName;
     private List<String> aliases;
     private String textColor;
-    private String hue;
+
+    private Set<String> colorCategories;
 
     private Color primaryColor;
     private Color secondaryColor;
@@ -49,8 +51,13 @@ public class ColorModel implements ModelInterface {
         return getPrimaryColor();
     }
 
-    public String getHue() {
-        return (hue == null ? "null" : hue);
+    public Set<String> getColorCategories() {
+        return (colorCategories == null ? Set.of() : colorCategories);
+    }
+
+    @JsonIgnore
+    public boolean isMulti() {
+        return getColorCategories().size() > 1;
     }
 
     @JsonIgnore
@@ -112,8 +119,8 @@ public class ColorModel implements ModelInterface {
                 + name + '\'' + ", displayName='"
                 + displayName + '\'' + ", aliases="
                 + aliases + ", textColor='"
-                + textColor + '\'' + ", hue='"
-                + hue + '\'' + ", primaryColor="
+                + textColor + '\'' + ", colorCategories="
+                + colorCategories + ", primaryColor="
                 + primaryColor + ", secondaryColor="
                 + secondaryColor + ", primaryColorRef='"
                 + primaryColorRef + '\'' + ", secondaryColorRef='"

--- a/src/main/java/ti4/service/game/GameColorsService.java
+++ b/src/main/java/ti4/service/game/GameColorsService.java
@@ -3,6 +3,8 @@ package ti4.service.game;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import ti4.game.Game;
 import ti4.game.Player;
@@ -37,7 +39,9 @@ public class GameColorsService {
                 .toList();
     }
 
-    public static List<String> getUsedHues(Game game) {
-        return getUsedColors(game).stream().map(ColorModel::getHue).toList();
+    public static Set<String> getUsedColorCategories(Game game) {
+        return getUsedColors(game).stream()
+                .flatMap(color -> color.getColorCategories().stream())
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/ti4/service/player/PlayerColorService.java
+++ b/src/main/java/ti4/service/player/PlayerColorService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import lombok.experimental.UtilityClass;
 import ti4.game.Player;
 import ti4.helpers.ColorChangeHelper;
@@ -25,11 +26,11 @@ public class PlayerColorService {
         String color = getUsersPreferredColor(player, unusedColors);
         if (color != null) return color;
 
-        List<String> usedHues = GameColorsService.getUsedHues(player.getGame());
-        color = getFactionsPreferredColor(faction, unusedColors, usedHues);
+        Set<String> usedCategories = GameColorsService.getUsedColorCategories(player.getGame());
+        color = getFactionsPreferredColor(faction, unusedColors, usedCategories);
         if (color != null) return color;
 
-        return getPreferredColor(unusedColors, usedHues);
+        return getPreferredColor(unusedColors, usedCategories);
     }
 
     private static String getUsersPreferredColor(Player player, Collection<ColorModel> unusedColors) {
@@ -41,22 +42,22 @@ public class PlayerColorService {
     }
 
     private static String getFactionsPreferredColor(
-            String faction, Collection<ColorModel> unusedColors, Collection<String> usedHues) {
+            String faction, Collection<ColorModel> unusedColors, Collection<String> usedCategories) {
         FactionModel factionModel = Mapper.getFaction(faction);
         if (factionModel == null) return null;
         List<String> preferredColors = new ArrayList<>(factionModel.getPreferredColours());
         Collections.shuffle(preferredColors);
         return preferredColors.stream()
                 .filter(color -> unusedColors.contains(Mapper.getColor(color)))
-                .filter(color -> !usedHues.contains(Mapper.getColor(color).getHue()))
+                .filter(color -> !overlapsUsedCategories(Mapper.getColor(color), usedCategories))
                 .findFirst()
                 .map(Mapper::getColorName)
                 .orElse(null);
     }
 
-    private static String getPreferredColor(Collection<ColorModel> unusedColors, Collection<String> usedHues) {
+    private static String getPreferredColor(Collection<ColorModel> unusedColors, Collection<String> usedCategories) {
         return unusedColors.stream()
-                .filter(c -> !usedHues.contains(c.getHue()))
+                .filter(c -> !overlapsUsedCategories(c, usedCategories))
                 .findFirst()
                 .map(ColorModel::getName)
                 .map(Mapper::getColorName)
@@ -65,6 +66,10 @@ public class PlayerColorService {
                         .map(ColorModel::getName)
                         .map(Mapper::getColorName)
                         .orElse(null));
+    }
+
+    private static boolean overlapsUsedCategories(ColorModel color, Collection<String> usedCategories) {
+        return color.getColorCategories().stream().anyMatch(usedCategories::contains);
     }
 
     private static boolean canUseColor(Player player, String color) {

--- a/src/main/resources/data/colors/gradientColors.json
+++ b/src/main/resources/data/colors/gradientColors.json
@@ -24,7 +24,7 @@
         "textColor": "white",
         "primaryColor": { "red": 240, "green": 6, "blue": 6 },
         "secondaryColor": { "red": 245, "green": 245, "blue": 6 },
-        "colorCategories": ["RED"]
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "gcr",
@@ -60,7 +60,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 100, "blue": 1 },
         "secondaryColor": { "red": 190, "green": 190, "blue": 1 },
-        "colorCategories": ["YELLOW"]
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "bld",
@@ -78,7 +78,7 @@
         "textColor": "white",
         "primaryColor": { "red": 229, "green": 134, "blue": 0 },
         "secondaryColor": { "red": 79, "green": 40, "blue": 0 },
-        "colorCategories": ["ORANGE"]
+        "colorCategories": ["BROWN"]
     },
     {
         "alias": "nvy",

--- a/src/main/resources/data/colors/gradientColors.json
+++ b/src/main/resources/data/colors/gradientColors.json
@@ -96,7 +96,7 @@
         "textColor": "white",
         "primaryColor": { "red": 140, "green": 60, "blue": 55 },
         "secondaryColor": { "red": 60, "green": 30, "blue": 25 },
-        "colorCategories": ["ORANGE"]
+        "colorCategories": ["BROWN"]
     },
     {
         "alias": "eme",
@@ -150,7 +150,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 0, "blue": 0 },
         "secondaryColor": { "red": 0, "green": 255, "blue": 0 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["BLACK"]
     },
     {
         "alias": "sbt",
@@ -168,7 +168,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 0, "blue": 0 },
         "secondaryColor": { "red": 0, "green": 255, "blue": 0 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["WHITE"]
     },
     {
         "alias": "wsp",
@@ -186,7 +186,7 @@
         "textColor": "white",
         "primaryColor": { "red": 255, "green": 255, "blue": 255 },
         "secondaryColor": { "red": 0, "green": 0, "blue": 0 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["BLACK", "WHITE"]
     },
     {
         "alias": "pld",
@@ -213,7 +213,7 @@
         "textColor": "white",
         "primaryColor": { "red": 74, "green": 27, "blue": 36 },
         "secondaryColor": { "red": 135, "green": 0, "blue": 4 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["BROWN"]
     },
     {
         "alias": "nm",
@@ -231,7 +231,7 @@
         "textColor": "black",
         "primaryColor": { "red": 242, "green": 242, "blue": 242 },
         "secondaryColor": { "red": 255, "green": 210, "blue": 112 },
-        "colorCategories": ["GRAY", "YELLOW"]
+        "colorCategories": ["WHITE", "YELLOW"]
     },
     {
         "alias": "abr",
@@ -240,7 +240,7 @@
         "textColor": "black",
         "primaryColor": { "red": 206, "green": 206, "blue": 206 },
         "secondaryColor": { "red": 50, "green": 50, "blue": 50 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["WHITE"]
     },
     {
         "alias": "ryl",
@@ -258,7 +258,7 @@
         "textColor": "black",
         "primaryColor": { "red": 243, "green": 229, "blue": 171 },
         "secondaryColor": { "red": 150, "green": 80, "blue": 42 },
-        "colorCategories": ["ORANGE"]
+        "colorCategories": ["BROWN"]
     },
     {
         "alias": "psy",
@@ -276,7 +276,7 @@
         "textColor": "white",
         "primaryColor": { "red": 90, "green": 150, "blue": 100 },
         "secondaryColor": { "red": 172, "green": 160, "blue": 116 },
-        "colorCategories": ["ORANGE"]
+        "colorCategories": ["BROWN"]
     },
     {
         "alias": "blt",

--- a/src/main/resources/data/colors/gradientColors.json
+++ b/src/main/resources/data/colors/gradientColors.json
@@ -6,7 +6,7 @@
         "textColor": "black",
         "primaryColor": { "red": 104, "green": 180, "blue": 238 },
         "secondaryColor": { "red": 228, "green": 175, "blue": 30 },
-        "hue": "MULTI2"
+        "colorCategories": ["YELLOW"]
     },
     {
         "alias": "sns",
@@ -15,7 +15,7 @@
         "textColor": "black",
         "primaryColor": { "red": 120, "green": 129, "blue": 255 },
         "secondaryColor": { "red": 255, "green": 90, "blue": 132 },
-        "hue": "PURPLE"
+        "colorCategories": ["PURPLE", "RED", "PINK"]
     },
     {
         "alias": "mgm",
@@ -24,7 +24,7 @@
         "textColor": "white",
         "primaryColor": { "red": 240, "green": 6, "blue": 6 },
         "secondaryColor": { "red": 245, "green": 245, "blue": 6 },
-        "hue": "RED"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "gcr",
@@ -33,7 +33,7 @@
         "textColor": "white",
         "primaryColor": { "red": 5, "green": 240, "blue": 240 },
         "secondaryColor": { "red": 5, "green": 5, "blue": 245 },
-        "hue": "BLUE"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "tpl",
@@ -42,7 +42,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 178, "blue": 120 },
         "secondaryColor": { "red": 89, "green": 255, "blue": 131 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "tqs",
@@ -51,7 +51,7 @@
         "textColor": "black",
         "primaryColor": { "red": 63, "green": 255, "blue": 145 },
         "secondaryColor": { "red": 40, "green": 255, "blue": 255 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "gld",
@@ -60,7 +60,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 100, "blue": 1 },
         "secondaryColor": { "red": 190, "green": 190, "blue": 1 },
-        "hue": "YELLOW"
+        "colorCategories": ["YELLOW"]
     },
     {
         "alias": "bld",
@@ -69,7 +69,7 @@
         "textColor": "white",
         "primaryColor": { "red": 230, "green": 0, "blue": 40 },
         "secondaryColor": { "red": 80, "green": 0, "blue": 20 },
-        "hue": "RED"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "cpr",
@@ -78,7 +78,7 @@
         "textColor": "white",
         "primaryColor": { "red": 229, "green": 134, "blue": 0 },
         "secondaryColor": { "red": 79, "green": 40, "blue": 0 },
-        "hue": "ORANGE"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "nvy",
@@ -87,7 +87,7 @@
         "textColor": "white",
         "primaryColor": { "red": 50, "green": 60, "blue": 255 },
         "secondaryColor": { "red": 5, "green": 5, "blue": 120 },
-        "hue": "BLUE"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "chk",
@@ -96,7 +96,7 @@
         "textColor": "white",
         "primaryColor": { "red": 140, "green": 60, "blue": 55 },
         "secondaryColor": { "red": 60, "green": 30, "blue": 25 },
-        "hue": "ORANGE"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "eme",
@@ -105,7 +105,7 @@
         "textColor": "white",
         "primaryColor": { "red": 37, "green": 255, "blue": 47 },
         "secondaryColor": { "red": 0, "green": 90, "blue": 30 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "wtm",
@@ -114,7 +114,7 @@
         "textColor": "white",
         "primaryColor": { "red": 240, "green": 6, "blue": 6 },
         "secondaryColor": { "red": 6, "green": 175, "blue": 50 },
-        "hue": "MULTI2"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "vpw",
@@ -123,7 +123,7 @@
         "textColor": "white",
         "primaryColor": { "red": 6, "green": 239, "blue": 240 },
         "secondaryColor": { "red": 175, "green": 6, "blue": 131 },
-        "hue": "MULTI2"
+        "colorCategories": ["PINK"]
     },
     {
         "alias": "jpt",
@@ -132,7 +132,7 @@
         "textColor": "black",
         "primaryColor": { "red": 6, "green": 75, "blue": 203 },
         "secondaryColor": { "red": 240, "green": 180, "blue": 6 },
-        "hue": "MULTI2"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "psn",
@@ -141,7 +141,7 @@
         "textColor": "white",
         "primaryColor": { "red": 6, "green": 175, "blue": 50 },
         "secondaryColor": { "red": 146, "green": 6, "blue": 186 },
-        "hue": "MULTI2"
+        "colorCategories": ["PURPLE"]
     },
     {
         "alias": "rbw",
@@ -150,7 +150,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 0, "blue": 0 },
         "secondaryColor": { "red": 0, "green": 255, "blue": 0 },
-        "hue": "MULTI1"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "sbt",
@@ -159,7 +159,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 0, "blue": 0 },
         "secondaryColor": { "red": 0, "green": 255, "blue": 0 },
-        "hue": "MULTI1"
+        "colorCategories": ["PINK"]
     },
     {
         "alias": "ptb",
@@ -168,7 +168,7 @@
         "textColor": "black",
         "primaryColor": { "red": 255, "green": 0, "blue": 0 },
         "secondaryColor": { "red": 0, "green": 255, "blue": 0 },
-        "hue": "MULTI1"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "wsp",
@@ -177,7 +177,7 @@
         "textColor": "black",
         "primaryColor": { "red": 245, "green": 245, "blue": 6 },
         "secondaryColor": { "red": 0, "green": 0, "blue": 0 },
-        "hue": "YELLOW"
+        "colorCategories": ["YELLOW"]
     },
     {
         "alias": "cqr",
@@ -186,7 +186,7 @@
         "textColor": "white",
         "primaryColor": { "red": 255, "green": 255, "blue": 255 },
         "secondaryColor": { "red": 0, "green": 0, "blue": 0 },
-        "hue": "GRAY"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "pld",
@@ -195,7 +195,7 @@
         "textColor": "white",
         "primaryColor": { "red": 240, "green": 6, "blue": 6 },
         "secondaryColor": { "red": 50, "green": 50, "blue": 50 },
-        "hue": "RED"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "hqn",
@@ -204,7 +204,7 @@
         "textColor": "white",
         "primaryColor": { "red": 6, "green": 175, "blue": 50 },
         "secondaryColor": { "red": 5, "green": 45, "blue": 176 },
-        "hue": "MULTI3"
+        "colorCategories": ["GREEN", "BLUE"]
     },
     {
         "alias": "ero",
@@ -213,7 +213,7 @@
         "textColor": "white",
         "primaryColor": { "red": 74, "green": 27, "blue": 36 },
         "secondaryColor": { "red": 135, "green": 0, "blue": 4 },
-        "hue": "GRAY"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "nm",
@@ -222,7 +222,7 @@
         "textColor": "white",
         "primaryColor": { "red": 109, "green": 0, "blue": 10 },
         "secondaryColor": { "red": 79, "green": 50, "blue": 81 },
-        "hue": "MULTI3"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "dw",
@@ -231,7 +231,7 @@
         "textColor": "black",
         "primaryColor": { "red": 242, "green": 242, "blue": 242 },
         "secondaryColor": { "red": 255, "green": 210, "blue": 112 },
-        "hue": "MULTI2"
+        "colorCategories": ["GRAY", "YELLOW"]
     },
     {
         "alias": "abr",
@@ -240,7 +240,7 @@
         "textColor": "black",
         "primaryColor": { "red": 206, "green": 206, "blue": 206 },
         "secondaryColor": { "red": 50, "green": 50, "blue": 50 },
-        "hue": "MULTI1"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "ryl",
@@ -249,7 +249,7 @@
         "textColor": "white",
         "primaryColor": { "red": 119, "green": 17, "blue": 247 },
         "secondaryColor": { "red": 42, "green": 7, "blue": 87 },
-        "hue": "PURPLE"
+        "colorCategories": ["PURPLE"]
     },
     {
         "alias": "nea",
@@ -258,7 +258,7 @@
         "textColor": "black",
         "primaryColor": { "red": 243, "green": 229, "blue": 171 },
         "secondaryColor": { "red": 150, "green": 80, "blue": 42 },
-        "hue": "MULTI2"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "psy",
@@ -267,7 +267,7 @@
         "textColor": "black",
         "primaryColor": { "red": 146, "green": 6, "blue": 186 },
         "secondaryColor": { "red": 245, "green": 245, "blue": 6 },
-        "hue": "MULTI3"
+        "colorCategories": ["PINK"]
     },
     {
         "alias": "cam",
@@ -276,7 +276,7 @@
         "textColor": "white",
         "primaryColor": { "red": 90, "green": 150, "blue": 100 },
         "secondaryColor": { "red": 172, "green": 160, "blue": 116 },
-        "hue": "MULTI3"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "blt",
@@ -285,6 +285,6 @@
         "textColor": "black",
         "primaryColor": { "red": 240, "green": 138, "blue": 240 },
         "secondaryColor": { "red": 177, "green": 229, "blue": 165 },
-        "hue": "MULTI3"
+        "colorCategories": ["PINK"]
     }
 ]

--- a/src/main/resources/data/colors/solidColors.json
+++ b/src/main/resources/data/colors/solidColors.json
@@ -6,7 +6,7 @@
         "aliases": ["lgy", "lightgrey", "white", "W"],
         "textColor": "black",
         "primaryColor": { "red": 206, "green": 206, "blue": 206 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["WHITE"]
     },
     {
         "alias": "red",
@@ -70,7 +70,7 @@
         "aliases": ["black", "blk"],
         "textColor": "white",
         "primaryColor": { "red": 50, "green": 50, "blue": 50 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["BLACK"]
     },
     {
         "alias": "ptr",
@@ -94,7 +94,7 @@
         "aliases": ["bwn"],
         "textColor": "white",
         "primaryColor": { "red": 150, "green": 80, "blue": 42 },
-        "colorCategories": ["ORANGE"]
+        "colorCategories": ["BROWN"]
     },
     {
         "alias": "gry",
@@ -102,7 +102,7 @@
         "aliases": ["gray", "grey", "gry"],
         "textColor": "white",
         "primaryColor": { "red": 110, "green": 122, "blue": 150 },
-        "colorCategories": ["GRAY"]
+        "colorCategories": ["BLACK"]
     },
     {
         "alias": "tan",
@@ -110,7 +110,7 @@
         "aliases": ["tan"],
         "textColor": "black",
         "primaryColor": { "red": 172, "green": 160, "blue": 116 },
-        "colorCategories": ["ORANGE"]
+        "colorCategories": ["BROWN"]
     },
     {
         "alias": "frs",

--- a/src/main/resources/data/colors/solidColors.json
+++ b/src/main/resources/data/colors/solidColors.json
@@ -174,7 +174,7 @@
         "aliases": ["pch"],
         "textColor": "black",
         "primaryColor": { "red": 232, "green": 184, "blue": 167 },
-        "colorCategories": ["ORANGE"]
+        "colorCategories": ["PINK"]
     },
     {
         "alias": "eth",
@@ -230,6 +230,6 @@
         "aliases": ["beg", "beige"],
         "textColor": "black",
         "primaryColor": { "red": 189, "green": 197, "blue": 133 },
-        "colorCategories": ["YELLOW"]
+        "colorCategories": ["BROWN"]
     }
 ]

--- a/src/main/resources/data/colors/solidColors.json
+++ b/src/main/resources/data/colors/solidColors.json
@@ -6,7 +6,7 @@
         "aliases": ["lgy", "lightgrey", "white", "W"],
         "textColor": "black",
         "primaryColor": { "red": 206, "green": 206, "blue": 206 },
-        "hue": "GRAY"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "red",
@@ -14,7 +14,7 @@
         "aliases": ["red"],
         "textColor": "white",
         "primaryColor": { "red": 240, "green": 6, "blue": 6 },
-        "hue": "RED"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "org",
@@ -22,7 +22,7 @@
         "aliases": ["orange", "E", "org"],
         "textColor": "black",
         "primaryColor": { "red": 240, "green": 180, "blue": 6 },
-        "hue": "ORANGE"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "ylw",
@@ -30,7 +30,7 @@
         "aliases": ["yellow", "Y", "ylw"],
         "textColor": "black",
         "primaryColor": { "red": 245, "green": 245, "blue": 6 },
-        "hue": "YELLOW"
+        "colorCategories": ["YELLOW"]
     },
     {
         "alias": "grn",
@@ -38,7 +38,7 @@
         "aliases": ["green", "grn"],
         "textColor": "white",
         "primaryColor": { "red": 6, "green": 175, "blue": 50 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "blu",
@@ -46,7 +46,7 @@
         "aliases": ["blue", "blu"],
         "textColor": "white",
         "primaryColor": { "red": 6, "green": 75, "blue": 203 },
-        "hue": "BLUE"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "ppl",
@@ -54,7 +54,7 @@
         "aliases": ["purple", "P", "ppl"],
         "textColor": "white",
         "primaryColor": { "red": 146, "green": 6, "blue": 186 },
-        "hue": "PURPLE"
+        "colorCategories": ["PURPLE"]
     },
     {
         "alias": "pnk",
@@ -62,7 +62,7 @@
         "aliases": ["pink", "K", "pnk"],
         "textColor": "black",
         "primaryColor": { "red": 240, "green": 138, "blue": 240 },
-        "hue": "PINK"
+        "colorCategories": ["PINK"]
     },
     {
         "alias": "blk",
@@ -70,7 +70,7 @@
         "aliases": ["black", "blk"],
         "textColor": "white",
         "primaryColor": { "red": 50, "green": 50, "blue": 50 },
-        "hue": "GRAY"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "ptr",
@@ -78,7 +78,7 @@
         "aliases": ["ptr"],
         "textColor": "white",
         "primaryColor": { "red": 66, "green": 140, "blue": 140 },
-        "hue": "BLUE"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "rst",
@@ -86,7 +86,7 @@
         "aliases": ["rst"],
         "textColor": "white",
         "primaryColor": { "red": 140, "green": 66, "blue": 72 },
-        "hue": "RED"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "bwn",
@@ -94,7 +94,7 @@
         "aliases": ["bwn"],
         "textColor": "white",
         "primaryColor": { "red": 150, "green": 80, "blue": 42 },
-        "hue": "ORANGE"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "gry",
@@ -102,7 +102,7 @@
         "aliases": ["gray", "grey", "gry"],
         "textColor": "white",
         "primaryColor": { "red": 110, "green": 122, "blue": 150 },
-        "hue": "GRAY"
+        "colorCategories": ["GRAY"]
     },
     {
         "alias": "tan",
@@ -110,7 +110,7 @@
         "aliases": ["tan"],
         "textColor": "black",
         "primaryColor": { "red": 172, "green": 160, "blue": 116 },
-        "hue": "ORANGE"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "frs",
@@ -118,7 +118,7 @@
         "aliases": ["frs"],
         "textColor": "white",
         "primaryColor": { "red": 90, "green": 150, "blue": 100 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "plm",
@@ -126,7 +126,7 @@
         "aliases": ["plm"],
         "textColor": "white",
         "primaryColor": { "red": 150, "green": 90, "blue": 140 },
-        "hue": "PURPLE"
+        "colorCategories": ["PURPLE"]
     },
     {
         "alias": "tea",
@@ -134,7 +134,7 @@
         "aliases": ["tea"],
         "textColor": "black",
         "primaryColor": { "red": 0, "green": 235, "blue": 255 },
-        "hue": "BLUE"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "rse",
@@ -142,7 +142,7 @@
         "aliases": ["rse"],
         "textColor": "black",
         "primaryColor": { "red": 217, "green": 165, "blue": 229 },
-        "hue": "PINK"
+        "colorCategories": ["PINK"]
     },
     {
         "alias": "lme",
@@ -150,7 +150,7 @@
         "aliases": ["lme"],
         "textColor": "black",
         "primaryColor": { "red": 177, "green": 229, "blue": 165 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "lvn",
@@ -158,7 +158,7 @@
         "aliases": ["lvn"],
         "textColor": "black",
         "primaryColor": { "red": 169, "green": 167, "blue": 231 },
-        "hue": "PURPLE"
+        "colorCategories": ["PURPLE"]
     },
     {
         "alias": "spr",
@@ -166,7 +166,7 @@
         "aliases": ["spr"],
         "textColor": "black",
         "primaryColor": { "red": 219, "green": 231, "blue": 167 },
-        "hue": "YELLOW"
+        "colorCategories": ["YELLOW"]
     },
     {
         "alias": "pch",
@@ -174,7 +174,7 @@
         "aliases": ["pch"],
         "textColor": "black",
         "primaryColor": { "red": 232, "green": 184, "blue": 167 },
-        "hue": "ORANGE"
+        "colorCategories": ["ORANGE"]
     },
     {
         "alias": "eth",
@@ -182,7 +182,7 @@
         "aliases": ["eth"],
         "textColor": "black",
         "primaryColor": { "red": 35, "green": 104, "blue": 200 },
-        "hue": "BLUE"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "rby",
@@ -190,7 +190,7 @@
         "aliases": ["rby"],
         "textColor": "black",
         "primaryColor": { "red": 212, "green": 43, "blue": 75 },
-        "hue": "RED"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "jad",
@@ -198,7 +198,7 @@
         "aliases": ["jad"],
         "textColor": "black",
         "primaryColor": { "red": 35, "green": 200, "blue": 49 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "azr",
@@ -206,7 +206,7 @@
         "aliases": ["azure", "azr"],
         "textColor": "black",
         "primaryColor": { "red": 139, "green": 190, "blue": 241 },
-        "hue": "BLUE"
+        "colorCategories": ["BLUE"]
     },
     {
         "alias": "cnb",
@@ -214,7 +214,7 @@
         "aliases": ["cinnabar", "cnb"],
         "textColor": "black",
         "primaryColor": { "red": 241, "green": 156, "blue": 139 },
-        "hue": "RED"
+        "colorCategories": ["RED"]
     },
     {
         "alias": "vdg",
@@ -222,7 +222,7 @@
         "aliases": ["verdigris", "vdg"],
         "textColor": "black",
         "primaryColor": { "red": 109, "green": 211, "blue": 206 },
-        "hue": "GREEN"
+        "colorCategories": ["GREEN"]
     },
     {
         "alias": "beg",
@@ -230,6 +230,6 @@
         "aliases": ["beg", "beige"],
         "textColor": "black",
         "primaryColor": { "red": 189, "green": 197, "blue": 133 },
-        "hue": "YELLOW"
+        "colorCategories": ["YELLOW"]
     }
 ]

--- a/src/test/java/ti4/model/ColorModelTest.java
+++ b/src/test/java/ti4/model/ColorModelTest.java
@@ -39,7 +39,7 @@ class ColorModelTest extends BaseTi4Test {
     }
 
     private static final Set<String> VALID_CATEGORIES =
-            Set.of("RED", "GRAY", "ORANGE", "YELLOW", "GREEN", "BLUE", "PURPLE", "PINK");
+            Set.of("RED", "ORANGE", "BROWN", "YELLOW", "GREEN", "BLUE", "PURPLE", "PINK", "WHITE", "BLACK");
 
     private static void checkColorCategories(ColorModel color) {
         for (String category : color.getColorCategories()) {

--- a/src/test/java/ti4/model/ColorModelTest.java
+++ b/src/test/java/ti4/model/ColorModelTest.java
@@ -34,7 +34,48 @@ class ColorModelTest extends BaseTi4Test {
             checkEmojisConfig(color);
             checkUnitImages(color);
             checkTokenImages(color);
+            checkColorCategories(color);
         }
+    }
+
+    private static final Set<String> VALID_CATEGORIES =
+            Set.of("RED", "GRAY", "ORANGE", "YELLOW", "GREEN", "BLUE", "PURPLE", "PINK");
+
+    private static void checkColorCategories(ColorModel color) {
+        for (String category : color.getColorCategories()) {
+            assertTrue(
+                    VALID_CATEGORIES.contains(category),
+                    color.getName() + " has an unknown colorCategory: " + category);
+        }
+    }
+
+    @Test
+    void testPinkishColorsAvoidEachOther() {
+        ColorModel pink = Mapper.getColor("pink");
+        ColorModel psychedelic = Mapper.getColor("psychedelic");
+        ColorModel sunset = Mapper.getColor("sunset");
+
+        assertTrue(overlaps(pink, psychedelic), "pink and psychedelic should be considered overlapping");
+        assertTrue(overlaps(pink, sunset), "pink and sunset should be considered overlapping");
+        assertTrue(overlaps(psychedelic, sunset), "psychedelic and sunset should be considered overlapping");
+    }
+
+    @Test
+    void testDisjointCategoriesDoNotOverlap() {
+        ColorModel psychedelic = Mapper.getColor("psychedelic");
+        ColorModel harlequin = Mapper.getColor("harlequin");
+
+        assertFalse(overlaps(psychedelic, harlequin), "disjoint categories should not count as overlapping");
+    }
+
+    @Test
+    void testMultiIsDerivedFromCategoryCount() {
+        assertTrue(Mapper.getColor("sunset").isMulti(), "sunset has three categories");
+        assertFalse(Mapper.getColor("red").isMulti(), "red has one category");
+    }
+
+    private static boolean overlaps(ColorModel c1, ColorModel c2) {
+        return c1.getColorCategories().stream().anyMatch(c2.getColorCategories()::contains);
     }
 
     private static boolean isDefault(String emoji) {


### PR DESCRIPTION
Colors carried a single `hue`, and the color-overlap check at game start compared those hues so two players wouldn't end up looking alike. That had a hole: `MULTI1`/`MULTI2`/`MULTI3` were pseudo-hues a gradient color had *instead of* a real one, so a multi-colored color could never overlap a plain one — psychedelic and sunset were happily handed out alongside pink.

This replaces `hue` with a `colorCategories` set.

## What changed

**One field instead of two.** A color's categories are the color groups it reads as on the map. Most colors have exactly one (`red` → `["RED"]`); gradient colors have as many as they need.

**MULTI is derived, not stored.** `isMulti()` is simply "more than one category". The three `MULTI*` sentinel values are gone.

**Overlap is a set intersection.** No special-casing left in the avoidance code — `PlayerColorService` rejects a candidate that shares any category with a color already in the game.

**The category list is finer than the old hue list.** `GRAY` is gone, replaced by `BLACK` and `WHITE`; `BROWN` is pulled out of `ORANGE`. Under the old list, "clashes with black" and "clashes with white" were unavoidably the same rule, and every brown-ish color clashed with orange.

**`/sample_colors`** pages on the ten categories plus one derived MULTI page, and its autocomplete offers the same list. The old `Greys`/`Blacks`/`Browns` entries that were commented out as duplicate keys are now real categories.

## Resulting categories

| category | colors |
|---|---|
| RED | red, rust, ruby, cinnabar, bloodred, plaid, nightmare |
| ORANGE | orange, magma, gold |
| BROWN | brown, tan, beige, copper, chocolate, riftset, neapolitan, camouflage |
| YELLOW | yellow, spring, chrome, wasp |
| GREEN | green, forest, lime, jade, verdigris, tropical, turquoise, emerald, watermelon |
| BLUE | blue, petrol, teal, ethereal, azure, glacier, navy, jupiter |
| PURPLE | purple, plum, lavender, poison, royal |
| PINK | pink, rose, peach, vapourwave, sherbet, psychedelic, blight |
| WHITE | lightgray, paintball, aberration |
| BLACK | black, gray, rainbow |

Four colors come out multi-colored: sunset `[PURPLE, RED, PINK]`, checker `[BLACK, WHITE]`, harlequin `[GREEN, BLUE]`, and dawn `[WHITE, YELLOW]`. Gradient colors are deliberately categorized by what they read as rather than by every stop in their gradient, so most of them are single-category — psychedelic is `[PINK]`, chrome is `[YELLOW]`.

## Behavior notes

**Split colors now clash with nothing.** They never had a `hue`, so they previously shared the sentinel `"null"` — which made every split color clash with every *other* split color while not clashing with its own base color (splitred vs red). They now carry no categories, which is intentional. In `/sample_colors` each split variant is still drawn beside its base color, so it follows that color to its new page.

**Saved games are unaffected.** Games persist a player's color as a bare alias (`color aberration`); the hue was never written to save data, so existing games load unchanged.

## Testing

`ColorModelTest` validates every category against the known set, and covers the overlap behavior and the `isMulti` derivation. Full suite passes.
