### PR TITLE
Show average opponent MMR alongside a player's own rating

### DIFF
--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -218,12 +218,49 @@ public class MatchmakingRatingEventService {
                             stringBuilder.append(" We cannot show your rating until it reaches high confidence.");
                         }
                     }
+                    if (showRating) {
+                        appendAverageOpponentRating(
+                                stringBuilder, ratingLabel, playerRating.userId(), games, playerRatings, averageRating);
+                    }
                 });
 
         MessageHelper.sendMessageToThread(
                 (MessageChannelUnion) event.getMessageChannel(),
                 "Player Matchmaking Ratings",
                 stringBuilder.toString());
+    }
+
+    private static void appendAverageOpponentRating(
+            StringBuilder stringBuilder,
+            String ratingLabel,
+            String userId,
+            List<MatchmakingGame> games,
+            List<MatchmakingRating> playerRatings,
+            BigDecimal defaultRating) {
+        Map<String, BigDecimal> ratingByUserId =
+                playerRatings.stream().collect(Collectors.toMap(MatchmakingRating::userId, MatchmakingRating::rating));
+
+        BigDecimal opponentRatingSum = BigDecimal.ZERO;
+        int opponentCount = 0;
+        int gameCount = 0;
+        for (MatchmakingGame game : games) {
+            if (game.players().stream().noneMatch(player -> player.userId().equals(userId))) continue;
+
+            gameCount++;
+            for (MatchmakingPlayer opponent : game.players()) {
+                if (opponent.userId().equals(userId)) continue;
+                opponentRatingSum =
+                        opponentRatingSum.add(ratingByUserId.getOrDefault(opponent.userId(), defaultRating));
+                opponentCount++;
+            }
+        }
+        if (opponentCount == 0) return;
+
+        BigDecimal averageOpponentRating =
+                opponentRatingSum.divide(BigDecimal.valueOf(opponentCount), MathContext.DECIMAL64);
+        stringBuilder.append(String.format(
+                "\nThe average %s of your opponents across your %d games is `%d`.",
+                ratingLabel.toLowerCase(), gameCount, toDisplayRating(averageOpponentRating)));
     }
 
     private static Map<Long, Long> bucketPlayersByBracket(List<MatchmakingRating> playerRatings) {


### PR DESCRIPTION
## What

When a player runs `/statistics matchmaking_rating` with `show_my_rating: true`, the response now also reports the average MMR of the opponents they have faced:

> The average rating of your opponents across your 27 games is `1042`.

## How the average is calculated

For every completed game the player appears in, each *other* seat contributes its rating as one data point. An opponent faced five times therefore counts five times toward the average, rather than being collapsed into a single entry.

Two decisions worth calling out for review:

- **Weighting is per opponent-appearance, not per game.** A six-player game contributes five data points where a three-player game contributes two, so larger tables pull harder on the average. The alternative — average each game's opponents first, then average across games — weights every game equally. Both satisfy "a repeat opponent counts N times"; they only diverge when table sizes differ.
- **Unrated opponents fall back to the player base average.** TrueSkill only publishes a rating after three games, so some opponents have none. Dropping them would bias the figure upward for anyone who regularly plays with newcomers. The fallback matches how `PlayerAverageOpponentMmrStatisticsService` already handles the same gap.

The line respects `tigl_only`, since it reuses the already-filtered game list that the ratings themselves are computed from, and it uses the same conservative ratings shown elsewhere in the message.

It is shown whenever `show_my_rating` is set, including for players who are not yet fully calibrated — an opponent's rating reveals nothing about the caller's own withheld rating, so there was no reason to gate it behind calibration.

## Testing

`mvn compile` passes (spotless included). No automated test was added: `sendMessage` is a private static method that assembles a string and hands it straight to Discord, so there is no seam to assert against without first extracting the calculation into a testable unit. Happy to do that extraction if reviewers would like coverage here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
