### PR TITLE
Let players cancel a thread's matchmaking queue

### DIFF
--- a/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
+++ b/src/main/java/ti4/discord/interactions/buttons/handlers/matchmaking/MatchmakingButtonHandler.java
@@ -13,6 +13,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.components.checkboxgroup.CheckboxGroup;
 import net.dv8tion.jda.api.components.label.Label;
 import net.dv8tion.jda.api.components.label.LabelChildComponent;
@@ -32,6 +34,7 @@ import net.dv8tion.jda.api.interactions.modals.ModalInteraction;
 import net.dv8tion.jda.api.interactions.modals.ModalMapping;
 import net.dv8tion.jda.api.modals.Modal;
 import org.apache.commons.lang3.function.Consumers;
+import ti4.discord.interactions.buttons.Buttons;
 import ti4.discord.interactions.buttons.handlers.game.CreateGameButtonHandler;
 import ti4.discord.interactions.routing.ButtonHandler;
 import ti4.discord.interactions.routing.ModalHandler;
@@ -60,6 +63,8 @@ class MatchmakingButtonHandler {
     private static final String LEAVE_QUEUE_BUTTON_ID = "leaveQueueForGame";
     private static final String VIEW_QUEUE_BUTTON_ID = "viewMatchmakingQueue";
     private static final String ADDITIONAL_SETTINGS_BUTTON_ID = "queueForGameAdditionalSettings~MDL";
+    private static final String CANCEL_SEARCH_CONFIRM_BUTTON_ID = "cancelMatchmakingSearchConfirm";
+    private static final String CANCEL_SEARCH_DECLINE_BUTTON_ID = "cancelMatchmakingSearchDecline";
     private static final String QUEUE_FOR_GAME_MODAL_ID = "queueForGameModal";
     private static final String QUEUE_FOR_TIGL_MODAL_ID = "queueForTiglModal";
     private static final String SEARCH_FOR_PLAYERS_MODAL_ID = "searchForPlayersModal";
@@ -119,8 +124,43 @@ class MatchmakingButtonHandler {
                     .queue(Consumers.nop(), BotLogger::catchRestError);
             return;
         }
+        if (MatchmakingQueueSearchService.get().isRegistered(event.getChannelId())) {
+            offerCancelSearchPrompt(event);
+            return;
+        }
         Modal modal = isTiglThread(event) ? buildTiglSearchModal(event) : buildSearchModal(event);
         event.replyModal(modal).queue(Consumers.nop(), BotLogger::catchRestError);
+    }
+
+    private static void offerCancelSearchPrompt(ButtonInteractionEvent event) {
+        Button yes = Buttons.red(CANCEL_SEARCH_CONFIRM_BUTTON_ID, "Yes");
+        Button no = Buttons.gray(CANCEL_SEARCH_DECLINE_BUTTON_ID, "No");
+        event.reply("This game is already in the matchmaking queue."
+                        + " Do you want to cancel your current matchmaking queue?")
+                .setEphemeral(true)
+                .addComponents(ActionRow.of(yes, no))
+                .queue(Consumers.nop(), BotLogger::catchRestError);
+    }
+
+    @ButtonHandler(value = CANCEL_SEARCH_CONFIRM_BUTTON_ID, save = false)
+    public static void cancelMatchmakingSearch(ButtonInteractionEvent event) {
+        if (!MatchmakingQueueSearchService.get().remove(event.getChannelId())) {
+            editPrompt(event, "This game was no longer in the matchmaking queue.");
+            return;
+        }
+        MessageHelper.sendMessageToChannel(
+                event.getChannel(),
+                "This game has left the matchmaking queue. The matchmaker will no longer add players to it.");
+        editPrompt(event, "This game has been removed from the matchmaking queue.");
+    }
+
+    @ButtonHandler(value = CANCEL_SEARCH_DECLINE_BUTTON_ID, save = false)
+    public static void keepMatchmakingSearch(ButtonInteractionEvent event) {
+        editPrompt(event, "This game is still in the matchmaking queue.");
+    }
+
+    private static void editPrompt(ButtonInteractionEvent event, String message) {
+        event.getHook().editOriginal(message).setComponents().queue(Consumers.nop(), BotLogger::catchRestError);
     }
 
     private static boolean isTiglThread(ButtonInteractionEvent event) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchService.java
@@ -47,10 +47,21 @@ public class MatchmakingQueueSearchService {
         repository.save(search);
     }
 
+    public boolean isRegistered(String threadId) {
+        if (DatabasePersistenceGate.isDisabled()) return false;
+        return repository.findByThreadId(threadId).isPresent();
+    }
+
+    /**
+     * @return whether a standing search existed for the thread and was removed
+     */
     @Transactional
-    public void remove(String threadId) {
-        if (DatabasePersistenceGate.isDisabled()) return;
-        repository.deleteByThreadId(threadId);
+    public boolean remove(String threadId) {
+        if (DatabasePersistenceGate.isDisabled()) return false;
+        Optional<MatchmakingQueueSearch> found = repository.findByThreadId(threadId);
+        if (found.isEmpty()) return false;
+        repository.delete(found.get());
+        return true;
     }
 
     public Optional<String> findJoinBlocker(String threadId, String joiningUserId, List<String> existingMemberIds) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/queue/MatchmakingQueueSearchService.java
@@ -52,9 +52,6 @@ public class MatchmakingQueueSearchService {
         return repository.findByThreadId(threadId).isPresent();
     }
 
-    /**
-     * @return whether a standing search existed for the thread and was removed
-     */
     @Transactional
     public boolean remove(String threadId) {
         if (DatabasePersistenceGate.isDisabled()) return false;


### PR DESCRIPTION
## Problem

Once a game thread joined the matchmaking queue there was no way to take it back out. Pressing **Join Matchmaking** again just reopened the search modal and silently overwrote the existing criteria via `register()`'s upsert. The only ways a standing search ever got cleared were launching the game, the roster growing past every queued player count, or the thread being archived/deleted and swept up by the cron.

## Change

**Join Matchmaking** now checks for an existing standing search first. If the thread already has one, instead of the modal it replies with an ephemeral prompt:

> This game is already in the matchmaking queue. Do you want to cancel your current matchmaking queue?

with red **Yes** / gray **No** buttons.

- **Yes** — removes the standing search, posts a public note in the thread (mirroring the public message `describeQueuedGame` posts on join), and rewrites the prompt with its buttons stripped.
- **No** — rewrites the prompt to "This game is still in the matchmaking queue."

After cancelling, pressing **Join Matchmaking** again goes straight to the search modal, so re-queueing with different criteria is a two-click flow.

### Service changes

- `MatchmakingQueueSearchService.isRegistered(threadId)` — new.
- `remove(threadId)` now returns `boolean` (whether a search actually existed and was deleted) and deletes the found entity rather than issuing a blind `deleteByThreadId`. Existing void callers are unaffected.

## Notes

- The prompt only fires for threads that actually have a DB record — `making-new-games` / `making-tigl-games` threads where `register()` ran, or games auto-registered by `MatchmakingNotifier`. Everywhere else the button behaves exactly as before.
- `searchForPlayers~MDL` is a modal spawner, so `ButtonListener` deliberately leaves it undeferred; the prompt therefore uses `event.reply(...)` rather than the `getHook()`-based `sendMessageToEventChannelWithEphemeralButtons` helper. The Yes/No buttons carry no `~MDL`, so they get the normal `deferEdit()` and `getHook().editOriginal(...).setComponents()` edits the ephemeral prompt in place.
- If the search is already gone by the time Yes is pressed (game launched while the prompt sat open), `remove()` returns `false` and the user gets "This game was no longer in the matchmaking queue" instead of a misleading success.

## Testing

`mvn spotless:check compile test-compile` clean. No automated coverage — this is Discord interaction plumbing; the behaviour needs a live thread to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)