### PR TITLE
Twilight kart/nova cup fixes

### DIFF
--- a/src/main/java/ti4/game/Game.java
+++ b/src/main/java/ti4/game/Game.java
@@ -668,7 +668,7 @@ public class Game extends GameProperties implements StoredValueHelper, TwilightF
         if (isTwilightKart() || isTkDestroyerCup()) {
             agendaDeck = "agendas_twilight_kart";
             setUnitSpliceDeckID("twilight_kart_units");
-            acDeck = isTkNovaCup() ? "action_cards_tk_destroyer_and_nova" : "action_cards_twilight_kart";
+            acDeck = "action_cards_tk_destroyer_and_nova";
         }
 
         // Set other normal decks

--- a/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
+++ b/src/main/java/ti4/helpers/ButtonHelperTwilightsFall.java
@@ -1390,7 +1390,7 @@ public final class ButtonHelperTwilightsFall {
         }
         if ("units".equalsIgnoreCase(type)) {
             for (String unit : player.getUnitsOwned()) {
-                if (unit.contains("tf_") || (!unit.contains("tf-") && !unit.contains("tk-"))) {
+                if (!Mapper.getUnit(unit).getIsUpgrade()) {
                     continue;
                 }
                 buttons.add(Buttons.red(

--- a/src/main/resources/data/decks/twilight_kart.json
+++ b/src/main/resources/data/decks/twilight_kart.json
@@ -27,7 +27,7 @@
         "alias": "action_cards_twilight_kart",
         "name": "Twilight Kart: Destroyer Cup Action Cards",
         "type": "action_card",
-        "description": "All action cards for the Homebrew; Twilight Kart: Destroyer Cup",
+        "description": "All action cards for the Homebrew; Twilight Kart: Destroyer Cup (Deprecated - still uses tf-starflare when it should use tk-nova-starflare) ",
         "cardIDs": [
             "tf-transpose1",
             "tf-transpose2",

--- a/src/main/resources/data/leaders/tf_leaders.json
+++ b/src/main/resources/data/leaders/tf_leaders.json
@@ -10,6 +10,7 @@
         "abilityWindow": "When a player spends resources",
         "abilityText": "You may exhaust this card to allow that player to remove any number of their infantry from the game board. For each unit removed, reduce the resources spent by 1.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/experimental_genome.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/experimental_genome.png?raw=true",
         "source": "twilights_fall"
     },
@@ -22,6 +23,7 @@
         "abilityWindow": "At any time",
         "abilityText": "You may exhaust this card and choose another player; that player gives you 1 trade good, if able, then you each draw 1 action card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/hyper_genome.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/hyper_genome.png?raw=true",
         "source": "twilights_fall"
     },
@@ -35,6 +37,7 @@
         "tfNotes": "In async, please play this ability before initiating the splice.",
         "abilityText": "You may exhaust this card to add 3 additional cards to that splice.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/research_genome.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/research_genome.png?raw=true",
         "source": "twilights_fall"
     },
@@ -47,6 +50,7 @@
         "abilityWindow": "After a player's unit is destroyed during combat",
         "abilityText": "You may exhaust this card to roll 1 die. If the result is equal to or greater than that unit's combat value, their opponent must choose and destroy 1 of their units.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/valiant_genome.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/valiant_genome.png?raw=true",
         "source": "twilights_fall"
     },
@@ -60,6 +64,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Draw 1 genome, 1 unit upgrade, and 1 ability. Then purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/jolnar_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/jolnar_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -72,6 +77,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Choose a planet that has a technology specialty in a system that contains your units. Destroy any other player's units on that planet. Gain trade goods equal to that planet's combined resource and influence values and draw 1 ability. Then, purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/nekro_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/nekro_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -84,6 +90,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Resolve the PRODUCTION abilities of your units in your home system. You may reduce the cost of each of your units to 0 during this use of PRODUCTION. Then, purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/nekro_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/nekro_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -96,6 +103,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Reveal 3 edicts; choose 1 to resolve and shuffle the rest back into the edict deck. Then, purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/xxcha_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/xxcha_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -108,6 +116,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Choose a player other than the current speaker to gain the speaker token. Choose a player other than the tyrant to gain the benediction token. Then purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/keleresx_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/keleresx_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -120,6 +129,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Gain 1 relic and 2 command tokens. Then, purge this card",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/naazrokha_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/naazrokha_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -133,6 +143,7 @@
         "abilityText": "You may choose an ability owned by another player; they must either give you that ability or give you 2 other abilities. If you do, purge this card.",
         "unlockCondition": "Always Unlocked",
         "tfNotes": "This hero is not affected by someone having bio-synthetic synergy.",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/naalu_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/naalu_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -145,6 +156,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Search the ability, unit upgrade, or genome deck for a card and gain it. Then, purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/obsidian_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/obsidian_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -157,6 +169,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Purge an ability owned by any player. Then, purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/deepwrought_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/deepwrought_paradigm.png?raw=true",
         "source": "twilights_fall"
     },
@@ -169,6 +182,7 @@
         "abilityWindow": "ACTION:",
         "abilityText": "Each other player rolls a die for each of their non-fighter ships that are in or adjacent to a system that contains a gravity rift; on a 1-5, return that unit to their reinforcements. Then, purge this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/vuilraith_paradigm.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/paradigm/vuilraith_paradigm.png?raw=true",
         "source": "twilights_fall"
     }

--- a/src/main/resources/data/leaders/tk_nova_genomes.json
+++ b/src/main/resources/data/leaders/tk_nova_genomes.json
@@ -9,6 +9,7 @@
         "abilityWindow": "When a player draws 1 or more edicts:",
         "abilityText": "You may exhaust this card to allow that player to draw 1 additional edict. If only 2 edicts were drawn, they choose 1 to resolve and discard the other.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/action_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/action_tk2.png?raw=true",
         "shortName": "Xander A. Victori III",
         "source": "tk_nova_cup"
@@ -25,6 +26,7 @@
         "abilityWindow": "At the start of a space combat round:",
         "abilityText": "You may exhaust this card to choose up to 2 ships in the active system. Those ships roll 1 additional die during this combat round.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/aristocratic_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/aristocratic_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -38,6 +40,7 @@
         "abilityWindow": "After a player's unit uses PRODUCTION:",
         "abilityText": "You may exhaust this card to allow that player to place 1 mech from their reinforcements on a planet they control in that unit's system.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/brutal_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/brutal_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -52,6 +55,7 @@
         "abilityWindow": "At the start of a player's turn:",
         "abilityText": "You may exhaust this card to allow that player to remove up to 4 of their ground forces from the game board and place them on 1 or more planets they control.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/deployment_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/deployment_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -65,6 +69,7 @@
         "abilityWindow": "At the start of a ground combat round:",
         "abilityText": "You may exhaust this card to choose up to 2 ground forces in the active system; those ground forces roll 1 additional die during this combat round.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/human_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/human_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -79,6 +84,7 @@
         "abilityWindow": "When any player gains trade goods from the supply:",
         "abilityText": "You may exhaust this card to place an equal number of trade goods on this card. When this card readies, gain the trade goods on this card.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/investment_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/investment_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -92,6 +98,7 @@
         "abilityWindow": "When a player moves ships:",
         "abilityText": "You may exhaust this card; if you do, SPACE CANNON cannot be used against those ships; they can also move through other players' ships.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/mirror_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/mirror_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -105,6 +112,7 @@
         "abilityWindow": "When a player produces units:",
         "abilityText": "You may exhaust this card to allow that player to also produce up to 6 fighters or infantry; they do not count against that player's PRODUCTION limit.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/ravenous_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/ravenous_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -118,6 +126,7 @@
         "abilityWindow": "During the action phase:",
         "abilityText": "You may exhaust this card to choose a player; they may discard 1 action card, or spend 1 command token or 2 trade goods, to draw 1 action card, or gain 1 command token or 2 trade goods.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/recursive_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/recursive_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -131,6 +140,7 @@
         "abilityWindow": "When a player produces ground forces in a system:",
         "abilityText": "You may exhaust this card; that player may place those units on any planets they control or in the space areas of any systems that contain their ships.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/scornful_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/scornful_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -144,6 +154,7 @@
         "abilityWindow": "After a player's unit is destroyed:",
         "abilityText": "You may exhaust this card to allow that player to place 2 fighters in the destroyed unit's system if it was a ship, or 2 infantry on its planet if it was a ground force.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/splitting_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/splitting_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -157,6 +168,7 @@
         "abilityWindow": "At the end of a player's turn:",
         "abilityText": "You may exhaust this card to allow that player to place 2 infantry from their reinforcements on a planet they control.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/swarm_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/swarm_tk2.png?raw=true",
         "source": "tk_nova_cup"
     },
@@ -170,6 +182,7 @@
         "abilityWindow": "After a player's unit is destroyed during combat:",
         "abilityText": "You may exhaust this card to roll 1 die. If the result is equal to or greater than that unit's combat value, their opponent must choose and destroy 2 of their units.",
         "unlockCondition": "Always Unlocked",
+        "imageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/valiant_tk2.png?raw=true",
         "tfImageURL": "https://cdn.statically.io/gh/AsyncTI4/TI4_map_generator_bot/master/src/main/resources/hover_images/twilights_fall/genome/twilight_kart/valiant_tk2.png?raw=true",
         "source": "tk_nova_cup"
     }


### PR DESCRIPTION
- disallow discarding nova king units with discard splice card
- add nova starflare to all future destroyer cup games, even if nova cup is not selected
- duplicate tfImageURL into imageURL for all tf-only leaders, so that tf-only leaders have at least some kind of hover image while tfImageURL remains unimplemented