### PR TITLE
Fix Overthrow's strategy card abilities and add its primary

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/FlawlessStrategyAcd2ButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/FlawlessStrategyAcd2ButtonHandler.java
@@ -8,42 +8,20 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.apache.commons.lang3.function.Consumers;
 import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.routing.ButtonHandler;
+import ti4.game.Game;
 import ti4.game.Player;
 import ti4.logging.BotLogger;
 import ti4.message.MessageHelper;
-import ti4.service.emoji.CardEmojis;
-import ti4.service.emoji.MiscEmojis;
-import ti4.service.emoji.UnitEmojis;
+import ti4.service.strategycard.StrategyCardSecondaryButtonService;
 
 @UtilityClass
 class FlawlessStrategyAcd2ButtonHandler {
 
     @ButtonHandler("resolveFlawlessStrategy")
-    public static void resolveFlawlessStrategy(Player player, ButtonInteractionEvent event) {
-        List<Button> scButtons = new ArrayList<>();
+    public static void resolveFlawlessStrategy(Player player, Game game, ButtonInteractionEvent event) {
         event.getMessage().delete().queue(Consumers.nop(), BotLogger::catchRestError);
-        if (player.getSCs().contains(2)) {
-            scButtons.add(Buttons.green("diploRefresh2", "Ready 2 Planets"));
-        }
-        if (player.getSCs().contains(3)) {
-            scButtons.add(Buttons.gray("draw2 AC", "Draw 2 Action Cards", CardEmojis.ActionCard));
-        }
-        if (player.getSCs().contains(4)) {
-            scButtons.add(Buttons.green("construction_spacedock", "Place 1 space dock", UnitEmojis.spacedock));
-            scButtons.add(Buttons.green("construction_pds", "Place 1 PDS", UnitEmojis.pds));
-        }
-        if (player.getSCs().contains(5)) {
-            scButtons.add(Buttons.gray("sc_refresh", "Replenish Commodities", MiscEmojis.comm));
-        }
-        if (player.getSCs().contains(6)) {
-            scButtons.add(Buttons.green("warfareBuild", "Build At Home"));
-        }
-        if (player.getSCs().contains(7)) {
-            scButtons.add(Buttons.GET_A_TECH);
-        }
-        if (player.getSCs().contains(8)) {
-            scButtons.add(Buttons.gray("non_sc_draw_so", "Draw Secret Objective", CardEmojis.SecretObjective));
-        }
+        List<Button> scButtons =
+                new ArrayList<>(StrategyCardSecondaryButtonService.getSecondaryAbilityButtons(game, player.getSCs()));
         scButtons.add(Buttons.red("deleteButtons", "Done resolving"));
         MessageHelper.sendMessageToChannelWithButtons(
                 event.getMessageChannel(), player.getRepresentation() + ", use the buttons to resolve.", scButtons);

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/OverthrowAcd2ButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/OverthrowAcd2ButtonHandler.java
@@ -32,7 +32,7 @@ class OverthrowAcd2ButtonHandler {
                 player.getRepresentationUnfogged()
                         + ", resolve an ability of 1 of the strategy cards of the player you took the planet from."
                         + " Perform the **primary** ability if that planet is in their home system, and the"
-                        + " **secondary** ability otherwise. No command token is spent.",
+                        + " **secondary** ability otherwise.",
                 buttons);
     }
 

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/OverthrowAcd2ButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/OverthrowAcd2ButtonHandler.java
@@ -11,9 +11,7 @@ import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.ButtonHelper;
 import ti4.message.MessageHelper;
-import ti4.service.emoji.CardEmojis;
-import ti4.service.emoji.MiscEmojis;
-import ti4.service.emoji.UnitEmojis;
+import ti4.service.strategycard.StrategyCardSecondaryButtonService;
 
 @UtilityClass
 class OverthrowAcd2ButtonHandler {
@@ -32,37 +30,8 @@ class OverthrowAcd2ButtonHandler {
     }
 
     private static List<Button> getOverthrowAbilityButtons(Game game) {
-        List<Integer> scs = game.getSCList();
-        List<Button> scButtons = new ArrayList<>();
-        if (scs.contains(1)) {
-            scButtons.add(Buttons.green("leadershipGenerateCCButtons", "Spend & Gain Command Tokens"));
-        }
-        if (scs.contains(2)) {
-            scButtons.add(Buttons.gray("anarchy2secondary", "Ready a Card (Other Than Strategy Card)"));
-            scButtons.add(Buttons.green("diploRefresh2", "Ready Planets"));
-        }
-        if (scs.contains(4)) {
-            scButtons.add(Buttons.gray("draw2 AC", "Draw 2 Action Cards", CardEmojis.ActionCard));
-        }
-        if (scs.contains(5)) {
-            scButtons.add(Buttons.green("construction_spacedock", "Place 1 space dock", UnitEmojis.spacedock));
-            scButtons.add(Buttons.green("construction_pds", "Place 1 PDS", UnitEmojis.pds));
-        }
-        if (scs.contains(6)) {
-            scButtons.add(Buttons.gray("sc_refresh", "Replenish Commodities", MiscEmojis.comm));
-        }
-        if (scs.contains(7)) {
-            scButtons.add(Buttons.green("warfareBuild", "Build At Home"));
-        }
-        if (scs.contains(8)) {
-            scButtons.add(Buttons.green("resolveAnarchy8Secondary", "Lift Command Token"));
-        }
-        if (scs.contains(9)) {
-            scButtons.add(Buttons.GET_A_TECH);
-        }
-        if (scs.contains(11)) {
-            scButtons.add(Buttons.gray("non_sc_draw_so", "Draw Secret Objective", CardEmojis.SecretObjective));
-        }
+        List<Button> scButtons =
+                new ArrayList<>(StrategyCardSecondaryButtonService.getSecondaryAbilityButtons(game, game.getSCList()));
         scButtons.add(Buttons.red("deleteButtons", "Done resolving"));
         return scButtons;
     }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/OverthrowAcd2ButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/actioncards/acd2/OverthrowAcd2ButtonHandler.java
@@ -10,7 +10,11 @@ import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.game.Game;
 import ti4.game.Player;
 import ti4.helpers.ButtonHelper;
+import ti4.helpers.Helper;
 import ti4.message.MessageHelper;
+import ti4.service.emoji.CardEmojis;
+import ti4.service.emoji.TI4Emoji;
+import ti4.service.strategycard.PlayStrategyCardService;
 import ti4.service.strategycard.StrategyCardSecondaryButtonService;
 
 @UtilityClass
@@ -18,18 +22,66 @@ class OverthrowAcd2ButtonHandler {
 
     @ButtonHandler("resolveOverthrow")
     public static void resolveOverthrow(Player player, Game game, ButtonInteractionEvent event) {
-        List<Button> buttons = getOverthrowAbilityButtons(game);
+        ButtonHelper.deleteMessage(event);
+        List<Button> buttons = List.of(
+                Buttons.green(player.factionButtonChecker() + "overthrowChoosePrimary", "Perform Primary"),
+                Buttons.blue(player.factionButtonChecker() + "overthrowChooseSecondary", "Perform Secondary"),
+                Buttons.red("deleteButtons", "Done resolving"));
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                player.getRepresentationUnfogged()
+                        + ", resolve an ability of 1 of the strategy cards of the player you took the planet from."
+                        + " Perform the **primary** ability if that planet is in their home system, and the"
+                        + " **secondary** ability otherwise. No command token is spent.",
+                buttons);
+    }
+
+    @ButtonHandler("overthrowChoosePrimary")
+    public static void chooseOverthrowPrimary(Player player, Game game, ButtonInteractionEvent event) {
         ButtonHelper.deleteMessage(event);
         MessageHelper.sendMessageToChannelWithButtons(
                 player.getCorrectChannel(),
                 player.getRepresentationUnfogged()
-                        + ", choose the strategy card ability to resolve for _Overthrow_. Resolve the **secondary**"
-                        + " ability of 1 of that player's strategy cards — or, if you gained control of a planet"
-                        + " in their home system, the **primary** ability instead. No command token is spent.",
-                buttons);
+                        + ", choose the strategy card whose **primary** ability you are resolving for _Overthrow_.",
+                getPrimaryAbilityButtons(game, player));
     }
 
-    private static List<Button> getOverthrowAbilityButtons(Game game) {
+    @ButtonHandler("overthrowChooseSecondary")
+    public static void chooseOverthrowSecondary(Player player, Game game, ButtonInteractionEvent event) {
+        ButtonHelper.deleteMessage(event);
+        MessageHelper.sendMessageToChannelWithButtons(
+                player.getCorrectChannel(),
+                player.getRepresentationUnfogged()
+                        + ", choose the **secondary** ability you are resolving for _Overthrow_.",
+                getSecondaryAbilityButtons(game));
+    }
+
+    @ButtonHandler("overthrowPrimary_")
+    public static void resolveOverthrowPrimary(
+            Player player, Game game, ButtonInteractionEvent event, String buttonID) {
+        int sc = Integer.parseInt(buttonID.split("_")[1]);
+        ButtonHelper.deleteMessage(event);
+        PlayStrategyCardService.playSC(event, sc, game, game.getMainGameChannel(), player, true, true, "overthrown");
+    }
+
+    private static List<Button> getPrimaryAbilityButtons(Game game, Player player) {
+        List<Button> scButtons = new ArrayList<>();
+        for (int sc : game.getSCList()) {
+            if (sc <= 0) continue;
+            String buttonID = player.factionButtonChecker() + "overthrowPrimary_" + sc;
+            String label = Helper.getSCName(sc, game);
+            TI4Emoji scEmoji = CardEmojis.getSCBackFromInteger(sc);
+            if (scEmoji != CardEmojis.SCBackBlank && !game.isHomebrewSCMode()) {
+                scButtons.add(Buttons.gray(buttonID, label, scEmoji));
+            } else {
+                scButtons.add(Buttons.gray(buttonID, sc + " " + label));
+            }
+        }
+        scButtons.add(Buttons.red("deleteButtons", "Done resolving"));
+        return scButtons;
+    }
+
+    private static List<Button> getSecondaryAbilityButtons(Game game) {
         List<Button> scButtons =
                 new ArrayList<>(StrategyCardSecondaryButtonService.getSecondaryAbilityButtons(game, game.getSCList()));
         scButtons.add(Buttons.red("deleteButtons", "Done resolving"));

--- a/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
+++ b/src/main/java/ti4/service/strategycard/PlayStrategyCardService.java
@@ -83,6 +83,26 @@ public class PlayStrategyCardService {
             Player player,
             boolean winnuHero,
             boolean isOverrule) {
+        playSC(
+                event,
+                scToPlay,
+                game,
+                mainGameChannel,
+                player,
+                winnuHero,
+                isOverrule,
+                isOverrule ? "overruled" : "played");
+    }
+
+    public static void playSC(
+            GenericInteractionCreateEvent event,
+            Integer scToPlay,
+            Game game,
+            MessageChannel mainGameChannel,
+            Player player,
+            boolean winnuHero,
+            boolean isOverrule,
+            String playVerb) {
         String stratCardName = Helper.getSCName(scToPlay, game);
         if (game.getPlayedSCs().contains(scToPlay) && !winnuHero) {
             MessageHelper.sendMessageToChannel(
@@ -123,7 +143,7 @@ public class PlayStrategyCardService {
                         + game.getSCEmojiWordRepresentation(scToPlay));
 
         StringBuilder message = new StringBuilder();
-        message.append(game.getSCEmojiWordRepresentation(scToPlay)).append(isOverrule ? " overruled" : " played");
+        message.append(game.getSCEmojiWordRepresentation(scToPlay)).append(" ").append(playVerb);
         if (!game.isFowMode()) {
             message.append(" by ").append(player.getRepresentation());
         }

--- a/src/main/java/ti4/service/strategycard/StrategyCardSecondaryButtonService.java
+++ b/src/main/java/ti4/service/strategycard/StrategyCardSecondaryButtonService.java
@@ -52,7 +52,7 @@ public class StrategyCardSecondaryButtonService {
                 List.of(Buttons.gray("draw2 AC", "Draw 2 Action Cards", CardEmojis.getACEmoji(game)));
             case "cryypter_3" ->
                 List.of(Buttons.gray("cryypterSC3Draw", "Draw Action Cards", CardEmojis.getACEmoji(game)));
-            case "pok4construction", "te4construction", "monuments4construction" ->
+            case "pok4construction", "te4construction", "monuments4construction", "monumentstf4" ->
                 getConstructionButtons(game, scModel);
             case "pok5trade" -> List.of(Buttons.gray("sc_refresh", "Replenish Commodities", MiscEmojis.comm));
             case "pok6warfare", "anarchy7", "luminous7" -> List.of(Buttons.green("warfareBuild", "Build At Home"));
@@ -83,8 +83,8 @@ public class StrategyCardSecondaryButtonService {
         List<Button> buttons = new ArrayList<>();
         buttons.add(Buttons.green("construction_spacedock", "Place 1 space dock", UnitEmojis.spacedock));
         buttons.add(Buttons.green("construction_pds", "Place 1 PDS", UnitEmojis.pds));
-        if (scModel.usesAutomationForSCID("monuments4construction")) {
-            buttons.add(Buttons.red("construction_monument", "Place 1 Monument", UnitEmojis.Monument));
+        if (scModel.usesAutomationForSCID("monuments4construction") || scModel.usesAutomationForSCID("monumentstf4")) {
+            buttons.add(Buttons.green("construction_monument", "Place 1 Monument", UnitEmojis.Monument));
         }
         if (game.isFacilitiesMode()) {
             buttons.add(Buttons.green("construction_facility", "Place A Facility"));

--- a/src/main/java/ti4/service/strategycard/StrategyCardSecondaryButtonService.java
+++ b/src/main/java/ti4/service/strategycard/StrategyCardSecondaryButtonService.java
@@ -1,0 +1,97 @@
+package ti4.service.strategycard;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.buttons.Button;
+import ti4.discord.interactions.buttons.Buttons;
+import ti4.game.Game;
+import ti4.model.StrategyCardModel;
+import ti4.service.emoji.CardEmojis;
+import ti4.service.emoji.ExploreEmojis;
+import ti4.service.emoji.MiscEmojis;
+import ti4.service.emoji.UnitEmojis;
+
+@UtilityClass
+public class StrategyCardSecondaryButtonService {
+
+    public static List<Button> getSecondaryAbilityButtons(Game game, Collection<Integer> scs) {
+        Map<String, Button> buttons = new LinkedHashMap<>();
+        for (int sc : scs) {
+            if (sc <= 0) continue;
+            for (Button button : getSecondaryAbilityButtons(game, sc)) {
+                buttons.putIfAbsent(button.getCustomId(), button);
+            }
+        }
+        return new ArrayList<>(buttons.values());
+    }
+
+    public static List<Button> getSecondaryAbilityButtons(Game game, int sc) {
+        StrategyCardModel scModel = game.getStrategyCardModelByInitiative(sc).orElse(null);
+        if (scModel == null) {
+            return List.of();
+        }
+        return switch (scModel.getBotSCAutomationID()) {
+            case "pok1leadership", "anarchy1" ->
+                List.of(Buttons.green("leadershipGenerateCCButtons", "Spend & Gain Command Tokens"));
+            case "pok2diplomacy", "base2", "luminous1" -> List.of(Buttons.green("diploRefresh2", "Ready 2 Planets"));
+            case "anarchy2" ->
+                List.of(
+                        Buttons.gray("anarchy2secondary", "Ready a Card (Other Than Strategy Card)"),
+                        Buttons.green("diploRefresh2", "Ready Planets"));
+            case "anarchy3", "luminous9" ->
+                List.of(Buttons.gray("anarchy3secondary", "Perform Unchosen Or Exhausted Secondary"));
+            case "luminous2" ->
+                List.of(
+                        Buttons.gray("lumiACdraw", "Draw 1 Action Card", CardEmojis.getACEmoji(game)),
+                        Buttons.gray("exploreAPlanet", "Explore a planet"));
+            case "pok3politics", "evenfall3", "ignisaurora3" ->
+                List.of(Buttons.gray("draw2 AC", "Draw 2 Action Cards", CardEmojis.getACEmoji(game)));
+            case "cryypter_3" ->
+                List.of(Buttons.gray("cryypterSC3Draw", "Draw Action Cards", CardEmojis.getACEmoji(game)));
+            case "pok4construction", "te4construction", "monuments4construction" ->
+                getConstructionButtons(game, scModel);
+            case "pok5trade" -> List.of(Buttons.gray("sc_refresh", "Replenish Commodities", MiscEmojis.comm));
+            case "pok6warfare", "anarchy7", "luminous7" -> List.of(Buttons.green("warfareBuild", "Build At Home"));
+            case "te6warfare" -> List.of(Buttons.green("warfareTeBuild", "Build At Home"));
+            case "anarchy8" -> List.of(Buttons.green("resolveAnarchy8Secondary", "Lift Command Token"));
+            case "anarchy10" -> List.of(Buttons.gray("anarchy10PeekStart", "Peek at Public", CardEmojis.Public1));
+            case "tf2" -> List.of(Buttons.blue("participateInSplice_2", "Participate In Splice"));
+            case "tf6" ->
+                List.of(
+                        Buttons.green("warfareTeBuild", "Build At Home"),
+                        Buttons.blue("participateInSplice_6", "Participate In Splice"));
+            case "tf7" -> List.of(Buttons.blue("participateInSplice_7", "Participate In Splice"));
+            case "tf8" ->
+                List.of(
+                        Buttons.gray("non_sc_draw_so", "Draw Secret Objective", CardEmojis.SecretObjective),
+                        Buttons.gray("drawParadigm", "Draw Paradigm"));
+            case "ignisaurora2" ->
+                List.of(Buttons.green("ignisAuroraSC8Secondary", "Draw Unknown Relic Fragment", ExploreEmojis.UFrag));
+            case "pok7technology", "manytech8", "manytech9", "manytech10", "manytech11", "manytech12" ->
+                List.of(Buttons.GET_A_TECH);
+            case "pok8imperial", "anarchy11", "manytech13" ->
+                List.of(Buttons.gray("non_sc_draw_so", "Draw Secret Objective", CardEmojis.SecretObjective));
+            default -> List.of();
+        };
+    }
+
+    private static List<Button> getConstructionButtons(Game game, StrategyCardModel scModel) {
+        List<Button> buttons = new ArrayList<>();
+        buttons.add(Buttons.green("construction_spacedock", "Place 1 space dock", UnitEmojis.spacedock));
+        buttons.add(Buttons.green("construction_pds", "Place 1 PDS", UnitEmojis.pds));
+        if (scModel.usesAutomationForSCID("monuments4construction")) {
+            buttons.add(Buttons.red("construction_monument", "Place 1 Monument", UnitEmojis.Monument));
+        }
+        if (game.isFacilitiesMode()) {
+            buttons.add(Buttons.green("construction_facility", "Place A Facility"));
+        }
+        if (game.isMonumentToTheAgesMode()) {
+            buttons.add(Buttons.green("construction_agesmonument", "Place A Monument (Cost 5 TG)"));
+        }
+        return buttons;
+    }
+}


### PR DESCRIPTION
## Problem

`OverthrowAcd2ButtonHandler` built its button list by hardcoded SC *number*, and the numbers were copied from `getAnarchy3SecondaryButtons` in `ButtonHelperSCs` — the **Anarchy** strategy card set (1, 2, 4, 5, 6, 7, 8, 9, 11). In a PoK or Thunder's Edge game that mapping is shifted by one from SC3 onward:

| SC | Card in a PoK/TE game | Button Overthrow offered |
|---|---|---|
| 2 | Diplomacy | Anarchy *Preparation* ("Ready a Card") + "Ready Planets" |
| 4 | Construction | Politics — Draw 2 Action Cards |
| 5 | Trade | Construction — space dock / PDS |
| 6 | Warfare | Trade — Replenish Commodities |
| 7 | Technology | Warfare — Build At Home |
| 8 | Imperial | Anarchy Warfare — "Lift Command Token" |
| 9 / 11 | don't exist | Technology / Imperial (never shown) |

Reported as Overthrow using the old Warfare ability rather than the Thunder's Edge one, and possibly the old Diplomacy ability.

Overthrow also resolves the **primary** ability when the planet gained is in the overthrown player's home system, but only secondary buttons were ever offered.

## Fix

**Secondaries.** New `StrategyCardSecondaryButtonService` resolves each SC through `game.getStrategyCardModelByInitiative(sc)` and switches on `getBotSCAutomationID()` — the same key `PlayStrategyCardService.getSCButtons` uses. It covers pok, te, tf, anarchy, luminous, monuments, manytech, evenfall, cryypter and ignis aurora, dedupes by custom ID, and returns nothing for cards with no automation.

Thunder's Edge Warfare now gets `warfareTeBuild` (te6warfare, PRODUCTION of every unit in the home system) instead of `warfareBuild`, and Diplomacy gets plain "Ready 2 Planets".

`FlawlessStrategyAcd2ButtonHandler` had the same defect with PoK numbering — `warfareBuild` for SC6 regardless of set, and no leadership secondary — so it uses the new service too.

**Primaries.** Overthrow now asks which half of the card is being resolved. *Perform Primary* lists the game's strategy cards and hands the chosen one to `PlayStrategyCardService.playSC(..., winnuHero=true, isOverrule=true)` — the follower-less primary path Overrule already uses. *Perform Secondary* shows the ability buttons as before. `playSC` gains an overload taking the verb for its announcement, so Overthrow is not reported as having "overruled" the card; the existing 7-arg signature delegates with the old wording.

## Known behavior inherited from the Overrule path

`playSC` marks the acting player as having followed the chosen SC. If the overthrown player has not played that card yet this round, they will show as already having followed it.

## Testing

`mvn compile` and `mvn test-compile` pass; spotless applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
