### PR TITLE
Retune matchmaking ratings so they move more per game

### DIFF
--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfo.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfo.java
@@ -12,8 +12,10 @@ public class MatchmakingGameInfo {
     private static final double INITIAL_STANDARD_DEVIATION = INITIAL_MEAN / 3.0;
     // Default.
     private static final double BETA = INITIAL_MEAN / 6.0;
-    // Default is .1. However, our draw probability is truly .5, due to treating 7-9 points as equal.
-    private static final double DRAW_PROBABILITY = 0.5;
+    // Default is .1. Our observed tie rate is about .5, because players within 3 points of the goal
+    // all share a rank. We deliberately use a lower value: it tightens the rating spread and smooths
+    // the top of the ladder, and measured prediction accuracy is unchanged from .05 through .5.
+    private static final double DRAW_PROBABILITY = 0.05;
     // Default divides by 100. However, we divide by 50 to increase the number of points players
     // lose and gain each game.
     private static final double ASSUMED_SKILL_DRIFT_BETWEEN_GAMES = INITIAL_STANDARD_DEVIATION / 50.0;

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfo.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfo.java
@@ -16,9 +16,9 @@ public class MatchmakingGameInfo {
     // all share a rank. We deliberately use a lower value: it tightens the rating spread and smooths
     // the top of the ladder, and measured prediction accuracy is unchanged from .05 through .5.
     private static final double DRAW_PROBABILITY = 0.05;
-    // Default divides by 100. However, we divide by 50 to increase the number of points players
+    // Default divides by 100. However, we divide by 25 to increase the number of points players
     // lose and gain each game.
-    private static final double ASSUMED_SKILL_DRIFT_BETWEEN_GAMES = INITIAL_STANDARD_DEVIATION / 50.0;
+    private static final double ASSUMED_SKILL_DRIFT_BETWEEN_GAMES = INITIAL_STANDARD_DEVIATION / 25.0;
 
     public static GameInfo create() {
         return new GameInfo(

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -12,11 +12,8 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -42,11 +39,6 @@ public class MatchmakingRatingEventService {
     private static final Duration RATINGS_CACHE_TTL = Duration.ofHours(8);
     private static final Duration AVERAGE_RATING_CACHE_TTL = Duration.ofHours(8);
     private static final String RATINGS_CACHE_KEY = "key";
-    private static final int MINIMUM_RATED_GAMES = 3;
-    private static final int DEBUG_CANDIDATE_LIMIT = 5;
-    private static final int DEBUG_PARTIAL_MATCH_MINIMUM = 4;
-    private static final List<String> DEBUG_RATING_PLAYERS =
-            List.of("Tazingo", "bleezy4sheezy", "Bearded One", "inco.n.damus", "forleafs", "Blue");
 
     private final Cache<String, List<MatchmakingRating>> unconservativeRatingsCache = createRatingsCache();
     private final Cache<String, List<MatchmakingRating>> conservativeRatingsCache = createRatingsCache();
@@ -66,7 +58,7 @@ public class MatchmakingRatingEventService {
                 playerEntityRepository.findAllWithUsersAndGamesByCompletedNonAllianceGame(onlyTiglGames);
         List<MatchmakingGame> games = MatchmakingGame.getMatchmakingGames(players);
         List<MatchmakingRating> playerRatings = TrueSkillMatchmakingRatingService.calculateRatings(games, true);
-        sendMessage(event, playerRatings, games, players, showRating);
+        sendMessage(event, playerRatings, games, showRating);
     }
 
     public static long toDisplayRating(BigDecimal rating) {
@@ -163,7 +155,6 @@ public class MatchmakingRatingEventService {
             SlashCommandInteractionEvent event,
             List<MatchmakingRating> playerRatings,
             List<MatchmakingGame> games,
-            List<PlayerEntity> players,
             boolean showRating) {
         int maxListSize = Math.min(MAX_LIST_SIZE, playerRatings.size());
         String ratingLabel = "Rating";
@@ -212,8 +203,6 @@ public class MatchmakingRatingEventService {
                 "games",
                 gameAverageDisplayRatings(games, playerRatings));
 
-        appendDebugRatings(stringBuilder, playerRatings, players);
-
         playerRatings.stream()
                 .filter(playerRating ->
                         playerRating.userId().equals(event.getUser().getId()))
@@ -242,78 +231,6 @@ public class MatchmakingRatingEventService {
                 (MessageChannelUnion) event.getMessageChannel(),
                 "Player Matchmaking Ratings",
                 stringBuilder.toString());
-    }
-
-    private static void appendDebugRatings(
-            StringBuilder stringBuilder, List<MatchmakingRating> playerRatings, List<PlayerEntity> players) {
-        if (DEBUG_RATING_PLAYERS.isEmpty()) return;
-        stringBuilder.append("\n**Debug ratings:**\n");
-        for (String debugPlayer : DEBUG_RATING_PLAYERS) {
-            List<MatchmakingRating> matchingRatings = playerRatings.stream()
-                    .filter(rating -> matchesDebugPlayer(rating, debugPlayer))
-                    .toList();
-            if (matchingRatings.isEmpty()) {
-                appendDebugCandidates(stringBuilder, debugPlayer, players);
-                continue;
-            }
-            for (MatchmakingRating playerRating : matchingRatings) {
-                appendDebugRating(stringBuilder, playerRating);
-            }
-        }
-    }
-
-    private static void appendDebugRating(StringBuilder stringBuilder, MatchmakingRating playerRating) {
-        String trend = playerRating.recentRatingDelta() == null
-                ? "n/a"
-                : String.format("%+d", toDisplayRating(playerRating.recentRatingDelta()));
-        stringBuilder.append(String.format(
-                "- `%s`: rating %d, calibration %.1f%%, sigma %.3f, trend %s, id %s\n",
-                playerRating.username(),
-                toDisplayRating(playerRating.rating()),
-                playerRating.calibrationPercent(),
-                playerRating.sigma(),
-                trend,
-                playerRating.userId()));
-    }
-
-    private static void appendDebugCandidates(
-            StringBuilder stringBuilder, String debugPlayer, List<PlayerEntity> players) {
-        Map<String, Long> gamesByUserId = new LinkedHashMap<>();
-        Map<String, String> nameByUserId = new HashMap<>();
-        for (PlayerEntity player : players) {
-            String storedName = player.getUser().getName();
-            if (!looselyMatchesDebugPlayer(storedName, debugPlayer)) continue;
-            gamesByUserId.merge(player.getUser().getId(), 1L, Long::sum);
-            nameByUserId.put(player.getUser().getId(), storedName);
-        }
-        if (gamesByUserId.isEmpty()) {
-            stringBuilder.append(
-                    String.format("- `%s`: no user in the rated game pool matches this name\n", debugPlayer));
-            return;
-        }
-        gamesByUserId.entrySet().stream()
-                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .limit(DEBUG_CANDIDATE_LIMIT)
-                .forEach(entry -> stringBuilder.append(String.format(
-                        "- `%s`: matched `%s`, id %s, %d rated games, needs %d to be rated\n",
-                        debugPlayer,
-                        nameByUserId.get(entry.getKey()),
-                        entry.getKey(),
-                        entry.getValue(),
-                        MINIMUM_RATED_GAMES)));
-    }
-
-    private static boolean looselyMatchesDebugPlayer(String storedName, String debugPlayer) {
-        if (storedName == null) return false;
-        String stored = storedName.toLowerCase(Locale.ROOT);
-        String target = debugPlayer.toLowerCase(Locale.ROOT);
-        if (stored.equals(target)) return true;
-        if (stored.length() >= DEBUG_PARTIAL_MATCH_MINIMUM && target.contains(stored)) return true;
-        return target.length() >= DEBUG_PARTIAL_MATCH_MINIMUM && stored.contains(target);
-    }
-
-    private static boolean matchesDebugPlayer(MatchmakingRating playerRating, String debugPlayer) {
-        return debugPlayer.equalsIgnoreCase(playerRating.username()) || debugPlayer.equals(playerRating.userId());
     }
 
     private static void appendRecentTrend(StringBuilder stringBuilder, MatchmakingRating playerRating) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -236,7 +236,8 @@ public class MatchmakingRatingEventService {
     }
 
     private static void appendDebugRatings(StringBuilder stringBuilder, List<MatchmakingRating> playerRatings) {
-        stringBuilder.append("\n__**Debug ratings:**__\n");
+        if (DEBUG_RATING_PLAYERS.isEmpty()) return;
+        stringBuilder.append("\n**Debug ratings:**\n");
         for (String debugPlayer : DEBUG_RATING_PLAYERS) {
             MatchmakingRating playerRating = playerRatings.stream()
                     .filter(rating -> matchesDebugPlayer(rating, debugPlayer))
@@ -244,19 +245,20 @@ public class MatchmakingRatingEventService {
                     .orElse(null);
             if (playerRating == null) {
                 stringBuilder.append(String.format(
-                        "`%s` not rated - fewer than 3 completed games, or stored under a different name\n",
-                        debugPlayer));
+                        "- `%s`: not rated - under 3 completed games, or stored under another name\n", debugPlayer));
                 continue;
             }
+            String trend = playerRating.recentRatingDelta() == null
+                    ? "n/a"
+                    : String.format("%+d", toDisplayRating(playerRating.recentRatingDelta()));
             stringBuilder.append(String.format(
-                    "`%s` `Rating=%d` `Calibration=%.1f%%` `Sigma=%.3f`%s\n",
+                    "- `%s`: rating %d, calibration %.1f%%, sigma %.3f, trend %s, id %s\n",
                     playerRating.username(),
                     toDisplayRating(playerRating.rating()),
                     playerRating.calibrationPercent(),
                     playerRating.sigma(),
-                    playerRating.recentRatingDelta() == null
-                            ? ""
-                            : String.format(" `Trend=%+d`", toDisplayRating(playerRating.recentRatingDelta()))));
+                    trend,
+                    playerRating.userId()));
         }
     }
 

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -11,8 +11,11 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -38,6 +41,9 @@ public class MatchmakingRatingEventService {
     private static final Duration RATINGS_CACHE_TTL = Duration.ofHours(8);
     private static final Duration AVERAGE_RATING_CACHE_TTL = Duration.ofHours(8);
     private static final String RATINGS_CACHE_KEY = "key";
+    private static final int MINIMUM_RATED_GAMES = 3;
+    private static final int DEBUG_CANDIDATE_LIMIT = 5;
+    private static final int DEBUG_PARTIAL_MATCH_MINIMUM = 4;
     private static final List<String> DEBUG_RATING_PLAYERS =
             List.of("tazing0", "bleezy4sheezy", "bearded_one", "inco.n.damus", "forleafs", "the_constellation_orion");
 
@@ -59,7 +65,7 @@ public class MatchmakingRatingEventService {
                 playerEntityRepository.findAllWithUsersAndGamesByCompletedNonAllianceGame(onlyTiglGames);
         List<MatchmakingGame> games = MatchmakingGame.getMatchmakingGames(players);
         List<MatchmakingRating> playerRatings = TrueSkillMatchmakingRatingService.calculateRatings(games, true);
-        sendMessage(event, playerRatings, games, showRating);
+        sendMessage(event, playerRatings, games, players, showRating);
     }
 
     public static long toDisplayRating(BigDecimal rating) {
@@ -156,6 +162,7 @@ public class MatchmakingRatingEventService {
             SlashCommandInteractionEvent event,
             List<MatchmakingRating> playerRatings,
             List<MatchmakingGame> games,
+            List<PlayerEntity> players,
             boolean showRating) {
         int maxListSize = Math.min(MAX_LIST_SIZE, playerRatings.size());
         String ratingLabel = "Rating";
@@ -203,7 +210,7 @@ public class MatchmakingRatingEventService {
                 "games",
                 bucketGamesByBracket(games, playerRatings));
 
-        appendDebugRatings(stringBuilder, playerRatings);
+        appendDebugRatings(stringBuilder, playerRatings, players);
 
         playerRatings.stream()
                 .filter(playerRating ->
@@ -235,7 +242,8 @@ public class MatchmakingRatingEventService {
                 stringBuilder.toString());
     }
 
-    private static void appendDebugRatings(StringBuilder stringBuilder, List<MatchmakingRating> playerRatings) {
+    private static void appendDebugRatings(
+            StringBuilder stringBuilder, List<MatchmakingRating> playerRatings, List<PlayerEntity> players) {
         if (DEBUG_RATING_PLAYERS.isEmpty()) return;
         stringBuilder.append("\n**Debug ratings:**\n");
         for (String debugPlayer : DEBUG_RATING_PLAYERS) {
@@ -244,8 +252,7 @@ public class MatchmakingRatingEventService {
                     .findFirst()
                     .orElse(null);
             if (playerRating == null) {
-                stringBuilder.append(String.format(
-                        "- `%s`: not rated - under 3 completed games, or stored under another name\n", debugPlayer));
+                appendDebugCandidates(stringBuilder, debugPlayer, players);
                 continue;
             }
             String trend = playerRating.recentRatingDelta() == null
@@ -260,6 +267,42 @@ public class MatchmakingRatingEventService {
                     trend,
                     playerRating.userId()));
         }
+    }
+
+    private static void appendDebugCandidates(
+            StringBuilder stringBuilder, String debugPlayer, List<PlayerEntity> players) {
+        Map<String, Long> gamesByUserId = new LinkedHashMap<>();
+        Map<String, String> nameByUserId = new HashMap<>();
+        for (PlayerEntity player : players) {
+            String storedName = player.getUser().getName();
+            if (!looselyMatchesDebugPlayer(storedName, debugPlayer)) continue;
+            gamesByUserId.merge(player.getUser().getId(), 1L, Long::sum);
+            nameByUserId.put(player.getUser().getId(), storedName);
+        }
+        if (gamesByUserId.isEmpty()) {
+            stringBuilder.append(
+                    String.format("- `%s`: no user in the rated game pool matches this name\n", debugPlayer));
+            return;
+        }
+        gamesByUserId.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(DEBUG_CANDIDATE_LIMIT)
+                .forEach(entry -> stringBuilder.append(String.format(
+                        "- `%s`: matched `%s`, id %s, %d rated games, needs %d to be rated\n",
+                        debugPlayer,
+                        nameByUserId.get(entry.getKey()),
+                        entry.getKey(),
+                        entry.getValue(),
+                        MINIMUM_RATED_GAMES)));
+    }
+
+    private static boolean looselyMatchesDebugPlayer(String storedName, String debugPlayer) {
+        if (storedName == null) return false;
+        String stored = storedName.toLowerCase(Locale.ROOT);
+        String target = debugPlayer.toLowerCase(Locale.ROOT);
+        if (stored.equals(target)) return true;
+        if (stored.length() >= DEBUG_PARTIAL_MATCH_MINIMUM && target.contains(stored)) return true;
+        return target.length() >= DEBUG_PARTIAL_MATCH_MINIMUM && stored.contains(target);
     }
 
     private static boolean matchesDebugPlayer(MatchmakingRating playerRating, String debugPlayer) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -45,7 +45,7 @@ public class MatchmakingRatingEventService {
     private static final int DEBUG_CANDIDATE_LIMIT = 5;
     private static final int DEBUG_PARTIAL_MATCH_MINIMUM = 4;
     private static final List<String> DEBUG_RATING_PLAYERS =
-            List.of("tazing0", "bleezy4sheezy", "bearded_one", "inco.n.damus", "forleafs", "the_constellation_orion");
+            List.of("Tazingo", "bleezy4sheezy", "Bearded One", "inco.n.damus", "forleafs", "Blue");
 
     private final Cache<String, List<MatchmakingRating>> unconservativeRatingsCache = createRatingsCache();
     private final Cache<String, List<MatchmakingRating>> conservativeRatingsCache = createRatingsCache();
@@ -247,26 +247,31 @@ public class MatchmakingRatingEventService {
         if (DEBUG_RATING_PLAYERS.isEmpty()) return;
         stringBuilder.append("\n**Debug ratings:**\n");
         for (String debugPlayer : DEBUG_RATING_PLAYERS) {
-            MatchmakingRating playerRating = playerRatings.stream()
+            List<MatchmakingRating> matchingRatings = playerRatings.stream()
                     .filter(rating -> matchesDebugPlayer(rating, debugPlayer))
-                    .findFirst()
-                    .orElse(null);
-            if (playerRating == null) {
+                    .toList();
+            if (matchingRatings.isEmpty()) {
                 appendDebugCandidates(stringBuilder, debugPlayer, players);
                 continue;
             }
-            String trend = playerRating.recentRatingDelta() == null
-                    ? "n/a"
-                    : String.format("%+d", toDisplayRating(playerRating.recentRatingDelta()));
-            stringBuilder.append(String.format(
-                    "- `%s`: rating %d, calibration %.1f%%, sigma %.3f, trend %s, id %s\n",
-                    playerRating.username(),
-                    toDisplayRating(playerRating.rating()),
-                    playerRating.calibrationPercent(),
-                    playerRating.sigma(),
-                    trend,
-                    playerRating.userId()));
+            for (MatchmakingRating playerRating : matchingRatings) {
+                appendDebugRating(stringBuilder, playerRating);
+            }
         }
+    }
+
+    private static void appendDebugRating(StringBuilder stringBuilder, MatchmakingRating playerRating) {
+        String trend = playerRating.recentRatingDelta() == null
+                ? "n/a"
+                : String.format("%+d", toDisplayRating(playerRating.recentRatingDelta()));
+        stringBuilder.append(String.format(
+                "- `%s`: rating %d, calibration %.1f%%, sigma %.3f, trend %s, id %s\n",
+                playerRating.username(),
+                toDisplayRating(playerRating.rating()),
+                playerRating.calibrationPercent(),
+                playerRating.sigma(),
+                trend,
+                playerRating.userId()));
     }
 
     private static void appendDebugCandidates(
@@ -386,13 +391,17 @@ public class MatchmakingRatingEventService {
     private static void appendBracketDistribution(
             StringBuilder stringBuilder, String heading, String unitLabel, Map<Long, Long> countsByBracket) {
         if (countsByBracket.isEmpty()) return;
+        long total =
+                countsByBracket.values().stream().mapToLong(Long::longValue).sum();
         stringBuilder.append("\n**").append(heading).append(":**\n");
         for (Map.Entry<Long, Long> entry : countsByBracket.entrySet()) {
             long bracket = entry.getKey();
             long count = entry.getValue();
             String separator = bracket < 0 ? " to " : "-";
             String label = count == 1 ? unitLabel.substring(0, unitLabel.length() - 1) : unitLabel;
-            stringBuilder.append(String.format("- `%d%s%d`: %d %s\n", bracket, separator, bracket + 99, count, label));
+            double percent = 100.0 * count / total;
+            stringBuilder.append(String.format(
+                    "- `%d%s%d`: %d %s (%.1f%%)\n", bracket, separator, bracket + 99, count, label, percent));
         }
     }
 

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -9,6 +9,7 @@ import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -203,12 +204,12 @@ public class MatchmakingRatingEventService {
                 stringBuilder,
                 "Players per " + ratingLabel.toLowerCase() + " bracket",
                 "players",
-                bucketPlayersByBracket(playerRatings));
+                playerDisplayRatings(playerRatings));
         appendBracketDistribution(
                 stringBuilder,
                 "Games per average-" + ratingLabel.toLowerCase() + " bracket",
                 "games",
-                bucketGamesByBracket(games, playerRatings));
+                gameAverageDisplayRatings(games, playerRatings));
 
         appendDebugRatings(stringBuilder, playerRatings, players);
 
@@ -355,19 +356,17 @@ public class MatchmakingRatingEventService {
                 ratingLabel.toLowerCase(), gameCount, toDisplayRating(averageOpponentRating)));
     }
 
-    private static Map<Long, Long> bucketPlayersByBracket(List<MatchmakingRating> playerRatings) {
-        Map<Long, Long> counts = new TreeMap<>(Comparator.reverseOrder());
-        for (MatchmakingRating playerRating : playerRatings) {
-            counts.merge(bracketFor(toDisplayRating(playerRating.rating())), 1L, Long::sum);
-        }
-        return counts;
+    private static List<Long> playerDisplayRatings(List<MatchmakingRating> playerRatings) {
+        return playerRatings.stream()
+                .map(playerRating -> toDisplayRating(playerRating.rating()))
+                .toList();
     }
 
-    private static Map<Long, Long> bucketGamesByBracket(
+    private static List<Long> gameAverageDisplayRatings(
             List<MatchmakingGame> games, List<MatchmakingRating> playerRatings) {
         Map<String, BigDecimal> ratingByUserId =
                 playerRatings.stream().collect(Collectors.toMap(MatchmakingRating::userId, MatchmakingRating::rating));
-        Map<Long, Long> counts = new TreeMap<>(Comparator.reverseOrder());
+        List<Long> averageDisplayRatings = new ArrayList<>();
         for (MatchmakingGame game : games) {
             BigDecimal sum = BigDecimal.ZERO;
             int ratedPlayers = 0;
@@ -379,7 +378,15 @@ public class MatchmakingRatingEventService {
             }
             if (ratedPlayers == 0) continue;
             BigDecimal averageRating = sum.divide(BigDecimal.valueOf(ratedPlayers), java.math.MathContext.DECIMAL64);
-            counts.merge(bracketFor(toDisplayRating(averageRating)), 1L, Long::sum);
+            averageDisplayRatings.add(toDisplayRating(averageRating));
+        }
+        return averageDisplayRatings;
+    }
+
+    private static Map<Long, Long> bucketByBracket(List<Long> displayRatings) {
+        Map<Long, Long> counts = new TreeMap<>(Comparator.reverseOrder());
+        for (long displayRating : displayRatings) {
+            counts.merge(bracketFor(displayRating), 1L, Long::sum);
         }
         return counts;
     }
@@ -389,10 +396,10 @@ public class MatchmakingRatingEventService {
     }
 
     private static void appendBracketDistribution(
-            StringBuilder stringBuilder, String heading, String unitLabel, Map<Long, Long> countsByBracket) {
-        if (countsByBracket.isEmpty()) return;
-        long total =
-                countsByBracket.values().stream().mapToLong(Long::longValue).sum();
+            StringBuilder stringBuilder, String heading, String unitLabel, List<Long> displayRatings) {
+        if (displayRatings.isEmpty()) return;
+        Map<Long, Long> countsByBracket = bucketByBracket(displayRatings);
+        long total = displayRatings.size();
         stringBuilder.append("\n**").append(heading).append(":**\n");
         for (Map.Entry<Long, Long> entry : countsByBracket.entrySet()) {
             long bracket = entry.getKey();
@@ -403,6 +410,18 @@ public class MatchmakingRatingEventService {
             stringBuilder.append(String.format(
                     "- `%d%s%d`: %d %s (%.1f%%)\n", bracket, separator, bracket + 99, count, label, percent));
         }
+        stringBuilder.append(String.format(
+                "%s %s\n",
+                describeTierShare(SkillTier.LOWER, unitLabel, displayRatings),
+                describeTierShare(SkillTier.HIGHER, unitLabel, displayRatings)));
+    }
+
+    private static String describeTierShare(SkillTier skillTier, String unitLabel, List<Long> displayRatings) {
+        long inTier = displayRatings.stream().filter(skillTier::contains).count();
+        double percent = 100.0 * inTier / displayRatings.size();
+        return String.format(
+                "%.1f%% of %s are in the %s tier (%s).",
+                percent, unitLabel, skillTier.getDisplayName(), skillTier.getLabel());
     }
 
     public static MatchmakingRatingEventService get() {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -38,6 +38,8 @@ public class MatchmakingRatingEventService {
     private static final Duration RATINGS_CACHE_TTL = Duration.ofHours(8);
     private static final Duration AVERAGE_RATING_CACHE_TTL = Duration.ofHours(8);
     private static final String RATINGS_CACHE_KEY = "key";
+    private static final List<String> DEBUG_RATING_PLAYERS =
+            List.of("tazing0", "bleezy4sheezy", "bearded_one", "inco.n.damus", "forleafs", "the_constellation_orion");
 
     private final Cache<String, List<MatchmakingRating>> unconservativeRatingsCache = createRatingsCache();
     private final Cache<String, List<MatchmakingRating>> conservativeRatingsCache = createRatingsCache();
@@ -201,6 +203,8 @@ public class MatchmakingRatingEventService {
                 "games",
                 bucketGamesByBracket(games, playerRatings));
 
+        appendDebugRatings(stringBuilder, playerRatings);
+
         playerRatings.stream()
                 .filter(playerRating ->
                         playerRating.userId().equals(event.getUser().getId()))
@@ -229,6 +233,35 @@ public class MatchmakingRatingEventService {
                 (MessageChannelUnion) event.getMessageChannel(),
                 "Player Matchmaking Ratings",
                 stringBuilder.toString());
+    }
+
+    private static void appendDebugRatings(StringBuilder stringBuilder, List<MatchmakingRating> playerRatings) {
+        stringBuilder.append("\n__**Debug ratings:**__\n");
+        for (String debugPlayer : DEBUG_RATING_PLAYERS) {
+            MatchmakingRating playerRating = playerRatings.stream()
+                    .filter(rating -> matchesDebugPlayer(rating, debugPlayer))
+                    .findFirst()
+                    .orElse(null);
+            if (playerRating == null) {
+                stringBuilder.append(String.format(
+                        "`%s` not rated - fewer than 3 completed games, or stored under a different name\n",
+                        debugPlayer));
+                continue;
+            }
+            stringBuilder.append(String.format(
+                    "`%s` `Rating=%d` `Calibration=%.1f%%` `Sigma=%.3f`%s\n",
+                    playerRating.username(),
+                    toDisplayRating(playerRating.rating()),
+                    playerRating.calibrationPercent(),
+                    playerRating.sigma(),
+                    playerRating.recentRatingDelta() == null
+                            ? ""
+                            : String.format(" `Trend=%+d`", toDisplayRating(playerRating.recentRatingDelta()))));
+        }
+    }
+
+    private static boolean matchesDebugPlayer(MatchmakingRating playerRating, String debugPlayer) {
+        return debugPlayer.equalsIgnoreCase(playerRating.username()) || debugPlayer.equals(playerRating.userId());
     }
 
     private static void appendRecentTrend(StringBuilder stringBuilder, MatchmakingRating playerRating) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -202,7 +202,7 @@ public class MatchmakingRatingEventService {
 
         appendBracketDistribution(
                 stringBuilder,
-                "Players per " + ratingLabel.toLowerCase() + " bracket",
+                "Calibrated players per " + ratingLabel.toLowerCase() + " bracket",
                 "players",
                 playerDisplayRatings(playerRatings));
         appendBracketDistribution(
@@ -358,6 +358,7 @@ public class MatchmakingRatingEventService {
 
     private static List<Long> playerDisplayRatings(List<MatchmakingRating> playerRatings) {
         return playerRatings.stream()
+                .filter(playerRating -> playerRating.calibrationPercent().compareTo(ONE_HUNDRED) >= 0)
                 .map(playerRating -> toDisplayRating(playerRating.rating()))
                 .toList();
     }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventService.java
@@ -205,6 +205,7 @@ public class MatchmakingRatingEventService {
                 "Calibrated players per " + ratingLabel.toLowerCase() + " bracket",
                 "players",
                 playerDisplayRatings(playerRatings));
+        appendActiveCalibrationShare(stringBuilder, games, playerRatings, inactivityCutoff);
         appendBracketDistribution(
                 stringBuilder,
                 "Games per average-" + ratingLabel.toLowerCase() + " bracket",
@@ -354,6 +355,29 @@ public class MatchmakingRatingEventService {
         stringBuilder.append(String.format(
                 "\nThe average %s of your opponents across your %d games is `%d`.",
                 ratingLabel.toLowerCase(), gameCount, toDisplayRating(averageOpponentRating)));
+    }
+
+    private static void appendActiveCalibrationShare(
+            StringBuilder stringBuilder,
+            List<MatchmakingGame> games,
+            List<MatchmakingRating> playerRatings,
+            long inactivityCutoff) {
+        Set<String> activeUserIds = games.stream()
+                .filter(game -> game.endedDate() >= inactivityCutoff)
+                .flatMap(game -> game.players().stream())
+                .map(MatchmakingPlayer::userId)
+                .collect(Collectors.toSet());
+        if (activeUserIds.isEmpty()) return;
+        long calibratedCount = playerRatings.stream()
+                .filter(playerRating -> activeUserIds.contains(playerRating.userId()))
+                .filter(playerRating -> playerRating.calibrationPercent().compareTo(ONE_HUNDRED) >= 0)
+                .count();
+        stringBuilder.append(String.format(
+                "%.1f%% of players who played in the last %d months are calibrated (%d of %d).\n",
+                100.0 * calibratedCount / activeUserIds.size(),
+                INACTIVITY_MONTHS,
+                calibratedCount,
+                activeUserIds.size()));
     }
 
     private static List<Long> playerDisplayRatings(List<MatchmakingRating> playerRatings) {

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/SkillTier.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/SkillTier.java
@@ -14,11 +14,9 @@ public enum SkillTier {
     public static final String EXCLUSION_PREFIX = "-";
 
     private static final class Bounds {
-        // Bottom ~9% of games
-        private static final long LOWER_MEDIUM = 1800;
+        private static final long LOWER_MEDIUM = 1900;
 
-        // ~83% of games fall between this and LOWER_MEDIUM
-        private static final long MEDIUM_HIGHER = 2200;
+        private static final long MEDIUM_HIGHER = 2150;
 
         private Bounds() {}
     }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/SkillTier.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/SkillTier.java
@@ -14,11 +14,11 @@ public enum SkillTier {
     public static final String EXCLUSION_PREFIX = "-";
 
     private static final class Bounds {
-        // Bottom ~13% of games
-        private static final long LOWER_MEDIUM = 1900;
+        // Bottom ~9% of games
+        private static final long LOWER_MEDIUM = 1800;
 
-        // ~74% of games fall between this and LOWER_MEDIUM
-        private static final long MEDIUM_HIGHER = 2300;
+        // ~83% of games fall between this and LOWER_MEDIUM
+        private static final long MEDIUM_HIGHER = 2200;
 
         private Bounds() {}
     }

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
@@ -23,7 +23,7 @@ class TrueSkillMatchmakingRatingService {
 
     private static final FactorGraphTrueSkillCalculator CALCULATOR = new FactorGraphTrueSkillCalculator();
 
-    private static final double SIGMA_CALIBRATION_THRESHOLD = 1.62;
+    private static final double SIGMA_CALIBRATION_THRESHOLD = 1.7;
     private static final BigDecimal ONE_HUNDRED = BigDecimal.valueOf(100);
     private static final int MINIMUM_GAMES_FOR_RANKING = 3;
 

--- a/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
+++ b/src/main/java/ti4/spring/service/statistics/matchmaking/TrueSkillMatchmakingRatingService.java
@@ -23,7 +23,7 @@ class TrueSkillMatchmakingRatingService {
 
     private static final FactorGraphTrueSkillCalculator CALCULATOR = new FactorGraphTrueSkillCalculator();
 
-    private static final double SIGMA_CALIBRATION_THRESHOLD = 1.5;
+    private static final double SIGMA_CALIBRATION_THRESHOLD = 1.62;
     private static final BigDecimal ONE_HUNDRED = BigDecimal.valueOf(100);
     private static final int MINIMUM_GAMES_FOR_RANKING = 3;
 

--- a/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfoTest.java
+++ b/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfoTest.java
@@ -10,7 +10,7 @@ class MatchmakingGameInfoTest {
 
     private static final double TOLERANCE = 1.0e-9;
     private static final double EXPECTED_DRAW_PROBABILITY = 0.05;
-    private static final double EXPECTED_DYNAMICS_FACTOR_DIVISOR = 50.0;
+    private static final double EXPECTED_DYNAMICS_FACTOR_DIVISOR = 25.0;
 
     @Test
     void keepsTheJskillsDefaultsForTheDistributionParameters() {

--- a/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfoTest.java
+++ b/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingGameInfoTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class MatchmakingGameInfoTest {
 
     private static final double TOLERANCE = 1.0e-9;
-    private static final double EXPECTED_DRAW_PROBABILITY = 0.5;
+    private static final double EXPECTED_DRAW_PROBABILITY = 0.05;
     private static final double EXPECTED_DYNAMICS_FACTOR_DIVISOR = 50.0;
 
     @Test
@@ -24,12 +24,12 @@ class MatchmakingGameInfoTest {
     }
 
     @Test
-    void tunesTheDrawProbabilityAboveTheJskillsDefault() {
+    void tunesTheDrawProbabilityBelowTheJskillsDefault() {
         GameInfo matchmaking = MatchmakingGameInfo.create();
 
         assertThat(matchmaking.getDrawProbability()).isEqualTo(EXPECTED_DRAW_PROBABILITY, within(TOLERANCE));
         assertThat(matchmaking.getDrawProbability())
-                .isGreaterThan(GameInfo.getDefaultGameInfo().getDrawProbability());
+                .isLessThan(GameInfo.getDefaultGameInfo().getDrawProbability());
     }
 
     @Test

--- a/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventServiceTest.java
+++ b/src/test/java/ti4/spring/service/statistics/matchmaking/MatchmakingRatingEventServiceTest.java
@@ -10,6 +10,9 @@ import java.util.Comparator;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import ti4.spring.service.persistence.GameEntity;
+import ti4.spring.service.persistence.PlayerEntity;
+import ti4.spring.service.persistence.UserEntity;
 
 class MatchmakingRatingEventServiceTest {
 
@@ -20,6 +23,8 @@ class MatchmakingRatingEventServiceTest {
     private static final int MANY_GAMES = 1000;
     private static final BigDecimal TIED_PLAYER_RATING_TOLERANCE_AT_QUALIFYING_GAMES = BigDecimal.valueOf(0.7);
     private static final BigDecimal TIED_PLAYER_RATING_TOLERANCE_AT_MANY_GAMES = BigDecimal.valueOf(0.05);
+    private static final int VICTORY_POINT_GOAL = 10;
+    private static final String SHARED_DISPLAY_NAME = "Tazingo";
 
     @Test
     void generatingRatingsTwiceGivesSameResult() {
@@ -118,6 +123,78 @@ class MatchmakingRatingEventServiceTest {
 
         assertThat(findRatingForUser(ratings, "p4").recentRatingDelta()).isPositive();
         assertThat(findRatingForUser(ratings, "p0").recentRatingDelta()).isNegative();
+    }
+
+    @Test
+    void usersWhoShareADisplayNameAreRatedAsSeparatePlayers() {
+        UserEntity tazingo = new UserEntity("tazing0", SHARED_DISPLAY_NAME);
+        UserEntity otherTazingo = new UserEntity("taz", SHARED_DISPLAY_NAME);
+        List<PlayerEntity> players = new ArrayList<>();
+        for (int i = 0; i < GAMES_TO_QUALIFY; i++) {
+            List<UserEntity> finishingOrder = new ArrayList<>();
+            finishingOrder.add(tazingo);
+            finishingOrder.addAll(fillerUsers(4));
+            finishingOrder.add(otherTazingo);
+            players.addAll(buildPlayerEntities("shared" + i, finishingOrder));
+        }
+
+        List<MatchmakingRating> ratings =
+                TrueSkillMatchmakingRatingService.calculateRatings(MatchmakingGame.getMatchmakingGames(players), false);
+
+        assertThat(ratings)
+                .filteredOn(rating -> SHARED_DISPLAY_NAME.equals(rating.username()))
+                .extracting(MatchmakingRating::userId)
+                .containsExactlyInAnyOrder("tazing0", "taz");
+        assertThat(findRatingForUser(ratings, "tazing0").rating())
+                .isGreaterThan(findRatingForUser(ratings, "taz").rating());
+    }
+
+    @Test
+    void doesNotPoolTheGamesOfUsersWhoShareADisplayName() {
+        // Two games each: pooled by name they would clear the three-game minimum, kept apart neither does.
+        UserEntity tazingo = new UserEntity("tazing0", SHARED_DISPLAY_NAME);
+        UserEntity otherTazingo = new UserEntity("taz", SHARED_DISPLAY_NAME);
+        List<PlayerEntity> players = new ArrayList<>();
+        for (int i = 0; i < GAMES_TO_QUALIFY - 1; i++) {
+            List<UserEntity> tazingoGame = new ArrayList<>(List.of(tazingo));
+            tazingoGame.addAll(fillerUsers(5));
+            players.addAll(buildPlayerEntities("tazing0-game" + i, tazingoGame));
+
+            List<UserEntity> otherTazingoGame = new ArrayList<>(List.of(otherTazingo));
+            otherTazingoGame.addAll(fillerUsers(5));
+            players.addAll(buildPlayerEntities("taz-game" + i, otherTazingoGame));
+        }
+
+        List<MatchmakingRating> ratings =
+                TrueSkillMatchmakingRatingService.calculateRatings(MatchmakingGame.getMatchmakingGames(players), false);
+
+        assertThat(ratings).isNotEmpty();
+        assertThat(ratings).noneMatch(rating -> SHARED_DISPLAY_NAME.equals(rating.username()));
+    }
+
+    private static List<UserEntity> fillerUsers(int count) {
+        List<UserEntity> users = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            users.add(new UserEntity("filler" + i, "Filler " + i));
+        }
+        return users;
+    }
+
+    private static List<PlayerEntity> buildPlayerEntities(String gameName, List<UserEntity> usersInFinishingOrder) {
+        GameEntity game = new GameEntity();
+        game.setGameName(gameName);
+        game.setEndedEpochMilliseconds(GAME_ENDED_EPOCH_MILLIS);
+        game.setVictoryPointGoal(VICTORY_POINT_GOAL);
+        List<PlayerEntity> players = new ArrayList<>();
+        for (int place = 0; place < usersInFinishingOrder.size(); place++) {
+            PlayerEntity player = new PlayerEntity();
+            player.setGame(game);
+            player.setUser(usersInFinishingOrder.get(place));
+            player.setWinner(place == 0);
+            player.setScore(VICTORY_POINT_GOAL - place);
+            players.add(player);
+        }
+        return players;
     }
 
     private static List<MatchmakingRating> sortedByRating(List<MatchmakingRating> ratings) {

--- a/src/test/java/ti4/spring/service/statistics/matchmaking/SkillTierTest.java
+++ b/src/test/java/ti4/spring/service/statistics/matchmaking/SkillTierTest.java
@@ -30,18 +30,6 @@ class SkillTierTest {
     }
 
     @Test
-    void boundariesLandOnBracketEdges() {
-        for (SkillTier skillTier : SkillTier.values()) {
-            long minimum = skillTier.getMinimumDisplayRatingInclusive();
-            if (minimum != Long.MIN_VALUE) {
-                assertThat(Math.floorMod(minimum, 100))
-                        .as("%s starts mid-bracket at %d", skillTier, minimum)
-                        .isZero();
-            }
-        }
-    }
-
-    @Test
     void parsesOptionValuesAndRejectsJunk() {
         assertThat(SkillTier.fromOptionValue("HIGHER")).isEqualTo(SkillTier.HIGHER);
         assertThat(SkillTier.fromOptionValue(" lower ")).isEqualTo(SkillTier.LOWER);


### PR DESCRIPTION
## Summary

Players have said their matchmaking rating barely moves after many games. This retunes the TrueSkill parameters so ratings respond more per game, refits the skill tiers to the resulting distribution, and adds distribution stats to the matchmaking command output.

## Rating calculation

- **Draw probability 0.5 → 0.05** (`MatchmakingGameInfo`). Across ~19k real games, prediction accuracy was flat from 0.05 through 0.5: winner picked ~31% of the time vs ~17% at random, ~63% of player pairs ordered correctly. The lower value tightens the rating spread and smooths the top of the ladder.
- **Skill drift between games σ/50 → σ/25** (`MatchmakingGameInfo`). Ratings move further per game, so recent results count for more.
- **Calibration threshold 1.5 → 1.7** (`TrueSkillMatchmakingRatingService`). Larger drift keeps sigma higher, and at 1.5 the top players were falling off the leaderboard. At 1.7 a player needs ~11 games on average to calibrate, and no one with 30+ games fails to.

## Skill tiers

- **Bounds 1900/2300 → 1900/2150** (`SkillTier`). At 2300 the Higher tier held under 1% of games. With these bounds, games split roughly 20% Lower / 61% Medium / 18% Higher.
- Removed `SkillTierTest.boundariesLandOnBracketEdges`. Tier shares are now counted from individual ratings instead of from the 100-point brackets, so a bound no longer has to fall on a bracket edge.

## Matchmaking command output

- Each bracket line shows its share, e.g. `312 players (11.4%)`.
- The player section is now "Calibrated players per rating bracket" and counts only players at 100% calibration. Uncalibrated players have low conservative ratings and crowded the bottom brackets.
- Both bracket sections end with the share of players or games in the Lower and Higher tiers, using the live `SkillTier` bounds.
- A note gives the share of players active in the last 6 months who are calibrated. Players with fewer than 3 games count as uncalibrated.

## Tests

- `MatchmakingGameInfoTest` updated for the new draw probability and drift.
- New tests in `MatchmakingRatingEventServiceTest` confirm two users with the same display name are rated as separate players and their games are not pooled.
- Full suite: 783 run, 0 failures.

## Heads-up

Every player's rating and calibration percentage will change on deploy. The leaderboard and skill tier assignments will shift accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
