### PR TITLE
Fix matchmaking restriction visibility and locked single-option modal fields

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.components.checkboxgroup.CheckboxGroup;
 import net.dv8tion.jda.api.components.label.Label;
+import net.dv8tion.jda.api.components.label.LabelChildComponent;
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu;
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu.SelectTarget;
 import net.dv8tion.jda.api.components.selections.SelectOption;
@@ -187,25 +188,25 @@ class MatchmakingButtonHandler {
         List<String> groupMemberIds = MatchmakerService.get().partyMemberIds(userId);
 
         final boolean REQUIRE_SELECTION = true;
-        CheckboxGroup expansions = buildCheckboxGroup(
+        LabelChildComponent expansions = buildMultiSelect(
                 EXPANSIONS_ID,
                 MatchmakingOptions.EXPANSION_OPTIONS,
                 userSettings.getMatchmakingExpansions(),
                 DEFAULT_EXPANSION_OPTIONS,
                 REQUIRE_SELECTION);
-        CheckboxGroup playerCounts = buildCheckboxGroup(
+        LabelChildComponent playerCounts = buildMultiSelect(
                 PLAYER_COUNTS_ID,
                 groupPlayerCountOptions(groupMemberIds.size()),
                 userSettings.getMatchmakingPlayerCounts(),
                 DEFAULT_PLAYER_COUNT_OPTIONS,
                 REQUIRE_SELECTION);
-        CheckboxGroup victoryPoints = buildCheckboxGroup(
+        LabelChildComponent victoryPoints = buildMultiSelect(
                 VICTORY_POINTS_ID,
                 VICTORY_POINT_OPTIONS,
                 userSettings.getMatchmakingVictoryPointGoals(),
                 DEFAULT_VICTORY_POINT_OPTIONS,
                 REQUIRE_SELECTION);
-        CheckboxGroup paces = buildCheckboxGroup(
+        LabelChildComponent paces = buildMultiSelect(
                 PACE_RESTRICTIONS_ID,
                 groupPaceOptions(groupMemberIds),
                 userSettings.getMatchmakingPaces(),
@@ -235,19 +236,19 @@ class MatchmakingButtonHandler {
         UserSettings userSettings = UserSettingsManager.get(userId);
 
         final boolean REQUIRE_SELECTION = true;
-        CheckboxGroup victoryPoints = buildCheckboxGroup(
+        LabelChildComponent victoryPoints = buildMultiSelect(
                 VICTORY_POINTS_ID,
                 VICTORY_POINT_OPTIONS,
                 userSettings.getMatchmakingVictoryPointGoals(),
                 DEFAULT_VICTORY_POINT_OPTIONS,
                 REQUIRE_SELECTION);
-        CheckboxGroup paces = buildCheckboxGroup(
+        LabelChildComponent paces = buildMultiSelect(
                 PACE_RESTRICTIONS_ID,
                 PartyValidator.getValidPaces(List.of(userId)),
                 userSettings.getMatchmakingPaces(),
                 DEFAULT_PACE_OPTIONS,
                 REQUIRE_SELECTION);
-        CheckboxGroup ranks = buildCheckboxGroup(
+        LabelChildComponent ranks = buildMultiSelect(
                 TIGL_RANKS_ID,
                 MatchmakingOptions.TIGL_RANK_OPTIONS,
                 userSettings.getMatchmakingTiglRanks(),
@@ -340,7 +341,7 @@ class MatchmakingButtonHandler {
         if (rankOptions.isEmpty()) {
             rankOptions = List.of(MatchmakingOptions.UNRANKED_OPTION);
         }
-        CheckboxGroup ranks = buildCheckboxGroup(
+        LabelChildComponent ranks = buildMultiSelect(
                 TIGL_RANKS_ID, rankOptions, userSettings.getMatchmakingTiglRanks(), DEFAULT_TIGL_RANK_OPTIONS, true);
         Modal.Builder modal = Modal.create(SEARCH_FOR_PLAYERS_TIGL_MODAL_ID, "Search for Players")
                 .addComponents(Label.of("Victory Point Goal", victoryPoints))
@@ -690,6 +691,19 @@ class MatchmakingButtonHandler {
 
     private static List<String> groupRestrictionOptions(List<String> groupMemberIds) {
         return new ArrayList<>(PartyValidator.getValidRestrictions(groupMemberIds, RESTRICTION_OPTIONS));
+    }
+
+    private static LabelChildComponent buildMultiSelect(
+            String id,
+            List<String> options,
+            List<String> selectedValues,
+            List<String> defaultValues,
+            boolean requireSelection) {
+        boolean rendersAsLockedCheckboxGroup = requireSelection && options.size() == 1;
+        if (rendersAsLockedCheckboxGroup) {
+            return buildSingleSelect(id, options, selectedValues, defaultValues);
+        }
+        return buildCheckboxGroup(id, options, selectedValues, defaultValues, requireSelection);
     }
 
     private static CheckboxGroup buildCheckboxGroup(

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/PartyValidator.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/PartyValidator.java
@@ -39,7 +39,7 @@ public class PartyValidator {
             if (!everyMemberCanUseRestriction(restriction, members, dataById)) {
                 continue;
             }
-            if (members.size() >= 2 && !groupInternallyCompatible(members, dataById)) {
+            if (members.size() >= 2 && !everyMemberPairSatisfiesRestriction(restriction, members, dataById)) {
                 continue;
             }
             available.add(restriction);
@@ -57,11 +57,14 @@ public class PartyValidator {
                 .allMatch(MatchmakingCompatibilityService::hasEnoughActiveHourDataToMatch);
     }
 
-    private static boolean groupInternallyCompatible(
-            List<String> members, Map<String, PlayerMatchmakingData> dataById) {
+    private static boolean everyMemberPairSatisfiesRestriction(
+            String restriction, List<String> members, Map<String, PlayerMatchmakingData> dataById) {
+        if (!MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION.equals(restriction)) {
+            return true;
+        }
         for (int i = 0; i < members.size(); i++) {
             for (int j = i + 1; j < members.size(); j++) {
-                if (MatchmakingCompatibilityService.areIncompatible(
+                if (!MatchmakingCompatibilityService.shareEnoughActiveHours(
                         dataById.get(members.get(i)), dataById.get(members.get(j)))) {
                     return false;
                 }


### PR DESCRIPTION
Two matchmaking modal bugs reported from game threads.

## "Similar active hours" never offered, even to rosters that share 12 hours

`PartyValidator.getValidRestrictions` decides which restrictions appear in the queue and search modals. It gated each restriction on two things: every member having enough logged active hours, **and** the roster being "internally compatible" — where that meant the full `MatchmakingCompatibilityService.areIncompatible` check.

That check does far more than active hours. With the `Duration.ZERO` queue wait that `getValidRestrictions` builds its data with, it also rejected a roster if any pair had:

- a TrueSkill rating gap above the starting threshold of 3, before any queue-wait widening
- a Floaters member alongside a Warriors member, since the 8-hour grace had not elapsed at zero wait
- each other on an avoid list

None of those say anything about whether *similar active hours* is a usable filter, but any one of them silently dropped the checkbox from the modal. On a thread with a few signed-up players the skill-gap rule alone hits routinely, which is how players sharing a full 12 hours ended up never seeing the option.

The pairwise check now takes the restriction and tests only that restriction's own rule.

Same fix also covers `MatchmakerService`, which calls `getValidRestrictions` to strip restrictions off already-queued parties — it was dropping "Similar active hours" from parties for the same unrelated reasons.

## A required field with one option renders locked and blocks submission

`buildCheckboxGroup` sets `setRequiredRange(1, options.size())`. When the option list narrows to a single entry that becomes min 1 / max 1 out of 1 — "you must select this one option" — which Discord renders greyed out and unclickable, so the required field can never be satisfied and the modal cannot be submitted.

This was hit on a TIGL search modal whose rank filter left only `Unranked`: the Rank field showed a single greyed-out, unchecked checkbox that could not be clicked, while the field was still marked required.

A new `buildMultiSelect` wrapper falls back to a pre-selected single-option `StringSelectMenu` in that case — the same component the Victory Point Goal and Pace fields beside it already use, read back identically via `getAsStringList()`. All the required fields (expansions, player count, VP goal, pace, rank) route through it, so any of them collapsing to one option is handled. The Restrictions group is optional (min 0) and is unaffected.

## Notes

I could not reproduce the Discord client rendering locally to confirm that `min == max == option count` is precisely what triggers the locked state; it is the only thing unusual about that field versus the ones rendering correctly beside it, and the fallback avoids the degenerate range either way. Worth a look in a real TIGL thread once this is deployed.

The two fixes are independent but surface in the same modals, so a thread hitting the second would never have reached the Restrictions field to hit the first.

## Testing

`mvn compile` clean; the 35 existing `MatchmakingCompatibilityServiceTest` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
