### PR TITLE
Rank matchmaking games by a simulated continuation of the game

### DIFF
--- a/src/main/java/ti4/discord/interactions/commands/developer/AnalyzeMatchmakingRankTies.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/AnalyzeMatchmakingRankTies.java
@@ -1,0 +1,39 @@
+package ti4.discord.interactions.commands.developer;
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import ti4.discord.interactions.commands.Subcommand;
+import ti4.executors.ExecutionLockType;
+import ti4.game.persistence.ConsumeGameUtility;
+import ti4.message.MessageHelper;
+import ti4.service.statistics.game.MatchmakingRankTieAnalysis;
+
+class AnalyzeMatchmakingRankTies extends Subcommand {
+
+    private static final int DEFAULT_SAMPLE_SIZE = 8;
+    private static final int MAX_SAMPLE_SIZE = 40;
+
+    AnalyzeMatchmakingRankTies() {
+        super("analyze_matchmaking_rank_ties", "Report why simulated matchmaking ranks still tie.");
+        addOptions(
+                new OptionData(OptionType.INTEGER, "sample_size", "Tied groups to print in detail - default 8", false));
+    }
+
+    @Override
+    public void execute(SlashCommandInteractionEvent event) {
+        int sampleSize =
+                Math.min(MAX_SAMPLE_SIZE, event.getOption("sample_size", DEFAULT_SAMPLE_SIZE, OptionMapping::getAsInt));
+        MessageHelper.sendMessageToChannel(
+                event.getMessageChannel(), "Analyzing simulated matchmaking rank ties across all games.");
+
+        var analysis = new MatchmakingRankTieAnalysis(sampleSize);
+        ConsumeGameUtility.consumeAllGames(analysis::consume, ExecutionLockType.READ);
+
+        MessageHelper.sendMessageToChannel(event.getMessageChannel(), analysis.summary());
+        for (String sample : analysis.getSamples()) {
+            MessageHelper.sendMessageToChannel(event.getMessageChannel(), sample);
+        }
+    }
+}

--- a/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
+++ b/src/main/java/ti4/discord/interactions/commands/developer/DeveloperCommand.java
@@ -30,6 +30,7 @@ public class DeveloperCommand implements ParentCommand {
                     new DeleteUserMessages(),
                     new PostMatchmakingButtons(),
                     new ModifyMatchmakingQueue(),
+                    new AnalyzeMatchmakingRankTies(),
                     new RunSql())
             .collect(Collectors.toMap(Subcommand::getName, subcommand -> subcommand));
 

--- a/src/main/java/ti4/helpers/StatusHelper.java
+++ b/src/main/java/ti4/helpers/StatusHelper.java
@@ -108,11 +108,7 @@ public final class StatusHelper {
             Map<String, Integer> secretsUnscored = player.getSecretsUnscored();
             for (Map.Entry<String, Integer> entry : secretsUnscored.entrySet()) {
                 String soID = entry.getKey();
-                if (ListPlayerInfoService.getObjectiveThreshold(soID, game) > 0
-                        && ListPlayerInfoService.getPlayerProgressOnObjective(soID, game, player)
-                                > (ListPlayerInfoService.getObjectiveThreshold(soID, game) - 1)
-                        && !"dp".equalsIgnoreCase(soID)) {
-
+                if (ListPlayerInfoService.canScoreStatusPhaseSecret(game, player, soID)) {
                     buttons.add(Buttons.green(
                             "preScoreObbie_SO_" + entry.getValue(),
                             Mapper.getSecretObjective(soID).getName()));
@@ -373,10 +369,7 @@ public final class StatusHelper {
             Map<String, Integer> secretsUnscored = player.getSecretsUnscored();
             for (Map.Entry<String, Integer> entry : secretsUnscored.entrySet()) {
                 String soID = entry.getKey();
-                if (ListPlayerInfoService.getObjectiveThreshold(soID, game) > 0
-                        && ListPlayerInfoService.getPlayerProgressOnObjective(soID, game, player)
-                                > (ListPlayerInfoService.getObjectiveThreshold(soID, game) - 1)
-                        && !"dp".equalsIgnoreCase(soID)) {
+                if (ListPlayerInfoService.canScoreStatusPhaseSecret(game, player, soID)) {
                     message3a
                             .append('\n')
                             .append(Mapper.getSecretObjective(soID).getRepresentation(false));

--- a/src/main/java/ti4/service/info/ListPlayerInfoService.java
+++ b/src/main/java/ti4/service/info/ListPlayerInfoService.java
@@ -2,6 +2,7 @@ package ti4.service.info;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -24,6 +25,7 @@ import ti4.logging.BotLogger;
 import ti4.logging.LogOrigin;
 import ti4.message.MessageHelper;
 import ti4.model.PublicObjectiveModel;
+import ti4.model.SecretObjectiveModel;
 import ti4.model.Source;
 import ti4.model.TechnologyModel.TechnologyType;
 import ti4.model.UnitModel;
@@ -1070,5 +1072,61 @@ public class ListPlayerInfoService {
             }
         }
         return 0;
+    }
+
+    public static boolean canScoreStatusPhaseSecret(Game game, Player player, String secretId) {
+        SecretObjectiveModel secretObjective = Mapper.getSecretObjective(secretId);
+        if (secretObjective == null || !"status".equalsIgnoreCase(secretObjective.getPhase())) {
+            return false;
+        }
+        int threshold = getObjectiveThreshold(secretId, game);
+        return threshold > 0 && getProgressOrZero(secretId, game, player) >= threshold;
+    }
+
+    public static List<String> getScoreableStatusPhaseSecrets(Game game, Player player) {
+        return player.getSecretsUnscored().keySet().stream()
+                .filter(secretId -> canScoreStatusPhaseSecret(game, player, secretId))
+                .sorted()
+                .toList();
+    }
+
+    public static List<String> getQualifyingPublicObjectiveIds(Game game, Player player) {
+        List<String> qualifying = new ArrayList<>();
+        for (String objectiveId : game.getRevealedPublicObjectives().keySet()) {
+            if (getPublicObjectivePoints(objectiveId) == null) {
+                continue;
+            }
+            if (game.getScoredPublicObjectives()
+                    .getOrDefault(objectiveId, List.of())
+                    .contains(player.getUserID())) {
+                continue;
+            }
+            int threshold = getObjectiveThreshold(objectiveId, game);
+            if (threshold > 0 && getProgressOrZero(objectiveId, game, player) >= threshold) {
+                qualifying.add(objectiveId);
+            }
+        }
+        qualifying.sort(Comparator.comparingInt((String objectiveId) -> publicObjectivePointsOrZero(objectiveId))
+                .reversed()
+                .thenComparing(Comparator.naturalOrder()));
+        return qualifying;
+    }
+
+    public static Integer getPublicObjectivePoints(String objectiveId) {
+        PublicObjectiveModel publicObjective = Mapper.getPublicObjective(objectiveId);
+        return publicObjective == null ? null : publicObjective.getPoints();
+    }
+
+    private static int publicObjectivePointsOrZero(String objectiveId) {
+        Integer points = getPublicObjectivePoints(objectiveId);
+        return points == null ? 0 : points;
+    }
+
+    private static int getProgressOrZero(String objectiveId, Game game, Player player) {
+        try {
+            return getPlayerProgressOnObjective(objectiveId, game, player);
+        } catch (Exception e) {
+            return 0;
+        }
     }
 }

--- a/src/main/java/ti4/service/statistics/game/MatchmakingGameRankEvaluator.java
+++ b/src/main/java/ti4/service/statistics/game/MatchmakingGameRankEvaluator.java
@@ -1,0 +1,303 @@
+package ti4.service.statistics.game;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import lombok.experimental.UtilityClass;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.helpers.Helper;
+import ti4.helpers.StatusHelper;
+import ti4.image.Mapper;
+import ti4.model.SecretObjectiveModel;
+import ti4.model.StrategyCardModel;
+import ti4.model.StrategyCardSetModel;
+import ti4.service.info.ListPlayerInfoService;
+
+@UtilityClass
+public class MatchmakingGameRankEvaluator {
+
+    private static final Set<String> SECRETS_THAT_CANNOT_BE_SCORED_ON_DEMAND = Set.of("ttfd", "bam", "pe");
+    private static final String PROVE_ENDURANCE = "pe";
+    private static final String ACTION_PHASE_CODE = "AP";
+    private static final String STATUS_PHASE_CODE = "SP";
+    private static final String ACTION_PHASE = "action";
+    private static final String IMPERIAL_AUTOMATION_ID = "pok8imperial";
+    private static final String TWILIGHTS_FALL_IMPERIAL_AUTOMATION_ID = "tf8";
+    private static final String IMPERIAL_CARD_NAME = "imperial";
+    private static final String AETERNA_CARD_NAME = "aeterna";
+    private static final int MECATOL_IMPERIAL_POINT = 1;
+    private static final int WINNER_RANK = 1;
+    private static final int FIRST_RANK_BELOW_WINNER = 2;
+
+    public static Map<String, Integer> evaluate(Game game) {
+        if (!game.isHasEnded()) {
+            return Map.of();
+        }
+        List<Player> winners = game.getWinners();
+        if (winners.size() != 1) {
+            return Map.of();
+        }
+
+        Player winner = winners.getFirst();
+        List<Player> contenders = game.getRealAndEliminatedPlayers().stream()
+                .filter(player -> !isSamePlayer(player, winner))
+                .toList();
+
+        Simulation simulation = new Simulation(game.getVp());
+        contenders.forEach(simulation::seed);
+
+        String phaseCode = EndingRoundPhaseStatisticsService.normalizePhaseCode(game.getPhaseOfGame());
+        if (ACTION_PHASE_CODE.equals(phaseCode)) {
+            simulateActionPhase(game, simulation, contenders);
+        } else if (STATUS_PHASE_CODE.equals(phaseCode)) {
+            simulateStatusPhase(game, simulation, contenders, winner);
+        }
+
+        return buildRanks(winner, contenders, simulation);
+    }
+
+    public static boolean isExcludedForWinnerCount(Game game) {
+        return someoneReachedTheGoal(game) && game.getWinners().size() != 1;
+    }
+
+    private static boolean someoneReachedTheGoal(Game game) {
+        return game.isHasEnded() && game.getHighestScore() >= game.getVp();
+    }
+
+    private static void simulateActionPhase(Game game, Simulation simulation, List<Player> contenders) {
+        List<Player> initiativeOrder = game.getActionPhaseTurnOrder().stream()
+                .filter(player -> containsPlayer(contenders, player))
+                .toList();
+        Player imperialHolder = findReadiedImperialHolder(game, initiativeOrder);
+
+        boolean imperialBonusPending = imperialHolder != null;
+        boolean firstPass = true;
+        boolean progressed = true;
+        while (progressed) {
+            progressed = false;
+            for (Player player : initiativeOrder) {
+                if (simulation.isFinished(player)) {
+                    continue;
+                }
+                if (firstPass && imperialBonusPending && isSamePlayer(player, imperialHolder)) {
+                    imperialBonusPending = false;
+                    simulation.award(player, imperialPrimaryPoints(game, player));
+                    progressed = true;
+                    continue;
+                }
+                String secretId = nextOnDemandActionSecret(player, simulation);
+                if (secretId == null) {
+                    continue;
+                }
+                simulation.consume(player, secretId);
+                simulation.award(player, secretPoints(secretId));
+                progressed = true;
+            }
+            firstPass = false;
+        }
+
+        for (Player player : initiativeOrder) {
+            if (!simulation.isFinished(player) && player.getSecretsUnscored().containsKey(PROVE_ENDURANCE)) {
+                simulation.award(player, secretPoints(PROVE_ENDURANCE));
+            }
+        }
+    }
+
+    private static void simulateStatusPhase(Game game, Simulation simulation, List<Player> contenders, Player winner) {
+        List<Player> scoringOrder = StatusHelper.getPlayersInScoringOrder(game);
+        int winnerIndex = indexOfPlayer(scoringOrder, winner);
+        if (winnerIndex < 0) {
+            return;
+        }
+        for (Player player : scoringOrder.subList(winnerIndex + 1, scoringOrder.size())) {
+            if (!containsPlayer(contenders, player)) {
+                continue;
+            }
+            simulation.award(
+                    player,
+                    bestScoreableStatusSecretPoints(game, player) + bestQualifyingPublicObjectivePoints(game, player));
+        }
+    }
+
+    private static Map<String, Integer> buildRanks(Player winner, List<Player> contenders, Simulation simulation) {
+        Map<String, Integer> ranks = new HashMap<>();
+        ranks.put(winner.getUserID(), WINNER_RANK);
+
+        for (int i = 0; i < simulation.crossedGoalInOrder.size(); i++) {
+            ranks.put(simulation.crossedGoalInOrder.get(i), FIRST_RANK_BELOW_WINNER + i);
+        }
+
+        List<Player> remaining = contenders.stream()
+                .filter(player -> !simulation.isFinished(player))
+                .sorted(Comparator.comparingInt(simulation::score).reversed().thenComparing(Player::getUserID))
+                .toList();
+
+        int firstRemainingRank = FIRST_RANK_BELOW_WINNER + simulation.crossedGoalInOrder.size();
+        int rankOfCurrentScore = firstRemainingRank;
+        Integer currentScore = null;
+        for (int i = 0; i < remaining.size(); i++) {
+            Player player = remaining.get(i);
+            int score = simulation.score(player);
+            if (currentScore == null || score != currentScore) {
+                currentScore = score;
+                rankOfCurrentScore = firstRemainingRank + i;
+            }
+            ranks.put(player.getUserID(), rankOfCurrentScore);
+        }
+        return ranks;
+    }
+
+    private static String nextOnDemandActionSecret(Player player, Simulation simulation) {
+        return player.getSecretsUnscored().keySet().stream()
+                .filter(secretId -> !SECRETS_THAT_CANNOT_BE_SCORED_ON_DEMAND.contains(secretId))
+                .filter(secretId -> !simulation.hasConsumed(player, secretId))
+                .filter(MatchmakingGameRankEvaluator::isActionPhaseSecret)
+                .sorted()
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean isActionPhaseSecret(String secretId) {
+        SecretObjectiveModel secretObjective = Mapper.getSecretObjective(secretId);
+        return secretObjective != null && ACTION_PHASE.equalsIgnoreCase(secretObjective.getPhase());
+    }
+
+    private static int secretPoints(String secretId) {
+        SecretObjectiveModel secretObjective = Mapper.getSecretObjective(secretId);
+        return secretObjective == null ? 0 : secretObjective.getPoints();
+    }
+
+    private static int bestScoreableStatusSecretPoints(Game game, Player player) {
+        return ListPlayerInfoService.getScoreableStatusPhaseSecrets(game, player).stream()
+                .mapToInt(MatchmakingGameRankEvaluator::secretPoints)
+                .max()
+                .orElse(0);
+    }
+
+    private static int bestQualifyingPublicObjectivePoints(Game game, Player player) {
+        if (!Helper.canPlayerScorePOs(game, player)) {
+            return 0;
+        }
+        List<String> qualifying = ListPlayerInfoService.getQualifyingPublicObjectiveIds(game, player);
+        if (qualifying.isEmpty()) {
+            return 0;
+        }
+        Integer points = ListPlayerInfoService.getPublicObjectivePoints(qualifying.getFirst());
+        return points == null ? 0 : points;
+    }
+
+    private static int imperialPrimaryPoints(Game game, Player player) {
+        int points = bestQualifyingPublicObjectivePoints(game, player);
+        if (player.controlsMecatol(true)) {
+            points += MECATOL_IMPERIAL_POINT;
+        }
+        return points;
+    }
+
+    private static Player findReadiedImperialHolder(Game game, List<Player> candidates) {
+        Integer imperialInitiative = findImperialInitiative(game);
+        if (imperialInitiative == null) {
+            return null;
+        }
+        return candidates.stream()
+                .filter(player -> player.getSCs().contains(imperialInitiative))
+                .filter(player -> !player.getExhaustedSCs().contains(imperialInitiative))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static Integer findImperialInitiative(Game game) {
+        StrategyCardSetModel strategyCardSet = game.getStrategyCardSet();
+        if (strategyCardSet == null) {
+            return null;
+        }
+        return strategyCardSet.getStrategyCardModels().stream()
+                .filter(Objects::nonNull)
+                .filter(card -> card.usesAutomationForSCID(IMPERIAL_AUTOMATION_ID)
+                        || card.usesAutomationForSCID(TWILIGHTS_FALL_IMPERIAL_AUTOMATION_ID))
+                .findFirst()
+                .or(() -> findCardByName(strategyCardSet, IMPERIAL_CARD_NAME))
+                .or(() -> findCardByName(strategyCardSet, AETERNA_CARD_NAME))
+                .map(StrategyCardModel::getInitiative)
+                .orElse(null);
+    }
+
+    private static Optional<StrategyCardModel> findCardByName(StrategyCardSetModel strategyCardSet, String name) {
+        return strategyCardSet.getStrategyCardModels().stream()
+                .filter(Objects::nonNull)
+                .filter(card -> name.equalsIgnoreCase(card.getName()))
+                .findFirst();
+    }
+
+    private static boolean isSamePlayer(Player left, Player right) {
+        return left != null && right != null && Objects.equals(left.getUserID(), right.getUserID());
+    }
+
+    private static boolean containsPlayer(List<Player> players, Player target) {
+        return players.stream().anyMatch(player -> isSamePlayer(player, target));
+    }
+
+    private static int indexOfPlayer(List<Player> players, Player target) {
+        for (int i = 0; i < players.size(); i++) {
+            if (isSamePlayer(players.get(i), target)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static final class Simulation {
+
+        private final int goal;
+        private final Map<String, Integer> scoreByUserId = new HashMap<>();
+        private final Map<String, Set<String>> consumedSecretsByUserId = new HashMap<>();
+        private final List<String> crossedGoalInOrder = new ArrayList<>();
+        private final Set<String> finished = new HashSet<>();
+
+        private Simulation(int goal) {
+            this.goal = goal;
+        }
+
+        private void seed(Player player) {
+            scoreByUserId.put(player.getUserID(), player.getTotalVictoryPoints());
+        }
+
+        private boolean isFinished(Player player) {
+            return finished.contains(player.getUserID());
+        }
+
+        private int score(Player player) {
+            return scoreByUserId.getOrDefault(player.getUserID(), 0);
+        }
+
+        private void award(Player player, int points) {
+            if (points <= 0 || isFinished(player)) {
+                return;
+            }
+            int updated = scoreByUserId.merge(player.getUserID(), points, Integer::sum);
+            if (updated >= goal) {
+                finished.add(player.getUserID());
+                crossedGoalInOrder.add(player.getUserID());
+            }
+        }
+
+        private boolean hasConsumed(Player player, String secretId) {
+            return consumedSecretsByUserId
+                    .getOrDefault(player.getUserID(), Set.of())
+                    .contains(secretId);
+        }
+
+        private void consume(Player player, String secretId) {
+            consumedSecretsByUserId
+                    .computeIfAbsent(player.getUserID(), userId -> new HashSet<>())
+                    .add(secretId);
+        }
+    }
+}

--- a/src/main/java/ti4/service/statistics/game/MatchmakingGameRankEvaluator.java
+++ b/src/main/java/ti4/service/statistics/game/MatchmakingGameRankEvaluator.java
@@ -36,7 +36,15 @@ public class MatchmakingGameRankEvaluator {
     private static final int WINNER_RANK = 1;
     private static final int FIRST_RANK_BELOW_WINNER = 2;
 
+    public record SimulatedStanding(int rank, int simulatedScore) {}
+
     public static Map<String, Integer> evaluate(Game game) {
+        Map<String, Integer> ranks = new HashMap<>();
+        evaluateStandings(game).forEach((userId, standing) -> ranks.put(userId, standing.rank()));
+        return ranks;
+    }
+
+    public static Map<String, SimulatedStanding> evaluateStandings(Game game) {
         if (!game.isHasEnded()) {
             return Map.of();
         }
@@ -60,7 +68,7 @@ public class MatchmakingGameRankEvaluator {
             simulateStatusPhase(game, simulation, contenders, winner);
         }
 
-        return buildRanks(winner, contenders, simulation);
+        return buildStandings(winner, contenders, simulation);
     }
 
     public static boolean isExcludedForWinnerCount(Game game) {
@@ -126,12 +134,14 @@ public class MatchmakingGameRankEvaluator {
         }
     }
 
-    private static Map<String, Integer> buildRanks(Player winner, List<Player> contenders, Simulation simulation) {
-        Map<String, Integer> ranks = new HashMap<>();
-        ranks.put(winner.getUserID(), WINNER_RANK);
+    private static Map<String, SimulatedStanding> buildStandings(
+            Player winner, List<Player> contenders, Simulation simulation) {
+        Map<String, SimulatedStanding> standings = new HashMap<>();
+        standings.put(winner.getUserID(), new SimulatedStanding(WINNER_RANK, winner.getTotalVictoryPoints()));
 
         for (int i = 0; i < simulation.crossedGoalInOrder.size(); i++) {
-            ranks.put(simulation.crossedGoalInOrder.get(i), FIRST_RANK_BELOW_WINNER + i);
+            String userId = simulation.crossedGoalInOrder.get(i);
+            standings.put(userId, new SimulatedStanding(FIRST_RANK_BELOW_WINNER + i, simulation.scoreOf(userId)));
         }
 
         List<Player> remaining = contenders.stream()
@@ -149,9 +159,9 @@ public class MatchmakingGameRankEvaluator {
                 currentScore = score;
                 rankOfCurrentScore = firstRemainingRank + i;
             }
-            ranks.put(player.getUserID(), rankOfCurrentScore);
+            standings.put(player.getUserID(), new SimulatedStanding(rankOfCurrentScore, score));
         }
-        return ranks;
+        return standings;
     }
 
     private static String nextOnDemandActionSecret(Player player, Simulation simulation) {
@@ -274,7 +284,11 @@ public class MatchmakingGameRankEvaluator {
         }
 
         private int score(Player player) {
-            return scoreByUserId.getOrDefault(player.getUserID(), 0);
+            return scoreOf(player.getUserID());
+        }
+
+        private int scoreOf(String userId) {
+            return scoreByUserId.getOrDefault(userId, 0);
         }
 
         private void award(Player player, int points) {

--- a/src/main/java/ti4/service/statistics/game/MatchmakingRankTieAnalysis.java
+++ b/src/main/java/ti4/service/statistics/game/MatchmakingRankTieAnalysis.java
@@ -1,0 +1,211 @@
+package ti4.service.statistics.game;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.ToIntFunction;
+import lombok.Getter;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.service.statistics.game.MatchmakingGameRankEvaluator.SimulatedStanding;
+
+public class MatchmakingRankTieAnalysis {
+
+    private static final String INITIATIVE = "initiative";
+
+    private static final Map<String, ToIntFunction<Player>> TIE_BREAKER_CANDIDATES = buildTieBreakerCandidates();
+
+    private final int sampleSize;
+
+    @Getter
+    private final List<String> samples = new ArrayList<>();
+
+    private int rankedGames;
+    private int gamesWithTies;
+    private long tiedPairs;
+    private long totalAdjacentPairs;
+    private long tiedAdjacentPairs;
+    private long pairsSeparatedByAnyBoardMetric;
+    private String lastSampledGame;
+    private final Map<Integer, Integer> tieGroupSizes = new TreeMap<>();
+    private final Map<String, Integer> tiesByPhase = new TreeMap<>();
+    private final Map<String, Long> separatedPairsByCandidate = new LinkedHashMap<>();
+
+    public MatchmakingRankTieAnalysis(int sampleSize) {
+        this.sampleSize = sampleSize;
+        TIE_BREAKER_CANDIDATES.keySet().forEach(name -> separatedPairsByCandidate.put(name, 0L));
+    }
+
+    private static Map<String, ToIntFunction<Player>> buildTieBreakerCandidates() {
+        Map<String, ToIntFunction<Player>> candidates = new LinkedHashMap<>();
+        candidates.put("victoryPoints", Player::getTotalVictoryPoints);
+        candidates.put("planets", player -> player.getPlanets().size());
+        candidates.put("secretsInHand", player -> player.getSecretsUnscored().size());
+        candidates.put("techs", player -> player.getTechs().size());
+        candidates.put("tradeGoods", Player::getTg);
+        candidates.put("turnsTaken", Player::getNumberOfTurns);
+        candidates.put(INITIATIVE, Player::getInitiative);
+        return candidates;
+    }
+
+    public void consume(Game game) {
+        Map<String, SimulatedStanding> standings;
+        try {
+            standings = MatchmakingGameRankEvaluator.evaluateStandings(game);
+        } catch (Exception e) {
+            return;
+        }
+        if (standings.isEmpty()) {
+            return;
+        }
+        rankedGames++;
+        countAdjacentPairs(standings);
+
+        Map<Integer, List<Player>> playersByRank = new TreeMap<>();
+        for (Player player : game.getRealAndEliminatedPlayers()) {
+            SimulatedStanding standing = standings.get(player.getUserID());
+            if (standing == null) continue;
+            playersByRank
+                    .computeIfAbsent(standing.rank(), rank -> new ArrayList<>())
+                    .add(player);
+        }
+
+        boolean gameHadTie = false;
+        for (Map.Entry<Integer, List<Player>> entry : playersByRank.entrySet()) {
+            List<Player> tied = entry.getValue();
+            if (tied.size() < 2) continue;
+            gameHadTie = true;
+            tieGroupSizes.merge(tied.size(), 1, Integer::sum);
+            tiesByPhase.merge(phaseOf(game), 1, Integer::sum);
+            scoreCandidates(tied);
+            recordSample(game, standings, entry.getKey(), tied);
+        }
+        if (gameHadTie) {
+            gamesWithTies++;
+        }
+    }
+
+    private void countAdjacentPairs(Map<String, SimulatedStanding> standings) {
+        List<Integer> ranks = standings.values().stream()
+                .map(SimulatedStanding::rank)
+                .sorted()
+                .toList();
+        for (int i = 0; i + 1 < ranks.size(); i++) {
+            totalAdjacentPairs++;
+            if (ranks.get(i).equals(ranks.get(i + 1))) {
+                tiedAdjacentPairs++;
+            }
+        }
+    }
+
+    private void scoreCandidates(List<Player> tied) {
+        for (int i = 0; i < tied.size(); i++) {
+            for (int j = i + 1; j < tied.size(); j++) {
+                tiedPairs++;
+                boolean separatedByBoardMetric = false;
+                for (Map.Entry<String, ToIntFunction<Player>> candidate : TIE_BREAKER_CANDIDATES.entrySet()) {
+                    int left = candidate.getValue().applyAsInt(tied.get(i));
+                    int right = candidate.getValue().applyAsInt(tied.get(j));
+                    if (left == right) continue;
+                    separatedPairsByCandidate.merge(candidate.getKey(), 1L, Long::sum);
+                    if (!INITIATIVE.equals(candidate.getKey())) {
+                        separatedByBoardMetric = true;
+                    }
+                }
+                if (separatedByBoardMetric) {
+                    pairsSeparatedByAnyBoardMetric++;
+                }
+            }
+        }
+    }
+
+    private void recordSample(Game game, Map<String, SimulatedStanding> standings, int rank, List<Player> tied) {
+        if (samples.size() >= sampleSize || game.getName().equals(lastSampledGame)) {
+            return;
+        }
+        lastSampledGame = game.getName();
+        StringBuilder sample = new StringBuilder();
+        sample.append('`')
+                .append(game.getName())
+                .append("` phase=")
+                .append(phaseOf(game))
+                .append(" goal=")
+                .append(game.getVp())
+                .append(" rank=")
+                .append(rank)
+                .append(" simulatedTotal=")
+                .append(standings.get(tied.getFirst().getUserID()).simulatedScore())
+                .append('\n');
+        for (Player player : tied) {
+            sample.append("  ").append(player.getFaction());
+            for (Map.Entry<String, ToIntFunction<Player>> candidate : TIE_BREAKER_CANDIDATES.entrySet()) {
+                sample.append(' ')
+                        .append(candidate.getKey())
+                        .append('=')
+                        .append(candidate.getValue().applyAsInt(player));
+            }
+            sample.append('\n');
+        }
+        samples.add(sample.toString());
+    }
+
+    private static String phaseOf(Game game) {
+        String phase = game.getPhaseOfGame();
+        return phase == null || phase.isBlank() ? "(none)" : phase;
+    }
+
+    public String summary() {
+        StringBuilder summary = new StringBuilder();
+        summary.append("## Simulated matchmaking rank ties\n");
+        summary.append("- ranked games: ").append(rankedGames).append('\n');
+        summary.append("- games with at least one tie: ")
+                .append(gamesWithTies)
+                .append(percentOf(gamesWithTies, rankedGames))
+                .append('\n');
+        summary.append("- adjacent pair tie rate: ")
+                .append(String.format(
+                        "%.4f (%d/%d)",
+                        totalAdjacentPairs == 0 ? 0.0 : tiedAdjacentPairs / (double) totalAdjacentPairs,
+                        tiedAdjacentPairs,
+                        totalAdjacentPairs))
+                .append('\n');
+        summary.append("- tied pairs: ").append(tiedPairs).append('\n');
+        summary.append("- tie group sizes: ").append(tieGroupSizes).append('\n');
+        summary.append("- ties by ending phase: ")
+                .append(sortedByValue(tiesByPhase))
+                .append('\n');
+        summary.append("\n### Tied pairs a candidate tie-breaker would separate\n");
+        for (Map.Entry<String, Long> entry : separatedPairsByCandidate.entrySet()) {
+            summary.append("- ")
+                    .append(entry.getKey())
+                    .append(": ")
+                    .append(entry.getValue())
+                    .append(percentOf(entry.getValue(), tiedPairs))
+                    .append('\n');
+        }
+        summary.append("- any board metric except ")
+                .append(INITIATIVE)
+                .append(": ")
+                .append(pairsSeparatedByAnyBoardMetric)
+                .append(percentOf(pairsSeparatedByAnyBoardMetric, tiedPairs))
+                .append('\n');
+        return summary.toString();
+    }
+
+    private static String percentOf(long value, long total) {
+        if (total == 0) {
+            return " (0.0%)";
+        }
+        return String.format(" (%.1f%%)", value * 100.0 / total);
+    }
+
+    private static Map<String, Integer> sortedByValue(Map<String, Integer> counts) {
+        Map<String, Integer> sorted = new LinkedHashMap<>();
+        counts.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .forEach(entry -> sorted.put(entry.getKey(), entry.getValue()));
+        return sorted;
+    }
+}

--- a/src/main/java/ti4/service/statistics/game/MatchmakingRankTieAnalysis.java
+++ b/src/main/java/ti4/service/statistics/game/MatchmakingRankTieAnalysis.java
@@ -14,6 +14,8 @@ import ti4.service.statistics.game.MatchmakingGameRankEvaluator.SimulatedStandin
 public class MatchmakingRankTieAnalysis {
 
     private static final String INITIATIVE = "initiative";
+    private static final int MINIMUM_RATED_PLAYERS = 5;
+    private static final int MAXIMUM_RATED_PLAYERS = 8;
 
     private static final Map<String, ToIntFunction<Player>> TIE_BREAKER_CANDIDATES = buildTieBreakerCandidates();
 
@@ -28,6 +30,7 @@ public class MatchmakingRankTieAnalysis {
     private long totalAdjacentPairs;
     private long tiedAdjacentPairs;
     private long pairsSeparatedByAnyBoardMetric;
+    private int gamesOutsideTheRatedCorpus;
     private String lastSampledGame;
     private final Map<Integer, Integer> tieGroupSizes = new TreeMap<>();
     private final Map<String, Integer> tiesByPhase = new TreeMap<>();
@@ -51,6 +54,12 @@ public class MatchmakingRankTieAnalysis {
     }
 
     public void consume(Game game) {
+        if (!isRatedByMatchmaking(game)) {
+            if (game.isHasEnded()) {
+                gamesOutsideTheRatedCorpus++;
+            }
+            return;
+        }
         Map<String, SimulatedStanding> standings;
         try {
             standings = MatchmakingGameRankEvaluator.evaluateStandings(game);
@@ -85,6 +94,11 @@ public class MatchmakingRankTieAnalysis {
         if (gameHadTie) {
             gamesWithTies++;
         }
+    }
+
+    private static boolean isRatedByMatchmaking(Game game) {
+        int playerCount = game.getRealAndEliminatedPlayers().size();
+        return !game.isAllianceMode() && playerCount >= MINIMUM_RATED_PLAYERS && playerCount <= MAXIMUM_RATED_PLAYERS;
     }
 
     private void countAdjacentPairs(Map<String, SimulatedStanding> standings) {
@@ -160,6 +174,9 @@ public class MatchmakingRankTieAnalysis {
         StringBuilder summary = new StringBuilder();
         summary.append("## Simulated matchmaking rank ties\n");
         summary.append("- ranked games: ").append(rankedGames).append('\n');
+        summary.append("- ended games skipped as outside the rated 5-8 player corpus: ")
+                .append(gamesOutsideTheRatedCorpus)
+                .append('\n');
         summary.append("- games with at least one tie: ")
                 .append(gamesWithTies)
                 .append(percentOf(gamesWithTies, rankedGames))

--- a/src/main/java/ti4/spring/service/persistence/PersistAllEntitiesService.java
+++ b/src/main/java/ti4/spring/service/persistence/PersistAllEntitiesService.java
@@ -15,10 +15,13 @@ import ti4.game.persistence.ManagedGame;
 import ti4.helpers.TIGLHelper;
 import ti4.logging.BotLogger;
 import ti4.service.map.FractureService;
+import ti4.service.statistics.game.MatchmakingGameRankEvaluator;
 
 @Service
 @RequiredArgsConstructor
 public class PersistAllEntitiesService {
+
+    private static final int MAX_LOGGED_EXCLUDED_GAMES = 25;
 
     private final GameEntityRepository gameEntityRepository;
     private final PlayerEntityRepository playerEntityRepository;
@@ -59,11 +62,13 @@ public class PersistAllEntitiesService {
 
         List<GameEntity> gameEntities = new ArrayList<>();
         List<TitleEntity> titleEntities = new ArrayList<>();
+        List<String> gamesExcludedForWinnerCount = new ArrayList<>();
         for (ManagedGame managedGame : GameManager.getManagedGames()) {
             Game game = managedGame.getGame();
             if (game.getRealAndEliminatedPlayers().size() < 3) continue;
 
-            var gameEntity = toEntity(game, userCache);
+            Map<String, Integer> simulatedRanks = evaluateSimulatedRanks(game, gamesExcludedForWinnerCount);
+            var gameEntity = toEntity(game, userCache, simulatedRanks);
             gameEntities.add(gameEntity);
             titleEntities.addAll(toTitleEntities(game, gameEntity, userCache));
         }
@@ -72,9 +77,33 @@ public class PersistAllEntitiesService {
         titleEntityRepository.saveAll(titleEntities);
         BotLogger.info(String.format("Persisted %,d game rows.", gameEntities.size()));
         BotLogger.info(String.format("Persisted %,d title rows.", titleEntities.size()));
+        logGamesExcludedForWinnerCount(gamesExcludedForWinnerCount);
     }
 
-    private GameEntity toEntity(Game game, Map<String, UserEntity> userCache) {
+    private static Map<String, Integer> evaluateSimulatedRanks(Game game, List<String> gamesExcludedForWinnerCount) {
+        try {
+            if (MatchmakingGameRankEvaluator.isExcludedForWinnerCount(game)) {
+                gamesExcludedForWinnerCount.add(game.getName());
+                return Map.of();
+            }
+            return MatchmakingGameRankEvaluator.evaluate(game);
+        } catch (Exception e) {
+            BotLogger.error("Failed to evaluate matchmaking ranks for " + game.getName(), e);
+            return Map.of();
+        }
+    }
+
+    private static void logGamesExcludedForWinnerCount(List<String> gameNames) {
+        if (gameNames.isEmpty()) {
+            return;
+        }
+        String sample = gameNames.stream().limit(MAX_LOGGED_EXCLUDED_GAMES).collect(Collectors.joining(", "));
+        BotLogger.info(String.format(
+                "Excluded %,d game(s) from matchmaking ranks for not having exactly one winner: %s",
+                gameNames.size(), sample));
+    }
+
+    private GameEntity toEntity(Game game, Map<String, UserEntity> userCache, Map<String, Integer> simulatedRanks) {
         var gameEntity = new GameEntity();
         gameEntity.setGameName(game.getName());
         gameEntity.setRound(game.getRound());
@@ -102,7 +131,7 @@ public class PersistAllEntitiesService {
 
         var players = gameEntity.getPlayers();
         for (Player player : game.getRealAndEliminatedPlayers()) {
-            var playerEntity = toEntity(player, gameEntity, userCache);
+            var playerEntity = toEntity(player, gameEntity, userCache, simulatedRanks.get(player.getUserID()));
             players.add(playerEntity);
         }
 
@@ -114,7 +143,8 @@ public class PersistAllEntitiesService {
         return endedDate == 0 ? null : endedDate;
     }
 
-    private PlayerEntity toEntity(Player player, GameEntity gameEntity, Map<String, UserEntity> userCache) {
+    private PlayerEntity toEntity(
+            Player player, GameEntity gameEntity, Map<String, UserEntity> userCache, Integer simulatedRank) {
         var playerEntity = new PlayerEntity();
 
         playerEntity.setFactionName(player.getFaction());
@@ -126,6 +156,7 @@ public class PersistAllEntitiesService {
         playerEntity.setEliminated(player.isEliminated());
         playerEntity.setWinner(player.getGame().getWinners().contains(player));
         playerEntity.setReplaced(!Objects.equals(player.getUserID(), player.getStatsTrackedUserID()));
+        playerEntity.setSimulatedRank(simulatedRank);
 
         playerEntity.setGame(gameEntity);
 

--- a/src/main/java/ti4/spring/service/persistence/PlayerEntity.java
+++ b/src/main/java/ti4/spring/service/persistence/PlayerEntity.java
@@ -61,6 +61,9 @@ public class PlayerEntity {
     @Column(name = "is_replaced")
     private boolean replaced;
 
+    @Column(name = "simulated_rank")
+    private Integer simulatedRank;
+
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGame.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGame.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import ti4.spring.service.persistence.GameEntity;
 import ti4.spring.service.persistence.PlayerEntity;
@@ -20,29 +21,19 @@ record MatchmakingGame(String name, long endedDate, List<MatchmakingPlayer> play
 
         return gamePlayers.entrySet().stream()
                 .map(entry -> toMatchmakingGame(entry.getKey(), entry.getValue()))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 
     private static MatchmakingGame toMatchmakingGame(GameEntity game, List<PlayerEntity> players) {
+        if (players.stream().anyMatch(player -> player.getSimulatedRank() == null)) {
+            return null;
+        }
         List<MatchmakingPlayer> matchmakingPlayers = players.stream()
-                .map(player -> {
-                    int rank = calculatePlayerRank(player.isWinner(), game.getVictoryPointGoal(), player.getScore());
-                    return new MatchmakingPlayer(
-                            player.getUser().getId(), player.getUser().getName(), rank);
-                })
+                .map(player -> new MatchmakingPlayer(
+                        player.getUser().getId(), player.getUser().getName(), player.getSimulatedRank()))
                 .toList();
         long endedDate = game.getEndedEpochMilliseconds();
         return new MatchmakingGame(game.getGameName(), endedDate, matchmakingPlayers);
-    }
-
-    private static int calculatePlayerRank(boolean isWinner, int gameVictoryPointGoal, int playerScore) {
-        if (isWinner) {
-            return 1;
-        }
-        int pointsAwayFromVictory = gameVictoryPointGoal - playerScore;
-        if (pointsAwayFromVictory <= 3) {
-            return 2;
-        }
-        return 3 + pointsAwayFromVictory;
     }
 }

--- a/src/test/java/ti4/service/statistics/game/MatchmakingGameRankEvaluatorTest.java
+++ b/src/test/java/ti4/service/statistics/game/MatchmakingGameRankEvaluatorTest.java
@@ -1,0 +1,334 @@
+package ti4.service.statistics.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.game.persistence.TestGameHarness;
+import ti4.testUtils.BaseTi4Test;
+
+class MatchmakingGameRankEvaluatorTest extends BaseTi4Test {
+
+    private static final int VICTORY_POINT_GOAL = 10;
+    private static final int IMPERIAL_STRATEGY_CARD = 8;
+    private static final String MECATOL_REX = "mr";
+
+    // Status-phase secrets, only ever used to hand out victory points. Never placed in a hand,
+    // so they cannot interfere with the action-phase simulation.
+    private static final List<String> SCORING_SECRETS =
+            List.of("pem", "otf", "mtm", "hrm", "eh", "dhw", "dfat", "te", "ose", "mrm", "mlp", "mp");
+
+    // Action-phase secrets that the simulation is allowed to score on demand.
+    private static final String ONE_POINT_ACTION_SECRET = "dtgs";
+    private static final String ANOTHER_ONE_POINT_ACTION_SECRET = "uf";
+    private static final String TWO_POINT_ACTION_SECRET = "savior";
+
+    // Action-phase secrets the spec excludes from the loop.
+    private static final String TURN_THEIR_FLEETS_TO_DUST = "ttfd";
+    private static final String BECOME_A_MARTYR = "bam";
+    private static final String PROVE_ENDURANCE = "pe";
+
+    // Adapt New Strategies: a status-phase secret that qualifies at 2 faction techs.
+    private static final String ADAPT_NEW_STRATEGIES = "ans";
+    private static final List<String> TWO_FACTION_TECHS = List.of("lw2", "l4");
+
+    private static final List<String> FACTIONS = List.of("sol", "hacan", "letnev", "xxcha", "arborec", "saar");
+    private static final List<String> COLORS = List.of("blue", "red", "green", "yellow", "black", "purple");
+
+    @Test
+    void returnsNoRanksWhenTheGameHasNotEnded() {
+        Game game = endedGame("action");
+        game.setHasEnded(false);
+        winnerWith(game, "winner", 1);
+        playerWith(game, "loser", 2, 5);
+
+        assertThat(MatchmakingGameRankEvaluator.evaluate(game)).isEmpty();
+    }
+
+    @Test
+    void returnsNoRanksWhenNobodyReachedTheGoal() {
+        Game game = endedGame("action");
+        playerWith(game, "first", 1, 9);
+        playerWith(game, "second", 2, 5);
+
+        assertThat(MatchmakingGameRankEvaluator.evaluate(game)).isEmpty();
+    }
+
+    @Test
+    void ranksTheWinnerFirst() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        playerWith(game, "second", 2, 8);
+        playerWith(game, "third", 3, 4);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("winner", 1);
+        assertThat(ranks).hasSize(3);
+    }
+
+    @Test
+    void actionPhaseSecretsAreScoredUntilTheHandIsDrained() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player climber = playerWith(game, "climber", 2, 8);
+        climber.setSecret(ONE_POINT_ACTION_SECRET);
+        climber.setSecret(ANOTHER_ONE_POINT_ACTION_SECRET);
+        playerWith(game, "static", 3, 8);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("winner", 1).containsEntry("climber", 2).containsEntry("static", 3);
+    }
+
+    @Test
+    void twoPointActionSecretsAreWorthTwoSimulatedPoints() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player doubleScorer = playerWith(game, "double", 2, 8);
+        doubleScorer.setSecret(TWO_POINT_ACTION_SECRET);
+        Player singleScorer = playerWith(game, "single", 3, 8);
+        singleScorer.setSecret(ONE_POINT_ACTION_SECRET);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("double", 2).containsEntry("single", 3);
+    }
+
+    @Test
+    void secretsThatCannotBeScoredOnDemandAreSkipped() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player blocked = playerWith(game, "blocked", 2, 8);
+        blocked.setSecret(TURN_THEIR_FLEETS_TO_DUST);
+        blocked.setSecret(BECOME_A_MARTYR);
+        Player scoring = playerWith(game, "scoring", 3, 8);
+        scoring.setSecret(ONE_POINT_ACTION_SECRET);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("scoring", 2).containsEntry("blocked", 3);
+    }
+
+    @Test
+    void proveEnduranceIsAwardedAfterTheLoop() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player enduring = playerWith(game, "enduring", 2, 9);
+        enduring.setSecret(PROVE_ENDURANCE);
+        playerWith(game, "other", 3, 9);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("enduring", 2).containsEntry("other", 3);
+    }
+
+    @Test
+    void theOrderOfCrossingTheGoalDeterminesRank() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player earlyInitiative = playerWith(game, "early", 2, 9);
+        earlyInitiative.setSecret(ONE_POINT_ACTION_SECRET);
+        Player lateInitiative = playerWith(game, "late", 3, 9);
+        lateInitiative.setSecret(ONE_POINT_ACTION_SECRET);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("early", 2).containsEntry("late", 3);
+    }
+
+    @Test
+    void aReadiedImperialHolderGainsTheMecatolPoint() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player imperial = playerWith(game, "imperial", IMPERIAL_STRATEGY_CARD, 9);
+        imperial.addPlanet(MECATOL_REX);
+        playerWith(game, "other", 2, 9);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("imperial", 2).containsEntry("other", 3);
+    }
+
+    @Test
+    void anExhaustedImperialHolderGainsNothing() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player imperial = playerWith(game, "imperial", IMPERIAL_STRATEGY_CARD, 9);
+        imperial.addPlanet(MECATOL_REX);
+        game.setSCPlayed(IMPERIAL_STRATEGY_CARD, true);
+        Player other = playerWith(game, "other", 2, 9);
+        other.setSecret(ONE_POINT_ACTION_SECRET);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("other", 2).containsEntry("imperial", 3);
+    }
+
+    @Test
+    void theImperialHolderStillScoresSecretsOnTheSecondPass() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player imperial = playerWith(game, "imperial", IMPERIAL_STRATEGY_CARD, 8);
+        imperial.addPlanet(MECATOL_REX);
+        imperial.setSecret(ONE_POINT_ACTION_SECRET);
+        playerWith(game, "other", 2, 9);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("imperial", 2).containsEntry("other", 3);
+    }
+
+    @Test
+    void onlyPlayersAfterTheWinnerScoreInTheStatusPhase() {
+        Game game = endedGame("statusScoring");
+        Player before = playerWith(game, "before", 1, 8);
+        qualifyForAdaptNewStrategies(before);
+        winnerWith(game, "winner", 3);
+        Player after = playerWith(game, "after", 5, 8);
+        qualifyForAdaptNewStrategies(after);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("winner", 1).containsEntry("after", 2).containsEntry("before", 3);
+    }
+
+    @Test
+    void agendaPhaseGamesAreRankedByPointTotalAlone() {
+        Game game = endedGame("agendaEnd");
+        winnerWith(game, "winner", 1);
+        Player high = playerWith(game, "high", 2, 8);
+        high.setSecret(ONE_POINT_ACTION_SECRET);
+        high.setSecret(ANOTHER_ONE_POINT_ACTION_SECRET);
+        playerWith(game, "tied", 3, 8);
+        playerWith(game, "low", 4, 5);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks).containsEntry("winner", 1);
+        assertThat(ranks).containsEntry("high", 2).containsEntry("tied", 2);
+        assertThat(ranks).containsEntry("low", 4);
+    }
+
+    @Test
+    void everyRealPlayerReceivesARank() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        playerWith(game, "second", 2, 8);
+        playerWith(game, "third", 3, 6);
+        playerWith(game, "fourth", 4, 2);
+
+        Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(ranks.keySet()).containsExactlyInAnyOrder("winner", "second", "third", "fourth");
+        assertThat(ranks.values()).allMatch(rank -> rank >= 1);
+    }
+
+    @Test
+    void repeatedEvaluationOfTheSameGameIsStable() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player first = playerWith(game, "first", 2, 7);
+        first.setSecret(ONE_POINT_ACTION_SECRET);
+        first.setSecret(ANOTHER_ONE_POINT_ACTION_SECRET);
+        Player second = playerWith(game, "second", 3, 7);
+        second.setSecret(TWO_POINT_ACTION_SECRET);
+
+        assertThat(MatchmakingGameRankEvaluator.evaluate(game)).isEqualTo(MatchmakingGameRankEvaluator.evaluate(game));
+    }
+
+    @Test
+    void evaluationDoesNotMutateTheGame() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        Player imperial = playerWith(game, "imperial", IMPERIAL_STRATEGY_CARD, 8);
+        imperial.addPlanet(MECATOL_REX);
+        imperial.setSecret(ONE_POINT_ACTION_SECRET);
+        Player other = playerWith(game, "other", 2, 8);
+        other.setSecret(TWO_POINT_ACTION_SECRET);
+        qualifyForAdaptNewStrategies(other);
+
+        String before = gameSnapshot(game);
+        MatchmakingGameRankEvaluator.evaluate(game);
+
+        assertThat(gameSnapshot(game)).isEqualTo(before);
+    }
+
+    @Test
+    void normalGamesAreNotFlaggedForWinnerCount() {
+        Game game = endedGame("action");
+        winnerWith(game, "winner", 1);
+        playerWith(game, "second", 2, 8);
+
+        assertThat(MatchmakingGameRankEvaluator.isExcludedForWinnerCount(game)).isFalse();
+    }
+
+    @Test
+    void handlesARealSaveWithoutThrowingOrMutating() {
+        try (TestGameHarness harness = TestGameHarness.forDefaultMap()) {
+            Game game = harness.load();
+            String before = gameSnapshot(game);
+
+            Map<String, Integer> ranks = MatchmakingGameRankEvaluator.evaluate(game);
+
+            assertThat(gameSnapshot(game)).isEqualTo(before);
+            assertThat(ranks.values()).allMatch(rank -> rank >= 1);
+        }
+    }
+
+    private static void qualifyForAdaptNewStrategies(Player player) {
+        player.setSecret(ADAPT_NEW_STRATEGIES);
+        TWO_FACTION_TECHS.forEach(player::addTech);
+    }
+
+    private static String gameSnapshot(Game game) {
+        StringBuilder snapshot = new StringBuilder();
+        snapshot.append(game.getScoredPublicObjectives())
+                .append(game.getRevealedPublicObjectives())
+                .append(game.getCustomPublicVP())
+                .append(game.getScPlayed())
+                .append(game.getPhaseOfGame());
+        for (Player player : game.getRealAndEliminatedPlayers()) {
+            snapshot.append(player.getUserID())
+                    .append(player.getSecrets())
+                    .append(player.getSecretsScored())
+                    .append(player.getSCs())
+                    .append(player.getPlanets())
+                    .append(player.getTechs());
+        }
+        return snapshot.toString();
+    }
+
+    private static Game endedGame(String phase) {
+        Game game = new Game();
+        game.setName("rank-evaluator-" + UUID.randomUUID());
+        game.newGameSetup();
+        game.setVp(VICTORY_POINT_GOAL);
+        game.setHasEnded(true);
+        game.setPhaseOfGame(phase);
+        return game;
+    }
+
+    private static Player winnerWith(Game game, String userId, int strategyCard) {
+        return playerWith(game, userId, strategyCard, VICTORY_POINT_GOAL);
+    }
+
+    private static Player playerWith(Game game, String userId, int strategyCard, int victoryPoints) {
+        int seat = game.getPlayers().size();
+        Player player = game.addPlayer(userId, userId);
+        player.setFaction(FACTIONS.get(seat % FACTIONS.size()));
+        player.setColor(COLORS.get(seat % COLORS.size()));
+        player.setSCs(Set.of(strategyCard));
+        AtomicInteger scored = new AtomicInteger();
+        while (scored.get() < victoryPoints) {
+            player.setSecretScored(SCORING_SECRETS.get(scored.getAndIncrement()));
+        }
+        return player;
+    }
+}

--- a/src/test/java/ti4/service/statistics/game/MatchmakingRankTieAnalysisTest.java
+++ b/src/test/java/ti4/service/statistics/game/MatchmakingRankTieAnalysisTest.java
@@ -13,21 +13,23 @@ import ti4.testUtils.BaseTi4Test;
 class MatchmakingRankTieAnalysisTest extends BaseTi4Test {
 
     private static final int VICTORY_POINT_GOAL = 10;
+    private static final int SAMPLE_SIZE = 5;
     private static final List<String> SCORING_SECRETS =
             List.of("pem", "otf", "mtm", "hrm", "eh", "dhw", "dfat", "te", "ose", "mrm");
-    private static final List<String> FACTIONS = List.of("sol", "hacan", "letnev", "xxcha");
-    private static final List<String> COLORS = List.of("blue", "red", "green", "yellow");
+    private static final List<String> FACTIONS = List.of("sol", "hacan", "letnev", "xxcha", "arborec", "saar");
+    private static final List<String> COLORS = List.of("blue", "red", "green", "yellow", "black", "purple");
 
     @Test
     void reportsATieAndTheMetricsThatWouldSeparateIt() {
-        Game game = agendaEndedGame();
+        Game game = endedGame();
         addPlayer(game, "winner", 1, VICTORY_POINT_GOAL);
-        Player firstTied = addPlayer(game, "tiedA", 2, 6);
-        Player secondTied = addPlayer(game, "tiedB", 3, 6);
-        addPlayer(game, "trailing", 4, 2);
-        firstTied.addPlanet("mr");
+        Player tiedWithAPlanet = addPlayer(game, "tiedA", 2, 6);
+        addPlayer(game, "tiedB", 3, 6);
+        addPlayer(game, "fourth", 4, 4);
+        addPlayer(game, "fifth", 5, 2);
+        tiedWithAPlanet.addPlanet("mr");
 
-        var analysis = new MatchmakingRankTieAnalysis(5);
+        var analysis = new MatchmakingRankTieAnalysis(SAMPLE_SIZE);
         analysis.consume(game);
         String summary = analysis.summary();
 
@@ -44,32 +46,86 @@ class MatchmakingRankTieAnalysisTest extends BaseTi4Test {
 
     @Test
     void reportsNothingForAGameWithoutTies() {
-        Game game = agendaEndedGame();
+        Game game = endedGame();
         addPlayer(game, "winner", 1, VICTORY_POINT_GOAL);
-        addPlayer(game, "second", 2, 7);
-        addPlayer(game, "third", 3, 4);
+        addPlayer(game, "second", 2, 8);
+        addPlayer(game, "third", 3, 6);
+        addPlayer(game, "fourth", 4, 4);
+        addPlayer(game, "fifth", 5, 2);
 
-        var analysis = new MatchmakingRankTieAnalysis(5);
+        var analysis = new MatchmakingRankTieAnalysis(SAMPLE_SIZE);
         analysis.consume(game);
 
+        assertThat(analysis.summary()).contains("ranked games: 1");
         assertThat(analysis.summary()).contains("games with at least one tie: 0");
         assertThat(analysis.summary()).contains("tied pairs: 0");
         assertThat(analysis.getSamples()).isEmpty();
     }
 
     @Test
-    void ignoresGamesThatCannotBeRanked() {
-        Game game = agendaEndedGame();
+    void ignoresGamesNobodyWon() {
+        Game game = endedGame();
         addPlayer(game, "first", 1, 4);
         addPlayer(game, "second", 2, 4);
+        addPlayer(game, "third", 3, 3);
+        addPlayer(game, "fourth", 4, 2);
+        addPlayer(game, "fifth", 5, 1);
 
-        var analysis = new MatchmakingRankTieAnalysis(5);
+        var analysis = new MatchmakingRankTieAnalysis(SAMPLE_SIZE);
         analysis.consume(game);
 
         assertThat(analysis.summary()).contains("ranked games: 0");
+        assertThat(analysis.summary()).contains("outside the rated 5-8 player corpus: 0");
     }
 
-    private static Game agendaEndedGame() {
+    @Test
+    void ignoresGamesBelowTheRatedPlayerCount() {
+        Game game = endedGame();
+        addPlayer(game, "winner", 1, VICTORY_POINT_GOAL);
+        addPlayer(game, "tiedA", 2, 6);
+        addPlayer(game, "tiedB", 3, 6);
+        addPlayer(game, "fourth", 4, 2);
+
+        var analysis = new MatchmakingRankTieAnalysis(SAMPLE_SIZE);
+        analysis.consume(game);
+
+        assertThat(analysis.summary()).contains("ranked games: 0");
+        assertThat(analysis.summary()).contains("outside the rated 5-8 player corpus: 1");
+    }
+
+    @Test
+    void ignoresGamesAboveTheRatedPlayerCount() {
+        Game game = endedGame();
+        addPlayer(game, "winner", 1, VICTORY_POINT_GOAL);
+        for (int seat = 1; seat <= 8; seat++) {
+            addPlayer(game, "player" + seat, seat, 6);
+        }
+
+        var analysis = new MatchmakingRankTieAnalysis(SAMPLE_SIZE);
+        analysis.consume(game);
+
+        assertThat(analysis.summary()).contains("ranked games: 0");
+        assertThat(analysis.summary()).contains("outside the rated 5-8 player corpus: 1");
+    }
+
+    @Test
+    void ignoresAllianceGames() {
+        Game game = endedGame();
+        game.setAllianceMode(true);
+        addPlayer(game, "winner", 1, VICTORY_POINT_GOAL);
+        addPlayer(game, "tiedA", 2, 6);
+        addPlayer(game, "tiedB", 3, 6);
+        addPlayer(game, "fourth", 4, 4);
+        addPlayer(game, "fifth", 5, 2);
+
+        var analysis = new MatchmakingRankTieAnalysis(SAMPLE_SIZE);
+        analysis.consume(game);
+
+        assertThat(analysis.summary()).contains("ranked games: 0");
+        assertThat(analysis.summary()).contains("outside the rated 5-8 player corpus: 1");
+    }
+
+    private static Game endedGame() {
         Game game = new Game();
         game.setName("tie-analysis-" + UUID.randomUUID());
         game.newGameSetup();

--- a/src/test/java/ti4/service/statistics/game/MatchmakingRankTieAnalysisTest.java
+++ b/src/test/java/ti4/service/statistics/game/MatchmakingRankTieAnalysisTest.java
@@ -1,0 +1,93 @@
+package ti4.service.statistics.game;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import ti4.game.Game;
+import ti4.game.Player;
+import ti4.testUtils.BaseTi4Test;
+
+class MatchmakingRankTieAnalysisTest extends BaseTi4Test {
+
+    private static final int VICTORY_POINT_GOAL = 10;
+    private static final List<String> SCORING_SECRETS =
+            List.of("pem", "otf", "mtm", "hrm", "eh", "dhw", "dfat", "te", "ose", "mrm");
+    private static final List<String> FACTIONS = List.of("sol", "hacan", "letnev", "xxcha");
+    private static final List<String> COLORS = List.of("blue", "red", "green", "yellow");
+
+    @Test
+    void reportsATieAndTheMetricsThatWouldSeparateIt() {
+        Game game = agendaEndedGame();
+        addPlayer(game, "winner", 1, VICTORY_POINT_GOAL);
+        Player firstTied = addPlayer(game, "tiedA", 2, 6);
+        Player secondTied = addPlayer(game, "tiedB", 3, 6);
+        addPlayer(game, "trailing", 4, 2);
+        firstTied.addPlanet("mr");
+
+        var analysis = new MatchmakingRankTieAnalysis(5);
+        analysis.consume(game);
+        String summary = analysis.summary();
+
+        assertThat(summary).contains("ranked games: 1");
+        assertThat(summary).contains("games with at least one tie: 1");
+        assertThat(summary).contains("tied pairs: 1");
+        assertThat(summary).contains("tie group sizes: {2=1}");
+        assertThat(summary).contains("planets: 1 (100.0%)");
+        assertThat(summary).contains("victoryPoints: 0 (0.0%)");
+        assertThat(summary).contains("any board metric except initiative: 1 (100.0%)");
+        assertThat(analysis.getSamples()).hasSize(1);
+        assertThat(analysis.getSamples().getFirst()).contains("simulatedTotal=6");
+    }
+
+    @Test
+    void reportsNothingForAGameWithoutTies() {
+        Game game = agendaEndedGame();
+        addPlayer(game, "winner", 1, VICTORY_POINT_GOAL);
+        addPlayer(game, "second", 2, 7);
+        addPlayer(game, "third", 3, 4);
+
+        var analysis = new MatchmakingRankTieAnalysis(5);
+        analysis.consume(game);
+
+        assertThat(analysis.summary()).contains("games with at least one tie: 0");
+        assertThat(analysis.summary()).contains("tied pairs: 0");
+        assertThat(analysis.getSamples()).isEmpty();
+    }
+
+    @Test
+    void ignoresGamesThatCannotBeRanked() {
+        Game game = agendaEndedGame();
+        addPlayer(game, "first", 1, 4);
+        addPlayer(game, "second", 2, 4);
+
+        var analysis = new MatchmakingRankTieAnalysis(5);
+        analysis.consume(game);
+
+        assertThat(analysis.summary()).contains("ranked games: 0");
+    }
+
+    private static Game agendaEndedGame() {
+        Game game = new Game();
+        game.setName("tie-analysis-" + UUID.randomUUID());
+        game.newGameSetup();
+        game.setVp(VICTORY_POINT_GOAL);
+        game.setHasEnded(true);
+        game.setPhaseOfGame("agendaEnd");
+        return game;
+    }
+
+    private static Player addPlayer(Game game, String userId, int strategyCard, int victoryPoints) {
+        int seat = game.getPlayers().size();
+        Player player = game.addPlayer(userId, userId);
+        player.setFaction(FACTIONS.get(seat % FACTIONS.size()));
+        player.setColor(COLORS.get(seat % COLORS.size()));
+        player.setSCs(Set.of(strategyCard));
+        for (int i = 0; i < victoryPoints; i++) {
+            player.setSecretScored(SCORING_SECRETS.get(i));
+        }
+        return player;
+    }
+}

--- a/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameTest.java
+++ b/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameTest.java
@@ -1,0 +1,81 @@
+package ti4.spring.service.statistics.matchmaking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import ti4.spring.service.persistence.GameEntity;
+import ti4.spring.service.persistence.PlayerEntity;
+import ti4.spring.service.persistence.UserEntity;
+
+class MatchmakingGameTest {
+
+    private static final long ENDED_EPOCH_MILLIS = 1_700_000_000_000L;
+
+    @Test
+    void usesTheStoredSimulatedRanks() {
+        List<PlayerEntity> players = gameWithRanks("game1", 1, 2, 3, 4, 5, 6);
+
+        List<MatchmakingGame> games = MatchmakingGame.getMatchmakingGames(players);
+
+        assertThat(games).hasSize(1);
+        assertThat(games.getFirst().players())
+                .extracting(MatchmakingPlayer::rank)
+                .containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    void keepsTiedRanksAsTies() {
+        List<PlayerEntity> players = gameWithRanks("game1", 1, 2, 2, 4, 5, 5);
+
+        List<MatchmakingGame> games = MatchmakingGame.getMatchmakingGames(players);
+
+        assertThat(games.getFirst().players())
+                .extracting(MatchmakingPlayer::rank)
+                .containsExactly(1, 2, 2, 4, 5, 5);
+    }
+
+    @Test
+    void dropsAnyGameWhereAPlayerHasNoSimulatedRank() {
+        List<PlayerEntity> players = gameWithRanks("game1", 1, 2, 3, null, 5, 6);
+
+        assertThat(MatchmakingGame.getMatchmakingGames(players)).isEmpty();
+    }
+
+    @Test
+    void oneUnrankedGameDoesNotDiscardTheOthers() {
+        List<PlayerEntity> players = new ArrayList<>();
+        players.addAll(gameWithRanks("ranked", 1, 2, 3, 4, 5, 6));
+        players.addAll(gameWithRanks("unranked", 1, 2, 3, 4, 5, null));
+        players.addAll(gameWithRanks("alsoRanked", 1, 2, 3, 4, 5, 6));
+
+        List<MatchmakingGame> games = MatchmakingGame.getMatchmakingGames(players);
+
+        assertThat(games).extracting(MatchmakingGame::name).containsExactly("ranked", "alsoRanked");
+    }
+
+    @Test
+    void returnsAMutableListBecauseTheRatingServiceSortsItInPlace() {
+        List<MatchmakingGame> games = MatchmakingGame.getMatchmakingGames(gameWithRanks("game1", 1, 2, 3));
+
+        assertThat(games).isInstanceOf(ArrayList.class);
+    }
+
+    private static List<PlayerEntity> gameWithRanks(String gameName, Integer... simulatedRanks) {
+        var gameEntity = new GameEntity();
+        gameEntity.setGameName(gameName);
+        gameEntity.setEndedEpochMilliseconds(ENDED_EPOCH_MILLIS);
+        gameEntity.setVictoryPointGoal(10);
+
+        List<PlayerEntity> players = new ArrayList<>();
+        for (int i = 0; i < simulatedRanks.length; i++) {
+            var playerEntity = new PlayerEntity();
+            playerEntity.setGame(gameEntity);
+            playerEntity.setUser(new UserEntity(gameName + "-user" + i, "player" + i));
+            playerEntity.setSimulatedRank(simulatedRanks[i]);
+            players.add(playerEntity);
+        }
+        return players;
+    }
+}


### PR DESCRIPTION
Matchmaking ranks came from a formula that put the winner at rank 1, everyone within 3 points of the goal at rank 2, and the rest at `3 + pointsAwayFromVictory`. That collapsed most of the table into one tied bucket, so TrueSkill could not tell a player one point off the goal from one three points off.

`MatchmakingGameRankEvaluator` replaces it with a counterfactual: **if the winner had not crossed the goal and the game had continued, in what order would the rest have finished?** Each player accrues a *simulated point total*; the order in which those totals cross the point goal sets ranks 2, 3, 4…, and whoever never crosses is ranked by simulated total, ties allowed.

## The simulation

**Action-phase ending.** Walk initiative order repeatedly, each player scoring one on-demand action secret per pass until nothing is left to score. Turn Their Fleets to Dust, Become a Martyr and Prove Endurance are skipped — none can be scored at will on your own turn. A readied Imperial holder instead takes their Imperial primary on the first pass (the best public objective they qualify for, plus 1 more only if they control Mecatol Rex) and resumes scoring secrets on the next pass. Prove Endurance is swept in at the end, since it resolves when the action phase closes.

**Status-phase ending.** Each player *after* the winner in scoring order takes one scoreable status secret and one qualifying public objective. Single pass — only players the winner cut off would have got to score.

**Any other ending** (agenda phase, or an unrecognised phase) ranks the winner first and everyone else by point total, which is Phase 3 on its own. An agenda-phase ending has already returned every strategy card, so there is no initiative order left to walk.

Secrets are worth their real `getPoints()`, so the ten 2-point secrets count double.

## Validation against real saves

Run over 600 real game files:

| | |
|---|---|
| loaded | 600, zero failures, zero exceptions |
| ended | 599 |
| ranked | 446 |
| completed (winner + ended) | 451 |
| **completed but unranked** | **5 — all alliance mode** |

The five unranked completed games are all `alliance_mode true`, which `findAllWithUsersAndGamesByCompletedNonAllianceGame` already filters out, so no game the matchmaking corpus actually wants loses its rank. Phase split among ended games: 265 status, 249 action, 20 agenda, 65 unknown.

## Effect on the draw model

Worth flagging, because it is smaller than I first assumed. Measured over those same 600 games, the adjacent-pair tie rate goes **0.4626 → 0.2876**. The new ranks are *not* tie-free — Phase 3 ties are common — but `DRAW_PROBABILITY = 0.5` was fitted to the old shape and is now too high. Retuning that, and re-checking the `SkillTier` 1900/2300 bounds, is deliberately left to a follow-up.

## Storage and consumption

`player.simulated_rank` (nullable `Integer`) is written during the nightly persist, where a fully hydrated `Game` is already in hand. PostgreSQL with `ddl-auto: update` adds the column, and because `persistAll()` deletes all rows before reinserting, the first nightly run backfills every historical game — no migration, no backfill script.

`MatchmakingGame` now reads that column, and drops any game where a player is missing a rank rather than mixing stored and formula ranks, which would hand that game an incoherent rank vector. `calculatePlayerRank` is deleted.

## Notes for review

- **The evaluator never mutates the `Game`.** The simulation runs entirely on scratch state — no `scoreSecretObjective`, no `computeIfAbsent` on a Game-owned map. A test snapshots scored/revealed objectives, played strategy cards, and every player's hand, scored secrets, planets and techs, and asserts they are unchanged.
- **Its call site is wrapped in try/catch on purpose.** `persistAll()` runs `deleteAllInBatch()` on all four tables first and holds no transaction, so an uncaught exception would leave the database empty until the next nightly run.
- `evaluate` calls `getTotalVictoryPoints()`, which reaches `getSecretVictoryPoints()` — a method that mutates `secretsScored` in place. This already happened in this code path before this change, and `managedGame.getGame()` is a fresh uncached disk parse that is never written back, so it is safe. It looks alarming; it isn't.
- Imperial is found by scanning the strategy card set for `pok8imperial`/`tf8` with `imperial`/`aeterna` name fallbacks, **not** by hardcoding initiative 8. `WebScoreBreakdown.java:66` and `Helper.java:250` both still hardcode 8 and are wrong for Absol/homebrew sets — worth a separate fix.
- `StatusHelper`'s two copies of the "can this player score this status secret" predicate now delegate to `ListPlayerInfoService.canScoreStatusPhaseSecret`. This is behaviour-preserving: the old predicate special-cased `!"dp"`, and `dp` is the only one of the 28 thresholded secret aliases whose phase is Agenda rather than Status, so a proper phase check subsumes the magic string.

## Testing

`mvn test` — 802 pass. 18 new evaluator cases (preconditions, each phase, crossing order, Imperial readied/exhausted/second-pass, Phase 3 ties, determinism, no-mutation, plus a smoke test over the real `pbd15036` save) and 5 covering the stored-rank consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
