### PR TITLE
Milty DS BR only fix

### DIFF
--- a/src/main/java/ti4/helpers/settingsFramework/menus/PlayerFactionSettings.java
+++ b/src/main/java/ti4/helpers/settingsFramework/menus/PlayerFactionSettings.java
@@ -21,7 +21,6 @@ import ti4.helpers.settingsFramework.settings.SettingInterface;
 import ti4.image.Mapper;
 import ti4.model.FactionModel;
 import ti4.model.Source.ComponentSource;
-import ti4.service.emoji.SourceEmojis;
 import tools.jackson.databind.JsonNode;
 
 // This is a sub-menu
@@ -32,6 +31,7 @@ public class PlayerFactionSettings extends SettingsMenu {
     // Settings & Submenus
     // ---------------------------------------------------------------------------------------------------------------------------------
     private final BooleanSetting presetDraftOrder;
+    private final BooleanSetting dsBrFactionsOnly;
     private ListSetting<Player> gamePlayers;
     private final ListSetting<FactionModel> banFactions;
     private final ListSetting<FactionModel> priFactions;
@@ -49,6 +49,7 @@ public class PlayerFactionSettings extends SettingsMenu {
 
         // Initialize Settings to default values
         presetDraftOrder = new BooleanSetting("StaticOrder", "static draft order", false);
+        dsBrFactionsOnly = new BooleanSetting("DsBrFactionsOnly", "limit faction pool to DS and BR", false);
 
         // Initialize values & keys for gamePlayers
         Set<Entry<String, Player>> allPlayers = game.getPlayers().entrySet();
@@ -97,6 +98,7 @@ public class PlayerFactionSettings extends SettingsMenu {
                 && json.has("menuId")
                 && historicIDs.contains(json.get("menuId").asString(""))) {
             presetDraftOrder.initialize(json.get("presetDraftOrder"));
+            dsBrFactionsOnly.initialize(json.get("dsBrFactionsOnly"));
             gamePlayers.initialize(json.get("gamePlayers"));
             banFactions.initialize(json.get("banFactions"));
             priFactions.initialize(json.get("priFactions"));
@@ -118,6 +120,7 @@ public class PlayerFactionSettings extends SettingsMenu {
         List<SettingInterface> ls = new ArrayList<>();
         ls.add(gamePlayers);
         ls.add(presetDraftOrder);
+        ls.add(dsBrFactionsOnly);
         ls.add(banFactions);
         ls.add(priFactions);
         return ls;
@@ -127,6 +130,12 @@ public class PlayerFactionSettings extends SettingsMenu {
     protected void updateTransientSettings() {
         if (parent instanceof MiltySettings m) {
             List<ComponentSource> sources = m.getSourceSettings().getFactionSources();
+            boolean dsOrBrEnabled =
+                    sources.contains(ComponentSource.ds) || sources.contains(ComponentSource.blue_reverie);
+            dsBrFactionsOnly.setDisabled(!dsOrBrEnabled);
+            if (!dsOrBrEnabled) {
+                dsBrFactionsOnly.setVal(false);
+            }
             List<String> nonDraftable = List.of("obsidian", "neutral", "keleresa", "keleresx");
 
             Map<String, FactionModel> allFactions = Mapper.getFactionsValues().stream()
@@ -146,12 +155,6 @@ public class PlayerFactionSettings extends SettingsMenu {
         String idPrefix = menuAction + "_" + navId() + "_";
         List<Button> ls = new ArrayList<>(super.specialButtons());
 
-        if (parent != null && parent instanceof MiltySettings ms) {
-            if (ms.getSourceSettings().getDiscoStars().isVal()
-                    || ms.getSourceSettings().getBlueReverie().isVal())
-                ls.add(Buttons.red(
-                        idPrefix + "dsFactionsOnly", "Only DS and BR Factions", SourceEmojis.DiscordantStars));
-        }
         ls.add(Buttons.green(idPrefix + "teFactions", "Prioritize Thunder's Edge Factions"));
         return ls;
     }
@@ -160,7 +163,6 @@ public class PlayerFactionSettings extends SettingsMenu {
     public String handleSpecialButtonAction(GenericInteractionCreateEvent event, String action) {
         String error =
                 switch (action) {
-                    case "dsFactionsOnly" -> prioritizeDSFactions();
                     case "teFactions" -> prioritizeTEFactions();
                     default -> null;
                 };
@@ -171,24 +173,6 @@ public class PlayerFactionSettings extends SettingsMenu {
     // ---------------------------------------------------------------------------------------------------------------------------------
     // Specific Implementation
     // ---------------------------------------------------------------------------------------------------------------------------------
-    private String prioritizeDSFactions() {
-        if (parent != null && parent instanceof MiltySettings ms) {
-            boolean dsEnabled = ms.getSourceSettings().getDiscoStars().isVal();
-            boolean brEnabled = ms.getSourceSettings().getBlueReverie().isVal();
-            if (!dsEnabled && !brEnabled) return "Neither Discordant Stars nor Blue Reverie is enabled";
-
-            List<String> newKeys = new ArrayList<>();
-            for (FactionModel model : priFactions.getAllValues().values()) {
-                if ((dsEnabled && model.getSource() == ComponentSource.ds)
-                        || (brEnabled && model.getSource().isBr())) {
-                    newKeys.add(model.getAlias());
-                }
-            }
-            priFactions.setKeys(newKeys);
-        }
-        return null;
-    }
-
     private String prioritizeTEFactions() {
         if (parent != null && parent instanceof MiltySettings) {
 

--- a/src/main/java/ti4/service/draft/DraftSpec.java
+++ b/src/main/java/ti4/service/draft/DraftSpec.java
@@ -97,6 +97,15 @@ public class DraftSpec {
         SourceSettings sources = settings.getSourceSettings();
         specs.tileSources = sources.getTileSources();
         specs.factionSources = sources.getFactionSources();
+        if (pfSettings.getDsBrFactionsOnly().isVal()
+                && specs.factionSources.stream()
+                        .anyMatch(source ->
+                                source == Source.ComponentSource.ds || source == Source.ComponentSource.blue_reverie)) {
+            specs.factionSources = specs.factionSources.stream()
+                    .filter(source ->
+                            source == Source.ComponentSource.ds || source == Source.ComponentSource.blue_reverie)
+                    .toList();
+        }
 
         if (sliceSettings.getParsedSlices() != null) {
             specs.presetSlices = sliceSettings.getParsedSlices();

--- a/src/main/java/ti4/service/milty/MiltyDraftSpec.java
+++ b/src/main/java/ti4/service/milty/MiltyDraftSpec.java
@@ -87,6 +87,15 @@ public class MiltyDraftSpec {
         SourceSettings sources = settings.getSourceSettings();
         specs.tileSources = sources.getTileSources();
         specs.factionSources = sources.getFactionSources();
+        if (pfSettings.getDsBrFactionsOnly().isVal()
+                && specs.factionSources.stream()
+                        .anyMatch(source ->
+                                source == Source.ComponentSource.ds || source == Source.ComponentSource.blue_reverie)) {
+            specs.factionSources = specs.factionSources.stream()
+                    .filter(source ->
+                            source == Source.ComponentSource.ds || source == Source.ComponentSource.blue_reverie)
+                    .toList();
+        }
         specs.sourceConstraints = pfSettings.getFactionSourceSettings().getConstraintMap();
 
         if (sliceSettings.getParsedSlices() != null) {


### PR DESCRIPTION
Removed the old button and flow that prioritized DS/BR factions

Added new button that sets a flag that filters factions to only DS and BR upon draft creation