### PR TITLE
Add a Support for the Throne statistics command

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand2.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/StatisticsCommand2.java
@@ -18,6 +18,7 @@ public class StatisticsCommand2 implements ParentCommand {
                     new ExpeditionWinRates(),
                     new SliceTileWinRates(),
                     new PlanetWinRates(),
+                    new SupportWinRates(),
                     new StellarConverterStatistics(),
                     new FactionRecordOfTech(),
                     new FactionRecordOfSCPick(),

--- a/src/main/java/ti4/discord/interactions/commands/statistics/SupportWinRates.java
+++ b/src/main/java/ti4/discord/interactions/commands/statistics/SupportWinRates.java
@@ -1,0 +1,18 @@
+package ti4.discord.interactions.commands.statistics;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.helpers.Constants;
+import ti4.service.statistics.SupportWinRateStatisticsService;
+
+class SupportWinRates extends Subcommand {
+
+    SupportWinRates() {
+        super(Constants.SUPPORT_WIN_RATES, "Win rates and swap rates for Support for the Throne");
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        SupportWinRateStatisticsService.queueReply(event);
+    }
+}

--- a/src/main/java/ti4/helpers/Constants.java
+++ b/src/main/java/ti4/helpers/Constants.java
@@ -514,6 +514,7 @@ public final class Constants {
     public static final String TWILIGHTS_FALL_SPLICE_WIN_RATES = "tf_splice_win_rates";
     public static final String SLICE_TILE_WIN_RATES = "slice_tile_win_rates";
     public static final String PLANET_WIN_RATES = "planet_win_rates";
+    public static final String SUPPORT_WIN_RATES = "support_win_rates";
     public static final String SEND_DEBT = "send_debt";
     public static final String DEBT_COUNT = "debt_count";
     public static final String REMOVE_DEBT = "remove_debt";

--- a/src/main/java/ti4/service/statistics/SupportWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/SupportWinRateStatisticsService.java
@@ -1,0 +1,479 @@
+package ti4.service.statistics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.apache.commons.lang3.StringUtils;
+import ti4.discord.interactions.commands.statistics.GameStatisticsFilterer;
+import ti4.executors.ExecutionLockType;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.persistence.ConsumeGameUtility;
+import ti4.image.Mapper;
+import ti4.message.MessageHelper;
+import ti4.model.FactionModel;
+
+@UtilityClass
+public class SupportWinRateStatisticsService {
+
+    private static final String SUPPORT_SUFFIX = "_sftt";
+    private static final int MINIMUM_FACTION_PLAYERS = 25;
+    private static final int MINIMUM_PLAYERS_ON_EACH_SIDE_OF_THE_SPLIT = 10;
+
+    private static final Comparator<Entry<String, FactionSupportStats>> BY_SUPPORT_GAP_DESC =
+            Comparator.comparingDouble((Entry<String, FactionSupportStats> entry) ->
+                            entry.getValue().supportGap())
+                    .reversed()
+                    .thenComparing(Entry::getKey);
+
+    private enum SupportFate {
+        KEPT("Kept it"),
+        SCORED_BY_ANOTHER("Given away and played for the point"),
+        IN_ANOTHER_HAND("Given away but never played"),
+        OFF_THE_TABLE("No longer anywhere in the game");
+
+        private final String label;
+
+        SupportFate(String label) {
+            this.label = label;
+        }
+    }
+
+    public static void queueReply(SlashCommandInteractionEvent event) {
+        StatisticsPipeline.queue(event, () -> showSupportWinRates(event));
+    }
+
+    private static void showSupportWinRates(SlashCommandInteractionEvent event) {
+        SupportStats stats = new SupportStats();
+        ConsumeGameUtility.consumeAllGames(
+                GameStatisticsFilterer.getStandardCompetitiveGamesFilter(),
+                game -> accumulateGame(game, stats),
+                ExecutionLockType.READ);
+
+        MessageHelper.sendMessageToThread(event.getChannel(), "Support for the Throne win rates", buildReport(stats));
+    }
+
+    static List<String> buildReport(List<Game> games) {
+        SupportStats stats = new SupportStats();
+        games.forEach(game -> accumulateGame(game, stats));
+        return buildReport(stats);
+    }
+
+    private static void accumulateGame(Game game, SupportStats stats) {
+        Player winner = game.getWinner().orElse(null);
+        if (winner == null) {
+            return;
+        }
+        List<Player> seats = game.getRealAndEliminatedPlayers().stream()
+                .filter(player -> StringUtils.isNotBlank(player.getFaction()))
+                .toList();
+        if (seats.isEmpty()) {
+            return;
+        }
+        stats.games++;
+
+        Map<String, Player> supportOwners = supportOwnersInTheGame(game);
+        Map<String, Player> playAreaHolders = supportsIn(seats, Player::getPromissoryNotesInPlayArea);
+        Map<String, Player> handHolders =
+                supportsIn(seats, player -> player.getPromissoryNotes().keySet());
+        Map<String, Set<String>> supportsHeldByFaction = supportsHeldByFaction(seats, supportOwners);
+        Set<String> swappingFactions = swappingFactions(supportsHeldByFaction);
+
+        stats.supportsPlayed +=
+                supportsHeldByFaction.values().stream().mapToInt(Set::size).sum();
+        stats.swaps += swappingFactions.size() / 2;
+        stats.gamesBySwapCount.merge(swappingFactions.size() / 2, 1, Integer::sum);
+
+        for (Player player : seats) {
+            String faction = player.getFaction();
+            boolean isWinner = faction.equals(winner.getFaction());
+            int supportsHeld = supportsHeldByFaction.get(faction).size();
+
+            stats.players++;
+            stats.supportsHeldAtTheirRealCounts += supportsHeld;
+            stats.playersBySupportsHeld
+                    .computeIfAbsent(supportsHeld, _ -> new WinRateCount())
+                    .record(isWinner);
+
+            stats.overall.record(supportsHeld > 0, isWinner);
+            for (String factionKey : FactionStatisticsHelper.getStatisticsFactionKeys(faction)) {
+                stats.byFaction
+                        .computeIfAbsent(factionKey, _ -> new FactionSupportStats())
+                        .record(supportsHeld > 0, isWinner);
+            }
+
+            String ownSupport = ownSupport(player);
+            if (ownSupport == null) {
+                stats.playersWithoutASupport++;
+                continue;
+            }
+            SupportFate fate = fateOf(ownSupport, player, playAreaHolders, handHolders);
+            stats.playersByFate.computeIfAbsent(fate, _ -> new WinRateCount()).record(isWinner);
+            if (fate == SupportFate.SCORED_BY_ANOTHER) {
+                (swappingFactions.contains(faction) ? stats.inASwap : stats.gaveAwayOutsideASwap).record(isWinner);
+            }
+        }
+    }
+
+    private static Map<String, Player> supportOwnersInTheGame(Game game) {
+        Map<String, Player> supportOwners = new HashMap<>();
+        for (Player player : game.getPlayers().values()) {
+            player.getPromissoryNotesOwned().stream()
+                    .filter(SupportWinRateStatisticsService::isSupport)
+                    .forEach(support -> supportOwners.put(support, player));
+        }
+        return supportOwners;
+    }
+
+    private static Map<String, Player> supportsIn(
+            List<Player> seats, Function<Player, Collection<String>> promissoryNotes) {
+        Map<String, Player> holders = new HashMap<>();
+        for (Player player : seats) {
+            promissoryNotes.apply(player).stream()
+                    .filter(SupportWinRateStatisticsService::isSupport)
+                    .forEach(support -> holders.put(support, player));
+        }
+        return holders;
+    }
+
+    private static Map<String, Set<String>> supportsHeldByFaction(
+            List<Player> seats, Map<String, Player> supportOwners) {
+        Map<String, Set<String>> supportsHeldByFaction = new HashMap<>();
+        for (Player player : seats) {
+            Set<String> givers = new HashSet<>();
+            for (String support : player.getPromissoryNotesInPlayArea()) {
+                if (!isSupport(support)) {
+                    continue;
+                }
+                Player owner = supportOwners.get(support);
+                if (owner != null && !isSameSeat(owner, player)) {
+                    givers.add(owner.getFaction());
+                }
+            }
+            supportsHeldByFaction.put(player.getFaction(), givers);
+        }
+        return supportsHeldByFaction;
+    }
+
+    private static Set<String> swappingFactions(Map<String, Set<String>> supportsHeldByFaction) {
+        Set<String> swappers = new HashSet<>();
+        for (Entry<String, Set<String>> holder : supportsHeldByFaction.entrySet()) {
+            for (String giver : holder.getValue()) {
+                if (supportsHeldByFaction.getOrDefault(giver, Set.of()).contains(holder.getKey())) {
+                    swappers.add(holder.getKey());
+                }
+            }
+        }
+        return swappers;
+    }
+
+    private static boolean isSupport(String promissoryNoteId) {
+        return promissoryNoteId != null && promissoryNoteId.endsWith(SUPPORT_SUFFIX);
+    }
+
+    private static String ownSupport(Player player) {
+        return player.getPromissoryNotesOwned().stream()
+                .filter(SupportWinRateStatisticsService::isSupport)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static SupportFate fateOf(
+            String ownSupport, Player owner, Map<String, Player> playAreaHolders, Map<String, Player> handHolders) {
+        Player playAreaHolder = playAreaHolders.get(ownSupport);
+        if (playAreaHolder != null) {
+            return isSameSeat(playAreaHolder, owner) ? SupportFate.KEPT : SupportFate.SCORED_BY_ANOTHER;
+        }
+        Player handHolder = handHolders.get(ownSupport);
+        if (handHolder != null) {
+            return isSameSeat(handHolder, owner) ? SupportFate.KEPT : SupportFate.IN_ANOTHER_HAND;
+        }
+        return SupportFate.OFF_THE_TABLE;
+    }
+
+    private static boolean isSameSeat(Player one, Player other) {
+        return one.getFaction() != null && one.getFaction().equals(other.getFaction());
+    }
+
+    private static List<String> buildReport(SupportStats stats) {
+        List<String> blocks = new ArrayList<>();
+
+        StringBuilder header = new StringBuilder("## __**Support for the Throne Win Rates**__\n");
+        header.append("_Where every Support for the Throne sat at the end of the game. A player's own support in"
+                + " their own play area is nobody's point, so it never counts as one held._\n");
+        header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario games with"
+                + " winners._\n");
+        if (stats.players == 0) {
+            header.append("\nNo games matched.\n");
+            blocks.add(header.toString());
+            return blocks;
+        }
+        header.append("Games analyzed: ")
+                .append(stats.games)
+                .append(" | Players analyzed: ")
+                .append(stats.players)
+                .append('\n');
+        blocks.add(header.toString());
+
+        appendSupportsHeldSection(blocks, stats);
+        appendOwnSupportSection(blocks, stats);
+        appendFactionSection(blocks, stats);
+        appendSwapSection(blocks, stats);
+
+        return blocks;
+    }
+
+    private static void appendSupportsHeldSection(List<String> blocks, SupportStats stats) {
+        blocks.add("### Win rate by supports held\n"
+                + "_Another player's Support for the Throne in your play area at the end of the game, one victory"
+                + " point each._\n"
+                + "_Each row reads: win rate (wins/players; share of players who held that many)._\n");
+
+        StringBuilder sb = new StringBuilder("- **All players**: ");
+        sb.append(String.format("%.2f", stats.averageSupportsHeld())).append(" supports held on average, from ");
+        ActionCardStatsService.appendCount(sb, stats.players, "player");
+        sb.append('\n');
+        stats.playersBySupportsHeld.forEach((supportsHeld, count) -> {
+            sb.append("  - ")
+                    .append(supportsHeld)
+                    .append(supportsHeld == 1 ? " support: " : " supports: ")
+                    .append(ActionCardStatsService.formatPercent(count.getWinRate()))
+                    .append(" (")
+                    .append(count.getWins())
+                    .append('/')
+                    .append(count.getPlayers())
+                    .append("; ")
+                    .append(ActionCardStatsService.formatPercent(count.getPlayers() / (double) stats.players))
+                    .append(")\n");
+        });
+        blocks.add(sb.toString());
+    }
+
+    private static void appendOwnSupportSection(List<String> blocks, SupportStats stats) {
+        StringBuilder heading = new StringBuilder("### Win rate by what became of your own support\n");
+        heading.append("_The card the player started with, wherever it ended up._\n");
+        if (stats.playersWithoutASupport > 0) {
+            heading.append('_')
+                    .append(stats.playersWithoutASupport)
+                    .append(" player(s) owned no Support for the Throne at all and are left out of this section._\n");
+        }
+        blocks.add(heading.toString());
+
+        int playersWithASupport = stats.playersByFate.values().stream()
+                .mapToInt(WinRateCount::getPlayers)
+                .sum();
+        if (playersWithASupport == 0) {
+            blocks.add("- No player owned a Support for the Throne.\n");
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (SupportFate fate : SupportFate.values()) {
+            WinRateCount count = stats.playersByFate.get(fate);
+            if (count == null) {
+                continue;
+            }
+            sb.append("- ")
+                    .append(fate.label)
+                    .append(": ")
+                    .append(ActionCardStatsService.formatPercent(count.getWinRate()))
+                    .append(" win rate (")
+                    .append(count.getWins())
+                    .append('/')
+                    .append(count.getPlayers())
+                    .append("; ")
+                    .append(ActionCardStatsService.formatPercent(count.getPlayers() / (double) playersWithASupport))
+                    .append(" of players)\n");
+        }
+        blocks.add(sb.toString());
+    }
+
+    private static void appendFactionSection(List<String> blocks, SupportStats stats) {
+        blocks.add("### Win rate holding another player's support, by faction\n"
+                + "_Factions with at least " + MINIMUM_FACTION_PLAYERS + " players in the sample and at least "
+                + MINIMUM_PLAYERS_ON_EACH_SIDE_OF_THE_SPLIT
+                + " on each side of the split. Sorted by the size of the gap._\n");
+
+        blocks.add(renderFactionLine("**All factions**", stats.overall));
+
+        List<Entry<String, FactionSupportStats>> ranked = stats.byFaction.entrySet().stream()
+                .filter(entry -> entry.getValue().isWellSampled())
+                .sorted(BY_SUPPORT_GAP_DESC)
+                .toList();
+        if (ranked.isEmpty()) {
+            blocks.add("- No faction had enough players on both sides of the split.\n");
+            return;
+        }
+        ranked.forEach(entry -> blocks.add(renderFactionLine(factionLabel(entry.getKey()), entry.getValue())));
+    }
+
+    private static String renderFactionLine(String label, FactionSupportStats group) {
+        return new StringBuilder("- ")
+                .append(label)
+                .append(": ")
+                .append(formatPercentagePointGap(group.supportGap()))
+                .append(" - ")
+                .append(ActionCardStatsService.formatPercent(group.withASupport.getWinRate()))
+                .append(" (")
+                .append(group.withASupport.getWins())
+                .append('/')
+                .append(group.withASupport.getPlayers())
+                .append(") holding one, ")
+                .append(ActionCardStatsService.formatPercent(group.withoutASupport.getWinRate()))
+                .append(" (")
+                .append(group.withoutASupport.getWins())
+                .append('/')
+                .append(group.withoutASupport.getPlayers())
+                .append(") holding none\n")
+                .toString();
+    }
+
+    private static void appendSwapSection(List<String> blocks, SupportStats stats) {
+        blocks.add("### Support swaps\n"
+                + "_Two players who each ended the game holding the other's Support for the Throne._\n");
+
+        int gamesWithASwap = stats.gamesBySwapCount.entrySet().stream()
+                .filter(entry -> entry.getKey() > 0)
+                .mapToInt(Entry::getValue)
+                .sum();
+        StringBuilder sb = new StringBuilder("- Games with at least one swap: ");
+        sb.append(gamesWithASwap)
+                .append('/')
+                .append(stats.games)
+                .append(" (")
+                .append(ActionCardStatsService.formatPercent(gamesWithASwap / (double) stats.games))
+                .append(")\n");
+        sb.append("- Swaps per game: ")
+                .append(String.format("%.2f", stats.swaps / (double) stats.games))
+                .append(" on average\n");
+        stats.gamesBySwapCount.forEach((swaps, games) -> sb.append("  - ")
+                .append(swaps)
+                .append(swaps == 1 ? " swap: " : " swaps: ")
+                .append(games)
+                .append(" game(s) (")
+                .append(ActionCardStatsService.formatPercent(games / (double) stats.games))
+                .append(")\n"));
+        appendReciprocalSupports(sb, stats);
+        appendSwapWinRates(sb, stats);
+        blocks.add(sb.toString());
+    }
+
+    private static void appendReciprocalSupports(StringBuilder sb, SupportStats stats) {
+        sb.append("- Supports played into a swap: ");
+        if (stats.supportsPlayed == 0) {
+            sb.append("no supports were played at all\n");
+            return;
+        }
+        sb.append(2 * stats.swaps)
+                .append('/')
+                .append(stats.supportsPlayed)
+                .append(" (")
+                .append(ActionCardStatsService.formatPercent(2.0 * stats.swaps / stats.supportsPlayed))
+                .append(" of the supports played)\n");
+    }
+
+    private static void appendSwapWinRates(StringBuilder sb, SupportStats stats) {
+        if (stats.inASwap.getPlayers() == 0 && stats.gaveAwayOutsideASwap.getPlayers() == 0) {
+            return;
+        }
+        sb.append("- Win rate after giving a support away: ")
+                .append(ActionCardStatsService.formatPercent(stats.inASwap.getWinRate()))
+                .append(" (")
+                .append(stats.inASwap.getWins())
+                .append('/')
+                .append(stats.inASwap.getPlayers())
+                .append(") in a swap, ")
+                .append(ActionCardStatsService.formatPercent(stats.gaveAwayOutsideASwap.getWinRate()))
+                .append(" (")
+                .append(stats.gaveAwayOutsideASwap.getWins())
+                .append('/')
+                .append(stats.gaveAwayOutsideASwap.getPlayers())
+                .append(") outside one\n");
+    }
+
+    private static String formatPercentagePointGap(double gap) {
+        return String.format("%+.1f pts", gap * 100);
+    }
+
+    private static String factionLabel(String faction) {
+        FactionModel factionModel = Mapper.getFaction(faction);
+        String factionName = factionModel != null ? factionModel.getFactionNameWithSourceEmoji() : faction;
+        return FactionStatisticsHelper.getFactionEmoji(faction) + " **" + factionName + "**";
+    }
+
+    private static class SupportStats {
+        final NavigableMap<Integer, WinRateCount> playersBySupportsHeld = new TreeMap<>();
+
+        final Map<SupportFate, WinRateCount> playersByFate = new HashMap<>();
+
+        final FactionSupportStats overall = new FactionSupportStats();
+
+        final Map<String, FactionSupportStats> byFaction = new HashMap<>();
+
+        final NavigableMap<Integer, Integer> gamesBySwapCount = new TreeMap<>();
+
+        final WinRateCount inASwap = new WinRateCount();
+
+        final WinRateCount gaveAwayOutsideASwap = new WinRateCount();
+
+        int games;
+        int players;
+        int playersWithoutASupport;
+        int supportsHeldAtTheirRealCounts;
+        int supportsPlayed;
+        int swaps;
+
+        double averageSupportsHeld() {
+            return players == 0 ? 0 : (double) supportsHeldAtTheirRealCounts / players;
+        }
+    }
+
+    private static class FactionSupportStats {
+        final WinRateCount withASupport = new WinRateCount();
+
+        final WinRateCount withoutASupport = new WinRateCount();
+
+        void record(boolean heldASupport, boolean isWinner) {
+            (heldASupport ? withASupport : withoutASupport).record(isWinner);
+        }
+
+        boolean isWellSampled() {
+            return withASupport.getPlayers() + withoutASupport.getPlayers() >= MINIMUM_FACTION_PLAYERS
+                    && withASupport.getPlayers() >= MINIMUM_PLAYERS_ON_EACH_SIDE_OF_THE_SPLIT
+                    && withoutASupport.getPlayers() >= MINIMUM_PLAYERS_ON_EACH_SIDE_OF_THE_SPLIT;
+        }
+
+        double supportGap() {
+            return withASupport.getWinRate() - withoutASupport.getWinRate();
+        }
+    }
+
+    @Getter
+    private static class WinRateCount {
+        private int players;
+        private int wins;
+
+        void record(boolean isWinner) {
+            players++;
+            if (isWinner) {
+                wins++;
+            }
+        }
+
+        double getWinRate() {
+            return players == 0 ? 0 : (double) wins / players;
+        }
+    }
+}

--- a/src/main/java/ti4/service/statistics/SupportWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/SupportWinRateStatisticsService.java
@@ -158,7 +158,7 @@ public class SupportWinRateStatisticsService {
                     continue;
                 }
                 Player owner = supportOwners.get(support);
-                if (owner != null && !isSameSeat(owner, player)) {
+                if (owner != null) {
                     givers.add(owner.getFaction());
                 }
             }
@@ -192,9 +192,8 @@ public class SupportWinRateStatisticsService {
 
     private static SupportFate fateOf(
             String ownSupport, Player owner, Map<String, Player> playAreaHolders, Map<String, Player> handHolders) {
-        Player playAreaHolder = playAreaHolders.get(ownSupport);
-        if (playAreaHolder != null) {
-            return isSameSeat(playAreaHolder, owner) ? SupportFate.KEPT : SupportFate.SCORED_BY_ANOTHER;
+        if (playAreaHolders.containsKey(ownSupport)) {
+            return SupportFate.SCORED_BY_ANOTHER;
         }
         Player handHolder = handHolders.get(ownSupport);
         if (handHolder != null) {
@@ -211,8 +210,7 @@ public class SupportWinRateStatisticsService {
         List<String> blocks = new ArrayList<>();
 
         StringBuilder header = new StringBuilder("## __**Support for the Throne Win Rates**__\n");
-        header.append("_Where every Support for the Throne sat at the end of the game. A player's own support in"
-                + " their own play area is nobody's point, so it never counts as one held._\n");
+        header.append("_Where every Support for the Throne sat at the end of the game._\n");
         header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario games with"
                 + " winners._\n");
         if (stats.players == 0) {

--- a/src/main/java/ti4/service/statistics/SupportWinRateStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/SupportWinRateStatisticsService.java
@@ -1,7 +1,6 @@
 package ti4.service.statistics;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -11,7 +10,7 @@ import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -29,6 +28,7 @@ import ti4.model.FactionModel;
 public class SupportWinRateStatisticsService {
 
     private static final String SUPPORT_SUFFIX = "_sftt";
+    private static final String SUPPORTS_PURGED_KEY = "removeSupports";
     private static final int MINIMUM_FACTION_PLAYERS = 25;
     private static final int MINIMUM_PLAYERS_ON_EACH_SIDE_OF_THE_SPLIT = 10;
 
@@ -37,19 +37,6 @@ public class SupportWinRateStatisticsService {
                             entry.getValue().supportGap())
                     .reversed()
                     .thenComparing(Entry::getKey);
-
-    private enum SupportFate {
-        KEPT("Kept it"),
-        SCORED_BY_ANOTHER("Given away and played for the point"),
-        IN_ANOTHER_HAND("Given away but never played"),
-        OFF_THE_TABLE("No longer anywhere in the game");
-
-        private final String label;
-
-        SupportFate(String label) {
-            this.label = label;
-        }
-    }
 
     public static void queueReply(SlashCommandInteractionEvent event) {
         StatisticsPipeline.queue(event, () -> showSupportWinRates(event));
@@ -82,19 +69,23 @@ public class SupportWinRateStatisticsService {
         if (seats.isEmpty()) {
             return;
         }
+
+        Set<String> supportsInPlayAreas = supportsInPlayAreas(seats);
+        if (supportsAreOutOfPlay(game, supportsInPlayAreas)) {
+            stats.gamesWithoutSupportsInPlay++;
+            return;
+        }
         stats.games++;
 
         Map<String, Player> supportOwners = supportOwnersInTheGame(game);
-        Map<String, Player> playAreaHolders = supportsIn(seats, Player::getPromissoryNotesInPlayArea);
-        Map<String, Player> handHolders =
-                supportsIn(seats, player -> player.getPromissoryNotes().keySet());
         Map<String, Set<String>> supportsHeldByFaction = supportsHeldByFaction(seats, supportOwners);
         Set<String> swappingFactions = swappingFactions(supportsHeldByFaction);
+        int swaps = swappingFactions.size() / 2;
 
         stats.supportsPlayed +=
                 supportsHeldByFaction.values().stream().mapToInt(Set::size).sum();
-        stats.swaps += swappingFactions.size() / 2;
-        stats.gamesBySwapCount.merge(swappingFactions.size() / 2, 1, Integer::sum);
+        stats.swaps += swaps;
+        stats.gamesBySwapCount.merge(swaps, 1, Integer::sum);
 
         for (Player player : seats) {
             String faction = player.getFaction();
@@ -116,15 +107,26 @@ public class SupportWinRateStatisticsService {
 
             String ownSupport = ownSupport(player);
             if (ownSupport == null) {
-                stats.playersWithoutASupport++;
                 continue;
             }
-            SupportFate fate = fateOf(ownSupport, player, playAreaHolders, handHolders);
-            stats.playersByFate.computeIfAbsent(fate, _ -> new WinRateCount()).record(isWinner);
-            if (fate == SupportFate.SCORED_BY_ANOTHER) {
+            if (supportsInPlayAreas.contains(ownSupport)) {
+                stats.gaveAway.record(isWinner);
                 (swappingFactions.contains(faction) ? stats.inASwap : stats.gaveAwayOutsideASwap).record(isWinner);
+            } else {
+                stats.keptIt.record(isWinner);
             }
         }
+    }
+
+    private static boolean supportsAreOutOfPlay(Game game, Set<String> supportsInPlayAreas) {
+        return supportsInPlayAreas.isEmpty() || "true".equalsIgnoreCase(game.getStoredValue(SUPPORTS_PURGED_KEY));
+    }
+
+    private static Set<String> supportsInPlayAreas(List<Player> seats) {
+        return seats.stream()
+                .flatMap(player -> player.getPromissoryNotesInPlayArea().stream())
+                .filter(SupportWinRateStatisticsService::isSupport)
+                .collect(Collectors.toCollection(HashSet::new));
     }
 
     private static Map<String, Player> supportOwnersInTheGame(Game game) {
@@ -135,17 +137,6 @@ public class SupportWinRateStatisticsService {
                     .forEach(support -> supportOwners.put(support, player));
         }
         return supportOwners;
-    }
-
-    private static Map<String, Player> supportsIn(
-            List<Player> seats, Function<Player, Collection<String>> promissoryNotes) {
-        Map<String, Player> holders = new HashMap<>();
-        for (Player player : seats) {
-            promissoryNotes.apply(player).stream()
-                    .filter(SupportWinRateStatisticsService::isSupport)
-                    .forEach(support -> holders.put(support, player));
-        }
-        return holders;
     }
 
     private static Map<String, Set<String>> supportsHeldByFaction(
@@ -190,31 +181,15 @@ public class SupportWinRateStatisticsService {
                 .orElse(null);
     }
 
-    private static SupportFate fateOf(
-            String ownSupport, Player owner, Map<String, Player> playAreaHolders, Map<String, Player> handHolders) {
-        if (playAreaHolders.containsKey(ownSupport)) {
-            return SupportFate.SCORED_BY_ANOTHER;
-        }
-        Player handHolder = handHolders.get(ownSupport);
-        if (handHolder != null) {
-            return isSameSeat(handHolder, owner) ? SupportFate.KEPT : SupportFate.IN_ANOTHER_HAND;
-        }
-        return SupportFate.OFF_THE_TABLE;
-    }
-
-    private static boolean isSameSeat(Player one, Player other) {
-        return one.getFaction() != null && one.getFaction().equals(other.getFaction());
-    }
-
     private static List<String> buildReport(SupportStats stats) {
         List<String> blocks = new ArrayList<>();
 
         StringBuilder header = new StringBuilder("## __**Support for the Throne Win Rates**__\n");
-        header.append("_Where every Support for the Throne sat at the end of the game._\n");
         header.append("_6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario games with"
                 + " winners._\n");
         if (stats.players == 0) {
             header.append("\nNo games matched.\n");
+            appendGamesWithoutSupportsInPlay(header, stats);
             blocks.add(header.toString());
             return blocks;
         }
@@ -223,20 +198,28 @@ public class SupportWinRateStatisticsService {
                 .append(" | Players analyzed: ")
                 .append(stats.players)
                 .append('\n');
+        appendGamesWithoutSupportsInPlay(header, stats);
         blocks.add(header.toString());
 
         appendSupportsHeldSection(blocks, stats);
-        appendOwnSupportSection(blocks, stats);
-        appendFactionSection(blocks, stats);
+        appendSupportLocationSection(blocks, stats);
         appendSwapSection(blocks, stats);
+        appendFactionSection(blocks, stats);
 
         return blocks;
     }
 
+    private static void appendGamesWithoutSupportsInPlay(StringBuilder header, SupportStats stats) {
+        if (stats.gamesWithoutSupportsInPlay == 0) {
+            return;
+        }
+        header.append("Dropped ")
+                .append(stats.gamesWithoutSupportsInPlay)
+                .append(" game(s) that purged Support for the Throne or never played one.\n");
+    }
+
     private static void appendSupportsHeldSection(List<String> blocks, SupportStats stats) {
         blocks.add("### Win rate by supports held\n"
-                + "_Another player's Support for the Throne in your play area at the end of the game, one victory"
-                + " point each._\n"
                 + "_Each row reads: win rate (wins/players; share of players who held that many)._\n");
 
         StringBuilder sb = new StringBuilder("- **All players**: ");
@@ -259,43 +242,96 @@ public class SupportWinRateStatisticsService {
         blocks.add(sb.toString());
     }
 
-    private static void appendOwnSupportSection(List<String> blocks, SupportStats stats) {
-        StringBuilder heading = new StringBuilder("### Win rate by what became of your own support\n");
-        heading.append("_The card the player started with, wherever it ended up._\n");
-        if (stats.playersWithoutASupport > 0) {
-            heading.append('_')
-                    .append(stats.playersWithoutASupport)
-                    .append(" player(s) owned no Support for the Throne at all and are left out of this section._\n");
-        }
-        blocks.add(heading.toString());
+    private static void appendSupportLocationSection(List<String> blocks, SupportStats stats) {
+        blocks.add("### Win rate by support location\n");
 
-        int playersWithASupport = stats.playersByFate.values().stream()
-                .mapToInt(WinRateCount::getPlayers)
-                .sum();
+        int playersWithASupport = stats.keptIt.getPlayers() + stats.gaveAway.getPlayers();
         if (playersWithASupport == 0) {
             blocks.add("- No player owned a Support for the Throne.\n");
             return;
         }
-
         StringBuilder sb = new StringBuilder();
-        for (SupportFate fate : SupportFate.values()) {
-            WinRateCount count = stats.playersByFate.get(fate);
-            if (count == null) {
-                continue;
-            }
-            sb.append("- ")
-                    .append(fate.label)
-                    .append(": ")
-                    .append(ActionCardStatsService.formatPercent(count.getWinRate()))
-                    .append(" win rate (")
-                    .append(count.getWins())
-                    .append('/')
-                    .append(count.getPlayers())
-                    .append("; ")
-                    .append(ActionCardStatsService.formatPercent(count.getPlayers() / (double) playersWithASupport))
-                    .append(" of players)\n");
-        }
+        appendLocationLine(sb, "Kept it", stats.keptIt, playersWithASupport);
+        appendLocationLine(sb, "Gave away", stats.gaveAway, playersWithASupport);
         blocks.add(sb.toString());
+    }
+
+    private static void appendLocationLine(
+            StringBuilder sb, String label, WinRateCount count, int playersWithASupport) {
+        sb.append("- ")
+                .append(label)
+                .append(": ")
+                .append(ActionCardStatsService.formatPercent(count.getWinRate()))
+                .append(" win rate (")
+                .append(count.getWins())
+                .append('/')
+                .append(count.getPlayers())
+                .append("; ")
+                .append(ActionCardStatsService.formatPercent(count.getPlayers() / (double) playersWithASupport))
+                .append(" of players)\n");
+    }
+
+    private static void appendSwapSection(List<String> blocks, SupportStats stats) {
+        blocks.add("### Support swaps\n"
+                + "_Two players who each ended the game holding the other's Support for the Throne._\n");
+
+        StringBuilder sb = new StringBuilder("- Swaps per game: ");
+        sb.append(String.format("%.2f", stats.swaps / (double) stats.games)).append(" on average\n");
+        stats.gamesBySwapCount.forEach((swaps, games) ->
+                appendSwapCountLine(sb, swaps + (swaps == 1 ? " swap" : " swaps"), games, stats.games));
+        int gamesWithASwap = stats.gamesBySwapCount.entrySet().stream()
+                .filter(entry -> entry.getKey() > 0)
+                .mapToInt(Entry::getValue)
+                .sum();
+        appendSwapCountLine(sb, "1+ swaps", gamesWithASwap, stats.games);
+        appendSwapRate(sb, stats);
+        appendSwapWinRates(sb, stats);
+        blocks.add(sb.toString());
+    }
+
+    private static void appendSwapCountLine(StringBuilder sb, String label, int games, int totalGames) {
+        sb.append("  - ")
+                .append(label)
+                .append(": ")
+                .append(games)
+                .append(" game(s) (")
+                .append(ActionCardStatsService.formatPercent(games / (double) totalGames))
+                .append(")\n");
+    }
+
+    private static void appendSwapRate(StringBuilder sb, SupportStats stats) {
+        sb.append("- Swap rate: ");
+        if (stats.supportsPlayed == 0) {
+            sb.append("no supports were played at all\n");
+            return;
+        }
+        sb.append(ActionCardStatsService.formatPercent(2.0 * stats.swaps / stats.supportsPlayed))
+                .append(" (")
+                .append(2 * stats.swaps)
+                .append('/')
+                .append(stats.supportsPlayed)
+                .append(" of the supports played)\n");
+    }
+
+    private static void appendSwapWinRates(StringBuilder sb, SupportStats stats) {
+        if (stats.inASwap.getPlayers() == 0 && stats.gaveAwayOutsideASwap.getPlayers() == 0) {
+            return;
+        }
+        sb.append("- Win rate after giving a support away:\n");
+        appendSwapWinRateLine(sb, "Swap", stats.inASwap);
+        appendSwapWinRateLine(sb, "No swap", stats.gaveAwayOutsideASwap);
+    }
+
+    private static void appendSwapWinRateLine(StringBuilder sb, String label, WinRateCount count) {
+        sb.append("  - ")
+                .append(label)
+                .append(": ")
+                .append(ActionCardStatsService.formatPercent(count.getWinRate()))
+                .append(" (")
+                .append(count.getWins())
+                .append('/')
+                .append(count.getPlayers())
+                .append(")\n");
     }
 
     private static void appendFactionSection(List<String> blocks, SupportStats stats) {
@@ -338,69 +374,6 @@ public class SupportWinRateStatisticsService {
                 .toString();
     }
 
-    private static void appendSwapSection(List<String> blocks, SupportStats stats) {
-        blocks.add("### Support swaps\n"
-                + "_Two players who each ended the game holding the other's Support for the Throne._\n");
-
-        int gamesWithASwap = stats.gamesBySwapCount.entrySet().stream()
-                .filter(entry -> entry.getKey() > 0)
-                .mapToInt(Entry::getValue)
-                .sum();
-        StringBuilder sb = new StringBuilder("- Games with at least one swap: ");
-        sb.append(gamesWithASwap)
-                .append('/')
-                .append(stats.games)
-                .append(" (")
-                .append(ActionCardStatsService.formatPercent(gamesWithASwap / (double) stats.games))
-                .append(")\n");
-        sb.append("- Swaps per game: ")
-                .append(String.format("%.2f", stats.swaps / (double) stats.games))
-                .append(" on average\n");
-        stats.gamesBySwapCount.forEach((swaps, games) -> sb.append("  - ")
-                .append(swaps)
-                .append(swaps == 1 ? " swap: " : " swaps: ")
-                .append(games)
-                .append(" game(s) (")
-                .append(ActionCardStatsService.formatPercent(games / (double) stats.games))
-                .append(")\n"));
-        appendReciprocalSupports(sb, stats);
-        appendSwapWinRates(sb, stats);
-        blocks.add(sb.toString());
-    }
-
-    private static void appendReciprocalSupports(StringBuilder sb, SupportStats stats) {
-        sb.append("- Supports played into a swap: ");
-        if (stats.supportsPlayed == 0) {
-            sb.append("no supports were played at all\n");
-            return;
-        }
-        sb.append(2 * stats.swaps)
-                .append('/')
-                .append(stats.supportsPlayed)
-                .append(" (")
-                .append(ActionCardStatsService.formatPercent(2.0 * stats.swaps / stats.supportsPlayed))
-                .append(" of the supports played)\n");
-    }
-
-    private static void appendSwapWinRates(StringBuilder sb, SupportStats stats) {
-        if (stats.inASwap.getPlayers() == 0 && stats.gaveAwayOutsideASwap.getPlayers() == 0) {
-            return;
-        }
-        sb.append("- Win rate after giving a support away: ")
-                .append(ActionCardStatsService.formatPercent(stats.inASwap.getWinRate()))
-                .append(" (")
-                .append(stats.inASwap.getWins())
-                .append('/')
-                .append(stats.inASwap.getPlayers())
-                .append(") in a swap, ")
-                .append(ActionCardStatsService.formatPercent(stats.gaveAwayOutsideASwap.getWinRate()))
-                .append(" (")
-                .append(stats.gaveAwayOutsideASwap.getWins())
-                .append('/')
-                .append(stats.gaveAwayOutsideASwap.getPlayers())
-                .append(") outside one\n");
-    }
-
     private static String formatPercentagePointGap(double gap) {
         return String.format("%+.1f pts", gap * 100);
     }
@@ -414,7 +387,9 @@ public class SupportWinRateStatisticsService {
     private static class SupportStats {
         final NavigableMap<Integer, WinRateCount> playersBySupportsHeld = new TreeMap<>();
 
-        final Map<SupportFate, WinRateCount> playersByFate = new HashMap<>();
+        final WinRateCount keptIt = new WinRateCount();
+
+        final WinRateCount gaveAway = new WinRateCount();
 
         final FactionSupportStats overall = new FactionSupportStats();
 
@@ -427,8 +402,8 @@ public class SupportWinRateStatisticsService {
         final WinRateCount gaveAwayOutsideASwap = new WinRateCount();
 
         int games;
+        int gamesWithoutSupportsInPlay;
         int players;
-        int playersWithoutASupport;
         int supportsHeldAtTheirRealCounts;
         int supportsPlayed;
         int swaps;

--- a/src/main/java/ti4/service/statistics/game/GameStatTypes.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatTypes.java
@@ -21,7 +21,6 @@ public enum GameStatTypes {
     WINNING_PATH("Winners Path to Victory", "Shows a count of each game's path to victory"),
     ENDING_ROUND_PHASE("End round and phase", "Shows how many games ended by round and phase"),
     PHASE_TIMES("Phase Times", "Shows how long each phase lasted, in days"),
-    SUPPORT_WIN_COUNT("Wins with SftT", "Shows a count of wins that occurred holding a Support for the Throne"),
     SECRET_OBJECTIVE_WIN_CHANCE("Secret objective win chance", "Shows win chance for secrets"),
     GAME_MODE_COUNT("Game count by mode", "Shows game counts and percentages for each game mode"),
     AVERAGE_MMR("Average MMR", "Show the average matchmaking rating of each game's players"),

--- a/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/GameStatisticsService.java
@@ -44,7 +44,6 @@ public class GameStatisticsService {
                 case AVERAGE_MMR -> AverageGameMmrStatisticsService.showAverageGameMmr(event);
                 case GAME_MODE_COUNT -> GameModeStatisticsService.showModeCounts(event);
                 case WINNING_PATH -> WinningPathsStatisticsService.showWinningPaths(event);
-                case SUPPORT_WIN_COUNT -> WinningPathsStatisticsService.showWinsWithSupport(event);
                 case SECRET_OBJECTIVE_WIN_CHANCE ->
                     SecretObjectiveWinChanceStatisticsService.showSecretObjectiveWinChance(event);
                 case ENDING_ROUND_PHASE -> EndingRoundPhaseStatisticsService.showEndingRoundPhaseStatistics(event);

--- a/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
+++ b/src/main/java/ti4/service/statistics/game/WinningPathsStatisticsService.java
@@ -47,41 +47,4 @@ class WinningPathsStatisticsService {
             winningPathCount.put(path, 1 + winningPathCount.getOrDefault(path, 0));
         });
     }
-
-    static void showWinsWithSupport(SlashCommandInteractionEvent event) {
-        Map<Integer, Integer> supportWinCount = new HashMap<>();
-        AtomicInteger gameWithWinnerCount = new AtomicInteger();
-
-        ConsumeGameUtility.consumeAllGames(
-                GameStatisticsFilterer.getGamesFilterForWonGame(event),
-                game -> getWinsWithSupport(game, supportWinCount, gameWithWinnerCount),
-                ExecutionLockType.READ);
-
-        AtomicInteger atomicInteger = new AtomicInteger();
-        StringBuilder sb = new StringBuilder();
-        sb.append("__**Winning Paths Holding _Support for the Throne_ Count:**__")
-                .append('\n');
-        supportWinCount.entrySet().stream()
-                .sorted(Map.Entry.<Integer, Integer>comparingByValue().reversed())
-                .forEach(entry -> sb.append(atomicInteger.getAndIncrement() + 1)
-                        .append(". `")
-                        .append(entry.getValue().toString())
-                        .append(" (")
-                        .append(Math.round(100 * entry.getValue() / (double) gameWithWinnerCount.get()))
-                        .append("%)` ")
-                        .append(entry.getKey())
-                        .append(" _Support for the Throne_ wins")
-                        .append('\n'));
-        MessageHelper.sendMessageToThread(
-                (MessageChannelUnion) event.getMessageChannel(), "Support for the Throne wins", sb.toString());
-    }
-
-    private static void getWinsWithSupport(
-            Game game, Map<Integer, Integer> supportWinCount, AtomicInteger gameWithWinnerCount) {
-        game.getWinner().ifPresent(winner -> {
-            gameWithWinnerCount.getAndIncrement();
-            int supportCount = winner.getSupportForTheThroneVictoryPoints();
-            supportWinCount.put(supportCount, 1 + supportWinCount.getOrDefault(supportCount, 0));
-        });
-    }
 }

--- a/src/test/java/ti4/service/statistics/SupportWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/SupportWinRateStatisticsServiceTest.java
@@ -1,0 +1,275 @@
+package ti4.service.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.testUtils.BaseTi4Test;
+
+class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
+
+    private static final int MINIMUM_SAMPLE = 25;
+
+    private static final int VICTORY_POINT_GOAL = 3;
+
+    private static final List<String> COLORS = List.of("red", "blue", "green", "yellow", "purple", "orange");
+
+    @Test
+    void shouldBandPlayersByHowManySupportsTheyHeld() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        Player letnev = addPlayer(game, "letnev", false);
+        Player jolnar = addPlayer(game, "jolnar", false);
+        playSupport(letnev, sol);
+        playSupport(jolnar, sol);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 3\n");
+        assertThat(report).contains("- **All players**: 0.67 supports held on average, from 3 players\n");
+        assertThat(report).contains("  - 0 supports: 0% (0/2; 66.67%)\n");
+        assertThat(report).contains("  - 2 supports: 100% (1/1; 33.33%)\n");
+    }
+
+    @Test
+    void shouldSayOneSupportInTheSingular() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        playSupport(addPlayer(game, "letnev", false), sol);
+
+        assertThat(render(List.of(game))).contains("  - 1 support: 100% (1/1; 50%)\n");
+    }
+
+    /** A player's own support sitting in their own play area is not a point anyone gave them. */
+    @Test
+    void shouldNotCountAPlayersOwnSupportAsOneTheyHold() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        addPlayer(game, "letnev", false);
+        sol.addPromissoryNoteToPlayArea(sol.getColor() + "_sftt");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("- **All players**: 0.00 supports held on average, from 2 players\n");
+        assertThat(report).contains("  - 0 supports: 50% (1/2; 100%)\n");
+        assertThat(report).contains("- Kept it: 50% win rate (1/2; 100% of players)\n");
+    }
+
+    @Test
+    void shouldSplitOnWhereAPlayersOwnSupportEndedUp() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        Player letnev = addPlayer(game, "letnev", false);
+        Player jolnar = addPlayer(game, "jolnar", false);
+        Player hacan = addPlayer(game, "hacan", false);
+        // Letnev's support was played for the point, Jol-Nar's was traded but never played, and
+        // Hacan's left the game entirely.
+        playSupport(letnev, sol);
+        handSupportOver(jolnar, sol);
+        discardSupport(hacan);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("### Win rate by what became of your own support\n");
+        assertThat(report).contains("- Kept it: 100% win rate (1/1; 25% of players)\n");
+        assertThat(report).contains("- Given away and played for the point: 0% win rate (0/1; 25% of players)\n");
+        assertThat(report).contains("- Given away but never played: 0% win rate (0/1; 25% of players)\n");
+        assertThat(report).contains("- No longer anywhere in the game: 0% win rate (0/1; 25% of players)\n");
+    }
+
+    @Test
+    void shouldLeavePlayersWhoOwnNoSupportOutOfTheOwnSupportSection() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", true);
+        Player letnev = addPlayer(game, "letnev", false);
+        letnev.removeOwnedPromissoryNoteByID(letnev.getColor() + "_sftt");
+        letnev.removePromissoryNote(letnev.getColor() + "_sftt");
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("Players analyzed: 2\n");
+        assertThat(report)
+                .contains("_1 player(s) owned no Support for the Throne at all and are left out of this section._\n");
+        assertThat(report).contains("- Kept it: 100% win rate (1/1; 100% of players)\n");
+    }
+
+    @Test
+    void shouldGiveAFactionItsOwnRowOnlyOnceBothSidesOfTheSplitAreSampled() {
+        Consumer<Game> table = game -> {
+            Player sol = addPlayer(game, "sol", true);
+            playSupport(addPlayer(game, "letnev", false), sol);
+        };
+
+        // Sol always holds a support and Letnev never does, so neither side ever splits.
+        assertThat(render(repeatGame(MINIMUM_SAMPLE, table)))
+                .contains("- No faction had enough players on both sides of the split.\n");
+    }
+
+    @Test
+    void shouldRankFactionsByTheGapBetweenHoldingASupportAndNot() {
+        List<Game> games = new ArrayList<>();
+        // Sol wins whenever it is handed a support and loses when it is not.
+        games.addAll(repeatGame(MINIMUM_SAMPLE, "won", game -> {
+            Player sol = addPlayer(game, "sol", true);
+            playSupport(addPlayer(game, "letnev", false), sol);
+        }));
+        games.addAll(repeatGame(MINIMUM_SAMPLE, "lost", game -> {
+            addPlayer(game, "sol", false);
+            addPlayer(game, "letnev", true);
+        }));
+
+        String report = render(games);
+
+        assertThat(report)
+                .contains("- **All factions**: +66.7 pts - 100% (25/25) holding one, 33.33% (25/75) holding none\n");
+        assertThat(report).contains("+100.0 pts - 100% (25/25) holding one, 0% (0/25) holding none\n");
+        assertThat(report).contains("The Federation of Sol");
+        // Letnev never held one, so it has no split to report.
+        assertThat(report).doesNotContain("Barony");
+    }
+
+    @Test
+    void shouldCountTwoPlayersHoldingEachOthersSupportAsOneSwap() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        Player letnev = addPlayer(game, "letnev", false);
+        Player jolnar = addPlayer(game, "jolnar", false);
+        playSupport(sol, letnev);
+        playSupport(letnev, sol);
+        playSupport(jolnar, sol);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("### Support swaps\n");
+        assertThat(report).contains("- Games with at least one swap: 1/1 (100%)\n");
+        assertThat(report).contains("- Swaps per game: 1.00 on average\n");
+        assertThat(report).contains("  - 1 swap: 1 game(s) (100%)\n");
+        assertThat(report).contains("- Supports played into a swap: 2/3 (66.67% of the supports played)\n");
+        assertThat(report)
+                .contains("- Win rate after giving a support away: 50% (1/2) in a swap, 0% (0/1)" + " outside one\n");
+    }
+
+    @Test
+    void shouldNotCallAOneWaySupportASwap() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        playSupport(addPlayer(game, "letnev", false), sol);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("- Games with at least one swap: 0/1 (0%)\n");
+        assertThat(report).contains("- Swaps per game: 0.00 on average\n");
+        assertThat(report).contains("  - 0 swaps: 1 game(s) (100%)\n");
+        assertThat(report).contains("- Supports played into a swap: 0/1 (0% of the supports played)\n");
+    }
+
+    /** A support handed over but left in hand is a trade, not a swap - nobody scored anything. */
+    @Test
+    void shouldNotCountUnplayedSupportsAsASwap() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        Player letnev = addPlayer(game, "letnev", false);
+        handSupportOver(sol, letnev);
+        handSupportOver(letnev, sol);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("- Games with at least one swap: 0/1 (0%)\n");
+        assertThat(report).contains("- Supports played into a swap: no supports were played at all\n");
+        assertThat(report).contains("- Given away but never played: 50% win rate (1/2; 100% of players)\n");
+    }
+
+    @Test
+    void shouldCountBothSwapsAtATableThatTradedTwice() {
+        Game game = newGame("1");
+        Player sol = addPlayer(game, "sol", true);
+        Player letnev = addPlayer(game, "letnev", false);
+        Player jolnar = addPlayer(game, "jolnar", false);
+        Player hacan = addPlayer(game, "hacan", false);
+        playSupport(sol, letnev);
+        playSupport(letnev, sol);
+        playSupport(jolnar, hacan);
+        playSupport(hacan, jolnar);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("- Swaps per game: 2.00 on average\n");
+        assertThat(report).contains("  - 2 swaps: 1 game(s) (100%)\n");
+        assertThat(report).contains("- Supports played into a swap: 4/4 (100% of the supports played)\n");
+    }
+
+    @Test
+    void shouldSayNothingMatchedWhenNoGameHadAWinner() {
+        Game game = newGame("1");
+        addPlayer(game, "sol", false);
+        addPlayer(game, "letnev", false);
+
+        String report = render(List.of(game));
+
+        assertThat(report).contains("No games matched.\n");
+        assertThat(report).doesNotContain("### Support swaps");
+    }
+
+    private static List<Game> repeatGame(int count, Consumer<Game> seatPlayers) {
+        return repeatGame(count, "", seatPlayers);
+    }
+
+    private static List<Game> repeatGame(int count, String prefix, Consumer<Game> seatPlayers) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(i -> {
+                    Game game = newGame(prefix + i);
+                    seatPlayers.accept(game);
+                    return game;
+                })
+                .toList();
+    }
+
+    private static String render(List<Game> games) {
+        return String.join("", SupportWinRateStatisticsService.buildReport(games));
+    }
+
+    private static Game newGame(String suffix) {
+        Game game = new Game();
+        game.setName("support-stats-" + suffix);
+        // The goal has to sit above the most supports anyone at these tables holds, or a player
+        // handed a support would meet it too and the game would have no single winner.
+        game.setVp(VICTORY_POINT_GOAL);
+        game.setRound(3);
+        game.setHasEnded(true);
+        return game;
+    }
+
+    private static Player addPlayer(Game game, String faction, boolean isWinner) {
+        Player player = game.addPlayer(faction + "-user-" + game.getName(), faction);
+        player.setFaction(faction);
+        player.setColor(COLORS.get(game.getPlayers().size() - 1));
+        player.addOwnedPromissoryNoteByID(player.getColor() + "_sftt");
+        player.setPromissoryNote(player.getColor() + "_sftt");
+        if (isWinner) {
+            IntStream.rangeClosed(1, VICTORY_POINT_GOAL)
+                    .forEach(i -> player.setSecretScored("so-" + i + "-" + faction + "-" + game.getName()));
+        }
+        return player;
+    }
+
+    /** The receiver played it to their play area, so it is a victory point against the giver. */
+    private static void playSupport(Player giver, Player receiver) {
+        giver.removePromissoryNote(giver.getColor() + "_sftt");
+        receiver.addPromissoryNoteToPlayArea(giver.getColor() + "_sftt");
+    }
+
+    /** Traded across the table but never played. */
+    private static void handSupportOver(Player giver, Player receiver) {
+        giver.removePromissoryNote(giver.getColor() + "_sftt");
+        receiver.setPromissoryNote(giver.getColor() + "_sftt");
+    }
+
+    private static void discardSupport(Player giver) {
+        giver.removePromissoryNote(giver.getColor() + "_sftt");
+    }
+}

--- a/src/test/java/ti4/service/statistics/SupportWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/SupportWinRateStatisticsServiceTest.java
@@ -45,21 +45,6 @@ class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
         assertThat(render(List.of(game))).contains("  - 1 support: 100% (1/1; 50%)\n");
     }
 
-    /** A player's own support sitting in their own play area is not a point anyone gave them. */
-    @Test
-    void shouldNotCountAPlayersOwnSupportAsOneTheyHold() {
-        Game game = newGame("1");
-        Player sol = addPlayer(game, "sol", true);
-        addPlayer(game, "letnev", false);
-        sol.addPromissoryNoteToPlayArea(sol.getColor() + "_sftt");
-
-        String report = render(List.of(game));
-
-        assertThat(report).contains("- **All players**: 0.00 supports held on average, from 2 players\n");
-        assertThat(report).contains("  - 0 supports: 50% (1/2; 100%)\n");
-        assertThat(report).contains("- Kept it: 50% win rate (1/2; 100% of players)\n");
-    }
-
     @Test
     void shouldSplitOnWhereAPlayersOwnSupportEndedUp() {
         Game game = newGame("1");

--- a/src/test/java/ti4/service/statistics/SupportWinRateStatisticsServiceTest.java
+++ b/src/test/java/ti4/service/statistics/SupportWinRateStatisticsServiceTest.java
@@ -46,41 +46,42 @@ class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldSplitOnWhereAPlayersOwnSupportEndedUp() {
+    void shouldSplitOnWhetherAPlayerGaveTheirOwnSupportAway() {
         Game game = newGame("1");
         Player sol = addPlayer(game, "sol", true);
         Player letnev = addPlayer(game, "letnev", false);
         Player jolnar = addPlayer(game, "jolnar", false);
         Player hacan = addPlayer(game, "hacan", false);
-        // Letnev's support was played for the point, Jol-Nar's was traded but never played, and
-        // Hacan's left the game entirely.
+        // Letnev and Jol-Nar gave theirs to Sol; Sol and Hacan still hold their own.
         playSupport(letnev, sol);
-        handSupportOver(jolnar, sol);
-        discardSupport(hacan);
+        playSupport(jolnar, sol);
 
         String report = render(List.of(game));
 
-        assertThat(report).contains("### Win rate by what became of your own support\n");
-        assertThat(report).contains("- Kept it: 100% win rate (1/1; 25% of players)\n");
-        assertThat(report).contains("- Given away and played for the point: 0% win rate (0/1; 25% of players)\n");
-        assertThat(report).contains("- Given away but never played: 0% win rate (0/1; 25% of players)\n");
-        assertThat(report).contains("- No longer anywhere in the game: 0% win rate (0/1; 25% of players)\n");
+        assertThat(report).contains("### Win rate by support location\n");
+        assertThat(report).contains("- Kept it: 50% win rate (1/2; 50% of players)\n");
+        assertThat(report).contains("- Gave away: 0% win rate (0/2; 50% of players)\n");
+        assertThat(hacan.getPromissoryNotes()).containsKey(hacan.getColor() + "_sftt");
     }
 
+    /** The Enlightenment ability leaves a player with no support to give. */
     @Test
-    void shouldLeavePlayersWhoOwnNoSupportOutOfTheOwnSupportSection() {
+    void shouldLeavePlayersWhoOwnNoSupportOutOfTheLocationSection() {
         Game game = newGame("1");
-        addPlayer(game, "sol", true);
+        Player sol = addPlayer(game, "sol", true);
         Player letnev = addPlayer(game, "letnev", false);
+        Player jolnar = addPlayer(game, "jolnar", false);
+        playSupport(jolnar, sol);
         letnev.removeOwnedPromissoryNoteByID(letnev.getColor() + "_sftt");
         letnev.removePromissoryNote(letnev.getColor() + "_sftt");
 
         String report = render(List.of(game));
 
-        assertThat(report).contains("Players analyzed: 2\n");
-        assertThat(report)
-                .contains("_1 player(s) owned no Support for the Throne at all and are left out of this section._\n");
-        assertThat(report).contains("- Kept it: 100% win rate (1/1; 100% of players)\n");
+        // Letnev is still one of the three players analyzed, just not one of the two with a support.
+        assertThat(report).contains("Players analyzed: 3\n");
+        assertThat(report).contains("- Kept it: 100% win rate (1/1; 50% of players)\n");
+        assertThat(report).contains("- Gave away: 0% win rate (0/1; 50% of players)\n");
+        assertThat(report).doesNotContain("owned no Support for the Throne");
     }
 
     @Test
@@ -96,26 +97,27 @@ class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
     }
 
     @Test
-    void shouldRankFactionsByTheGapBetweenHoldingASupportAndNot() {
+    void shouldSplitEachWellSampledFactionOnHoldingASupport() {
         List<Game> games = new ArrayList<>();
-        // Sol wins whenever it is handed a support and loses when it is not.
-        games.addAll(repeatGame(MINIMUM_SAMPLE, "won", game -> {
+        // Whoever is handed a support wins, so both Sol and Letnev see each side of the split.
+        games.addAll(repeatGame(MINIMUM_SAMPLE, "sol", game -> {
             Player sol = addPlayer(game, "sol", true);
             playSupport(addPlayer(game, "letnev", false), sol);
         }));
-        games.addAll(repeatGame(MINIMUM_SAMPLE, "lost", game -> {
+        games.addAll(repeatGame(MINIMUM_SAMPLE, "letnev", game -> {
             addPlayer(game, "sol", false);
-            addPlayer(game, "letnev", true);
+            Player letnev = addPlayer(game, "letnev", true);
+            playSupport(addPlayer(game, "jolnar", false), letnev);
         }));
 
         String report = render(games);
 
         assertThat(report)
-                .contains("- **All factions**: +66.7 pts - 100% (25/25) holding one, 33.33% (25/75) holding none\n");
-        assertThat(report).contains("+100.0 pts - 100% (25/25) holding one, 0% (0/25) holding none\n");
+                .contains("- **All factions**: +100.0 pts - 100% (50/50) holding one, 0% (0/75) holding none\n");
         assertThat(report).contains("The Federation of Sol");
-        // Letnev never held one, so it has no split to report.
-        assertThat(report).doesNotContain("Barony");
+        assertThat(report).contains("The Barony of Letnev");
+        // Jol-Nar only ever gave one away, so it has no with-a-support side to report.
+        assertThat(report).doesNotContain("Jol-Nar");
     }
 
     @Test
@@ -131,12 +133,15 @@ class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
         String report = render(List.of(game));
 
         assertThat(report).contains("### Support swaps\n");
-        assertThat(report).contains("- Games with at least one swap: 1/1 (100%)\n");
         assertThat(report).contains("- Swaps per game: 1.00 on average\n");
         assertThat(report).contains("  - 1 swap: 1 game(s) (100%)\n");
-        assertThat(report).contains("- Supports played into a swap: 2/3 (66.67% of the supports played)\n");
-        assertThat(report)
-                .contains("- Win rate after giving a support away: 50% (1/2) in a swap, 0% (0/1)" + " outside one\n");
+        assertThat(report).contains("  - 1+ swaps: 1 game(s) (100%)\n");
+        assertThat(report).contains("- Swap rate: 66.67% (2/3 of the supports played)\n");
+        assertThat(report).contains("- Win rate after giving a support away:\n");
+        assertThat(report).contains("  - Swap: 50% (1/2)\n");
+        assertThat(report).contains("  - No swap: 0% (0/1)\n");
+        // The swaps section is read before the faction split.
+        assertThat(report.indexOf("### Support swaps")).isLessThan(report.indexOf("by faction"));
     }
 
     @Test
@@ -147,26 +152,65 @@ class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
 
         String report = render(List.of(game));
 
-        assertThat(report).contains("- Games with at least one swap: 0/1 (0%)\n");
         assertThat(report).contains("- Swaps per game: 0.00 on average\n");
         assertThat(report).contains("  - 0 swaps: 1 game(s) (100%)\n");
-        assertThat(report).contains("- Supports played into a swap: 0/1 (0% of the supports played)\n");
+        assertThat(report).contains("  - 1+ swaps: 0 game(s) (0%)\n");
+        assertThat(report).contains("- Swap rate: 0% (0/1 of the supports played)\n");
     }
 
-    /** A support handed over but left in hand is a trade, not a swap - nobody scored anything. */
+    /** Nobody played a support, so the table almost certainly agreed not to use them. */
     @Test
-    void shouldNotCountUnplayedSupportsAsASwap() {
-        Game game = newGame("1");
-        Player sol = addPlayer(game, "sol", true);
-        Player letnev = addPlayer(game, "letnev", false);
-        handSupportOver(sol, letnev);
-        handSupportOver(letnev, sol);
+    void shouldDropGamesWhereEveryPlayerStillHoldsTheirOwnSupport() {
+        Game noneplayed = newGame("1");
+        addPlayer(noneplayed, "sol", true);
+        addPlayer(noneplayed, "letnev", false);
 
-        String report = render(List.of(game));
+        String report = render(List.of(noneplayed));
 
-        assertThat(report).contains("- Games with at least one swap: 0/1 (0%)\n");
-        assertThat(report).contains("- Supports played into a swap: no supports were played at all\n");
-        assertThat(report).contains("- Given away but never played: 50% win rate (1/2; 100% of players)\n");
+        assertThat(report).contains("No games matched.\n");
+        assertThat(report).contains("Dropped 1 game(s) that purged Support for the Throne or never played one.\n");
+    }
+
+    @Test
+    void shouldDropGamesFlaggedAsHavingPurgedSupports() {
+        Game purged = newGame("1");
+        Player sol = addPlayer(purged, "sol", true);
+        playSupport(addPlayer(purged, "letnev", false), sol);
+        purged.setStoredValue("removeSupports", "true");
+
+        // A support is sitting in a play area, but the game says they were purged, so it is stale data.
+        String report = render(List.of(purged));
+
+        assertThat(report).contains("No games matched.\n");
+        assertThat(report).contains("Dropped 1 game(s) that purged Support for the Throne or never played one.\n");
+    }
+
+    @Test
+    void shouldDropGamesWhoseSupportsWereRemovedOutright() {
+        Game purged = newGame("1");
+        for (String faction : List.of("sol", "letnev")) {
+            Player player = addPlayer(purged, faction, "sol".equals(faction));
+            player.removeOwnedPromissoryNoteByID(player.getColor() + "_sftt");
+            player.removePromissoryNote(player.getColor() + "_sftt");
+        }
+
+        assertThat(render(List.of(purged))).contains("No games matched.\n");
+    }
+
+    @Test
+    void shouldStillCountGamesAlongsideDroppedOnes() {
+        Game noneplayed = newGame("1");
+        addPlayer(noneplayed, "sol", true);
+        addPlayer(noneplayed, "letnev", false);
+
+        Game played = newGame("2");
+        Player sol = addPlayer(played, "sol", true);
+        playSupport(addPlayer(played, "letnev", false), sol);
+
+        String report = render(List.of(noneplayed, played));
+
+        assertThat(report).contains("Games analyzed: 1 | Players analyzed: 2\n");
+        assertThat(report).contains("Dropped 1 game(s) that purged Support for the Throne or never played one.\n");
     }
 
     @Test
@@ -185,7 +229,8 @@ class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
 
         assertThat(report).contains("- Swaps per game: 2.00 on average\n");
         assertThat(report).contains("  - 2 swaps: 1 game(s) (100%)\n");
-        assertThat(report).contains("- Supports played into a swap: 4/4 (100% of the supports played)\n");
+        assertThat(report).contains("  - 1+ swaps: 1 game(s) (100%)\n");
+        assertThat(report).contains("- Swap rate: 100% (4/4 of the supports played)\n");
     }
 
     @Test
@@ -246,15 +291,5 @@ class SupportWinRateStatisticsServiceTest extends BaseTi4Test {
     private static void playSupport(Player giver, Player receiver) {
         giver.removePromissoryNote(giver.getColor() + "_sftt");
         receiver.addPromissoryNoteToPlayArea(giver.getColor() + "_sftt");
-    }
-
-    /** Traded across the table but never played. */
-    private static void handSupportOver(Player giver, Player receiver) {
-        giver.removePromissoryNote(giver.getColor() + "_sftt");
-        receiver.setPromissoryNote(giver.getColor() + "_sftt");
-    }
-
-    private static void discardSupport(Player giver) {
-        giver.removePromissoryNote(giver.getColor() + "_sftt");
     }
 }


### PR DESCRIPTION
Replaces the one Support for the Throne statistic we had with a command that actually asks what the card does to a game.

### Removed

`/statistics game_statistics stat: support_win_count` counted how many supports the *winner* happened to be holding at the end. That tells you nothing about who gave one away, what it cost them, or whether holding one helps — and the same number is already visible in the winning-path breakdown.

### Added

`/statistics2 support_win_rates`, over the same games as the expedition win rates (`getStandardCompetitiveGamesFilter()`: 6-player, 10-victory-point, non-homebrew, non-Galactic-Event, non-Scenario, with winners). Four sections:

1. **Win rate by supports held** — per player, at each exact count, with the share of players who got that far and the average held.
2. **Win rate by support location** — kept it versus gave away.
3. **Support swaps** — average per game, the distribution including a `1+ swaps` row, what share of played supports were reciprocal, and win rate after giving a support away inside a swap versus outside one.
4. **Win rate holding another player's support, by faction** — with-versus-without, ranked by the gap in percentage points, gated at 25 players per faction and 10 on each side of the split so a thin sample can't top the list. An "All factions" row leads.

### Games that are dropped

A game says nothing about Support for the Throne if the card was not in play, so two kinds are excluded and counted in the header rather than silently swallowed:

- **Purged** — `getStoredValue("removeSupports")` is `"true"`, the flag `GameSurveyService` and the `HBREMOVESFTT` homebrew both set.
- **Never played** — no support sits in any play area at the end. That covers purged games whose flag was never set, and tables that informally agreed not to play them.

### Reading decisions worth knowing about

- A support can only be in two places: its owner's hand, or another player's play area. You cannot play your own, and no one else can hold yours in hand. So "gave away" is exactly "someone else's play area holds it", and the location split is binary.
- A **swap requires both cards to have reached a play area**. Since a player can only ever give their support away once, each player is in at most one swap, so the swap count is just `swappers / 2`.
- Players who own no support at all (the Enlightenment ability) stay in the analyzed count but out of the location section's denominators.

### Testing

14 tests in `SupportWinRateStatisticsServiceTest`, built on the same `buildReport(List<Game>)` seam `PlanetWinRateStatisticsService` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
