### PR TITLE
Make matchmaking ratings keep moving for experienced players

### DIFF
--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfo.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfo.java
@@ -1,0 +1,19 @@
+package ti4.spring.service.statistics.matchmaking;
+
+import de.gesundkrank.jskills.GameInfo;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MatchmakingGameInfo {
+
+    private static final double INITIAL_MEAN = 25.0;
+    private static final double INITIAL_STANDARD_DEVIATION = INITIAL_MEAN / 3.0;
+    private static final double BETA = INITIAL_MEAN / 6.0;
+    private static final double DRAW_PROBABILITY = 0.10;
+    private static final double ASSUMED_SKILL_DRIFT_BETWEEN_GAMES = INITIAL_STANDARD_DEVIATION / 25.0;
+
+    public static GameInfo create() {
+        return new GameInfo(
+                INITIAL_MEAN, INITIAL_STANDARD_DEVIATION, BETA, ASSUMED_SKILL_DRIFT_BETWEEN_GAMES, DRAW_PROBABILITY);
+    }
+}

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRating.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRating.java
@@ -8,4 +8,5 @@ record MatchmakingRating(
         BigDecimal rating,
         BigDecimal sigma,
         BigDecimal calibrationPercent,
-        long lastGameEndedDate) {}
+        long lastGameEndedDate,
+        BigDecimal recentRatingDelta) {}

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -210,6 +210,7 @@ public class MatchmakingRatingEventService {
                         stringBuilder.append(String.format(
                                 "\nYour %s is `%d`.",
                                 ratingLabel.toLowerCase(), toDisplayRating(playerRating.rating())));
+                        appendRecentTrend(stringBuilder, playerRating);
                     } else {
                         stringBuilder.append(String.format(
                                 "\nWe are `%.1f%%` of the way to a high confidence in your rating.",
@@ -228,6 +229,14 @@ public class MatchmakingRatingEventService {
                 (MessageChannelUnion) event.getMessageChannel(),
                 "Player Matchmaking Ratings",
                 stringBuilder.toString());
+    }
+
+    private static void appendRecentTrend(StringBuilder stringBuilder, MatchmakingRating playerRating) {
+        BigDecimal recentRatingDelta = playerRating.recentRatingDelta();
+        if (recentRatingDelta == null) return;
+        stringBuilder.append(String.format(
+                " That is `%+d` over your last %d games.",
+                toDisplayRating(recentRatingDelta), TrueSkillMatchmakingRatingService.RECENT_GAMES_WINDOW));
     }
 
     private static void appendAverageOpponentRating(

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
@@ -9,8 +9,10 @@ import de.gesundkrank.jskills.Team;
 import de.gesundkrank.jskills.trueskill.FactorGraphTrueSkillCalculator;
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,19 +22,24 @@ import lombok.experimental.UtilityClass;
 class TrueSkillMatchmakingRatingService {
 
     private static final FactorGraphTrueSkillCalculator CALCULATOR = new FactorGraphTrueSkillCalculator();
-    private static final double SIGMA_CALIBRATION_THRESHOLD = 1.5;
+
+    private static final double SIGMA_CALIBRATION_THRESHOLD = 1.7;
     private static final BigDecimal ONE_HUNDRED = BigDecimal.valueOf(100);
     private static final int MINIMUM_GAMES_FOR_RANKING = 3;
+
+    static final int RECENT_GAMES_WINDOW = 10;
+    private static final int RATINGS_RETAINED_PER_PLAYER = RECENT_GAMES_WINDOW + 1;
 
     static List<MatchmakingRating> calculateRatings(List<MatchmakingGame> games, boolean useConservativeRating) {
         games.sort(Comparator.comparingLong(MatchmakingGame::endedDate).thenComparing(MatchmakingGame::name));
 
-        GameInfo gameInfo = GameInfo.getDefaultGameInfo();
+        GameInfo gameInfo = MatchmakingGameInfo.create();
         Map<String, Player<String>> userIdToTrueSkillPlayer = new HashMap<>();
         Map<IPlayer, Rating> trueSkillPlayerToRating = new HashMap<>();
         Map<String, String> userIdToUsername = new HashMap<>();
         Map<String, Integer> gamesPlayedByUserId = new HashMap<>();
         Map<String, Long> lastGameEndedDateByUserId = new HashMap<>();
+        Map<String, Deque<Rating>> recentRatingsByUserId = new HashMap<>();
 
         for (MatchmakingGame game : games) {
             List<MatchmakingPlayer> gamePlayers = game.players();
@@ -56,6 +63,7 @@ class TrueSkillMatchmakingRatingService {
 
             Map<IPlayer, Rating> newRatings = CALCULATOR.calculateNewRatings(gameInfo, teams, ranks);
             trueSkillPlayerToRating.putAll(newRatings);
+            recordRecentRatings(gamePlayers, userIdToTrueSkillPlayer, trueSkillPlayerToRating, recentRatingsByUserId);
         }
 
         return buildMatchmakingRatings(
@@ -64,7 +72,24 @@ class TrueSkillMatchmakingRatingService {
                 userIdToUsername,
                 gamesPlayedByUserId,
                 lastGameEndedDateByUserId,
+                recentRatingsByUserId,
                 useConservativeRating);
+    }
+
+    private static void recordRecentRatings(
+            List<MatchmakingPlayer> gamePlayers,
+            Map<String, Player<String>> userIdToTrueSkillPlayer,
+            Map<IPlayer, Rating> trueSkillPlayerToRating,
+            Map<String, Deque<Rating>> recentRatingsByUserId) {
+        for (MatchmakingPlayer gamePlayer : gamePlayers) {
+            Player<String> trueSkillPlayer = userIdToTrueSkillPlayer.get(gamePlayer.userId());
+            Deque<Rating> recentRatings =
+                    recentRatingsByUserId.computeIfAbsent(gamePlayer.userId(), _ -> new ArrayDeque<>());
+            recentRatings.addLast(trueSkillPlayerToRating.get(trueSkillPlayer));
+            if (recentRatings.size() > RATINGS_RETAINED_PER_PLAYER) {
+                recentRatings.removeFirst();
+            }
+        }
     }
 
     private static List<MatchmakingRating> buildMatchmakingRatings(
@@ -73,6 +98,7 @@ class TrueSkillMatchmakingRatingService {
             Map<String, String> userIdToUsername,
             Map<String, Integer> gamesPlayedByUserId,
             Map<String, Long> lastGameEndedDateByUserId,
+            Map<String, Deque<Rating>> recentRatingsByUserId,
             boolean useConservativeRating) {
         return players.entrySet().stream()
                 .filter(entry -> gamesPlayedByUserId.getOrDefault(entry.getKey(), 0) >= MINIMUM_GAMES_FOR_RANKING)
@@ -86,7 +112,7 @@ class TrueSkillMatchmakingRatingService {
                             .divide(standardDeviation, MathContext.DECIMAL64)
                             .multiply(ONE_HUNDRED);
                     BigDecimal calibrationPercent = calculatedPercent.min(ONE_HUNDRED);
-                    double rawRating = useConservativeRating ? rating.getConservativeRating() : rating.getMean();
+                    double rawRating = ratingValue(rating, useConservativeRating);
                     long lastGameEndedDate = lastGameEndedDateByUserId.getOrDefault(userId, 0L);
                     return new MatchmakingRating(
                             userId,
@@ -94,9 +120,23 @@ class TrueSkillMatchmakingRatingService {
                             BigDecimal.valueOf(rawRating),
                             standardDeviation,
                             calibrationPercent,
-                            lastGameEndedDate);
+                            lastGameEndedDate,
+                            recentRatingDelta(recentRatingsByUserId.get(userId), rawRating, useConservativeRating));
                 })
                 .sorted(Comparator.comparing(MatchmakingRating::rating).reversed())
                 .toList();
+    }
+
+    private static BigDecimal recentRatingDelta(
+            Deque<Rating> recentRatings, double currentRating, boolean useConservativeRating) {
+        if (recentRatings == null || recentRatings.size() < RATINGS_RETAINED_PER_PLAYER) {
+            return null;
+        }
+        double ratingBeforeWindow = ratingValue(recentRatings.peekFirst(), useConservativeRating);
+        return BigDecimal.valueOf(currentRating - ratingBeforeWindow);
+    }
+
+    private static double ratingValue(Rating rating, boolean useConservativeRating) {
+        return useConservativeRating ? rating.getConservativeRating() : rating.getMean();
     }
 }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
@@ -28,7 +28,6 @@ class TrueSkillMatchmakingRatingService {
     private static final int MINIMUM_GAMES_FOR_RANKING = 3;
 
     static final int RECENT_GAMES_WINDOW = 10;
-    private static final int RATINGS_RETAINED_PER_PLAYER = RECENT_GAMES_WINDOW + 1;
 
     static List<MatchmakingRating> calculateRatings(List<MatchmakingGame> games, boolean useConservativeRating) {
         games.sort(Comparator.comparingLong(MatchmakingGame::endedDate).thenComparing(MatchmakingGame::name));
@@ -86,7 +85,7 @@ class TrueSkillMatchmakingRatingService {
             Deque<Rating> recentRatings =
                     recentRatingsByUserId.computeIfAbsent(gamePlayer.userId(), _ -> new ArrayDeque<>());
             recentRatings.addLast(trueSkillPlayerToRating.get(trueSkillPlayer));
-            if (recentRatings.size() > RATINGS_RETAINED_PER_PLAYER) {
+            if (recentRatings.size() > RECENT_GAMES_WINDOW + 1) {
                 recentRatings.removeFirst();
             }
         }
@@ -129,7 +128,7 @@ class TrueSkillMatchmakingRatingService {
 
     private static BigDecimal recentRatingDelta(
             Deque<Rating> recentRatings, double currentRating, boolean useConservativeRating) {
-        if (recentRatings == null || recentRatings.size() < RATINGS_RETAINED_PER_PLAYER) {
+        if (recentRatings == null || recentRatings.size() < RECENT_GAMES_WINDOW + 1) {
             return null;
         }
         double ratingBeforeWindow = ratingValue(recentRatings.peekFirst(), useConservativeRating);

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchQualityCalculator.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchQualityCalculator.java
@@ -9,11 +9,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
+import ti4.spring.service.statistics.matchmaking.MatchmakingGameInfo;
 
 @UtilityClass
 class MatchQualityCalculator {
 
-    private static final GameInfo GAME_INFO = GameInfo.getDefaultGameInfo();
+    private static final GameInfo GAME_INFO = MatchmakingGameInfo.create();
     private static final FactorGraphTrueSkillCalculator CALCULATOR = new FactorGraphTrueSkillCalculator();
 
     static double matchQuality(

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/PlayerMatchmakingDataFactory.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/PlayerMatchmakingDataFactory.java
@@ -1,6 +1,5 @@
 package ti4.spring.service.statistics.matchmaking.queue;
 
-import de.gesundkrank.jskills.GameInfo;
 import de.gesundkrank.jskills.Rating;
 import java.time.Duration;
 import java.time.Instant;
@@ -21,6 +20,7 @@ import ti4.game.persistence.ManagedPlayer;
 import ti4.settings.users.UserSettings;
 import ti4.settings.users.UserSettingsManager;
 import ti4.spring.service.statistics.UserGameInfoService;
+import ti4.spring.service.statistics.matchmaking.MatchmakingGameInfo;
 import ti4.spring.service.statistics.matchmaking.MatchmakingRatingEventService;
 
 @UtilityClass
@@ -29,7 +29,7 @@ class PlayerMatchmakingDataFactory {
     private static final List<String> ROLES_TO_TRACK =
             List.of(MatchmakingOptions.FLOATERS_ROLE_NAME, MatchmakingOptions.WARRIORS_ROLE_NAME);
     private static final Rating DEFAULT_NEW_PLAYER_RATING =
-            GameInfo.getDefaultGameInfo().getDefaultRating();
+            MatchmakingGameInfo.create().getDefaultRating();
 
     static Map<MatchmakingQueueMember, PlayerMatchmakingData> buildForParties(List<QueuedParty> parties) {
         Set<String> userIds = parties.stream()

--- a/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventServiceTest.java
+++ b/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventServiceTest.java
@@ -1,6 +1,7 @@
 package ti4.spring.service.statistics.matchmaking;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static ti4.spring.service.statistics.matchmaking.TrueSkillMatchmakingRatingService.RECENT_GAMES_WINDOW;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -13,23 +14,24 @@ import org.junit.jupiter.api.Test;
 class MatchmakingRatingEventServiceTest {
 
     private static final int GAMES_TO_QUALIFY = 3;
-    private static final int[] RANKS = {1, 2, 2, 4, 5, 5};
+    private static final int[] RANKS_P0_WINS = {1, 2, 2, 4, 5, 5};
+    private static final int[] RANKS_P4_WINS = {5, 2, 2, 4, 1, 5};
     private static final long GAME_ENDED_EPOCH_MILLIS = Instant.now().toEpochMilli();
 
     @Test
     void generatingRatingsTwiceGivesSameResult() {
-        List<MatchmakingRating> sortedRatings = sortedByRating(
-                TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(GAMES_TO_QUALIFY, RANKS), false));
-        List<MatchmakingRating> sortedRatings2 = sortedByRating(
-                TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(GAMES_TO_QUALIFY, RANKS), false));
+        List<MatchmakingRating> sortedRatings = sortedByRating(TrueSkillMatchmakingRatingService.calculateRatings(
+                buildRankedGames(GAMES_TO_QUALIFY, RANKS_P0_WINS), false));
+        List<MatchmakingRating> sortedRatings2 = sortedByRating(TrueSkillMatchmakingRatingService.calculateRatings(
+                buildRankedGames(GAMES_TO_QUALIFY, RANKS_P0_WINS), false));
 
         assertThat(sortedRatings).isEqualTo(sortedRatings2);
     }
 
     @Test
     void generatesSensibleRatings() {
-        List<MatchmakingRating> ratings =
-                TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(GAMES_TO_QUALIFY, RANKS), false);
+        List<MatchmakingRating> ratings = TrueSkillMatchmakingRatingService.calculateRatings(
+                buildRankedGames(GAMES_TO_QUALIFY, RANKS_P0_WINS), false);
 
         List<MatchmakingRating> sortedRatings = sortedByRating(ratings);
 
@@ -49,24 +51,49 @@ class MatchmakingRatingEventServiceTest {
     @Test
     void excludesPlayersWithFewerThanThreeCompletedGames() {
         // Two games each means every player has only two completed games, below the three-game minimum.
-        assertThat(TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(2, RANKS), false))
+        assertThat(TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(2, RANKS_P0_WINS), false))
                 .isEmpty();
-        assertThat(TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(3, RANKS), false))
+        assertThat(TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(3, RANKS_P0_WINS), false))
                 .hasSize(6);
     }
 
     @Test
     void conservativeRatingsUseConservativeTrueSkillValue() {
-        List<MatchmakingRating> meanRatings =
-                TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(GAMES_TO_QUALIFY, RANKS), false);
-        List<MatchmakingRating> conservativeRatings =
-                TrueSkillMatchmakingRatingService.calculateRatings(buildRankedGames(GAMES_TO_QUALIFY, RANKS), true);
+        List<MatchmakingRating> meanRatings = TrueSkillMatchmakingRatingService.calculateRatings(
+                buildRankedGames(GAMES_TO_QUALIFY, RANKS_P0_WINS), false);
+        List<MatchmakingRating> conservativeRatings = TrueSkillMatchmakingRatingService.calculateRatings(
+                buildRankedGames(GAMES_TO_QUALIFY, RANKS_P0_WINS), true);
 
         MatchmakingRating meanWinnerRating = findRatingForUser(meanRatings, "p0");
         MatchmakingRating conservativeWinnerRating = findRatingForUser(conservativeRatings, "p0");
 
         assertThat(conservativeWinnerRating.rating()).isLessThan(meanWinnerRating.rating());
         assertThat(conservativeWinnerRating.calibrationPercent()).isEqualTo(meanWinnerRating.calibrationPercent());
+    }
+
+    @Test
+    void reportsNoRecentTrendUntilTheWindowIsFull() {
+        int gamesOneShortOfAFullWindow = RECENT_GAMES_WINDOW;
+        assertThat(TrueSkillMatchmakingRatingService.calculateRatings(
+                        buildRankedGames(gamesOneShortOfAFullWindow, RANKS_P0_WINS), true))
+                .allSatisfy(rating -> assertThat(rating.recentRatingDelta()).isNull());
+
+        assertThat(TrueSkillMatchmakingRatingService.calculateRatings(
+                        buildRankedGames(RECENT_GAMES_WINDOW + 1, RANKS_P0_WINS), true))
+                .allSatisfy(rating -> assertThat(rating.recentRatingDelta()).isNotNull());
+    }
+
+    @Test
+    void recentTrendFollowsTheDirectionOfRecentResults() {
+        List<MatchmakingGame> games = new ArrayList<>(buildRankedGames(30, RANKS_P0_WINS));
+        for (int i = 0; i < RECENT_GAMES_WINDOW; i++) {
+            games.add(buildMatchmakingGame("late" + i, RANKS_P4_WINS));
+        }
+
+        List<MatchmakingRating> ratings = TrueSkillMatchmakingRatingService.calculateRatings(games, true);
+
+        assertThat(findRatingForUser(ratings, "p4").recentRatingDelta()).isPositive();
+        assertThat(findRatingForUser(ratings, "p0").recentRatingDelta()).isNegative();
     }
 
     private static List<MatchmakingRating> sortedByRating(List<MatchmakingRating> ratings) {


### PR DESCRIPTION
## Why

TrueSkill's dynamics factor is the only thing that puts uncertainty back into a rating between games. jskills defaults it to `sigma/100`, which is close enough to zero that sigma ratchets down forever — and since the size of a rating update scales with sigma squared, updates collapse along with it.

Simulated against the real `FactorGraphTrueSkillCalculator` (200-player 6p FFA league, using our own `calculatePlayerRank`):

| games played | median move/game | sigma |
|---|---|---|
| 0–4 | 241 pts | 3.62 |
| 10–19 | 31 pts | 1.45 |
| 40–79 | 8.6 pts | 0.79 |
| 80+ | **6.7 pts** | 0.69 |

Then giving 20 established players a genuine one-tier (+400 display point) improvement and letting the league run 3000 more games: **13 of the 20 were never reflected on the ladder at all.** The 7 that were took a median of 73 games.

So the "my rating never moves" complaint is accurate, not a perception problem — a veteran who really does improve cannot demonstrate it.

## What changed

**Dynamics factor `sigma/100` → `sigma/25`.** Sigma settles near 1.3 instead of 0.66, veteran movement goes 6.7 → 24 points a game, and a real one-tier improvement surfaces in ~30 games with 2/20 missed. Per-game movement stays around 2% of the ladder's spread, so it is not swingy.

| | vet sigma | games to show a real tier gain | never noticed |
|---|---|---|---|
| current | 0.66 | 73 | 13/20 |
| **sigma/25** | **1.32** | **29** | **2/20** |
| sigma/15 | 1.69 | 13 | 1/20 |
| sigma/10 | 2.07 | 9 | 1/20 |

**New `MatchmakingGameInfo`.** Rating, match quality and the default rating handed to unrated players were each building their own `GameInfo.getDefaultGameInfo()`; they now share one source and cannot drift apart. It returns a fresh instance per call because `GameInfo` has public setters — the library hands out copies for the same reason.

**Calibration threshold sigma 1.5 → 1.7.** This one is load-bearing: the leaderboard and "show my rating" both require calibration to hit exactly 100%, so at `sigma/15` or lower the leaderboard would silently empty and nobody would ever be shown their rating again. `sigma/25` clears 1.5, but with much less headroom than before, so players near the line would flicker on and off between games.

**Rating trend over the last 10 games**, shown alongside the personal rating:

> Your rating is `2412`. That is `+34` over your last 10 games.

Display rating is `(mu - 3*sigma)`, so a player's first ten games add roughly 2000 points on their own purely from sigma collapsing. Measuring from the start of the window rather than their first ever game keeps the number about how they have actually been playing. It is null until a player has more than 10 games, sits behind the same calibration gate as the rating itself, and is on the personal line only rather than all 50 leaderboard rows.

## Follow-up needed

`SkillTier`'s 1900/2300 bounds still need refitting. Higher sigma means lower conservative ratings across the board — roughly 185 points at the median in simulation. Left as-is, players get over-classified into LOWER/MEDIUM, which feeds both matchmaking grouping and the `/statistics` tier filters. I could not derive the new bounds here (the simulated distribution is close to ours but not the one those percentiles were fitted to); the real numbers can be read off the per-bracket distribution `/matchmaking_rating` already prints after the first recompute.

## Notes

Ratings are recomputed from full history every 8 hours, so there is no migration — but every player's number moves at once at the next recompute. Worth announcing, or it will read as a reset.

## Testing

`mvn test` on the matchmaking suites: 60 pass, including two new tests covering the trend window and its direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
