### PR TITLE
Make similar active hours a strict/loose/no enforcement level

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
@@ -1,7 +1,6 @@
 package ti4.discord.interactions.buttons.handlers.matchmaking;
 
 import static ti4.discord.interactions.buttons.handlers.matchmaking.MatchmakingOptions.MAX_QUEUE_TIME_OPTIONS_TO_HOURS;
-import static ti4.discord.interactions.buttons.handlers.matchmaking.MatchmakingOptions.PACE_RESTRICTION_OPTIONS;
 import static ti4.discord.interactions.buttons.handlers.matchmaking.MatchmakingOptions.PLAYER_COUNT_OPTIONS;
 import static ti4.discord.interactions.buttons.handlers.matchmaking.MatchmakingOptions.RESTRICTION_OPTIONS;
 import static ti4.discord.interactions.buttons.handlers.matchmaking.MatchmakingOptions.SLOWER_PACE_OPTION;
@@ -71,7 +70,7 @@ class MatchmakingButtonHandler {
     private static final String PLAYER_COUNTS_ID = "queue_player_counts";
     private static final String VICTORY_POINTS_ID = "queue_victory_points";
     private static final String PACE_RESTRICTIONS_ID = "queue_pace_restrictions";
-    private static final String RESTRICTIONS_ID = "queue_restrictions";
+    private static final String ACTIVE_HOURS_ID = "queue_active_hours";
     private static final String MAX_QUEUE_TIME_ID = "queue_max_time";
     private static final String AVOID_PLAYERS_ID = "queue_avoid_players";
     private static final String GROUP_MEMBERS_ID = "queue_group_members";
@@ -83,8 +82,8 @@ class MatchmakingButtonHandler {
     private static final List<String> DEFAULT_PLAYER_COUNT_OPTIONS = List.of("6");
     private static final List<String> DEFAULT_VICTORY_POINT_OPTIONS = List.of("10");
     private static final List<String> DEFAULT_PACE_OPTIONS = List.of(SLOWER_PACE_OPTION);
-    private static final List<String> DEFAULT_RESTRICTION_OPTIONS =
-            List.of(MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION);
+    private static final String DEFAULT_SIMILAR_ACTIVE_HOURS_OPTION =
+            MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_OPTION;
     private static final List<String> DEFAULT_TIGL_RANK_OPTIONS = List.of(MatchmakingOptions.UNRANKED_OPTION);
 
     private static final int MAX_GROUP_MEMBERS = 7;
@@ -218,16 +217,7 @@ class MatchmakingButtonHandler {
                 .addComponents(Label.of("Victory Point Goal", victoryPoints))
                 .addComponents(Label.of("Pace", paces));
 
-        List<String> restrictionOptions = groupRestrictionOptions(groupMemberIds);
-        if (!restrictionOptions.isEmpty()) {
-            CheckboxGroup restrictions = buildCheckboxGroup(
-                    RESTRICTIONS_ID,
-                    restrictionOptions,
-                    userSettings.getMatchmakingRestrictions(),
-                    userSettings.hasConfiguredMatchmakingRestrictions() ? List.of() : DEFAULT_RESTRICTION_OPTIONS,
-                    !REQUIRE_SELECTION);
-            modal.addComponents(Label.of("Restrictions", restrictions));
-        }
+        buildSimilarActiveHoursLabel(userSettings, groupMemberIds).ifPresent(modal::addComponents);
         return modal.build();
     }
 
@@ -259,16 +249,7 @@ class MatchmakingButtonHandler {
                 .addComponents(Label.of("Pace", paces))
                 .addComponents(Label.of("Rank", ranks));
 
-        List<String> restrictionOptions = groupRestrictionOptions(List.of(userId));
-        if (!restrictionOptions.isEmpty()) {
-            CheckboxGroup restrictions = buildCheckboxGroup(
-                    RESTRICTIONS_ID,
-                    restrictionOptions,
-                    userSettings.getMatchmakingRestrictions(),
-                    userSettings.hasConfiguredMatchmakingRestrictions() ? List.of() : DEFAULT_RESTRICTION_OPTIONS,
-                    !REQUIRE_SELECTION);
-            modal.addComponents(Label.of("Restrictions", restrictions));
-        }
+        buildSimilarActiveHoursLabel(userSettings, List.of(userId)).ifPresent(modal::addComponents);
         return modal.build();
     }
 
@@ -307,16 +288,7 @@ class MatchmakingButtonHandler {
                 .addComponents(Label.of("Victory Point Goal", victoryPoints))
                 .addComponents(Label.of("Pace", paces));
 
-        List<String> restrictionOptions = groupRestrictionOptions(gameMemberIds);
-        if (!restrictionOptions.isEmpty()) {
-            CheckboxGroup restrictions = buildCheckboxGroup(
-                    RESTRICTIONS_ID,
-                    restrictionOptions,
-                    userSettings.getMatchmakingRestrictions(),
-                    userSettings.hasConfiguredMatchmakingRestrictions() ? List.of() : DEFAULT_RESTRICTION_OPTIONS,
-                    false);
-            modal.addComponents(Label.of("Restrictions", restrictions));
-        }
+        buildSimilarActiveHoursLabel(userSettings, gameMemberIds).ifPresent(modal::addComponents);
         return modal.build();
     }
 
@@ -348,17 +320,28 @@ class MatchmakingButtonHandler {
                 .addComponents(Label.of("Pace", paces))
                 .addComponents(Label.of("Rank", ranks));
 
-        List<String> restrictionOptions = groupRestrictionOptions(gameMemberIds);
-        if (!restrictionOptions.isEmpty()) {
-            CheckboxGroup restrictions = buildCheckboxGroup(
-                    RESTRICTIONS_ID,
-                    restrictionOptions,
-                    userSettings.getMatchmakingRestrictions(),
-                    userSettings.hasConfiguredMatchmakingRestrictions() ? List.of() : DEFAULT_RESTRICTION_OPTIONS,
-                    false);
-            modal.addComponents(Label.of("Restrictions", restrictions));
-        }
+        buildSimilarActiveHoursLabel(userSettings, gameMemberIds).ifPresent(modal::addComponents);
         return modal.build();
+    }
+
+    private static Optional<Label> buildSimilarActiveHoursLabel(UserSettings settings, List<String> memberIds) {
+        List<String> reachableLevels = groupRestrictionOptions(memberIds);
+        if (reachableLevels.isEmpty()) {
+            return Optional.empty();
+        }
+        List<String> options = new ArrayList<>(reachableLevels);
+        options.add(MatchmakingOptions.NO_SIMILAR_ACTIVE_HOURS_OPTION);
+        List<String> selected = List.of(selectedSimilarActiveHours(settings, options));
+        return Optional.of(
+                Label.of("Similar Active Hours", buildSingleSelect(ACTIVE_HOURS_ID, options, selected, selected)));
+    }
+
+    private static String selectedSimilarActiveHours(UserSettings settings, List<String> optionsStrictestFirst) {
+        String saved = MatchmakingOptions.strictestSimilarActiveHours(settings.getMatchmakingRestrictions())
+                .orElseGet(() -> settings.hasConfiguredMatchmakingRestrictions()
+                        ? MatchmakingOptions.NO_SIMILAR_ACTIVE_HOURS_OPTION
+                        : DEFAULT_SIMILAR_ACTIVE_HOURS_OPTION);
+        return optionsStrictestFirst.contains(saved) ? saved : optionsStrictestFirst.getFirst();
     }
 
     @ButtonHandler(value = ADDITIONAL_SETTINGS_BUTTON_ID, save = false)
@@ -439,14 +422,12 @@ class MatchmakingButtonHandler {
     }
 
     private static String describeQueuePreferences(UserSettings settings) {
-        String restrictionsText = settings.getMatchmakingRestrictions().isEmpty()
-                ? "None"
-                : String.join(", ", settings.getMatchmakingRestrictions());
         return "- **Expansions:** " + String.join(", ", settings.getMatchmakingExpansions()) + "\n"
                 + "- **Player counts:** " + String.join(", ", settings.getMatchmakingPlayerCounts()) + "\n"
                 + "- **Victory point goals:** " + String.join(", ", settings.getMatchmakingVictoryPointGoals()) + "\n"
                 + "- **Paces:** " + String.join(", ", settings.getMatchmakingPaces()) + "\n"
-                + "- **Restrictions:** " + restrictionsText + "\n";
+                + "- **Similar active hours:** "
+                + MatchmakingOptions.describeSimilarActiveHours(settings.getMatchmakingRestrictions()) + "\n";
     }
 
     @ModalHandler(QUEUE_FOR_TIGL_MODAL_ID)
@@ -517,7 +498,8 @@ class MatchmakingButtonHandler {
         if (criteria.tigl()) {
             message.append("\n- **Rank:** ").append(describeOptions(criteria.tiglRanks()));
         }
-        message.append("\n- **Restrictions:** ").append(describeOptions(criteria.restrictions()));
+        message.append("\n- **Similar active hours:** ")
+                .append(MatchmakingOptions.describeSimilarActiveHours(criteria.restrictions()));
         return message.append("\nThe matchmaker will keep adding matching players until the game is launched.")
                 .toString();
     }
@@ -541,7 +523,7 @@ class MatchmakingButtonHandler {
                 getSelectedValues(event, VICTORY_POINTS_ID),
                 getSelectedValues(event, EXPANSIONS_ID),
                 getSelectedValues(event, PACE_RESTRICTIONS_ID),
-                searchRestrictions(event),
+                selectedRestrictions(event),
                 false,
                 List.of());
     }
@@ -556,14 +538,14 @@ class MatchmakingButtonHandler {
                 getSelectedValues(event, VICTORY_POINTS_ID),
                 List.of(MatchmakingOptions.POK_AND_TE_EXPANSION_OPTION),
                 getSelectedValues(event, PACE_RESTRICTIONS_ID),
-                searchRestrictions(event),
+                selectedRestrictions(event),
                 true,
                 allowedRanks);
     }
 
-    private static List<String> searchRestrictions(ModalInteractionEvent event) {
-        return getSelectedValues(event, RESTRICTIONS_ID).stream()
-                .filter(restriction -> !PACE_RESTRICTION_OPTIONS.contains(restriction))
+    private static List<String> selectedRestrictions(ModalInteraction event) {
+        return getSelectedValues(event, ACTIVE_HOURS_ID).stream()
+                .filter(RESTRICTION_OPTIONS::contains)
                 .toList();
     }
 
@@ -614,9 +596,7 @@ class MatchmakingButtonHandler {
         userSettings.setMatchmakingPlayerCounts(getSelectedValues(event, PLAYER_COUNTS_ID));
         userSettings.setMatchmakingVictoryPointGoals(getSelectedValues(event, VICTORY_POINTS_ID));
         userSettings.setMatchmakingPaces(getSelectedValues(event, PACE_RESTRICTIONS_ID));
-        userSettings.setMatchmakingRestrictions(getSelectedValues(event, RESTRICTIONS_ID).stream()
-                .filter(restriction -> !PACE_RESTRICTION_OPTIONS.contains(restriction))
-                .toList());
+        userSettings.setMatchmakingRestrictions(selectedRestrictions(event));
         UserSettingsManager.save(userSettings);
     }
 
@@ -625,9 +605,7 @@ class MatchmakingButtonHandler {
         userSettings.setMatchmakingPlayerCounts(List.of("6"));
         userSettings.setMatchmakingVictoryPointGoals(getSelectedValues(event, VICTORY_POINTS_ID));
         userSettings.setMatchmakingPaces(getSelectedValues(event, PACE_RESTRICTIONS_ID));
-        userSettings.setMatchmakingRestrictions(getSelectedValues(event, RESTRICTIONS_ID).stream()
-                .filter(restriction -> !PACE_RESTRICTION_OPTIONS.contains(restriction))
-                .toList());
+        userSettings.setMatchmakingRestrictions(selectedRestrictions(event));
         userSettings.setMatchmakingTiglRanks(getSelectedValues(event, TIGL_RANKS_ID));
         UserSettingsManager.save(userSettings);
     }

--- a/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingOptions.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingOptions.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -36,7 +37,25 @@ public class MatchmakingOptions {
 
     public static final List<String> PLAYER_COUNT_OPTIONS = List.of("3", "4", "5", "6", "7", "8");
     public static final List<String> VICTORY_POINT_OPTIONS = List.of("10", "12", "14");
-    public static final String SIMILAR_ACTIVE_HOURS_OPTION = "Similar active hours";
+
+    public static final int STRICT_SIMILAR_ACTIVE_HOURS_REQUIREMENT = 12;
+    public static final int LOOSE_SIMILAR_ACTIVE_HOURS_REQUIREMENT = 10;
+    public static final String STRICT_SIMILAR_ACTIVE_HOURS_OPTION =
+            "Strict (" + STRICT_SIMILAR_ACTIVE_HOURS_REQUIREMENT + " hours must match)";
+    public static final String LOOSE_SIMILAR_ACTIVE_HOURS_OPTION =
+            "Loose (" + LOOSE_SIMILAR_ACTIVE_HOURS_REQUIREMENT + " hours must match)";
+    public static final String NO_SIMILAR_ACTIVE_HOURS_OPTION = "No";
+
+    public static final List<String> SIMILAR_ACTIVE_HOURS_OPTIONS_STRICTEST_FIRST =
+            List.of(STRICT_SIMILAR_ACTIVE_HOURS_OPTION, LOOSE_SIMILAR_ACTIVE_HOURS_OPTION);
+
+    private static final Map<String, Integer> SIMILAR_ACTIVE_HOURS_SHARED_HOUR_REQUIREMENTS = Map.of(
+            STRICT_SIMILAR_ACTIVE_HOURS_OPTION, STRICT_SIMILAR_ACTIVE_HOURS_REQUIREMENT,
+            LOOSE_SIMILAR_ACTIVE_HOURS_OPTION, LOOSE_SIMILAR_ACTIVE_HOURS_REQUIREMENT);
+
+    private static final Map<String, String> SIMILAR_ACTIVE_HOURS_SHORT_NAMES = Map.of(
+            STRICT_SIMILAR_ACTIVE_HOURS_OPTION, "strict",
+            LOOSE_SIMILAR_ACTIVE_HOURS_OPTION, "loose");
 
     // Discord role names the matchmaker tracks to keep Floaters and Warriors apart.
     public static final String FLOATERS_ROLE_NAME = "Floaters";
@@ -52,7 +71,7 @@ public class MatchmakingOptions {
     public static final Map<String, Integer> PACE_RESTRICTION_TO_GAME_DAYS_TO_COMPLETE_REQUIREMENT =
             Map.of(FASTER_PACE_OPTION, 21, FASTEST_PACE_OPTION, 11);
 
-    public static final List<String> RESTRICTION_OPTIONS = List.of(SIMILAR_ACTIVE_HOURS_OPTION);
+    public static final List<String> RESTRICTION_OPTIONS = SIMILAR_ACTIVE_HOURS_OPTIONS_STRICTEST_FIRST;
 
     private static final Map<String, String> PACE_SHORT_NAMES = Map.of(
             SLOWER_PACE_OPTION, "Slower",
@@ -77,8 +96,41 @@ public class MatchmakingOptions {
 
     private static final int DEFAULT_MAX_QUEUE_TIME_HOURS = 48;
 
-    public static boolean wantsSimilarActiveHours(Collection<String> restrictions) {
-        return restrictions.contains(SIMILAR_ACTIVE_HOURS_OPTION);
+    public static boolean isSimilarActiveHoursLevel(String restriction) {
+        return SIMILAR_ACTIVE_HOURS_SHARED_HOUR_REQUIREMENTS.containsKey(restriction);
+    }
+
+    public static int requiredSharedActiveHours(Collection<String> restrictions) {
+        return restrictions.stream()
+                .mapToInt(restriction -> SIMILAR_ACTIVE_HOURS_SHARED_HOUR_REQUIREMENTS.getOrDefault(restriction, 0))
+                .max()
+                .orElse(0);
+    }
+
+    public static Optional<String> strictestSimilarActiveHours(Collection<String> restrictions) {
+        return SIMILAR_ACTIVE_HOURS_OPTIONS_STRICTEST_FIRST.stream()
+                .filter(restrictions::contains)
+                .findFirst();
+    }
+
+    public static List<String> collapseToStrictestActiveHours(Collection<String> restrictions) {
+        Optional<String> strictest = strictestSimilarActiveHours(restrictions);
+        return restrictions.stream()
+                .distinct()
+                .filter(restriction -> !isSimilarActiveHoursLevel(restriction)
+                        || strictest.filter(restriction::equals).isPresent())
+                .sorted()
+                .toList();
+    }
+
+    public static String shortSimilarActiveHoursLabel(String similarActiveHoursOption) {
+        return "similar hours ("
+                + SIMILAR_ACTIVE_HOURS_SHORT_NAMES.getOrDefault(similarActiveHoursOption, similarActiveHoursOption)
+                + ")";
+    }
+
+    public static String describeSimilarActiveHours(Collection<String> restrictions) {
+        return strictestSimilarActiveHours(restrictions).orElse(NO_SIMILAR_ACTIVE_HOURS_OPTION);
     }
 
     public static String shortExpansionName(String expansion) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchDescriber.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchDescriber.java
@@ -32,13 +32,12 @@ class MatchDescriber {
     }
 
     static String setupBody(MatchedGame game) {
-        String restrictionsText = game.restrictions().isEmpty() ? "None" : String.join(", ", game.restrictions());
         return "The players were matched on the following game setup:\n"
                 + "- **Player count:** " + game.playerCount() + "\n"
                 + "- **Victory point goal:** " + game.victoryPointGoal() + "\n"
                 + "- **Expansion:** " + game.expansion() + "\n"
                 + "- **Pace:** " + game.pace() + "\n"
-                + "- **Restrictions:** " + restrictionsText;
+                + "- **Similar active hours:** " + MatchmakingOptions.describeSimilarActiveHours(game.restrictions());
     }
 
     static void logFormedMatch(
@@ -58,9 +57,8 @@ class MatchDescriber {
     private static String titleRestrictions(MatchedGame game) {
         List<String> restrictions = game.restrictions();
         List<String> labels = new ArrayList<>();
-        if (restrictions.contains(MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION)) {
-            labels.add("similar timezone");
-        }
+        MatchmakingOptions.strictestSimilarActiveHours(restrictions)
+                .ifPresent(level -> labels.add(MatchmakingOptions.shortSimilarActiveHoursLabel(level)));
         return String.join(", ", labels);
     }
 

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingCompatibilityService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingCompatibilityService.java
@@ -2,15 +2,13 @@ package ti4.spring.service.statistics.matchmaking.queue;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
 import lombok.experimental.UtilityClass;
 import ti4.discord.interactions.buttons.handlers.matchmaking.MatchmakingOptions;
 
 @UtilityClass
 class MatchmakingCompatibilityService {
 
-    private static final long ACTIVE_HOUR_DATA_REQUIREMENT = 13;
-    private static final long ACTIVE_HOUR_SHARED_HOUR_REQUIREMENT = 11;
+    private static final int ACTIVE_HOUR_DATA_MARGIN_OVER_SHARED_REQUIREMENT = 2;
 
     private static final double SKILL_DIFFERENCE_STARTING_THRESHOLD = 3;
     private static final double SKILL_DIFFERENCE_WIDENING_PER_WINDOW = 1;
@@ -18,14 +16,18 @@ class MatchmakingCompatibilityService {
 
     private static final int HOURS_TO_AVOID_FLOATERS_WARRIORS = 8;
 
-    static boolean hasEnoughActiveHourDataToMatch(PlayerMatchmakingData data) {
-        return data.activeHours().size() >= ACTIVE_HOUR_DATA_REQUIREMENT;
+    static int requiredActiveHourData(int requiredSharedHours) {
+        return requiredSharedHours + ACTIVE_HOUR_DATA_MARGIN_OVER_SHARED_REQUIREMENT;
     }
 
-    static boolean shareEnoughActiveHours(PlayerMatchmakingData a, PlayerMatchmakingData b) {
+    static boolean hasEnoughActiveHourDataToMatch(PlayerMatchmakingData data, int requiredSharedHours) {
+        return data.activeHours().size() >= requiredActiveHourData(requiredSharedHours);
+    }
+
+    static boolean shareEnoughActiveHours(PlayerMatchmakingData a, PlayerMatchmakingData b, int requiredSharedHours) {
         long sharedHours =
                 a.activeHours().stream().filter(b.activeHours()::contains).count();
-        return sharedHours >= ACTIVE_HOUR_SHARED_HOUR_REQUIREMENT;
+        return sharedHours >= requiredSharedHours;
     }
 
     static boolean areIncompatible(PlayerMatchmakingData a, PlayerMatchmakingData b) {
@@ -33,12 +35,8 @@ class MatchmakingCompatibilityService {
             return true;
         }
 
-        List<String> aRestrictions = a.restrictions();
-        List<String> bRestrictions = b.restrictions();
-
-        if ((MatchmakingOptions.wantsSimilarActiveHours(aRestrictions)
-                        || MatchmakingOptions.wantsSimilarActiveHours(bRestrictions))
-                && !shareEnoughActiveHours(a, b)) {
+        int requiredSharedHours = strictestRequiredSharedActiveHours(a, b);
+        if (requiredSharedHours > 0 && !shareEnoughActiveHours(a, b, requiredSharedHours)) {
             return true;
         }
 
@@ -57,6 +55,12 @@ class MatchmakingCompatibilityService {
         }
 
         return isSkillGapTooLarge(a, b);
+    }
+
+    private static int strictestRequiredSharedActiveHours(PlayerMatchmakingData a, PlayerMatchmakingData b) {
+        return Math.max(
+                MatchmakingOptions.requiredSharedActiveHours(a.restrictions()),
+                MatchmakingOptions.requiredSharedActiveHours(b.restrictions()));
     }
 
     private static boolean isSkillGapTooLarge(PlayerMatchmakingData a, PlayerMatchmakingData b) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingGrouper.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingGrouper.java
@@ -165,11 +165,9 @@ class MatchmakingGrouper {
         List<MatchmakingQueueMember> members = groupParties.stream()
                 .flatMap(party -> party.members().stream())
                 .collect(Collectors.toCollection(ArrayList::new));
-        List<String> restrictions = groupParties.stream()
+        List<String> restrictions = MatchmakingOptions.collapseToStrictestActiveHours(groupParties.stream()
                 .flatMap(party -> party.leaderSettings().getMatchmakingRestrictions().stream())
-                .distinct()
-                .sorted()
-                .toList();
+                .toList());
         MatchedGame game = new MatchedGame(
                 members,
                 new ArrayList<>(groupParties.stream().map(QueuedParty::party).toList()),

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/PartyValidator.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/PartyValidator.java
@@ -30,12 +30,12 @@ public class PartyValidator {
     }
 
     public static List<String> getValidRestrictions(List<String> userIds, List<String> restrictions) {
-        List<String> members = userIds.stream().distinct().toList();
+        if (restrictions.isEmpty()) return List.of();
 
+        List<String> members = userIds.stream().distinct().toList();
+        Map<String, PlayerMatchmakingData> dataById = PlayerMatchmakingDataFactory.buildForUsers(members, restrictions);
         List<String> available = new ArrayList<>();
         for (String restriction : restrictions) {
-            Map<String, PlayerMatchmakingData> dataById =
-                    PlayerMatchmakingDataFactory.buildForUsers(members, List.of(restriction));
             if (!everyMemberCanUseRestriction(restriction, members, dataById)) {
                 continue;
             }
@@ -49,23 +49,26 @@ public class PartyValidator {
 
     private static boolean everyMemberCanUseRestriction(
             String restriction, List<String> members, Map<String, PlayerMatchmakingData> dataById) {
-        if (!MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION.equals(restriction)) {
+        int requiredSharedHours = MatchmakingOptions.requiredSharedActiveHours(List.of(restriction));
+        if (requiredSharedHours == 0) {
             return true;
         }
         return members.stream()
                 .map(dataById::get)
-                .allMatch(MatchmakingCompatibilityService::hasEnoughActiveHourDataToMatch);
+                .allMatch(data ->
+                        MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(data, requiredSharedHours));
     }
 
     private static boolean everyMemberPairSatisfiesRestriction(
             String restriction, List<String> members, Map<String, PlayerMatchmakingData> dataById) {
-        if (!MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION.equals(restriction)) {
+        int requiredSharedHours = MatchmakingOptions.requiredSharedActiveHours(List.of(restriction));
+        if (requiredSharedHours == 0) {
             return true;
         }
         for (int i = 0; i < members.size(); i++) {
             for (int j = i + 1; j < members.size(); j++) {
                 if (!MatchmakingCompatibilityService.shareEnoughActiveHours(
-                        dataById.get(members.get(i)), dataById.get(members.get(j)))) {
+                        dataById.get(members.get(i)), dataById.get(members.get(j)), requiredSharedHours)) {
                     return false;
                 }
             }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/QueuedGameJoinValidator.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/QueuedGameJoinValidator.java
@@ -78,20 +78,24 @@ class QueuedGameJoinValidator {
 
     private static Optional<String> findActiveHoursBlocker(
             PlayerSearchCriteria criteria, String joiningUserId, List<String> others) {
-        if (!MatchmakingOptions.wantsSimilarActiveHours(criteria.restrictions())) return Optional.empty();
+        int requiredSharedHours = MatchmakingOptions.requiredSharedActiveHours(criteria.restrictions());
+        if (requiredSharedHours == 0) return Optional.empty();
 
+        String level = MatchmakingOptions.describeSimilarActiveHours(criteria.restrictions());
         Map<String, PlayerMatchmakingData> dataById = PlayerMatchmakingDataFactory.buildForUsers(
                 Stream.concat(Stream.of(joiningUserId), others.stream()).toList(), criteria.restrictions());
         PlayerMatchmakingData joiner = dataById.get(joiningUserId);
-        if (!MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(joiner)) {
-            return Optional.of("it is queued with the **" + MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION
-                    + "** restriction and you have not set enough active hours. Use `/user active_hours` to set them.");
+        if (!MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(joiner, requiredSharedHours)) {
+            return Optional.of("it is queued with **similar active hours: " + level
+                    + "** and you have not set enough active hours (at least "
+                    + MatchmakingCompatibilityService.requiredActiveHourData(requiredSharedHours)
+                    + " are needed). Use `/user active_hours` to set them.");
         }
         for (String otherId : others) {
-            if (!MatchmakingCompatibilityService.shareEnoughActiveHours(joiner, dataById.get(otherId))) {
-                return Optional.of(
-                        "it is queued with the **" + MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION
-                                + "** restriction and your active hours do not overlap enough with the players already signed up.");
+            if (!MatchmakingCompatibilityService.shareEnoughActiveHours(
+                    joiner, dataById.get(otherId), requiredSharedHours)) {
+                return Optional.of("it is queued with **similar active hours: " + level
+                        + "** and your active hours do not overlap enough with the players already signed up.");
             }
         }
         return Optional.empty();

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/ViewMatchmakingQueueService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/ViewMatchmakingQueueService.java
@@ -125,8 +125,8 @@ public class ViewMatchmakingQueueService {
     }
 
     private static String labelRestriction(String restriction) {
-        if (MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION.equals(restriction)) {
-            return "similar hours";
+        if (MatchmakingOptions.isSimilarActiveHoursLevel(restriction)) {
+            return MatchmakingOptions.shortSimilarActiveHoursLabel(restriction);
         }
         return restriction;
     }

--- a/src/test/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingCompatibilityServiceTest.java
+++ b/src/test/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingCompatibilityServiceTest.java
@@ -99,37 +99,83 @@ class MatchmakingCompatibilityServiceTest {
     }
 
     @Test
-    void similarActiveHoursRequiresElevenSharedHours() {
+    void strictActiveHoursRequiresTwelveSharedHours() {
         PlayerMatchmakingData picky = player("a")
-                .restrictions(MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION)
-                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+                .restrictions(MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_OPTION)
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
                 .build();
-        PlayerMatchmakingData fewShared = player("b")
-                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 20, 21, 22, 23)
-                .build();
-        PlayerMatchmakingData manyShared = player("c")
+        PlayerMatchmakingData elevenShared = player("b")
                 .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 21, 22, 23)
                 .build();
+        PlayerMatchmakingData twelveShared = player("c")
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 21, 22, 23)
+                .build();
 
-        assertThat(MatchmakingCompatibilityService.areIncompatible(picky, fewShared))
+        assertThat(MatchmakingCompatibilityService.areIncompatible(picky, elevenShared))
                 .isTrue();
-        assertThat(MatchmakingCompatibilityService.areIncompatible(picky, manyShared))
+        assertThat(MatchmakingCompatibilityService.areIncompatible(picky, twelveShared))
                 .isFalse();
+    }
+
+    @Test
+    void looseActiveHoursRequiresTenSharedHours() {
+        PlayerMatchmakingData picky = player("a")
+                .restrictions(MatchmakingOptions.LOOSE_SIMILAR_ACTIVE_HOURS_OPTION)
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+                .build();
+        PlayerMatchmakingData nineShared = player("b")
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 20, 21, 22, 23)
+                .build();
+        PlayerMatchmakingData tenShared = player("c")
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 20, 21, 22, 23)
+                .build();
+
+        assertThat(MatchmakingCompatibilityService.areIncompatible(picky, nineShared))
+                .isTrue();
+        assertThat(MatchmakingCompatibilityService.areIncompatible(picky, tenShared))
+                .isFalse();
+    }
+
+    @Test
+    void theStricterOfTheTwoLevelsApplies() {
+        PlayerMatchmakingData strict = player("a")
+                .restrictions(MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_OPTION)
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+                .build();
+        PlayerMatchmakingData loose = player("b")
+                .restrictions(MatchmakingOptions.LOOSE_SIMILAR_ACTIVE_HOURS_OPTION)
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 21, 22, 23)
+                .build();
+
+        // 11 shared hours clears the loose level but not the strict one.
+        assertThat(MatchmakingCompatibilityService.areIncompatible(strict, loose))
+                .isTrue();
+        assertThat(MatchmakingCompatibilityService.areIncompatible(loose, strict))
+                .isTrue();
     }
 
     @Test
     void playerWithTooFewActiveHoursCanNeverMatch() {
-        assertThat(MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(player("a")
-                        .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
-                        .build()))
+        PlayerMatchmakingData thirteenHours = player("a")
+                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+                .build();
+
+        // Strict needs 12 shared hours out of at least 14 on record; loose needs 10 out of 12.
+        assertThat(MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(
+                        thirteenHours, MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_REQUIREMENT))
                 .isFalse();
+        assertThat(MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(
+                        thirteenHours, MatchmakingOptions.LOOSE_SIMILAR_ACTIVE_HOURS_REQUIREMENT))
+                .isTrue();
     }
 
     @Test
     void playerWithEnoughActiveHoursCanMatch() {
-        assertThat(MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(player("a")
-                        .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
-                        .build()))
+        assertThat(MatchmakingCompatibilityService.hasEnoughActiveHourDataToMatch(
+                        player("a")
+                                .activeHours(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+                                .build(),
+                        MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_REQUIREMENT))
                 .isTrue();
     }
 
@@ -152,8 +198,18 @@ class MatchmakingCompatibilityServiceTest {
     }
 
     @Test
-    void euAndSeaPlayersAreNotMatched() {
+    void euAndSeaPlayersAreMatchedOnTheLooseLevel() {
+        // Their evening windows overlap for exactly 10 hours: enough for loose, short of strict.
         PlayerMatchmakingData eu = regional("eu", EU_HOURS);
+        PlayerMatchmakingData sea = regional("sea", SEA_HOURS);
+
+        assertThat(MatchmakingCompatibilityService.areIncompatible(eu, sea)).isFalse();
+        assertThat(MatchmakingCompatibilityService.areIncompatible(sea, eu)).isFalse();
+    }
+
+    @Test
+    void euAndSeaPlayersAreNotMatchedOnTheStrictLevel() {
+        PlayerMatchmakingData eu = regional("eu", EU_HOURS, MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_OPTION);
         PlayerMatchmakingData sea = regional("sea", SEA_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(eu, sea)).isTrue();
@@ -179,8 +235,19 @@ class MatchmakingCompatibilityServiceTest {
     }
 
     @Test
-    void apacAndSeaPlayersAreNotMatched() {
+    void apacAndSeaPlayersAreMatchedOnTheLooseLevel() {
+        // One timezone apart: 10 shared hours, which the loose level accepts.
         PlayerMatchmakingData apac = regional("apac", APAC_HOURS);
+        PlayerMatchmakingData sea = regional("sea", SEA_HOURS);
+
+        assertThat(MatchmakingCompatibilityService.areIncompatible(apac, sea)).isFalse();
+        assertThat(MatchmakingCompatibilityService.areIncompatible(sea, apac)).isFalse();
+    }
+
+    @Test
+    void apacAndSeaPlayersAreNotMatchedOnTheStrictLevel() {
+        PlayerMatchmakingData apac =
+                regional("apac", APAC_HOURS, MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_OPTION);
         PlayerMatchmakingData sea = regional("sea", SEA_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(apac, sea)).isTrue();
@@ -221,8 +288,8 @@ class MatchmakingCompatibilityServiceTest {
 
     @Test
     void euAndUsaAwakeSixteenHoursAreNotMatched() {
-        PlayerMatchmakingData eu = regional("eu", EU_16H_HOURS);
-        PlayerMatchmakingData usa = regional("usa", USA_16H_HOURS);
+        PlayerMatchmakingData eu = regional16h("eu", EU_16H_HOURS);
+        PlayerMatchmakingData usa = regional16h("usa", USA_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(eu, usa)).isTrue();
         assertThat(MatchmakingCompatibilityService.areIncompatible(usa, eu)).isTrue();
@@ -230,8 +297,8 @@ class MatchmakingCompatibilityServiceTest {
 
     @Test
     void euAndApacAwakeSixteenHoursAreNotMatched() {
-        PlayerMatchmakingData eu = regional("eu", EU_16H_HOURS);
-        PlayerMatchmakingData apac = regional("apac", APAC_16H_HOURS);
+        PlayerMatchmakingData eu = regional16h("eu", EU_16H_HOURS);
+        PlayerMatchmakingData apac = regional16h("apac", APAC_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(eu, apac)).isTrue();
         assertThat(MatchmakingCompatibilityService.areIncompatible(apac, eu)).isTrue();
@@ -239,8 +306,8 @@ class MatchmakingCompatibilityServiceTest {
 
     @Test
     void euAndSeaAwakeSixteenHoursAreNotMatched() {
-        PlayerMatchmakingData eu = regional("eu", EU_16H_HOURS);
-        PlayerMatchmakingData sea = regional("sea", SEA_16H_HOURS);
+        PlayerMatchmakingData eu = regional16h("eu", EU_16H_HOURS);
+        PlayerMatchmakingData sea = regional16h("sea", SEA_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(eu, sea)).isTrue();
         assertThat(MatchmakingCompatibilityService.areIncompatible(sea, eu)).isTrue();
@@ -248,8 +315,8 @@ class MatchmakingCompatibilityServiceTest {
 
     @Test
     void usaAndApacAwakeSixteenHoursAreNotMatched() {
-        PlayerMatchmakingData usa = regional("usa", USA_16H_HOURS);
-        PlayerMatchmakingData apac = regional("apac", APAC_16H_HOURS);
+        PlayerMatchmakingData usa = regional16h("usa", USA_16H_HOURS);
+        PlayerMatchmakingData apac = regional16h("apac", APAC_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(usa, apac)).isTrue();
         assertThat(MatchmakingCompatibilityService.areIncompatible(apac, usa)).isTrue();
@@ -257,8 +324,8 @@ class MatchmakingCompatibilityServiceTest {
 
     @Test
     void usaAndSeaAwakeSixteenHoursAreNotMatched() {
-        PlayerMatchmakingData usa = regional("usa", USA_16H_HOURS);
-        PlayerMatchmakingData sea = regional("sea", SEA_16H_HOURS);
+        PlayerMatchmakingData usa = regional16h("usa", USA_16H_HOURS);
+        PlayerMatchmakingData sea = regional16h("sea", SEA_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(usa, sea)).isTrue();
         assertThat(MatchmakingCompatibilityService.areIncompatible(sea, usa)).isTrue();
@@ -267,10 +334,10 @@ class MatchmakingCompatibilityServiceTest {
     @Test
     void apacAndSeaAwakeSixteenHoursAreMatched() {
         // APAC and SEA are only one timezone apart. With full 16h awake windows their overlap
-        // grows from ~10h to ~15h, which clears the 11-shared-hour bar. This is the intended
-        // outcome for geographically close regions.
-        PlayerMatchmakingData apac = regional("apac", APAC_16H_HOURS);
-        PlayerMatchmakingData sea = regional("sea", SEA_16H_HOURS);
+        // grows from ~10h to ~15h, which clears even the strict 12-shared-hour bar. This is the
+        // intended outcome for geographically close regions.
+        PlayerMatchmakingData apac = regional16h("apac", APAC_16H_HOURS);
+        PlayerMatchmakingData sea = regional16h("sea", SEA_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(apac, sea)).isFalse();
         assertThat(MatchmakingCompatibilityService.areIncompatible(sea, apac)).isFalse();
@@ -278,39 +345,49 @@ class MatchmakingCompatibilityServiceTest {
 
     @Test
     void twoEuAwakeSixteenHoursPlayersMatch() {
-        PlayerMatchmakingData a = regional("eu1", EU_16H_HOURS);
-        PlayerMatchmakingData b = regional("eu2", EU_16H_HOURS);
+        PlayerMatchmakingData a = regional16h("eu1", EU_16H_HOURS);
+        PlayerMatchmakingData b = regional16h("eu2", EU_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(a, b)).isFalse();
     }
 
     @Test
     void twoUsaAwakeSixteenHoursPlayersMatch() {
-        PlayerMatchmakingData a = regional("usa1", USA_16H_HOURS);
-        PlayerMatchmakingData b = regional("usa2", USA_16H_HOURS);
+        PlayerMatchmakingData a = regional16h("usa1", USA_16H_HOURS);
+        PlayerMatchmakingData b = regional16h("usa2", USA_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(a, b)).isFalse();
     }
 
     @Test
     void twoApacAwakeSixteenHoursPlayersMatch() {
-        PlayerMatchmakingData a = regional("apac1", APAC_16H_HOURS);
-        PlayerMatchmakingData b = regional("apac2", APAC_16H_HOURS);
+        PlayerMatchmakingData a = regional16h("apac1", APAC_16H_HOURS);
+        PlayerMatchmakingData b = regional16h("apac2", APAC_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(a, b)).isFalse();
     }
 
     @Test
     void twoSeaAwakeSixteenHoursPlayersMatch() {
-        PlayerMatchmakingData a = regional("sea1", SEA_16H_HOURS);
-        PlayerMatchmakingData b = regional("sea2", SEA_16H_HOURS);
+        PlayerMatchmakingData a = regional16h("sea1", SEA_16H_HOURS);
+        PlayerMatchmakingData b = regional16h("sea2", SEA_16H_HOURS);
 
         assertThat(MatchmakingCompatibilityService.areIncompatible(a, b)).isFalse();
     }
 
+    // The 12-hour profiles below only hold enough active hour data for the loose level (10 of 12),
+    // while the 16-hour profiles hold enough for the strict level (12 of 14).
     private static PlayerMatchmakingData regional(String userId, Set<Integer> hours) {
+        return regional(userId, hours, MatchmakingOptions.LOOSE_SIMILAR_ACTIVE_HOURS_OPTION);
+    }
+
+    private static PlayerMatchmakingData regional16h(String userId, Set<Integer> hours) {
+        return regional(userId, hours, MatchmakingOptions.STRICT_SIMILAR_ACTIVE_HOURS_OPTION);
+    }
+
+    private static PlayerMatchmakingData regional(String userId, Set<Integer> hours, String level) {
         return player(userId)
-                .restrictions(MatchmakingOptions.SIMILAR_ACTIVE_HOURS_OPTION)
+                .restrictions(level)
                 .activeHours(hours.toArray(new Integer[0]))
                 .build();
     }


### PR DESCRIPTION
Similar active hours was an on/off restriction requiring 11 shared hours out of 13 recorded. It is now a level chosen in the queue and search modals:

| Level | Shared hours required | Active hours needed on record |
| --- | --- | --- |
| `Strict (12 hours must match)` | 12 | 14 |
| `Loose (10 hours must match)` | 10 | 12 |
| `No` | — | — |

The record requirement is always the shared requirement plus two, derived in one place, and the option labels are built from the same constants as the thresholds so the numbers cannot drift apart.

- The select only offers levels every group or game member has enough active hour data for; `No` is always offered. A saved level a group cannot reach falls back to the strictest level still available.
- When two queued players ask for different levels, the stricter one applies to both. A formed game records a single level, so titles and descriptions do not list two.
- Users who have never configured restrictions default to Strict. Players already queued under the old `Similar active hours` flag match as if unrestricted until they requeue.

## Testing

`mvn test` — 762 tests, 0 failures. The regional timezone suite is now split by level: the 12-hour evening profiles exercise Loose, which is the only level they hold enough data for, and the 16-hour profiles exercise Strict. That surfaces the intended consequence that EU/SEA and APAC/SEA (10 shared hours) match under Loose but not Strict, so both cases have a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
