### PR TITLE
Monuments+ initial implementation

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/monuments/MonumentsActionCardHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/monuments/MonumentsActionCardHandler.java
@@ -1,0 +1,403 @@
+package ti4.discord.interactions.buttons.handlers.actioncards.monuments;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Planet;
+import ti4.game.Player;
+import ti4.game.Tile;
+import ti4.game.UnitHolder;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.Helper;
+import ti4.helpers.Units;
+import ti4.helpers.Units.UnitKey;
+import ti4.helpers.Units.UnitState;
+import ti4.helpers.Units.UnitType;
+import ti4.message.MessageHelper;
+import ti4.model.UnitModel;
+import ti4.service.emoji.UnitEmojis;
+import ti4.service.unit.AddUnitService;
+import ti4.service.unit.DestroyUnitService;
+import ti4.service.unit.ParseUnitService;
+import ti4.service.unit.RemoveUnitService;
+
+@UtilityClass
+public class MonumentsActionCardHandler {
+    private static final String RESOLVE = "resolveMonumentsActionCard_";
+    private static final String FESTIVAL_PLANET = "monumentsFestivalPlanet_";
+    private static final String FESTIVAL_PLACE = "monumentsFestivalPlace_";
+    private static final String REBEL_BOMBING = "monumentsRebelBombing_";
+    private static final String RENOVATION_STRUCTURE = "monumentsRenovationStructure_";
+    private static final String RENOVATION_PLACE = "monumentsRenovationPlace_";
+
+    @ButtonHandler(RESOLVE)
+    public static void resolveMonumentsActionCard(
+            ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        String automationId = buttonID.replace(RESOLVE, "");
+        switch (automationId) {
+            case "monuments_festival" -> {
+                List<Button> buttons = new ArrayList<>();
+                for (String planetName : player.getPlanets()) {
+                    Tile tile = game.getTileFromPlanet(planetName);
+                    Planet planet = game.getUnitHolderFromPlanet(planetName);
+                    if (tile == null || planet == null || tile.isHomeSystem(game)) {
+                        continue;
+                    }
+                    boolean hasStructure = planet.getUnitKeysForPlayer(player).stream()
+                            .map(player::getUnitFromUnitKey)
+                            .anyMatch(unit -> unit != null && unit.getIsStructure());
+                    if (hasStructure) {
+                        buttons.add(Buttons.green(
+                                player.factionButtonChecker() + FESTIVAL_PLANET + planetName,
+                                "Ready " + Helper.getPlanetRepresentation(planetName, game)));
+                    }
+                }
+                if (buttons.isEmpty()) {
+                    MessageHelper.sendMessageToChannel(
+                            event.getMessageChannel(),
+                            player.getRepresentationNoPing() + " has no eligible planet for _Festival_.");
+                    ButtonHelper.deleteMessage(event);
+                    return;
+                }
+                MessageHelper.editMessageWithButtons(
+                        event,
+                        player.getRepresentationNoPing() + ", choose a non-home planet to ready for _Festival_.",
+                        buttons);
+            }
+            case "monuments_rebel_bombing" -> {
+                List<Button> buttons = new ArrayList<>();
+                for (Player neighbor : player.getNeighbouringPlayers(true)) {
+                    for (Tile tile : game.getTileMap().values()) {
+                        if (tile.isHomeSystem(game)) {
+                            continue;
+                        }
+                        for (UnitHolder holder : tile.getUnitHolders().values()) {
+                            for (UnitKey key : holder.getUnitKeysForPlayer(neighbor)) {
+                                UnitModel unit = neighbor.getUnitFromUnitKey(key);
+                                if (unit == null || !unit.getIsStructure()) {
+                                    continue;
+                                }
+                                for (UnitState state : UnitState.values()) {
+                                    if (holder.getUnitCountForState(key, state) < 1) {
+                                        continue;
+                                    }
+                                    String location = holder instanceof Planet
+                                            ? " on " + Helper.getPlanetRepresentation(holder.getName(), game)
+                                            : " in " + tile.getRepresentationForButtons(game, player);
+                                    buttons.add(Buttons.red(
+                                            player.factionButtonChecker() + REBEL_BOMBING + neighbor.getFaction()
+                                                    + "|" + tile.getPosition() + "|" + holder.getName() + "|"
+                                                    + key.unitType().getValue() + "|" + state.name(),
+                                            "Destroy " + key.humanReadableName() + location,
+                                            key.unitEmoji()));
+                                }
+                            }
+                        }
+                    }
+                }
+                if (buttons.isEmpty()) {
+                    MessageHelper.sendMessageToChannel(
+                            event.getMessageChannel(),
+                            player.getRepresentationNoPing()
+                                    + " has no neighboring structure to target with _Rebel Bombing_.");
+                    ButtonHelper.deleteMessage(event);
+                    return;
+                }
+                MessageHelper.editMessageWithButtons(
+                        event,
+                        player.getRepresentationNoPing()
+                                + ", spend 2 trade goods to choose a neighboring structure to destroy with _Rebel Bombing_.",
+                        buttons);
+            }
+            case "monuments_renovation" -> {
+                List<Button> buttons = new ArrayList<>();
+                for (Tile tile : game.getTileMap().values()) {
+                    for (UnitHolder holder : tile.getUnitHolders().values()) {
+                        for (UnitKey key : holder.getUnitKeysForPlayer(player)) {
+                            UnitModel unit = player.getUnitFromUnitKey(key);
+                            if (unit == null || !unit.getIsStructure()) {
+                                continue;
+                            }
+                            for (UnitState state : UnitState.values()) {
+                                if (holder.getUnitCountForState(key, state) < 1) {
+                                    continue;
+                                }
+                                String location = holder instanceof Planet
+                                        ? " on " + Helper.getPlanetRepresentation(holder.getName(), game)
+                                        : " in " + tile.getRepresentationForButtons(game, player);
+                                buttons.add(Buttons.green(
+                                        player.factionButtonChecker() + RENOVATION_STRUCTURE + tile.getPosition() + "|"
+                                                + holder.getName() + "|"
+                                                + key.unitType().getValue() + "|" + state.name(),
+                                        "Replace " + key.humanReadableName() + location,
+                                        key.unitEmoji()));
+                            }
+                        }
+                    }
+                }
+                if (buttons.isEmpty()) {
+                    MessageHelper.sendMessageToChannel(
+                            event.getMessageChannel(),
+                            player.getRepresentationNoPing() + " has no structure to replace with _Renovation_.");
+                    ButtonHelper.deleteMessage(event);
+                    return;
+                }
+                MessageHelper.editMessageWithButtons(
+                        event,
+                        player.getRepresentationNoPing() + ", choose the structure to replace with _Renovation_.",
+                        buttons);
+            }
+            default -> MessageHelper.sendEphemeralMessageToEventChannel(event, "Unknown Monuments action card.");
+        }
+    }
+
+    @ButtonHandler(FESTIVAL_PLANET)
+    public static void resolveFestivalPlanet(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        String planetName = buttonID.replace(FESTIVAL_PLANET, "");
+        Tile tile = game.getTileFromPlanet(planetName);
+        Planet planet = game.getUnitHolderFromPlanet(planetName);
+        boolean hasStructure = planet != null
+                && planet.getUnitKeysForPlayer(player).stream()
+                        .map(player::getUnitFromUnitKey)
+                        .anyMatch(unit -> unit != null && unit.getIsStructure());
+        if (tile == null
+                || planet == null
+                || tile.isHomeSystem(game)
+                || !player.getPlanets().contains(planetName)
+                || !hasStructure) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "That planet is no longer eligible for _Festival_.");
+            return;
+        }
+
+        player.refreshPlanet(planetName);
+        ButtonHelper.deleteMessage(event);
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(),
+                player.getRepresentationNoPing() + " readied " + Helper.getPlanetRepresentation(planetName, game)
+                        + " with _Festival_.");
+
+        if (planet.getUnitCount(UnitType.Monument, player) < 1) {
+            return;
+        }
+
+        List<Button> buttons = List.of(
+                Buttons.green(
+                        player.factionButtonChecker() + FESTIVAL_PLACE + "infantry|" + planetName,
+                        "Place 4 Infantry",
+                        UnitEmojis.infantry),
+                Buttons.green(
+                        player.factionButtonChecker() + FESTIVAL_PLACE + "mech|" + planetName,
+                        "Place 1 Mech",
+                        UnitEmojis.mech));
+        MessageHelper.sendMessageToChannelWithButtons(
+                event.getMessageChannel(),
+                player.getRepresentationNoPing()
+                        + ", your Monument is on that planet. Choose the additional units to place for _Festival_.",
+                buttons);
+    }
+
+    @ButtonHandler(FESTIVAL_PLACE)
+    public static void resolveFestivalPlacement(
+            ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        String[] payload = buttonID.replace(FESTIVAL_PLACE, "").split("\\|", 2);
+        if (payload.length != 2) {
+            return;
+        }
+        String unit = payload[0];
+        String planetName = payload[1];
+        Tile tile = game.getTileFromPlanet(planetName);
+        Planet planet = game.getUnitHolderFromPlanet(planetName);
+        if (tile == null
+                || planet == null
+                || !player.getPlanets().contains(planetName)
+                || planet.getUnitCount(UnitType.Monument, player) < 1) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "That Monument is no longer on the selected planet.");
+            return;
+        }
+
+        if ("infantry".equals(unit)) {
+            AddUnitService.addUnits(event, tile, game, player.getColor(), "4 infantry " + planetName);
+        } else if ("mech".equals(unit)) {
+            AddUnitService.addUnits(event, tile, game, player.getColor(), "1 mech " + planetName);
+        } else {
+            return;
+        }
+        ButtonHelper.deleteMessage(event);
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(),
+                player.getRepresentationNoPing() + " placed " + ("infantry".equals(unit) ? "4 infantry" : "1 mech")
+                        + " on " + Helper.getPlanetRepresentation(planetName, game) + " with _Festival_.");
+    }
+
+    @ButtonHandler(REBEL_BOMBING)
+    public static void resolveRebelBombing(ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        String[] payload = buttonID.replace(REBEL_BOMBING, "").split("\\|", 5);
+        if (payload.length != 5) {
+            return;
+        }
+        Player target = game.getPlayerFromColorOrFaction(payload[0]);
+        Tile tile = game.getTileByPosition(payload[1]);
+        UnitHolder holder = tile == null ? null : tile.getUnitHolders().get(payload[2]);
+        UnitType type = Units.findUnitType(payload[3]);
+        UnitState state = Units.findUnitState(payload[4]);
+        UnitKey key = target == null || type == null ? null : new UnitKey(type, target.getColorID());
+        UnitModel unit = key == null ? null : target.getUnitFromUnitKey(key);
+        if (target == null
+                || tile == null
+                || holder == null
+                || type == null
+                || state == null
+                || key == null
+                || unit == null
+                || tile.isHomeSystem(game)
+                || !player.getNeighbouringPlayers(true).contains(target)
+                || !unit.getIsStructure()
+                || holder.getUnitCountForState(key, state) < 1) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "That structure is no longer eligible for _Rebel Bombing_.");
+            return;
+        }
+        if (player.getTg() < 2) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "You need 2 trade goods to resolve _Rebel Bombing_.");
+            return;
+        }
+
+        player.setTg(player.getTg() - 2);
+        DestroyUnitService.destroyUnit(
+                event, tile, game, ParseUnitService.simpleParsedUnit(target, type, holder, 1), false, state);
+        ButtonHelper.deleteMessage(event);
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(),
+                player.getRepresentationNoPing() + " spent 2 trade goods and destroyed "
+                        + target.getRepresentationNoPing() + "'s " + key.humanReadableName()
+                        + " with _Rebel Bombing_.");
+    }
+
+    @ButtonHandler(RENOVATION_STRUCTURE)
+    public static void resolveRenovationStructure(
+            ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        String[] payload = buttonID.replace(RENOVATION_STRUCTURE, "").split("\\|", 4);
+        if (payload.length != 4) {
+            return;
+        }
+        Tile tile = game.getTileByPosition(payload[0]);
+        UnitHolder holder = tile == null ? null : tile.getUnitHolders().get(payload[1]);
+        UnitType type = Units.findUnitType(payload[2]);
+        UnitState state = Units.findUnitState(payload[3]);
+        UnitKey key = type == null ? null : new UnitKey(type, player.getColorID());
+        UnitModel oldUnit = key == null ? null : player.getUnitFromUnitKey(key);
+        if (tile == null
+                || holder == null
+                || type == null
+                || state == null
+                || key == null
+                || oldUnit == null
+                || !oldUnit.getIsStructure()
+                || holder.getUnitCountForState(key, state) < 1) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "That structure is no longer eligible for _Renovation_.");
+            return;
+        }
+
+        List<Button> buttons = new ArrayList<>();
+        List<UnitModel> replacementStructures = new ArrayList<>();
+        for (UnitModel unit : player.getUnitModels().stream()
+                .filter(UnitModel::getIsStructure)
+                .sorted(Comparator.comparing(UnitModel::getName))
+                .toList()) {
+            boolean canBePlacedHere = holder instanceof Planet ? unit.getIsPlanetOnly() : unit.getIsSpaceOnly();
+            if (canBePlacedHere
+                    && replacementStructures.stream()
+                            .noneMatch(existing -> existing.getBaseType().equalsIgnoreCase(unit.getBaseType()))) {
+                replacementStructures.add(unit);
+            }
+        }
+        for (UnitModel unit : replacementStructures) {
+            buttons.add(Buttons.green(
+                    player.factionButtonChecker() + RENOVATION_PLACE + tile.getPosition() + "|" + holder.getName() + "|"
+                            + type.getValue() + "|" + state.name() + "|" + unit.getBaseType(),
+                    "Place " + unit.getName(),
+                    unit.getUnitEmoji()));
+        }
+        if (buttons.isEmpty()) {
+            MessageHelper.sendEphemeralMessageToEventChannel(event, "You have no structure available to place.");
+            return;
+        }
+
+        ButtonHelper.deleteMessage(event);
+        MessageHelper.sendMessageToChannelWithButtons(
+                event.getMessageChannel(),
+                player.getRepresentationNoPing() + ", choose the replacement structure for _Renovation_.",
+                buttons);
+    }
+
+    @ButtonHandler(RENOVATION_PLACE)
+    public static void resolveRenovationPlacement(
+            ButtonInteractionEvent event, Game game, Player player, String buttonID) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        String[] payload = buttonID.replace(RENOVATION_PLACE, "").split("\\|", 5);
+        if (payload.length != 5) {
+            return;
+        }
+        Tile tile = game.getTileByPosition(payload[0]);
+        UnitHolder holder = tile == null ? null : tile.getUnitHolders().get(payload[1]);
+        UnitType oldType = Units.findUnitType(payload[2]);
+        UnitState state = Units.findUnitState(payload[3]);
+        UnitKey oldKey = oldType == null ? null : new UnitKey(oldType, player.getColorID());
+        UnitModel replacement = player.getUnitByBaseType(payload[4]);
+        UnitModel oldUnit = oldKey == null ? null : player.getUnitFromUnitKey(oldKey);
+        boolean correctPlacement = holder instanceof Planet
+                ? replacement != null && replacement.getIsPlanetOnly()
+                : replacement != null && replacement.getIsSpaceOnly();
+        if (tile == null
+                || holder == null
+                || oldType == null
+                || state == null
+                || oldKey == null
+                || oldUnit == null
+                || replacement == null
+                || !oldUnit.getIsStructure()
+                || !replacement.getIsStructure()
+                || !correctPlacement
+                || holder.getUnitCountForState(oldKey, state) < 1) {
+            MessageHelper.sendEphemeralMessageToEventChannel(
+                    event, "That replacement is no longer eligible for _Renovation_.");
+            return;
+        }
+
+        RemoveUnitService.removeUnit(event, tile, game, player, holder, oldType, 1, state);
+        AddUnitService.addUnits(
+                event, tile, game, player.getColor(), "1 " + replacement.getBaseType() + " " + holder.getName());
+        ButtonHelper.deleteMessage(event);
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(),
+                player.getRepresentationNoPing() + " replaced " + oldKey.humanReadableName() + " with "
+                        + replacement.getName() + " using _Renovation_.");
+    }
+}

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/agenda/AgendaResolveButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/agenda/AgendaResolveButtonHandler.java
@@ -36,6 +36,7 @@ import ti4.discord.interactions.buttons.handlers.agenda.resolver.GrantReallocati
 import ti4.discord.interactions.buttons.handlers.agenda.resolver.IncentiveAgendaResolver;
 import ti4.discord.interactions.buttons.handlers.agenda.resolver.MinisterAntiquitiesAgendaResolver;
 import ti4.discord.interactions.buttons.handlers.agenda.resolver.MiscountMessageAgendaResolver;
+import ti4.discord.interactions.buttons.handlers.agenda.resolver.MonumentsAgendaResolver;
 import ti4.discord.interactions.buttons.handlers.agenda.resolver.MutinyAgendaResolver;
 import ti4.discord.interactions.buttons.handlers.agenda.resolver.NexusAgendaResolver;
 import ti4.discord.interactions.buttons.handlers.agenda.resolver.PlowsharesAgendaResolver;
@@ -129,6 +130,9 @@ class AgendaResolveButtonHandler {
         AGENDA_HANDLERS.put("warrant", new WarrantAgendaResolver());
         AGENDA_HANDLERS.put("wormhole_recon", new WormholeReconAgendaResolver());
         AGENDA_HANDLERS.put("wormhole_research", new WormholeResearchAgendaResolver());
+
+        AGENDA_HANDLERS.put("cathedralofixth", new MonumentsAgendaResolver("cathedralofixth"));
+        AGENDA_HANDLERS.put("ministerofculture", new MonumentsAgendaResolver("ministerofculture"));
     }
 
     @ButtonHandler("agendaResolution_")

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/agenda/resolver/MonumentsAgendaResolver.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/agenda/resolver/MonumentsAgendaResolver.java
@@ -1,0 +1,40 @@
+package ti4.discord.interactions.buttons.handlers.agenda.resolver;
+
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.ButtonHelperStats;
+import ti4.service.agenda.MonumentsAgendaService;
+
+public class MonumentsAgendaResolver implements AgendaResolver {
+    private final String agendaId;
+
+    public MonumentsAgendaResolver(String agendaId) {
+        this.agendaId = agendaId;
+    }
+
+    @Override
+    public String agendaId() {
+        return agendaId;
+    }
+
+    @Override
+    public void handle(Game game, ButtonInteractionEvent event, int agendaNumericId, String winner) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        if ("cathedralofixth".equals(agendaId)) {
+            game.addLaw(agendaNumericId, winner);
+            MonumentsAgendaService.resolveCathedralOfIxthPlacement(
+                    game, game.getPlayerThatControlsPlanet(winner), winner);
+            return;
+        }
+
+        if ("ministerofculture".equals(agendaId)) {
+            Player electedPlayer = game.getPlayerFromColorOrFaction(winner);
+            if (electedPlayer != null) {
+                ButtonHelperStats.replenishComms(event, game, electedPlayer, false);
+            }
+        }
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/game/WeirdGameSetup.java
+++ b/src/main/java/ti4/discord/interactions/commands/game/WeirdGameSetup.java
@@ -23,6 +23,7 @@ import ti4.model.UnitModel;
 import ti4.service.fow.FOWPlusService;
 import ti4.service.fow.GMService;
 import ti4.service.fow.RiftSetModeService;
+import ti4.service.game.MonumentsService;
 import ti4.service.option.FOWOptionService.FOWOption;
 import ti4.service.option.TEOptionService;
 
@@ -72,6 +73,7 @@ public class WeirdGameSetup extends GameStateSubcommand {
                 "True to enable Lore triggers in this non-FoW game (always on in FoW games)"));
         addOptions(new OptionData(
                 OptionType.BOOLEAN, Constants.FEAST_OR_FAMINE_MODE, "True to enable Feast or Famine Mode"));
+        addOptions(new OptionData(OptionType.BOOLEAN, Constants.MONUMENTS_MODE, "True to enable Monuments+"));
         addOptions(new OptionData(
                 OptionType.BOOLEAN,
                 FOWOption.RIFTSET_MODE.toString(),
@@ -160,6 +162,23 @@ public class WeirdGameSetup extends GameStateSubcommand {
 
         Boolean feastOrFamineMode = event.getOption(Constants.FEAST_OR_FAMINE_MODE, null, OptionMapping::getAsBoolean);
         if (feastOrFamineMode != null) game.setFeastOrFamineMode(feastOrFamineMode);
+
+        Boolean monumentsMode = event.getOption(Constants.MONUMENTS_MODE, null, OptionMapping::getAsBoolean);
+        if (monumentsMode != null) {
+            game.setMonumentsMode(monumentsMode);
+            if (monumentsMode) {
+                MonumentsService.applyMonuments(game);
+                if (!game.isFrankenGame()) {
+                    game.getRealPlayers().forEach(player -> MonumentsService.addFactionMonument(player, game));
+                }
+                MessageHelper.sendMessageToChannel(
+                        event.getMessageChannel(),
+                        "Added Monuments+ cards and strategy cards"
+                                + (game.isFrankenGame()
+                                        ? ". Faction monuments are not added in Franken games."
+                                        : ", and added each player's faction monument."));
+            }
+        }
 
         Boolean limitedMode = event.getOption(Constants.LIMITED_WHISPERS_MODE, null, OptionMapping::getAsBoolean);
         if (limitedMode != null) game.setLimitedWhispersMode(limitedMode);

--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -108,6 +108,7 @@ import ti4.service.draft.DraftManager;
 import ti4.service.draft.DraftTileManager;
 import ti4.service.emoji.MiscEmojis;
 import ti4.service.emoji.SourceEmojis;
+import ti4.service.game.MonumentsService;
 import ti4.service.milty.MiltyDraftManager;
 import ti4.service.option.FOWOptionService.FOWOption;
 import tools.jackson.databind.JsonNode;
@@ -961,6 +962,7 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
         gameModes.put("Conventions of War Abandoned", isConventionsOfWarAbandonedMode());
         gameModes.put("Rapid Mobilization", isRapidMobilizationMode());
         gameModes.put("Monuments to the Ages", isMonumentToTheAgesMode());
+        gameModes.put(SourceEmojis.Monuments + "Monuments+", isMonumentsMode());
         gameModes.put("Weird Wormholes", isWeirdWormholesMode());
         gameModes.put("Cosmic Phenomenae", isCosmicPhenomenaeMode());
         gameModes.put("Cosmic Convergence", isCosmicConvergenceMode());
@@ -3421,6 +3423,7 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
     public boolean loadGameSettingsFromSettings(GenericInteractionCreateEvent event, MiltySettings miltySettings) {
         SourceSettings sources = miltySettings.getSourceSettings();
         if (sources.getAbsol().isVal()) setAbsolMode(true);
+        setMonumentsMode(sources.getMonuments().isVal());
 
         GameSettings settings = miltySettings.getGameSettings();
         setVp(settings.getPointTotal().getVal());
@@ -3450,6 +3453,7 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
         GameSetupSettings gameSetupSettings = draftSettings.getGameSetupSettings();
         SourceSettings sources = draftSettings.getSourceSettings();
         if (sources.getAbsol().isVal()) setAbsolMode(true);
+        setMonumentsMode(sources.getMonuments().isVal());
 
         setVp(gameSetupSettings.getPointTotal().getVal());
 
@@ -3517,6 +3521,8 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
         } else {
             success &= validateAndSetRelicDeck(deckSettings.getRelics().getValue());
         }
+
+        MonumentsService.applyMonuments(this);
 
         return success;
     }

--- a/src/main/java/ti4/game/GameProperties.java
+++ b/src/main/java/ti4/game/GameProperties.java
@@ -146,6 +146,7 @@ public class GameProperties {
     private @ExportableField boolean callOfTheVoidMode;
     private @ExportableField boolean cosmicPhenomenaeMode;
     private @ExportableField boolean monumentToTheAgesMode;
+    private @ExportableField boolean monumentsMode;
     private @ExportableField boolean wildWildGalaxyMode;
     private @ExportableField boolean feastOrFamineMode;
     private @ExportableField boolean zealousOrthodoxyMode;

--- a/src/main/java/ti4/game/Player.java
+++ b/src/main/java/ti4/game/Player.java
@@ -99,6 +99,7 @@ import ti4.model.TechnologyModel.TechnologyType;
 import ti4.model.TemporaryCombatModifierModel;
 import ti4.model.UnitModel;
 import ti4.service.agenda.IsPlayerElectedService;
+import ti4.service.agenda.MonumentsAgendaService;
 import ti4.service.breakthrough.DeepgloomService;
 import ti4.service.breakthrough.ValefarZService;
 import ti4.service.emoji.ApplicationEmojiService;
@@ -1461,6 +1462,9 @@ public class Player extends PlayerProperties implements StoredValueHelper {
         }
         if (ButtonHelper.isLawInPlay(game, "absol_equality")) {
             bonus = 3 - getCommoditiesBase();
+        }
+        if (MonumentsAgendaService.hasMinisterOfCultureBonus(game, this)) {
+            bonus += 2;
         }
         if (game.playerHasLeaderUnlockedOrAlliance(this, "bentorcommander")) {
             bonus++;

--- a/src/main/java/ti4/game/persistence/GameLoadService.java
+++ b/src/main/java/ti4/game/persistence/GameLoadService.java
@@ -632,6 +632,7 @@ class GameLoadService {
                     game.setCosmicPhenomenaeMode(parseBooleanOrDefault(info, false));
                 case Constants.MONUMENTS_TO_THE_AGES_MODE ->
                     game.setMonumentToTheAgesMode(parseBooleanOrDefault(info, false));
+                case Constants.MONUMENTS_MODE -> game.setMonumentsMode(parseBooleanOrDefault(info, false));
                 case Constants.CIVILIZED_SOCIETY_MODE ->
                     game.setCivilizedSocietyMode(parseBooleanOrDefault(info, false));
                 case Constants.NO_SWAP_MODE -> game.setNoSwapMode(parseBooleanOrDefault(info, false));

--- a/src/main/java/ti4/game/persistence/GameSaveService.java
+++ b/src/main/java/ti4/game/persistence/GameSaveService.java
@@ -555,6 +555,8 @@ class GameSaveService {
         writer.write(System.lineSeparator());
         writer.write(Constants.MONUMENTS_TO_THE_AGES_MODE + " " + game.isMonumentToTheAgesMode());
         writer.write(System.lineSeparator());
+        writer.write(Constants.MONUMENTS_MODE + " " + game.isMonumentsMode());
+        writer.write(System.lineSeparator());
         writer.write(Constants.WEIRD_WORMHOLES_MODE + " " + game.isWeirdWormholesMode());
         writer.write(System.lineSeparator());
         writer.write(Constants.COSMIC_CONVERGENCE_MODE + " " + game.isCosmicConvergenceMode());

--- a/src/main/java/ti4/helpers/ActionCardHelper.java
+++ b/src/main/java/ti4/helpers/ActionCardHelper.java
@@ -2008,6 +2008,14 @@ public class ActionCardHelper {
                         channel2, String.format(targetMsg, "ground forces"), codedButtons);
             }
 
+            if (game.isMonumentsMode()
+                    && List.of("monuments_festival", "monuments_rebel_bombing", "monuments_renovation")
+                            .contains(automationID)) {
+                codedButtons.add(Buttons.green(
+                        player.factionButtonChecker() + "resolveMonumentsActionCard_" + automationID, buttonLabel));
+                MessageHelper.sendMessageToChannelWithButtons(channel2, introMsg, codedButtons);
+            }
+
             // Lost Legacies AC's
             if ("unchart_space".equals(automationID)) {
                 codedButtons.add(Buttons.green(player.factionButtonChecker() + "resolveUnchartedSpaceAC", buttonLabel));

--- a/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
+++ b/src/main/java/ti4/helpers/ButtonHelperModifyUnits.java
@@ -51,6 +51,7 @@ import ti4.message.MessageHelper;
 import ti4.model.StrategyCardModel;
 import ti4.model.UnitModel;
 import ti4.service.agenda.IsPlayerElectedService;
+import ti4.service.agenda.MonumentsAgendaService;
 import ti4.service.combat.CombatRollService;
 import ti4.service.combat.CombatRollType;
 import ti4.service.combat.StartCombatService;
@@ -1959,6 +1960,41 @@ public final class ButtonHelperModifyUnits {
         String successMessage;
         String playerRep = player.getRepresentationNoPing();
         Tile tile = game.getTile(AliasHandler.resolveTile(planetName));
+        Planet planet = game.getUnitHolderFromPlanet(planetName);
+        if ("monument".equalsIgnoreCase(unitLong)) {
+            if (!game.isMonumentsMode()) {
+                MessageHelper.sendEphemeralMessageToEventChannel(event, "Monuments+ is not enabled for this game.");
+                return;
+            }
+            UnitModel monument = player.getUnitByBaseType("monument");
+            List<String> planetTypes = planet == null ? new ArrayList<>() : new ArrayList<>(planet.getPlanetTypes());
+            if (tile != null && tile.isSupernova()) {
+                planetTypes.add("SUPERNOVA");
+            }
+            if (tile != null && tile.equals(player.getHomeSystemTile())) {
+                planetTypes.add("HOME_PLANET");
+            }
+            if (planet != null && !planet.getTechSpecialities().isEmpty()) {
+                planetTypes.add("TECH_SPECIALTY");
+            }
+            if (planet != null && planet.isLegendary()) {
+                planetTypes.add("LEGENDARY");
+            }
+            if (tile != null && tile.isMecatol(game)) {
+                planetTypes.add("MECATOL_REX");
+            }
+            if (planet != null
+                    && planet.getPlanetModel() != null
+                    && planet.getPlanetModel().getPlanetTypes().stream()
+                            .anyMatch(type -> "lightning".equalsIgnoreCase(type.toString()))) {
+                planetTypes.add("LIGHTNING");
+            }
+            if (monument != null && (planet == null || !monument.canBePlacedOnPlanetTypes(planetTypes))) {
+                MessageHelper.sendEphemeralMessageToEventChannel(
+                        event, "That planet is not eligible for your Monument.");
+                return;
+            }
+        }
         if ("mf".equalsIgnoreCase(unitID) && "tyris".equalsIgnoreCase(player.getFaction())) {
             MessageHelper.sendMessageToChannel(
                     player.getCorrectChannel(),
@@ -2008,6 +2044,7 @@ public final class ButtonHelperModifyUnits {
                         + Helper.getPlanetRepresentation(planetName, game) + " system.";
             } else {
                 AddUnitService.addUnits(event, tile, game, player.getColor(), unitLong + " " + planetName);
+                MonumentsAgendaService.resolveCathedralOfIxthPlacement(game, player, planetName);
                 successMessage = "Placed 1 monument on " + Helper.getPlanetRepresentation(planetName, game) + ".";
             }
         } else {

--- a/src/main/java/ti4/helpers/ButtonHelperSCs.java
+++ b/src/main/java/ti4/helpers/ButtonHelperSCs.java
@@ -979,7 +979,10 @@ public final class ButtonHelperSCs {
         StrategyCardModel scModel = null;
         for (int scNum : player.getUnfollowedSCs()) {
             if (game.getStrategyCardModelByInitiative(scNum).get().usesAutomationForSCID("pok4construction")
-                    || game.getStrategyCardModelByInitiative(scNum).get().usesAutomationForSCID("te4construction")) {
+                    || game.getStrategyCardModelByInitiative(scNum).get().usesAutomationForSCID("te4construction")
+                    || game.getStrategyCardModelByInitiative(scNum)
+                            .get()
+                            .usesAutomationForSCID("monuments4construction")) {
                 scModel = game.getStrategyCardModelByInitiative(scNum).get();
             }
         }
@@ -990,8 +993,9 @@ public final class ButtonHelperSCs {
             scModel = game.getStrategyCardModelByName("civitas").orElse(null);
         }
         int scNum = scModel.getInitiative();
-        boolean automationExists =
-                scModel.usesAutomationForSCID("pok4construction") || scModel.usesAutomationForSCID("te4construction");
+        boolean automationExists = scModel.usesAutomationForSCID("pok4construction")
+                || scModel.usesAutomationForSCID("te4construction")
+                || scModel.usesAutomationForSCID("monuments4construction");
         if (!used
                 && !player.getFollowedSCs().contains(scNum)
                 && automationExists
@@ -1047,14 +1051,26 @@ public final class ButtonHelperSCs {
                 }
                 MessageHelper.sendMessageToEventChannelWithEphemeralButtons(event, message, buttons);
             } else {
-
                 UnitKey unitKey = Mapper.getUnitKey(AliasHandler.resolveUnit(unit), player.getColorID());
+                if ("monument".equalsIgnoreCase(unit) && player.getUnitByBaseType("monument") == null) {
+                    MessageHelper.sendEphemeralMessageToEventChannel(event, "You do not have a Monument to place.");
+                    return;
+                }
+                if (unitKey == null) {
+                    MessageHelper.sendEphemeralMessageToEventChannel(event, "Unable to resolve that unit.");
+                    return;
+                }
                 String message = player.getRepresentationUnfogged() + ", please choose the planet you wish to put your "
                         + unitKey.unitName() + " on for **Construction**.";
                 if (!player.getSCs().contains(4) && !"te4construction".equals(scModel.getBotSCAutomationID())) {
                     message += "\n-# It will place a command token in the system as well.";
                 }
                 List<Button> buttons = Helper.getPlanetPlaceUnitButtons(player, game, unit, "place");
+                if (buttons.isEmpty()) {
+                    MessageHelper.sendEphemeralMessageToEventChannel(
+                            event, "You have no eligible planet on which to place that unit.");
+                    return;
+                }
                 MessageHelper.sendMessageToEventChannelWithEphemeralButtons(event, message, buttons);
             }
         }

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -1352,6 +1352,7 @@ public final class Constants {
     public static final String CONVENTIONS_OF_WAR_ABANDONED_MODE = "conventions_of_war_abandoned_mode";
     public static final String RAPID_MOBILIZATION_MODE = "rapid_mobilization_mode";
     public static final String MONUMENTS_TO_THE_AGES_MODE = "monuments_to_the_ages_mode";
+    public static final String MONUMENTS_MODE = "monuments_mode";
     public static final String COSMIC_PHENOMENAE_MODE = "cosmic_phenomenae_mode";
     public static final String COSMIC_CONVERGENCE_MODE = "cosmic_convergence_mode";
     public static final String MUAAT_MANIA_MODE = "muaat_mania_mode";

--- a/src/main/java/ti4/helpers/Helper.java
+++ b/src/main/java/ti4/helpers/Helper.java
@@ -1127,10 +1127,39 @@ public final class Helper {
     public static List<Button> getPlanetPlaceUnitButtons(Player player, Game game, String unit, String prefix) {
         List<Button> planetButtons = new ArrayList<>();
         List<String> planets = new ArrayList<>(player.getPlanetsAllianceMode());
+        UnitModel unitModel = "monument".equalsIgnoreCase(unit) ? player.getUnitByBaseType("monument") : null;
         player.resetProducedUnits();
         for (String planet : planets) {
             Planet uh = game.getUnitHolderFromPlanet(planet);
             if (uh == null) continue; // custodia, ghoti, etc.
+
+            if (unitModel != null) {
+                List<String> planetTypes = new ArrayList<>(uh.getPlanetTypes());
+                Tile tile = game.getTileFromPlanet(planet);
+                if (tile != null && tile.isSupernova()) {
+                    planetTypes.add("SUPERNOVA");
+                }
+                if (tile != null && tile.equals(player.getHomeSystemTile())) {
+                    planetTypes.add("HOME_PLANET");
+                }
+                if (!uh.getTechSpecialities().isEmpty()) {
+                    planetTypes.add("TECH_SPECIALTY");
+                }
+                if (uh.isLegendary()) {
+                    planetTypes.add("LEGENDARY");
+                }
+                if (tile != null && tile.isMecatol(game)) {
+                    planetTypes.add("MECATOL_REX");
+                }
+                if (uh.getPlanetModel() != null
+                        && uh.getPlanetModel().getPlanetTypes().stream()
+                                .anyMatch(type -> "lightning".equalsIgnoreCase(type.toString()))) {
+                    planetTypes.add("LIGHTNING");
+                }
+                if (!unitModel.canBePlacedOnPlanetTypes(planetTypes)) {
+                    continue;
+                }
+            }
 
             boolean containsDMZ = uh.getTokenList().stream().anyMatch(token -> token.contains("dmz"));
 

--- a/src/main/java/ti4/helpers/SecretObjectiveHelper.java
+++ b/src/main/java/ti4/helpers/SecretObjectiveHelper.java
@@ -19,6 +19,7 @@ import ti4.game.Player;
 import ti4.image.Mapper;
 import ti4.message.MessageHelper;
 import ti4.model.SecretObjectiveModel;
+import ti4.model.Source.ComponentSource;
 import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.ExploreEmojis;
 import ti4.service.emoji.UnitEmojis;
@@ -332,7 +333,15 @@ public class SecretObjectiveHelper {
             MessageHelper.sendMessageToChannel(event.getMessageChannel(), "This command is disabled for fog mode.");
             return;
         }
-        List<String> defaultSecrets = Mapper.getDecks().get(game.getSoDeckID()).getNewShuffledDeck();
+        List<String> defaultSecrets =
+                new ArrayList<>(Mapper.getDecks().get(game.getSoDeckID()).getNewShuffledDeck());
+        if (game.isMonumentsMode()) {
+            Mapper.getSecretObjectives().values().stream()
+                    .filter(objective -> objective.getSource() == ComponentSource.monuments)
+                    .map(SecretObjectiveModel::getAlias)
+                    .filter(objective -> !defaultSecrets.contains(objective))
+                    .forEach(defaultSecrets::add);
+        }
         List<String> currentSecrets = new ArrayList<>(defaultSecrets);
         for (Player player : game.getPlayers().values()) {
             if (player == null) {

--- a/src/main/java/ti4/helpers/settingsFramework/menus/SourceSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/SourceSettings.java
@@ -42,6 +42,7 @@ public class SourceSettings extends SettingsMenu {
     private final BooleanSetting whispers;
     private final BooleanSetting deepreaches;
     private final BooleanSetting lostLegacies;
+    private final BooleanSetting monuments;
 
     // ---------------------------------------------------------------------------------------------------------------------------------
     // Constructor & Initialization
@@ -71,6 +72,7 @@ public class SourceSettings extends SettingsMenu {
         whispers = new BooleanSetting("WhispersVoid", "Whispers from the Void", false);
         deepreaches = new BooleanSetting("DeepReaches", "Deep Reaches", false);
         lostLegacies = new BooleanSetting("LostLegacies", "Lost Legacies", false);
+        monuments = new BooleanSetting("Monuments", "Monuments+", game.isMonumentsMode());
         actionCardDeck2 = new BooleanSetting("ActionCardDeck2", "Action Card Deck 2", game.isAcd2());
         // Emojis
         base.setEmoji(SourceEmojis.TI4BaseGame);
@@ -83,12 +85,15 @@ public class SourceSettings extends SettingsMenu {
         actionCardDeck2.setEmoji(SourceEmojis.ActionDeck2);
         deepreaches.setEmoji(SourceEmojis.DeepReaches);
         lostLegacies.setEmoji(SourceEmojis.Theodisi);
+        monuments.setEmoji(SourceEmojis.Monuments);
 
         // Other Initialization
         discoStars.setExtraInfo("Adds Discordant Stars factions only.");
         blueReverie.setExtraInfo("Adds Blue Reverie factions only.");
         unchartedSpace.setExtraInfo("Adds Uncharted Space content.");
         lostLegacies.setExtraInfo("Adds Lost Legacies factions only.");
+        monuments.setExtraInfo(
+                "Adds faction monuments plus Monuments action cards, agendas, secrets, and strategy cards.");
         // miltymod.setExtraInfo("NOTE: this is NOT \"milty draft\", this is a homebrew mod that replaces components in
         // the game");
 
@@ -114,6 +119,7 @@ public class SourceSettings extends SettingsMenu {
             whispers.initialize(json.get("whispers"));
             deepreaches.initialize(json.get("deepreaches"));
             lostLegacies.initialize(json.get("lostLegacies"));
+            monuments.initialize(json.get("monuments"));
             actionCardDeck2.initialize(json.get("actionCardDeck2"));
         }
         base.setEditable(false);
@@ -139,6 +145,7 @@ public class SourceSettings extends SettingsMenu {
         ls.add(whispers);
         ls.add(deepreaches);
         ls.add(lostLegacies);
+        ls.add(monuments);
         ls.add(actionCardDeck2);
         return ls;
     }
@@ -289,6 +296,7 @@ public class SourceSettings extends SettingsMenu {
                         .queue(Consumers.nop(), BotLogger::catchRestError);
             }
             case "Eronous" -> {}
+            case "Monuments" -> game.setMonumentsMode(monuments.isVal());
         }
     }
 

--- a/src/main/java/ti4/model/UnitModel.java
+++ b/src/main/java/ti4/model/UnitModel.java
@@ -2,10 +2,12 @@ package ti4.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.Data;
@@ -42,6 +44,7 @@ public class UnitModel implements ModelInterface, EmbeddableModel {
     private String faction;
     private Boolean isUpgrade;
     private List<String> eligiblePlanetTypes;
+    private List<String> ineligiblePlanetTypes;
     private int moveValue;
     private int productionValue;
     private String basicProduction;
@@ -99,10 +102,30 @@ public class UnitModel implements ModelInterface, EmbeddableModel {
                                 "INDUSTRIAL",
                                 "TECH_SPECIALTY",
                                 "LEGENDARY",
+                                "LIGHTNING",
+                                "SUPERNOVA",
+                                "HOME_PLANET",
                                 "MECATOL_REX",
                                 "EMPTY_NONANOMALY",
                                 "EMPTY"))
-                        .containsAll(getEligiblePlanetTypes());
+                        .containsAll(getEligiblePlanetTypes().stream()
+                                .map(String::toUpperCase)
+                                .toList())
+                && new HashSet<>(List.of(
+                                "CULTURAL",
+                                "HAZARDOUS",
+                                "INDUSTRIAL",
+                                "TECH_SPECIALTY",
+                                "LEGENDARY",
+                                "LIGHTNING",
+                                "SUPERNOVA",
+                                "HOME_PLANET",
+                                "MECATOL_REX",
+                                "EMPTY_NONANOMALY",
+                                "EMPTY"))
+                        .containsAll(getIneligiblePlanetTypes().stream()
+                                .map(String::toUpperCase)
+                                .toList());
     }
 
     public String getAlias() {
@@ -155,7 +178,9 @@ public class UnitModel implements ModelInterface, EmbeddableModel {
 
         String name = this.name;
         eb.setTitle(factionEmoji + unitEmoji + " __" + name + "__ " + getSourceEmoji(), null);
-        if (getSubtitle().isPresent()) eb.setDescription("-# " + getSubtitle().get() + " " + getEligiblePlanetEmojis());
+        if (getSubtitle().isPresent()) {
+            eb.setDescription("-# " + getSubtitle().get() + " " + getPlanetPlacementRestrictions());
+        }
 
         if (!getValuesText().isEmpty()) eb.addField("Values:", getValuesText(), true);
         if (!getDiceText().isEmpty()) eb.addField("Dice Rolls:", getDiceText(), true);
@@ -647,25 +672,56 @@ public class UnitModel implements ModelInterface, EmbeddableModel {
         return Optional.ofNullable(homebrewReplacesID);
     }
 
-    private List<String> getEligiblePlanetTypes() {
+    public List<String> getEligiblePlanetTypes() {
         return Optional.ofNullable(eligiblePlanetTypes).orElse(Collections.emptyList());
+    }
+
+    public List<String> getIneligiblePlanetTypes() {
+        return Optional.ofNullable(ineligiblePlanetTypes).orElse(Collections.emptyList());
+    }
+
+    public boolean canBePlacedOnPlanetTypes(Collection<String> planetTypes) {
+        if (planetTypes == null) {
+            return false;
+        }
+        List<String> normalizedTypes = planetTypes.stream()
+                .filter(Objects::nonNull)
+                .map(String::toUpperCase)
+                .toList();
+        return (getEligiblePlanetTypes().isEmpty()
+                        || getEligiblePlanetTypes().stream()
+                                .map(String::toUpperCase)
+                                .anyMatch(normalizedTypes::contains))
+                && getIneligiblePlanetTypes().stream().map(String::toUpperCase).noneMatch(normalizedTypes::contains);
     }
 
     private TI4Emoji getMonumentPlanetTypeEmoji(String planetType) {
         return switch (planetType.toLowerCase()) {
             case "cultural", "industrial", "hazardous" -> ExploreEmojis.getTraitEmoji(planetType);
             case "legendary" -> MiscEmojis.LegendaryPlanet;
-            case "empty_nonanomaly" -> MiscEmojis.EmptySystem;
+            case "lightning" -> PlanetEmojis.Lightning;
+            case "supernova" -> MiscEmojis.Supernova;
+            case "home_planet" -> getFactionEmoji();
+            case "empty", "empty_nonanomaly" -> ExploreEmojis.Frontier;
             case "tech_specialty" -> TechEmojis.NonUnitTechSkip;
             case "mecatol_rex" -> PlanetEmojis.Mecatol;
             default -> TI4Emoji.getRandomGoodDog();
         };
     }
 
-    private String getEligiblePlanetEmojis() {
+    private String getPlanetPlacementRestrictions() {
         StringBuilder sb = new StringBuilder();
         for (String type : getEligiblePlanetTypes()) {
             sb.append(getMonumentPlanetTypeEmoji(type));
+        }
+        if (!getIneligiblePlanetTypes().isEmpty()) {
+            if (!sb.isEmpty()) {
+                sb.append(" · ");
+            }
+            sb.append("Not: ");
+            for (String type : getIneligiblePlanetTypes()) {
+                sb.append(getMonumentPlanetTypeEmoji(type));
+            }
         }
         return sb.toString();
     }

--- a/src/main/java/ti4/service/agenda/MonumentsAgendaService.java
+++ b/src/main/java/ti4/service/agenda/MonumentsAgendaService.java
@@ -1,0 +1,98 @@
+package ti4.service.agenda;
+
+import lombok.experimental.UtilityClass;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.UnitHolder;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.Helper;
+import ti4.helpers.Units.UnitType;
+import ti4.message.MessageHelper;
+
+@UtilityClass
+public class MonumentsAgendaService {
+    private static final String CATHEDRAL_OF_IXTH = "cathedralofixth";
+    private static final String MINISTER_OF_CULTURE = "ministerofculture";
+
+    public static boolean playerControlsMonument(Game game, Player player) {
+        if (game == null || !game.isMonumentsMode() || player == null) {
+            return false;
+        }
+
+        for (String planetName : player.getPlanets()) {
+            UnitHolder holder = game.getUnitHolderFromPlanet(planetName);
+            if (holder != null && holder.getUnitCount(UnitType.Monument, player) > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void resolveCathedralOfIxthPlacement(Game game, Player player, String planetName) {
+        if (game == null
+                || !game.isMonumentsMode()
+                || player == null
+                || planetName == null
+                || !ButtonHelper.isLawInPlay(game, CATHEDRAL_OF_IXTH)
+                || !planetName.equals(game.getLawsInfo().get(CATHEDRAL_OF_IXTH))) {
+            return;
+        }
+
+        UnitHolder holder = game.getUnitHolderFromPlanet(planetName);
+        if (holder == null || holder.getUnitCount(UnitType.Monument, player) < 1) {
+            return;
+        }
+
+        String objectiveName = "Cathedral Of Ixth (" + player.getFaction() + ")";
+        if (!game.getCustomPublicVP().containsKey(objectiveName)) {
+            game.addCustomPO(objectiveName, 1);
+        }
+
+        if (game.scorePublicObjective(
+                player.getUserID(), game.getRevealedPublicObjectives().get(objectiveName))) {
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    player.getRepresentationNoPing()
+                            + " gained 1 victory point from _Cathedral Of Ixth_ for placing their Monument on "
+                            + Helper.getPlanetRepresentation(planetName, game)
+                            + ".");
+            Helper.checkEndGame(game, player);
+        }
+    }
+
+    public static void resolveCathedralOfIxthRemoval(Game game, Player player, String planetName) {
+        if (game == null
+                || !game.isMonumentsMode()
+                || player == null
+                || planetName == null
+                || !ButtonHelper.isLawInPlay(game, CATHEDRAL_OF_IXTH)
+                || !planetName.equals(game.getLawsInfo().get(CATHEDRAL_OF_IXTH))) {
+            return;
+        }
+
+        UnitHolder holder = game.getUnitHolderFromPlanet(planetName);
+        if (holder != null && holder.getUnitCount(UnitType.Monument, player) > 0) {
+            return;
+        }
+
+        String objectiveName = "Cathedral Of Ixth (" + player.getFaction() + ")";
+        if (game.getCustomPublicVP().containsKey(objectiveName)
+                && game.unscorePublicObjective(player.getUserID(), objectiveName)) {
+            MessageHelper.sendMessageToChannel(
+                    player.getCorrectChannel(),
+                    player.getRepresentationNoPing()
+                            + " lost 1 victory point from _Cathedral Of Ixth_ because their Monument was removed from "
+                            + Helper.getPlanetRepresentation(planetName, game)
+                            + ".");
+        }
+    }
+
+    public static boolean hasMinisterOfCultureBonus(Game game, Player player) {
+        return game != null
+                && game.isMonumentsMode()
+                && player != null
+                && ButtonHelper.isLawInPlay(game, MINISTER_OF_CULTURE)
+                && player.getFaction().equals(game.getLawsInfo().get(MINISTER_OF_CULTURE))
+                && playerControlsMonument(game, player);
+    }
+}

--- a/src/main/java/ti4/service/draft/PlayerSetupService.java
+++ b/src/main/java/ti4/service/draft/PlayerSetupService.java
@@ -40,6 +40,7 @@ import ti4.model.Source;
 import ti4.model.TechnologyModel;
 import ti4.model.UnitModel;
 import ti4.service.emoji.MiscEmojis;
+import ti4.service.game.MonumentsService;
 import ti4.service.info.AbilityInfoService;
 import ti4.service.info.CardsInfoService;
 import ti4.service.info.LeaderInfoService;
@@ -286,6 +287,7 @@ public class PlayerSetupService {
         // STARTING OWNED UNITS
         Set<String> playerOwnedUnits = new HashSet<>(factionModel.getUnits());
         player.setUnitsOwned(playerOwnedUnits);
+        MonumentsService.addFactionMonument(player, game);
         if (game.isBaseGameMode()) {
             UnitModel mech = player.getUnitByBaseType("mech");
             if (mech != null) {

--- a/src/main/java/ti4/service/game/GameModeService.java
+++ b/src/main/java/ti4/service/game/GameModeService.java
@@ -59,6 +59,7 @@ public class GameModeService {
                         Map.entry("Weird Wormholes", (Supplier<Boolean>) game::isWeirdWormholesMode),
                         Map.entry("Cosmic Phenomenae", (Supplier<Boolean>) game::isCosmicPhenomenaeMode),
                         Map.entry("Monument to the Ages", (Supplier<Boolean>) game::isMonumentToTheAgesMode),
+                        Map.entry("Monuments+", (Supplier<Boolean>) game::isMonumentsMode),
                         Map.entry("Wild, Wild Galaxy", (Supplier<Boolean>) game::isWildWildGalaxyMode),
                         Map.entry("Feast or Famine", (Supplier<Boolean>) game::isFeastOrFamineMode),
                         Map.entry("Zealous Orthodoxy", (Supplier<Boolean>) game::isZealousOrthodoxyMode),

--- a/src/main/java/ti4/service/game/HomebrewService.java
+++ b/src/main/java/ti4/service/game/HomebrewService.java
@@ -39,6 +39,10 @@ public class HomebrewService {
         HBACDECK2("AC2 Deck", "Action Cards Deck 2", SourceEmojis.ActionDeck2),
         HBREDTAPE("Red Tape", "Red Tape mode", null),
         HBIGNISAURORA("Ignis Aurora", "Ignis Aurora decks for SC/agendas/techs/events/relics", null),
+        HBMONUMENTS(
+                "Monuments+",
+                "Faction monuments plus Monuments action cards, agendas, secret objectives, and strategy cards",
+                SourceEmojis.Monuments),
         HBREMOVESFTT("No Supports", "Remove Support for the Thrones", null),
         HBHBSC("Homebrew SCs", "Indicate game uses homebrew Strategy Cards", CardEmojis.SCBackBlank),
         HBOMEGAPHASE("Omega Phase", "Enable Omega Phase homebrew mode", null),
@@ -97,6 +101,7 @@ public class HomebrewService {
         game.setAbsolMode(false);
         game.setOmegaPhaseMode(false);
         game.setVotcMode(false);
+        game.setMonumentsMode(false);
         game.setStoredValue("homebrewMode", "");
         MessageHelper.sendMessageToChannel(
                 event.getMessageChannel(),
@@ -160,6 +165,13 @@ public class HomebrewService {
                 MessageHelper.sendMessageToChannel(
                         event.getMessageChannel(),
                         "Set the stuff (Relic, Agenda, SCs, Tech, Event) to Ignis Aurora stuff");
+            }
+            case HBMONUMENTS -> {
+                game.setMonumentsMode(true);
+                MonumentsService.applyMonuments(game);
+                MessageHelper.sendMessageToChannel(
+                        event.getMessageChannel(),
+                        "Added Monuments+ cards and strategy cards. Each player will receive their faction monument during setup.");
             }
             case HBABSOLTECHSMECHS -> {
                 game.setAbsolMode(true);

--- a/src/main/java/ti4/service/game/MonumentsService.java
+++ b/src/main/java/ti4/service/game/MonumentsService.java
@@ -1,0 +1,88 @@
+package ti4.service.game;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.ButtonHelper;
+import ti4.helpers.SecretObjectiveHelper;
+import ti4.image.Mapper;
+import ti4.model.ActionCardModel;
+import ti4.model.AgendaModel;
+import ti4.model.SecretObjectiveModel;
+import ti4.model.Source.ComponentSource;
+
+@UtilityClass
+public class MonumentsService {
+
+    public static void applyMonuments(Game game) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+
+        game.setHomebrew(true);
+        game.setStrategyCardSet("monuments");
+
+        List<String> actionCards = Mapper.getActionCards().values().stream()
+                .filter(card -> card.getSource() == ComponentSource.monuments)
+                .map(ActionCardModel::getAlias)
+                .filter(card -> !game.getActionCards().contains(card))
+                .toList();
+        if (!actionCards.isEmpty()) {
+            game.getActionCards().addAll(actionCards);
+            Collections.shuffle(game.getActionCards());
+        }
+
+        List<String> secretObjectives = Mapper.getSecretObjectives().values().stream()
+                .filter(objective -> objective.getSource() == ComponentSource.monuments)
+                .map(SecretObjectiveModel::getAlias)
+                .filter(objective -> !game.getSecretObjectives().contains(objective))
+                .toList();
+        if (!secretObjectives.isEmpty()) {
+            game.getSecretObjectives().addAll(secretObjectives);
+            Collections.shuffle(game.getSecretObjectives());
+        }
+
+        List<String> agendas = Mapper.getAgendas().values().stream()
+                .filter(agenda -> agenda.getSource() == ComponentSource.monuments)
+                .map(AgendaModel::getAlias)
+                .filter(agenda -> !game.getAgendas().contains(agenda))
+                .toList();
+        if (!agendas.isEmpty()) {
+            game.getAgendas().addAll(agendas);
+            Collections.shuffle(game.getAgendas());
+        }
+    }
+
+    public static void addFactionMonument(Player player, Game game) {
+        if (!game.isMonumentsMode() || game.isFrankenGame()) {
+            return;
+        }
+
+        Mapper.getUnits().values().stream()
+                .filter(unit -> unit.getSource() == ComponentSource.monuments)
+                .filter(unit ->
+                        unit.getFaction().filter(player.getFaction()::equals).isPresent())
+                .filter(unit -> !player.ownsUnit(unit.getId()))
+                .findFirst()
+                .ifPresent(unit -> player.addOwnedUnitByID(unit.getId()));
+    }
+
+    @ButtonHandler("scoreToppleAMonument")
+    public static void scoreToppleAMonument(ButtonInteractionEvent event, Game game, Player player) {
+        if (!game.isMonumentsMode()) {
+            return;
+        }
+        Integer secretIndex = player.getSecretsUnscored().get("tam");
+        if (secretIndex == null) {
+            return;
+        }
+
+        if (SecretObjectiveHelper.scoreSO(event, game, player, secretIndex, player.getCorrectChannel())) {
+            ButtonHelper.deleteMessage(event);
+        }
+    }
+}

--- a/src/main/java/ti4/service/info/ListPlayerInfoService.java
+++ b/src/main/java/ti4/service/info/ListPlayerInfoService.java
@@ -26,6 +26,7 @@ import ti4.message.MessageHelper;
 import ti4.model.PublicObjectiveModel;
 import ti4.model.Source;
 import ti4.model.TechnologyModel.TechnologyType;
+import ti4.model.UnitModel;
 import ti4.service.emoji.ExploreEmojis;
 import ti4.service.emoji.TileEmojis;
 import ti4.service.emoji.UnitEmojis;
@@ -102,6 +103,7 @@ public class ListPlayerInfoService {
             case "eap" -> 4; // 4 PDS
             case "faa" -> 4; // 4 cultural
             case "fc" -> (game.getRealPlayers().size() - 1); // neighbors
+            case "dagw" -> 1;
 
             // Omega Phase objectives
             case "corner_omegaphase" -> 4;
@@ -1033,6 +1035,38 @@ public class ListPlayerInfoService {
             }
             case "fc" -> {
                 return player.getNeighbourCount(); // neighbors
+            }
+            case "dagw" -> {
+                if (!game.isMonumentsMode()) {
+                    return 0;
+                }
+                for (Tile tile : game.getTileMap().values()) {
+                    for (UnitHolder holder : tile.getUnitHolders().values()) {
+                        if (holder.getUnitCount(Units.UnitType.Monument, player) < 1) {
+                            continue;
+                        }
+
+                        int spaceGroundForces = tile.getSpaceUnitHolder().getUnitKeysForPlayer(player).stream()
+                                .filter(unitKey -> {
+                                    UnitModel unit = player.getUnitFromUnitKey(unitKey);
+                                    return unit != null && unit.getIsGroundForce();
+                                })
+                                .mapToInt(tile.getSpaceUnitHolder()::getUnitCount)
+                                .sum();
+                        int holderGroundForces = holder.getUnitKeysForPlayer(player).stream()
+                                .filter(unitKey -> {
+                                    UnitModel unit = player.getUnitFromUnitKey(unitKey);
+                                    return unit != null && unit.getIsGroundForce();
+                                })
+                                .mapToInt(holder::getUnitCount)
+                                .sum();
+
+                        if (spaceGroundForces >= 3 || holderGroundForces >= 3) {
+                            return 1;
+                        }
+                    }
+                }
+                return 0;
             }
         }
         return 0;

--- a/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
+++ b/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
@@ -1283,14 +1283,19 @@ public class PlayStrategyCardService {
      */
     private static List<Button> getMonumentsConstructionButtons(int sc, Game game) {
         Button followButton = Buttons.green("sc_follow_" + sc, "Spend A Strategy Token");
-        Button sdButton = Buttons.green("construction_spacedock", "Place 1 space dock", UnitEmojis.spacedock);
-        Button pdsButton = Buttons.green("construction_pds", "Place 1 PDS", UnitEmojis.pds);
-        Button monumentButton = Buttons.red("construction_monument", "Place 1 Monument", UnitEmojis.Monument);
+        Button buildButton = Buttons.green("constructionPrimary_produce", "[Primary] Use Production");
+        Button sdButton = Buttons.green("construction_spacedock", "Place A Space Dock", UnitEmojis.spacedock);
+        Button pdsButton = Buttons.green("construction_pds", "Place a PDS", UnitEmojis.pds);
+        Button monumentButton = Buttons.green("construction_monument", "Place 1 Monument", UnitEmojis.Monument);
         Button noFollowButton = Buttons.blue("sc_no_follow_" + sc, "Not Following");
+        List<Button> buttons = new ArrayList<>(List.of(followButton, buildButton, sdButton, pdsButton, monumentButton));
         if (game.isFacilitiesMode()) {
-            Button facilityButton = Buttons.green("construction_facility", "Place A Facility");
-            return List.of(followButton, sdButton, pdsButton, monumentButton, facilityButton, noFollowButton);
+            buttons.add(Buttons.green("construction_facility", "Place A Facility"));
         }
-        return List.of(followButton, sdButton, pdsButton, monumentButton, noFollowButton);
+        if (game.isMonumentToTheAgesMode()) {
+            buttons.add(Buttons.green("construction_agesmonument", "Place A Monument (Cost 5 TG)"));
+        }
+        buttons.add(noFollowButton);
+        return buttons;
     }
 }

--- a/src/main/java/ti4/service/unit/DestroyUnitService.java
+++ b/src/main/java/ti4/service/unit/DestroyUnitService.java
@@ -48,6 +48,7 @@ import ti4.helpers.Units.UnitType;
 import ti4.helpers.thundersedge.BreakthroughCommandHelper;
 import ti4.message.MessageHelper;
 import ti4.model.UnitModel;
+import ti4.service.emoji.CardEmojis;
 import ti4.service.emoji.FactionEmojis;
 import ti4.service.emoji.UnitEmojis;
 import ti4.service.unit.RemoveUnitService.RemovedUnit;
@@ -198,6 +199,24 @@ public class DestroyUnitService {
         int totalAmount = unit.getTotalRemoved();
         Player player = game.getPlayerFromColorOrFaction(unit.unitKey().colorID());
 
+        if (game.isMonumentsMode()
+                && unit.unitKey().unitType() == UnitType.Monument
+                && game.getActiveSystem() != null) {
+            for (Player secretHolder : game.getRealPlayers()) {
+                if (secretHolder == player || !secretHolder.getSecretsUnscored().containsKey("tam")) {
+                    continue;
+                }
+                Button scoreButton = Buttons.green(
+                        secretHolder.factionButtonChecker() + "scoreToppleAMonument",
+                        "Score Topple a Monument",
+                        CardEmojis.SecretObjective);
+                MessageHelper.sendMessageToChannelWithButton(
+                        secretHolder.getCardsInfoThread(),
+                        secretHolder.getRepresentation() + ", a monument was destroyed during a tactical action. "
+                                + "If you destroyed another player's monument, you can score _Topple a Monument_.",
+                        scoreButton);
+            }
+        }
         if (player != null && player.hasAbility("fragmentation")) {
             CrystellumAbilityHandler.resolveFragmentation(event, game, player, unit);
         }

--- a/src/main/java/ti4/service/unit/RemoveUnitService.java
+++ b/src/main/java/ti4/service/unit/RemoveUnitService.java
@@ -22,6 +22,7 @@ import ti4.helpers.Units.UnitType;
 import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.message.MessageHelper;
+import ti4.service.agenda.MonumentsAgendaService;
 import ti4.service.planet.AddPlanetToPlayAreaService;
 
 @UtilityClass
@@ -202,6 +203,13 @@ public class RemoveUnitService {
                     event,
                     "Did not find enough " + parsedUnit.unitKey().getColor() + " units to remove, " + toRemoveCount
                             + " missing.");
+        }
+
+        for (RemovedUnit removedUnit : allUnitsRemoved) {
+            if (removedUnit.unitKey().unitType() == UnitType.Monument) {
+                MonumentsAgendaService.resolveCathedralOfIxthRemoval(
+                        game, removedUnit.getPlayer(game), removedUnit.uh().getName());
+            }
         }
 
         allUnitsRemoved.stream()

--- a/src/main/resources/data/action_cards/monuments.json
+++ b/src/main/resources/data/action_cards/monuments.json
@@ -1,0 +1,32 @@
+[
+    {
+        "alias": "festival",
+        "name": "Festival",
+        "automationID": "monuments_festival",
+        "phase": "Action",
+        "window": "Action",
+        "text": "Ready a non-home planet that contains 1 of your structures. If that planet contains your monument, place 4 infantry or 1 mech on it.",
+        "flavorText": "\"Party time, your excellency.\"",
+        "source": "monuments"
+    },
+    {
+        "alias": "rebelbombing",
+        "name": "Rebel Bombing",
+        "automationID": "monuments_rebel_bombing",
+        "phase": "Action",
+        "window": "Action",
+        "text": "Spend 2 trade goods to destroy 1 of your neighbor's structures in a non-home system.",
+        "flavorText": "The bombs were placed with care.",
+        "source": "monuments"
+    },
+    {
+        "alias": "renovation",
+        "name": "Renovation",
+        "automationID": "monuments_renovation",
+        "phase": "Action",
+        "window": "Action",
+        "text": "Replace 1 of your structures with 1 structure from your reinforcements.",
+        "flavorText": "\"Necessity demands that this shell be repurposed for a greater good.\"",
+        "source": "monuments"
+    }
+]

--- a/src/main/resources/data/agendas/monuments.json
+++ b/src/main/resources/data/agendas/monuments.json
@@ -1,0 +1,22 @@
+[
+    {
+        "alias": "cathedralofixth",
+        "name": "Cathedral Of Ixth",
+        "type": "Law",
+        "target": "Elect Non-Home Planet",
+        "text1": "Attach this card to the elected planet. The owner of this planet gains 1 VP if their monument is on this planet.\nWhen a player places their monument on this planet, they gain 1 VP. When a player's monument on this planet is removed, they lose 1 VP.",
+        "text2": "",
+        "mapText": "When a player places their monument on this planet, they gain 1 VP. When a player's monument on this planet is removed, they lose 1 VP.",
+        "source": "monuments"
+    },
+    {
+        "alias": "ministerofculture",
+        "name": "Minister Of Culture",
+        "type": "Law",
+        "target": "Elect Player",
+        "text1": "As long as the owner of this card controls their monument their commodity value is increased by 2.\nThe elected player gains this card and replenishes their commodities.",
+        "text2": "",
+        "mapText": "As long as the owner of this card controls their monument their commodity value is increased by 2.",
+        "source": "monuments"
+    }
+]

--- a/src/main/resources/data/secret_objectives/monuments.json
+++ b/src/main/resources/data/secret_objectives/monuments.json
@@ -1,0 +1,18 @@
+[
+    {
+    "alias": "dagw",
+    "name": "Defend A Great Work",
+    "phase": "Status",
+    "text": "Have a monument on the game board and at least 3 ground forces on its planet or in its space area.",
+    "points": 1,
+    "source": "monuments"
+  },
+  {
+    "alias": "tam",
+    "name": "Topple A Monument",
+    "phase": "Action",
+    "text": "Destroy another player's monument during a tactical action.",
+    "points": 1,
+    "source": "monuments"
+  }
+]

--- a/src/main/resources/data/strategy_card_sets/monuments.json
+++ b/src/main/resources/data/strategy_card_sets/monuments.json
@@ -8,11 +8,11 @@
             "pok3politics",
             "monuments4construction",
             "pok5trade",
-            "pok6warfare",
+            "te6warfare",
             "pok7technology",
             "pok8imperial"
         ],
-        "description": "Monuments SCs (PoK with new Construction)",
+        "description": "Monuments SCs (TE with new Construction)",
         "source": "monuments"
     }
 ]

--- a/src/main/resources/data/strategy_cards/monuments.json
+++ b/src/main/resources/data/strategy_cards/monuments.json
@@ -4,13 +4,14 @@
         "initiative": 4,
         "name": "Construction",
         "primaryTexts": [
-            "Place 1 PDS or 1 Space Dock on a planet you control.",
-            "Place 1 PDS on a planet you control.",
-            "Place your Monument on a planet you control that matches at least one of it's listed planetary requirements."
+            "Either place 1 structure on a planet you control or use the PRODUCTION ability of 1 of your space docks.",
+            "Place 1 structure on a planet you control.",
+            "If your monument is not on the board, place your monument."
         ],
         "secondaryTexts": [
-            "Spend 1 token from your strategy pool and place it in any system; you may place either 1 space dock or 1 PDS on a planet you control in that system"
+            "Spend 1 token from your strategy pool to place 1 non-monument structure on a planet you control."
         ],
+        "imageFileName": "monuments_construction",
         "colourHexCode": "#39b54a",
         "source": "monuments"
     }

--- a/src/main/resources/data/units/monuments.json
+++ b/src/main/resources/data/units/monuments.json
@@ -12,10 +12,10 @@
             "CULTURAL"
         ],
         "spaceCannonHitsOn": 8,
-        "spaceCannonDieCount": 2,
+        "spaceCannonDieCount": 1,
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you pass, place 1 infantry on a planet in or adjacent to this system other than Mecatol Rex that contains no other player's units.\nThen, gain control of that planet, if able."
+        "ability": "When you pass, place 1 infantry on a planet in or adjacent to this system other than Mecatol Rex. If that planet contains another player's units, place that unit into coexistence."
     },
     {
         "id": "argent_monument",
@@ -28,15 +28,18 @@
         "eligiblePlanetTypes": [
             "HAZARDOUS"
         ],
+        "ineligiblePlanetTypes": [
+            "LIGHTNING"
+        ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "ACTION: Exhaust this card to destroy 1 damaged ship in or adjacent to this system."
+        "ability": "ACTION: Exhaust this card to choose this or an adjacent system that does not contain 1 or more of your ships.\nProduce a hit against each ship in that system that has SUSTAIN DAMAGE."
     },
     {
         "id": "letnev_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "Platine Obelisk",
+        "name": "Palatine Obelisk",
         "subtitle": "Letnev Monument",
         "source": "monuments",
         "faction": "letnev",
@@ -46,7 +49,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you exhaust this planet to cast votes, you may cast an additional number of votes equal to the number of your non-fighter ships in this system.\nDouble the PRODUCTION values of your units in this system."
+        "ability": "Double the PRODUCTION values of your units in this system.\nWhen you exhaust this planet to cast votes, you may cast an additional number of votes equal to the number of your non-fighter ships in this system."
     },
     {
         "id": "saar_monument",
@@ -64,7 +67,7 @@
         "spaceCannonDieCount": 2,
         "isStructure": true,
         "isMonument": true,
-        "ability": "This system is adjacent to your flagship."
+        "ability": "You may treat this system as being adjacent to 1 of your space docks."
     },
     {
         "id": "keleres_monument",
@@ -78,10 +81,13 @@
             "CULTURAL",
             "LEGENDARY"
         ],
+        "ineligiblePlanetTypes": [
+            "MECATOL_REX"
+        ],
         "productionValue": "1",
         "isStructure": true,
         "isMonument": true,
-        "ability": "After a law enters play, add a command token from your reinforcements to this card.\nWhen you would place a command token in this or an adjacent system, you may place that token from this card instead."
+        "ability": "After a law enters play, you may add a command token from your reinforcements to this card; When you would place a command token in this or an adjacent system, you may place that token from this card instead."
     },
     {
         "id": "muaat_monument",
@@ -96,7 +102,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you exhaust this planet to cast votes:\nFor each war sun or flagship you control in this system, and for each adjacent supernova, cast 2 additional votes or produce 1 hit against another player's ships in a system adjacent to this planet."
+        "ability": "When you exhaust this planet to cast votes, for each war sun or flagship you control in this system, and for each supernova adjacent to this system, choose: cast 3 additional votes, or produce a hit against another player's ships in this or an adjacent system."
     },
     {
         "id": "hacan_monument",
@@ -112,7 +118,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "As part of a transaction, one player may return any of their ships in or adjacent to this system to their reinforcements.\nFor each of those ships, the other player produces 1 ship of that type in this system without spending resources."
+        "ability": "Outside of combat, players may trade their units in the space area of this and adjacent systems as part of a transaction. A player who gained units this way then replaces them and moves them to a system that contains their ships and 1 of their command tokens, if able; otherwise, remove those units."
     },
     {
         "id": "empyrean_monument",
@@ -123,12 +129,16 @@
         "source": "monuments",
         "faction": "empyrean",
         "eligiblePlanetTypes": [
-            "EMPTY_NONANOMALY"
+            "EMPTY"
+        ],
+        "ineligiblePlanetTypes": [
+            "LIGHTNING",
+            "SUPERNOVA"
         ],
         "productionValue": "1",
         "isStructure": true,
         "isMonument": true,
-        "ability": "This unit is placed in the space area of any system that is not an anomaly and does not contain planets, instead of on a planet.\nIf this unit is blockaded, destroy it."
+        "ability": "This unit is placed in the space area of a non-fracture, non-supernova system that does not contain planets, instead of on a planet.\nIf this unit is blockaded, destroy it."
     },
     {
         "id": "sol_monument",
@@ -144,7 +154,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you place 1 or more infantry on a planet, exhaust this card to place up to 4 of those infantry on this planet instead."
+        "ability": "When you place 1 or more infantry on a planet, exhaust this card to place any of those infantry on this planet instead."
     },
     {
         "id": "creuss_monument",
@@ -160,7 +170,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "After a player activates this system:\nFor each system adjacent to this planet that contains a wormhole, you may produce 1 hit against another player's ships in that system."
+        "ability": "After a player activates this system:\nYou may produce 1 hit against player's ships in each system adjacent to this planet that contains a wormhole."
     },
     {
         "id": "l1z1x_monument",
@@ -177,7 +187,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "At the start of your turn, you may exhaust this card to take a player's command token from an adjacent system and place it in this system, if it does not already contain that player's command token."
+        "ability": "At the start of your turn, you may exhaust this card to remove a player's command token from an adjacent system and place it in this system."
     },
     {
         "id": "mahact_monument",
@@ -194,7 +204,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "At the start of the status phase, the Mahact player may place 1 command token in this system into their fleet pool, if it does not already contain that player's token."
+        "ability": "At the start of the status phase, the Mahact player may place 1 command token in this system into their fleet pool."
     },
     {
         "id": "mentak_monument",
@@ -211,7 +221,7 @@
         "productionValue": "2",
         "isStructure": true,
         "isMonument": true,
-        "ability": "When a player activates this system, you may take 1 of their unscored secret objective cards at random, if able. If you do, give that player 1 of your unscored secret objective cards."
+        "ability": "At the start of a player's turn, exhaust this card to have each ship in this or an adjacent system with SUSTAIN DAMAGE become damaged."
     },
     {
         "id": "naalu_monument",
@@ -226,7 +236,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "During the agenda phase, when an outcome you voted for is resolved:\nPlace up to 2 fighters from your reinforcements in this or an adjacent system. If that system contains another player’s ships, immediately resolve\na space combat."
+        "ability": "Infantry that you commit to planets in this and adjacent systems may be committed into coexistence, if able."
     },
     {
         "id": "naaz-rokha_monument",
@@ -242,19 +252,25 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you are negotiating a transaction with a player who controls units in or adjacent to this system, 1 of your relics can be exchanged as part of that transaction."
+        "ability": "When you are negotiating a transaction with a player who controls units in or adjacent to this system, relics can be exchanged as part of that transaction; ignore \"when you gain\" effects of those relics."
     },
     {
         "id": "nekro_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "Valefar Assimilator W",
+        "name": "Valefar Assimilator M",
         "subtitle": "Nekro Monument",
         "source": "monuments",
         "faction": "nekro",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "INDUSTRIAL",
+            "CULTURAL",
+            "LEGENDARY"
+        ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you gain control of a planet that contains another player's structure, you may place the \"W\" assimilator token on that player's monument card.\nWhile that token is on a monument card, this card gains that card's attributes, abilities, and ability text."
+        "ability": "When you destroy another player's structure, you may place or move an \"M\" or \"Z\" assimilator token onto that player's monument card.\nWhile any of those tokens are on a monument card, this card gains that card's attributes, abilities, and ability text."
     },
     {
         "id": "nomad_monument",
@@ -265,11 +281,13 @@
         "source": "monuments",
         "faction": "nomad",
         "eligiblePlanetTypes": [
-            "TECH_SPECIALTY"
+            "HAZARDOUS",
+            "INDUSTRIAL",
+            "CULTURAL"
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "At the start of your turn, you may return this unit to your reinforcements. If you do, produce your flagship in this system without spending resources."
+        "ability": "At the start of your turn, you may return this unit to your reinforcements to produce, or remove and produce, your flagship in this system."
     },
     {
         "id": "norr_monument",
@@ -280,11 +298,12 @@
         "source": "monuments",
         "faction": "sardakk",
         "eligiblePlanetTypes": [
-            "CULTURAL"
+            "HAZARDOUS",
+            "INDUSTRIAL"
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you place your monument, place 1 infantry on this planet, and a total of 2 infantry on up to 2 other planets you control in adjacent systems."
+        "ability": "When you place your monument, produce up to a total of 3 infantry or fighters in this or adjacent systems without spending resources.\nAt the end of your turn, you may replace this unit with a different structure from your reinforcements."
     },
     {
         "id": "titans_monument",
@@ -299,7 +318,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "ACTION: Exhaust this card to remove an attachment from a planet you control and attach it to a planet you control with the same planetary trait in this or an adjacent system."
+        "ability": "ACTION: Exhaust this card to place a sleeper token on a planet in this or an adjacent system that has a planetary trait."
     },
     {
         "id": "jolnar_monument",
@@ -325,16 +344,15 @@
         "source": "monuments",
         "faction": "cabal",
         "eligiblePlanetTypes": [
+            "HAZARDOUS",
             "CULTURAL",
             "INDUSTRIAL",
-            "HAZARDOUS",
-            "MECATOL_REX",
             "LEGENDARY"
         ],
         "productionValue": "1",
         "isStructure": true,
         "isMonument": true,
-        "ability": "DEPLOY: When you gain control of a planet, you may place this unit on that planet and capture every other structure on that planet."
+        "ability": "DEPLOY: When you gain control of a planet that contains 1 or more structures, you may place this unit on that planet and capture each other structure on that planet as if it were a non-fighter ship."
     },
     {
         "id": "winnu_monument",
@@ -349,7 +367,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "At the start of the agenda phase:\nIf your monument is on the game board, gain any number of trade goods on this card. Otherwise, spend any number of resources to place 1 trade good from the supply on this card for every 3 resources spent."
+        "ability": "At the start of the agenda phase, if your monument is on the game board, gain any number of trade goods on this card. Otherwise, spend any number of resources to place 1 trade good from the supply on this card for every 3 resources spent."
     },
     {
         "id": "xxcha_monument",
@@ -365,7 +383,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "During the agenda phase, when an outcome you voted for or predicted is resolved, you may exhaust this card to place 1 PDS from your reinforcements on this planet."
+        "ability": "When an outcome you voted for or predicted is resolved, you may exhaust this card to place a structure on a planet you control in this system."
     },
     {
         "id": "yin_monument",
@@ -398,6 +416,258 @@
         "isStructure": true,
         "isMonument": true,
         "ability": "When another player plays an action card:\nIf that player controls 1 or more units in this or an adjacent system, you may gain 2 trade goods."
+    },
+    {
+        "id": "bastion_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Seraph Data Center",
+        "subtitle": "Bastion Monument",
+        "source": "monuments",
+        "faction": "bastion",
+        "eligiblePlanetTypes": [
+            "EMPTY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "notes": "This is a space station, and as such, has all the normal space station abilities.",
+        "ability": "This unit is a station and placed in the space area of a system that contains your ships and exactly 1 non-legendary planet. Take its matching station card while you control it.\nWhen you lost control of this station, destroy it and produce 2 hits against ships in this system."
+    },
+    {
+        "id": "crimson_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Veils Of Lost Creuss",
+        "subtitle": "Crimson Monument",
+        "source": "monuments",
+        "faction": "crimson",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "CULTURAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "After a breach becomes or is placed active side up in any system, if that system is adjacent to this planet, you may produce 1 hit in that system against another player's ships."
+    },
+    {
+        "id": "deepwrought_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "The Pelagion",
+        "subtitle": "Deepwrought Monument",
+        "source": "monuments",
+        "faction": "deepwrought",
+        "eligiblePlanetTypes": [
+            "INDUSTRIAL",
+            "CULTURAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "Other player's ships in this system do not trigger space combat. After this unit is removed from a planet, choose a player with ships in that system to resolve a space combat. Repeat this until it contains no more than 1 player's ships."
+    },
+    {
+        "id": "firmament_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Epiphany",
+        "subtitle": "Firmament Monument",
+        "source": "monuments",
+        "faction": "firmament",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "INDUSTRIAL",
+            "CULTURAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "After a player activates this system, you may replace 1 control token on one of your plots with 1 of that player's control tokens."
+    },
+    {
+        "id": "obsidian_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Epiphany Hollow",
+        "subtitle": "Decayed Monument",
+        "source": "monuments",
+        "faction": "obsidian",
+        "eligiblePlanetTypes": [],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "After a puppeted player activates this system, replace up to 2 of that player's infantry on a planet they control with your infantry; those units coexist."
+    },
+    {
+        "id": "ralnel_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Sor Tek Linkhub",
+        "subtitle": "Ral Nel Monument",
+        "source": "monuments",
+        "faction": "ralnel",
+        "eligiblePlanetTypes": [
+            "INDUSTRIAL",
+            "CULTURAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "At the end of your tactical action, you may move 1 structure in the space area of this or an adjacent system to the space area of a system adjacent to that structure."
+    },
+    {
+        "id": "blacktf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "The Flesh Cathedral",
+        "subtitle": "Raithborn Monument",
+        "source": "monuments",
+        "faction": "blacktf",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "INDUSTRIAL"
+        ],
+        "ineligiblePlanetTypes": [
+            "LEGENDARY"
+        ],
+        "productionValue": 2,
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "Capture all infantry destroyed in this system. You may spend captured infantry as if they were resources when producing units on this planet."
+    },
+    {
+        "id": "bluetf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Caracas",
+        "subtitle": "Tempered Monument",
+        "source": "monuments",
+        "faction": "bluetf",
+        "eligiblePlanetTypes": [
+            "LIGHTNING",
+            "HAZARDOUS",
+            "INDUSTRIAL"
+        ],
+        "ineligiblePlanetTypes": [
+            "LEGENDARY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "At the start of any tactical action, you may choose any number of destroyers or cruisers in this system. Those units wihtout a capacity gain a capacity value of 1 until the end of this tactical action."
+    },
+    {
+        "id": "greentf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "The Crown Of Thorns",
+        "subtitle": "Blossoming Monument",
+        "source": "monuments",
+        "faction": "greentf",
+        "eligiblePlanetTypes": [
+            "LIGHTNING",
+            "CULTURAL",
+            "INDUSTRIAL"
+        ],
+        "ineligiblePlanetTypes": [
+            "LEGENDARY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "At the start of a ground combat not involving your units in this and adjacent systems, you may produce 1 hit against a player's units in that combat. Units cannot be placed into coexistence in this system."
+    },
+    {
+        "id": "orangetf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "The Starlit Redoubt",
+        "subtitle": "Divine Monument",
+        "source": "monuments",
+        "faction": "orangetf",
+        "eligiblePlanetTypes": [
+            "LIGHTNING",
+            "LEGENDARY",
+            "HAZARDOUS"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "At the start of an action you may allow any players' mechs in this and adjacent systems to gain +1 to their combat rolls until the end of that action."
+    },
+    {
+        "id": "pinktf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Avatar of Mirrors",
+        "subtitle": "Replicant Monument",
+        "source": "monuments",
+        "faction": "pinktf",
+        "eligiblePlanetTypes": [
+            "LIGHTNING",
+            "CULTURAL",
+            "HAZARDOUS"
+        ],
+        "ineligiblePlanetTypes": [
+            "LEGENDARY"
+        ],
+        "capacityUsed": 1,
+        "combatHitsOn": 4,
+        "combatDieCount": 2,
+        "isGroundForce": true,
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "This unit is a ground force as well as a monument. It can be transported. This unit gains the non-DEPLOY unit abilities and text abilities of your ground forces."
+    },
+    {
+        "id": "purpletf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Halo Cortex",
+        "subtitle": "Paradox Monument",
+        "source": "monuments",
+        "faction": "purpletf",
+        "eligiblePlanetTypes": [
+            "EMPTY"
+        ],
+        "productionValue": 3,
+        "capacityValue": 3,
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "This unit is placed in the space area of a system that contains a planet you control, instead of on a planet. 1 Ship in this system does not count against your fleet limit."
+    },
+    {
+        "id": "redtf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "The Serrated Throne",
+        "subtitle": "Vermillion Monument",
+        "source": "monuments",
+        "faction": "redtf",
+        "eligiblePlanetTypes": [
+            "LIGHTNING",
+            "HAZARDOUS",
+            "INDUSTRIAL"
+        ],
+        "ineligiblePlanetTypes": [
+            "LEGENDARY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "DEPLOY: At the start of a ground combat involving your units, place this unit on that planet, then produce 2 hits against each other player's units on this planet."
+    },
+    {
+        "id": "yellowtf_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Aura Vault",
+        "subtitle": "Glimmering Monument",
+        "source": "monuments",
+        "faction": "yellowtf",
+        "eligiblePlanetTypes": [
+            "LIGHTNING",
+            "CULTURAL",
+            "HAZARDOUS"
+        ],
+        "ineligiblePlanetTypes": [
+            "LEGENDARY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "When you splice, you may place 1 command token from your reinforcements on this card, if able.\nYou may remove a token form this card to cancel a hit in this or an adjacent system."
     },
     {
         "id": "axis_monument",
@@ -442,13 +712,12 @@
         "source": "monuments",
         "faction": "mykomentori",
         "eligiblePlanetTypes": [
-            "CULTURAL",
-            "INDUSTRIAL"
+            "INDUSTRIAL",
+            "CULTURAL"
         ],
-        "planetaryShield": true,
         "isStructure": true,
         "isMonument": true,
-        "ability": "After each round of ground combat on this planet, if you have units in combat, place 1 infantry from your reinforcements on this planet."
+        "ability": "Up to 3 fighters in this and each adjacent system do not count against your ships' capacity. After a player uses an omen die, you may produce 1 fighter in this system without spending resources."
     },
     {
         "id": "cymiae_monument",
@@ -512,7 +781,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When a player activates this system, you may place 2 of their control tokens on your faction sheet."
+        "ability": "After another player with ships in this or an adjacent system replenishes commodities, if that player has control tokens on the Vaden player's faction sheet, you may take one of their commodities."
     },
     {
         "id": "florzen_monument",
@@ -528,7 +797,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "After each round of space combat in this system, if you have any fighters in combat, you may place 1 fighter from your reinforcement in this system's space area."
+        "ability": "When you produce fighters, you may place that many plastic fighter units on this card instead. At the start of your turn, you may produce fighter units on this card in this system without spending resources."
     },
     {
         "id": "ghemina_monument",
@@ -543,9 +812,12 @@
             "INDUSTRIAL",
             "CULTURAL"
         ],
+        "spaceCannonHitsOn": 6,
+        "spaceCannonDieCount": 2,
+        "planetaryShield": true,
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you win a space combat while you are the active player, ready this planet."
+        "ability": "You may treat this system as adjacent to systems that contain 2 of your structures of the same type."
     },
     {
         "id": "olradin_monument",
@@ -560,6 +832,7 @@
             "INDUSTRIAL",
             "CULTURAL"
         ],
+        "planetaryShield": true,
         "isStructure": true,
         "isMonument": true,
         "ability": "After you resolve the primary or secondary ability of the \"Diplomacy\" strategy card, ready this planet."
@@ -595,7 +868,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "Once per space combat, when a ship you control that has SUSTAIN DAMAGE is destroyed in this system, you may place 1 unit of that type in this system damaged from your reinforcements; that unit cannot repair until after that space combat."
+        "ability": "ACTION: Exhaust this card and choose an adjacent system that contains another player's non-fighter ships. That player moves those ships into this system if able, until they have moved at least 4 resources worth of ships, or all ships. Then, resolve a space combat."
     },
     {
         "id": "nivyn_monument",
@@ -610,13 +883,13 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "Other players' ships cannot move out of ore through this system.\nYour ships may treat this system as adjacent to the wound"
+        "ability": "Other players' ships cannot move out of or through this system.\nYour ships may treat this system as adjacent to the wound"
     },
     {
         "id": "rhodun_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "New Phrad",
+        "name": "Vault Of New Phrad",
         "subtitle": "Rhodun Monument",
         "source": "monuments",
         "faction": "zealots",
@@ -625,13 +898,27 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "During space combat in this system, for each unit upgrade technology your opponent owns, apply +1 to each of your units' combat rolls."
+        "ability": "Start with this side face up; when a player activates this system, you may flip this card.\nDuring combat, apply +1 to each of your units' combat rolls in this and adjacent systems if your opponent has any unit technology upgrades."
+    },
+    {
+        "id": "rhodun_monumentback",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Reliquat Unleashed",
+        "subtitle": "Rhodun Monument",
+        "source": "monuments",
+        "eligiblePlanetTypes": [
+            "TECH_SPECIALTY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "Flip this card at any time.\nOther players with units in the Fracture cannot activate this system.\nDuring combat, apply +2 to each of your units' combat rolls in this and adjacent systems if your opponent has any units in the fracture."
     },
     {
         "id": "augurs_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "AI Onyxxa",
+        "name": "AI Conclave",
         "subtitle": "Augurs Monument",
         "source": "monuments",
         "faction": "augers",
@@ -640,7 +927,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "After you explore another planet, you may explore this planet."
+        "ability": "When you would explore another planet, you may explore this planet instead. If you do, you may gain trade goods equal to the number of your scored objectives."
     },
     {
         "id": "veldyr_monument",
@@ -672,13 +959,13 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you lose a ground combat on this planet, destroy each unit on this planet."
+        "ability": "When you lose a ground combat on this planet, you may destroy each unit on this planet. At the start of your turn you may destroy 1 other player's unit in this system."
     },
     {
         "id": "vaylerian_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "Drive Disruptor",
+        "name": "Aylor Raider Hoard",
         "subtitle": "Vaylerian Monument",
         "source": "monuments",
         "faction": "vaylerian",
@@ -688,7 +975,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "Other players cannot declare a retreat during combat in this system.\nYou may treat this system as adjacent to the active system when you retreat."
+        "ability": "When a player spends trade goods during a space combat in or adjacent to this system, you may exhaust this card to draw 1 action card.\nWhile another player has ships in or adjacent to this system, your commodity value is increased by 1."
     },
     {
         "id": "free_systems_monument",
@@ -703,13 +990,13 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When a planet adjacent to this system is exhausted for influence, that planet produces 1 additional influence."
+        "ability": "After you resolve the primary or secondary ability of the \"Leadership\" strategy card, each other player with units in or adjacent to this system who reveals 1 of your promissory notes from their hand gains 1 command token."
     },
     {
         "id": "celdauri_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "Jump Relay",
+        "name": "Hyperlane Relay",
         "subtitle": "Celdauri Monument",
         "source": "monuments",
         "faction": "celdauri",
@@ -718,7 +1005,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "Ships you control in this system may treat this system as adjacent to each system that contains 1 or more of your space docks."
+        "ability": "During each of your tactical actions, you may commit ground forces on this planet to planets that contain your space docks."
     },
     {
         "id": "zelian_monument",
@@ -733,7 +1020,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "During the first round of space combat in this system, cancel up to 2 hits produced against your units."
+        "ability": "This system is treated as an asteroid field. Units can move into this system as it it were a non-anomaly tile.\nPlace the Zelian asteroid field token in this system as a reminder."
     },
     {
         "id": "kollecc_monument",
@@ -761,9 +1048,11 @@
         "eligiblePlanetTypes": [
             "INDUSTRIAL"
         ],
+        "spaceCannonHitsOn": 7,
+        "spaceCannonDieCount": 2,
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you produce 1 or more units, you may treat up to 4 of those units as if you produced them on this planet instead."
+        "ability": "When you produce any number of units in this system, reduce the combined cost of those units by 2."
     },
     {
         "id": "kortali_monument",
@@ -778,7 +1067,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "At the start of each round of space combat in this system, repair 1 ship you control in this system."
+        "ability": "When a non-fighter, non-infantry unit you control is destroyed in this system, roll a die. If you roll equal to or higher than that unit's combat value, or 8 if that unit has no combat value, produce 1 hit against another player's ships in this system."
     },
     {
         "id": "bentor_monument",
@@ -789,19 +1078,19 @@
         "source": "monuments",
         "faction": "bentor",
         "eligiblePlanetTypes": [
-            "HAZARDOUS",
             "INDUSTRIAL",
             "CULTURAL"
         ],
+        "productionValue": 1,
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you pass, explore this planet twice."
+        "ability": "DEPLOY: After another player explores a planet that is not adjacent to a home system, you may place this unit into coexistence on that planet and explore it."
     },
     {
         "id": "kjalengard_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "Bannerhall",
+        "name": "Krotas Bannerhall",
         "subtitle": "Kjalengard Monument",
         "source": "monuments",
         "faction": "kjalengard",
@@ -811,7 +1100,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When a player wins a combat in or adjacent to this system, you and that player may each gain 1 command token."
+        "ability": "Once per action, when a player wins a combat in or adjacent to this system, you and that player may each gain 1 command token."
     },
     {
         "id": "nokar_monument",
@@ -825,9 +1114,10 @@
             "INDUSTRIAL",
             "CULTURAL"
         ],
+        "productionValue": 3,
         "isStructure": true,
         "isMonument": true,
-        "ability": "Your ships may move out of this system, even if it contains 1 of your command tokens."
+        "ability": "Your ships may move out of this system, and transport units, even if it contains 1 of your command tokens."
     },
     {
         "id": "edyn_monument",
@@ -838,12 +1128,11 @@
         "source": "monuments",
         "faction": "edyn",
         "eligiblePlanetTypes": [
-            "LEGENDARY",
-            "MECATOL_REX"
+            "LEGENDARY"
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "When you exhaust this planet for resources or influence, it produces an additional resource or influence for each law in play."
+        "ability": "At any time, you may exhaust this card to produce a mech on this planet wihtout spending resources."
     },
     {
         "id": "lanefir_monument",
@@ -860,7 +1149,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "Once per action, you may use the technology specialty of a planet in or adjacent to this system."
+        "ability": "Once per action, you may use the technology specialty of a planet in or adjacent to this system, even if it is exhausted."
     },
     {
         "id": "cheiran_monument",
@@ -873,7 +1162,7 @@
         "eligiblePlanetTypes": [
             "CULTURAL"
         ],
-        "productionValue": "+0",
+        "productionValue": "+1",
         "basicProduction": "struct",
         "isStructure": true,
         "isMonument": true,
@@ -892,7 +1181,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "This planet counts as a legendary planet with an attachment and a technology speciality of no type.\nWhen this unit is destroyed, you must place it on a valid adjacent planet you control, if able."
+        "ability": "This planet counts as a legendary planet with an attachment and a technology speciality of no type.\nWhen this unit is destroyed, you must place it on a planet you control in this or an adjacent system, if able. If you do, draw a relic."
     },
     {
         "id": "ghoti_monument",
@@ -907,7 +1196,7 @@
         ],
         "isStructure": true,
         "isMonument": true,
-        "ability": "At any time, you may chose to treat this system as being adjacent to your home system."
+        "ability": "During movement, you may choose to treat this system as thought it contains no planets. You treat this system as though it contains a frontier token."
     },
     {
         "id": "kolume_monument",
@@ -920,33 +1209,33 @@
         "eligiblePlanetTypes": [
             "INDUSTRIAL"
         ],
-        "spaceCannonHitsOn": 4,
-        "spaceCannonDieCount": 1,
+        "spaceCannonHitsOn": 6,
+        "spaceCannonDieCount": 2,
         "isStructure": true,
         "isMonument": true,
-        "ability": "When this unit produces a hit against another player's ships, gain 1 command token."
+        "ability": "When another player passes, choose this or an adjacent system that contains a unit with SPACE CANNON; either use this unit's SPACE CANNON against another player's ships in that system, or repeat this ability, starting in that system."
     },
     {
         "id": "gledge_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "Central Mining Hub",
+        "name": "Verdant Halo",
         "subtitle": "Gledge Monument",
         "source": "monuments",
         "faction": "gledge",
         "eligiblePlanetTypes": [
-            "HAZARDOUS",
-            "INDUSTRIAL"
+            "CULTURAL"
         ],
+        "productionValue": 1,
         "isStructure": true,
         "isMonument": true,
-        "ability": "When a planet with an attachment is exhausted for resources in this or an adjacent system, that planet produces an additional resource."
+        "ability": "At the start of your turn, you may exhaust 2 planets you control that contain a Core token; 1 player treats all laws as blank until the end of this turn."
     },
     {
         "id": "drahn_monument",
         "baseType": "monument",
         "asyncId": "monument",
-        "name": "Drahn Monument",
+        "name": "Koldan's Outpost",
         "subtitle": "Drahn Monument",
         "source": "monuments",
         "faction": "drahn",
@@ -958,6 +1247,174 @@
         "spaceCannonDieCount": 2,
         "isStructure": true,
         "isMonument": true,
-        "ability": "At the beginning of your turn you may remove this unit from this planet and place it onto a different valid planet you control."
+        "ability": "At the beginning of your turn you may remove this unit from this planet and place it onto a different planet you control."
+    },
+    {
+        "id": "atokera_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Deepmantle Interface",
+        "subtitle": "Atokera Monument",
+        "source": "monuments",
+        "faction": "atokera",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "INDUSTRIAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "During the agenda phase, when an outcome you voted for or predicted is resolved, produce up to 1 unit in this system."
+    },
+    {
+        "id": "belkosea_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Armageddon Project",
+        "subtitle": "Belkosea Monument",
+        "source": "monuments",
+        "faction": "belkosea",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "INDUSTRIAL",
+            "CULTURAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "At the end of the strategy phase, choose and place 1 control token on a super weapon card in your play area. This card has the text abilities of each superweapon card in your play area that has 1 of your control tokens."
+    },
+    {
+        "id": "kaltrim_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "The Crown Temple",
+        "subtitle": "Kaltrim Monument",
+        "source": "monuments",
+        "faction": "kaltrim",
+        "eligiblePlanetTypes": [
+            "HOME_PLANET"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "DEPLOY: When the Kaltrim Crown token is revealed, place this structure on a planet in your home system.\nWhile you have the Kaltrim Crown token, other players must spend.1 command token from their command sheet to activate this system."
+    },
+    {
+        "id": "pharadn_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Black Pyramid",
+        "subtitle": "Pharadn Monument",
+        "source": "monuments",
+        "faction": "pharadn",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "LEGENDARY"
+        ],
+        "combatHitsOn": 8,
+        "combatDieCount": 2,
+        "sustainDamage": true,
+        "isGroundForce": true,
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "This unit is treated as a structure and a ground force.\nDEPLOY: During your \"Commit Ground Forces\" step, if you control a planet in the active system, place this unit on a planet in that system."
+    },
+    {
+        "id": "qhet_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Sacred Pools",
+        "subtitle": "Qhet Monument",
+        "source": "monuments",
+        "faction": "qhet",
+        "eligiblePlanetTypes": [
+            "INDUSTRIAL",
+            "CULTURAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "When 1 or more of your infantry would be destroyed, you may exhaust this card to place those units on this planet instead."
+    },
+    {
+        "id": "sarcosa_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Raider Stronghold",
+        "subtitle": "Sarcosa Monument",
+        "source": "monuments",
+        "faction": "sarcosa",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "CULTURAL"
+        ],
+        "ineligiblePlanetTypes": [
+            "HOME_PLANET",
+            "LIGHTNING"
+        ],
+        "productionValue": 2,
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "You may place this structure into coexistence on a non-home, non-Fracture planet adjacent to a system that contains your or neutral units."
+    },
+    {
+        "id": "toldar_monumentdishonor",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Charnel Fane",
+        "subtitle": "Toldar Monument",
+        "source": "monuments",
+        "faction": "toldar",
+        "eligiblePlanetTypes": [
+            "CULTURAL",
+            "LEGENDARY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "If you have more Honor than Dishonor, flip this card.\nAfter a player wins a combat in this system, they may draw a secret objective.\nIf your Dishonor is 8, move this unit to the space area; it cannot be destroyed."
+    },
+    {
+        "id": "toldar_monumenthonor",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "The People's Temple",
+        "subtitle": "Toldar Monument",
+        "source": "monuments",
+        "eligiblePlanetTypes": [
+            "CULTURAL",
+            "LEGENDARY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "If you have more Dishonour and Honour, flip this card.\nThis unit gains the abilities matching your Honor:\n2+: PRODUCTION 2\n5+: PLANETARY SHIELD\n8: SPACE CANNON 4 (x3)"
+    },
+    {
+        "id": "uydai_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Hidden Oasis",
+        "subtitle": "Uydai Monument",
+        "source": "monuments",
+        "faction": "uydai",
+        "eligiblePlanetTypes": [
+            "HAZARDOUS",
+            "CULTURAL"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "At the start of your turn, if this system contains 1 of your command tokens, you may exhaust this card to swap a plan card on your faction sheet for any other plan card."
+    },
+    {
+        "id": "xin_monument",
+        "baseType": "monument",
+        "asyncId": "monument",
+        "name": "Celestial Court",
+        "subtitle": "Xin Monument",
+        "source": "monuments",
+        "faction": "xin",
+        "eligiblePlanetTypes": [
+            "TECH_SPECIALTY",
+            "LEGENDARY"
+        ],
+        "isStructure": true,
+        "isMonument": true,
+        "ability": "When a player activates this system, gain 1 balance token or flip 1 balance token on your faction sheet.\nThis unit may also be placed on a legendary planet."
     }
 ]


### PR DESCRIPTION
# Monuments+ v3.1

## Added
### All automated
- TE Monuments+ Strategy Card
- 2 Secret Objectives
- 2 Agendas
- 3 Action Cards
- Option to `/game weird_game_setup`

### Not automated, TF monuments+ homebrew not implemented
- BR and TF monuments

## Updated
- All existing monuments to their 3.1 version