### PR TITLE
Fix swapped Yssaril homeworld flavour text + typo sweep

### DIFF
--- a/src/main/resources/data/action_cards/action_cards.json
+++ b/src/main/resources/data/action_cards/action_cards.json
@@ -505,7 +505,7 @@
         "phase": "Action",
         "window": "After your opponent declares a retreat during a space combat",
         "text": "Your opponent cannot retreat during this round of space combat.",
-        "flavorText": "The space before the fleeing ship shimmered and warped, revealing the bow of the Y'sia Yssrila bearing down on its position. There would be no escape today.",
+        "flavorText": "The space before the fleeing ship shimmered and warped, revealing the bow of the Y'sia Y'ssrila bearing down on its position. There would be no escape today.",
         "source": "base"
     },
     {
@@ -1034,7 +1034,7 @@
         "playTiming": "AGENDA_WHEN",
         "text": "Discard that agenda and reveal 1 agenda from the top of the deck. Players vote on this agenda instead.",
         "automationID": "veto",
-        "flavorText": "Magmus batted the now charred corpse aside with the back of his golden gauntlet. \"The Muuat reject your proposal.\"",
+        "flavorText": "Magmus batted the now charred corpse aside with the back of his golden gauntlet. \"The Muaat reject your proposal.\"",
         "source": "base"
     },
     {
@@ -1056,7 +1056,7 @@
         "playTiming": "AGENDA_WHEN",
         "text": "Discard that agenda and reveal 1 agenda from the top of the deck. Players vote on this agenda instead.",
         "automationID": "veto",
-        "flavorText": "Magmus batted the now charred corpse aside with the back of his golden gauntlet. \"The Muuat reject your proposal.\"",
+        "flavorText": "Magmus batted the now charred corpse aside with the back of his golden gauntlet. \"The Muaat reject your proposal.\"",
         "source": "base"
     },
     {
@@ -1067,7 +1067,7 @@
         "playTiming": "AGENDA_WHEN",
         "text": "Discard that agenda and reveal 1 agenda from the top of the deck. Players vote on this agenda instead.",
         "automationID": "veto",
-        "flavorText": "Magmus batted the now charred corpse aside with the back of his golden gauntlet. \"The Muuat reject your proposal.\"",
+        "flavorText": "Magmus batted the now charred corpse aside with the back of his golden gauntlet. \"The Muaat reject your proposal.\"",
         "source": "base"
     },
     {

--- a/src/main/resources/data/action_cards/uncharted_space.json
+++ b/src/main/resources/data/action_cards/uncharted_space.json
@@ -300,7 +300,7 @@
         "name": "Forbidden Knowledge",
         "phase": "Any",
         "window": "When you research a technology:",
-        "text": "You may ignore 1 of that technologys prerequisites. If that technology is not a unit upgrade technology, you may ignore 2 of that technology's prerequisites.",
+        "text": "You may ignore 1 of that technology's prerequisites. If that technology is not a unit upgrade technology, you may ignore 2 of that technology's prerequisites.",
         "flavorText": "The Zealots knew many secrets long forgotten.",
         "source": "ds",
         "actualSource": "uncharted_space"

--- a/src/main/resources/data/explores/explores.json
+++ b/src/main/resources/data/explores/explores.json
@@ -386,7 +386,7 @@
         "type": "Industrial",
         "resolution": "Instant",
         "text": "You may gain 1 commodity, or you may spend 1 trade good or 1 commodity to draw 1 action card.",
-        "flavorText": "*The Imperial Survey Corp outpost had been adandoned since the Twilight Wars, but the facilities had been built to last for millennia.*",
+        "flavorText": "*The Imperial Survey Corp outpost had been abandoned since the Twilight Wars, but the facilities had been built to last for millennia.*",
         "source": "pok"
     },
     {

--- a/src/main/resources/data/genericcards/lizhotraps.json
+++ b/src/main/resources/data/genericcards/lizhotraps.json
@@ -10,7 +10,7 @@
         "alias": "dshc_2_lizho",
         "cardType": "trap",
         "name": "Account Siphon",
-        "text": "While this card is attached, you may reveal this card after a player gains control of this planet. Take upto 2 trade goods or 3 commodities from that player. At the end of this tactical action, return this card to your reinforcements.",
+        "text": "While this card is attached, you may reveal this card after a player gains control of this planet. Take up to 2 trade goods or 3 commodities from that player. At the end of this tactical action, return this card to your reinforcements.",
         "source": "ds"
     },
     {

--- a/src/main/resources/data/relics/te_relics.json
+++ b/src/main/resources/data/relics/te_relics.json
@@ -28,7 +28,7 @@
         "alias": "metalivoidshielding",
         "name": "Metali Void Shielding",
         "text": "Each time hits are produced against 1 or more of your non-fighter ships, 1 of those ships may use SUSTAIN DAMAGE as if it had that ability.",
-        "flavourText": "Capable of more than destruction, the Metali also wrapped their ships in nigh-indestructable plating unable to be replicated using today's methods.",
+        "flavourText": "Capable of more than destruction, the Metali also wrapped their ships in nigh-indestructible plating unable to be replicated using today's methods.",
         "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/relics/te/metalivoidshielding.png?raw=true",
         "source": "thunders_edge"
     },

--- a/src/main/resources/planets/akhassi.json
+++ b/src/main/resources/planets/akhassi.json
@@ -115,6 +115,6 @@
         },
         "removeUnitCoordinate": true
     },
-    "flavourText": "While its surface is barren, sprawling undergound cities house millions. It has served as a vault for valuable artifacts and data-matrices.",
+    "flavourText": "While its surface is barren, sprawling underground cities house millions. It has served as a vault for valuable artifacts and data-matrices.",
     "source": "eronous"
 }

--- a/src/main/resources/planets/breakpoint.json
+++ b/src/main/resources/planets/breakpoint.json
@@ -112,6 +112,6 @@
         },
         "removeUnitCoordinate": true
     },
-    "flavourText": "Located nearby an inportant gateway. A great network of bunkers and military installations are interwoven both on the surface and deep underground.",
+    "flavourText": "Located nearby an important gateway. A great network of bunkers and military installations are interwoven both on the surface and deep underground.",
     "source": "eronous"
 }

--- a/src/main/resources/planets/malbolge.json
+++ b/src/main/resources/planets/malbolge.json
@@ -114,6 +114,6 @@
         },
         "removeUnitCoordinate": true
     },
-    "flavourText": "Boiling swamps cover the surface. Well hidden tunnels lead to fortifed bunkers. Sealed deep within are vast libraries, any record can be found stored within their info-matrices.",
+    "flavourText": "Boiling swamps cover the surface. Well hidden tunnels lead to fortified bunkers. Sealed deep within are vast libraries, any record can be found stored within their info-matrices.",
     "source": "eronous"
 }

--- a/src/main/resources/planets/mayris.json
+++ b/src/main/resources/planets/mayris.json
@@ -112,6 +112,6 @@
         },
         "removeUnitCoordinate": true
     },
-    "flavourText": "A gas-giant renowed for its stunning polar auroras. Energy harnessed from Mayris's constant storms is used to power the various space ports.",
+    "flavourText": "A gas-giant renowned for its stunning polar auroras. Energy harnessed from Mayris's constant storms is used to power the various space ports.",
     "source": "eronous"
 }

--- a/src/main/resources/planets/retillion.json
+++ b/src/main/resources/planets/retillion.json
@@ -121,6 +121,6 @@
         "removeUnitCoordinate": true
     },
     "contrastColor": "orange",
-    "flavourText": "*Darien is the heart of the brotherhood's realm. Here, within the great Monastery of Lucas, rests the Yin, the holy egg from which all the Brotherhood were made.*",
+    "flavourText": "*A mix of tundra, swamps, rivers, and dense forests. Home to the mysterious, chameleonic Yssaril, whose capital Wueca has eluded all attempts at cartography.*",
     "source": "base"
 }

--- a/src/main/resources/planets/shalloq.json
+++ b/src/main/resources/planets/shalloq.json
@@ -120,6 +120,6 @@
         "removeUnitCoordinate": true
     },
     "contrastColor": "orange",
-    "flavourText": "*A mix of tundra, swamps, rivers, and dense forests. Home to the mysterious, chameleonic Yssaril, whose capital Wueca has eluded all attempts at cartography.*",
+    "flavourText": "*Covered with tundra, wetlands, and rainforest, much like its sister-planet Retillion. Home to the Mojeb, the only major Yssaril city catalogued by off-worlders.*",
     "source": "base"
 }

--- a/src/main/resources/planets/viliguard.json
+++ b/src/main/resources/planets/viliguard.json
@@ -27,7 +27,7 @@
     "legendaryAbilityName": null,
     "legendaryAbilityText": null,
     "legendaryAbilityFlavourText": null,
-    "flavourText": "Deep beneath the frozen soil are spawling mines. What little metal can be harvested are sent off the the facilities of Nokturn.",
+    "flavourText": "Deep beneath the frozen soil are sprawling mines. What little metal can be harvested are sent off to the facilities of Nokturn.",
     "unitPositions": {
         "unitHolderName": "viliguard",
         "coordinateMap": {

--- a/src/main/resources/planets/zhgen.json
+++ b/src/main/resources/planets/zhgen.json
@@ -112,6 +112,6 @@
         },
         "removeUnitCoordinate": true
     },
-    "flavourText": "A flat dusty desert of a planet, the strong winds kick up blinding sandstorms. It is known for the strange religon of its inhabitants.",
+    "flavourText": "A flat dusty desert of a planet, the strong winds kick up blinding sandstorms. It is known for the strange religion of its inhabitants.",
     "source": "eronous"
 }


### PR DESCRIPTION
## What
- Fixes Retillion and Shalloq (Yssaril's two homeworlds) having each other's flavour text swapped with Darien's (Yin's homeworld) — Retillion had Darien's text, Shalloq had what should be Retillion's.
- Sweeps for and fixes plain typos in planet flavour text (all sources).
- Sweeps for and fixes typos in card/relic/tech text scoped to `base`, `pok`, `codex3`, `thunders_edge`, and `ds` sources (left homebrew-only sources like `eronous`, `theodisi`, etc. untouched, aside from planet flavour text which was swept across all sources).

## Changes
- `retillion.json` / `shalloq.json`: corrected flavour text (see planet homeworld bug above)
- `akhassi.json`, `breakpoint.json`, `malbolge.json`, `mayris.json`, `viliguard.json`, `zhgen.json`: typo fixes in flavour text
- `action_cards.json`: Muuat → Muaat (3x, base-sourced Veto flavor text), Y'sia Yssrila → Y'sia Y'ssrila (matches spelling used elsewhere for this flagship)
- `explores.json` (pok): adandoned → abandoned
- `te_relics.json` (thunders_edge): indestructable → indestructible
- `uncharted_space.json` (ds): "that technologys prerequisites" → "that technology's prerequisites"
- `lizhotraps.json` (ds): upto → up to

## Testing
- All edited JSON files validated as syntactically valid.
- Confirmed no Java code, tests, or aliases reference any of the old (typo'd) strings — this is purely display text.
- Text-only change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)